### PR TITLE
Comment on the plan, and accept the thread as a decision

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -161,6 +161,15 @@ failed tool chips; without that a boundary the agent keeps hitting is invisible.
 `transform`. They compose rather than override, so an element positioned by
 script must not also carry them.
 
+**A transport comes up on its own schedule; whatever mounted against it does
+not.** The provider opened the document once, when the editor mounted, so a
+socket still mid-handshake cost the plan entirely — `ask` refused, nothing
+tried again, and the editor sat locked for the session under a status chip
+still saying "Loading". The same gap swallowed reconnects: `#open` is the only
+thing that asks for what was missed and the only thing that replays the outbox,
+so a client came back unlocked over a document quietly short of everyone else's
+edits. Opening is driven by the connection now, not by the mount.
+
 **A gate on a message is not a gate on a button.** `chat:send` checks
 `config.agent`; accepting a comment reached `Chat.instruct` directly and opened
 a session under `AGENT=off`. Anything that can start a turn has to check, and

--- a/agents.md
+++ b/agents.md
@@ -20,11 +20,11 @@ agent, which is what the tests use.
 ## Shape
 
 ```
-packages/dialect     4.0k   the MDX dialect and its Lexical schema
-packages/editor      4.0k   the browser editor, cursors, decisions pane
+packages/dialect     4.5k   the MDX dialect and its Lexical schema
+packages/editor      5.4k   the browser editor, cursors, the sidecar
 packages/question    1.8k   questionnaires: definition, shared answer, derivation
-packages/protocol    0.6k   the wire, as types, plus the addressing rule
-apps/server          6.9k   rooms, documents, questions, the agent
+packages/protocol    0.9k   the wire, as types, plus the addressing rule
+apps/server          8.8k   rooms, documents, questions, comments, the agent
 apps/web             1.4k   the three panes
 scripts/dev.ts              the development supervisor
 ```
@@ -52,9 +52,9 @@ tree, so blocks the agent did not touch keep their Lexical identity and nobody
 loses a cursor to somebody else's edit.
 
 Canonical MDX goes to `data/<room>/plan.mdx` on a debounce, with questionnaire
-records, anchors and the transcript beside it. Yjs history is deliberately not
-persisted: it would buy undo across a restart at the price of a binary
-checkpoint that could disagree with the source.
+records, comment threads, anchors and the transcript beside it. Yjs history is
+deliberately not persisted: it would buy undo across a restart at the price of
+a binary checkpoint that could disagree with the source.
 
 ## Decisions, and why
 
@@ -89,11 +89,33 @@ conversation, carried into its next turn as context. Without this, two people
 planning together cannot talk — "should we ask about auth first?" would start a
 turn. Not `@plan`: it is the most common noun in the product.
 
+**Accepting a comment is an address.** The `@ai` rule separates conversation
+from instruction, and a button press is already the latter — so accept starts a
+turn, through the same queue a message does. It writes a system line into the
+transcript, because an agent that begins editing for no visible reason is worse
+than a noisy log. Accepting also freezes the thread: it is what the room
+settled, so `edit_plan` cannot author or remove the `<Decision>` it projects.
+
 **Anchors are a relative position plus a digest**, and the two do different
 jobs. The position survives edits around a block; the digest recovers it when
 the position cannot resolve — a move rebuilds a block's collaborative identity,
 and an epoch rotation discards the history the position was expressed in. A
 digest matching two blocks recovers neither.
+
+**A passage is the same idea one level finer.** A comment marks a phrase, not a
+block, so it carries the block anchors plus a pair of relative positions into
+the text and the quoted words. The positions make the highlight stretch as
+somebody types inside the phrase; the quote finds it again when they cannot
+resolve. Two occurrences equally near the recorded offset recover neither.
+
+**A client sends what it read, not where it thinks that is.** `comment:start`
+carries block indices and the selected text; the server finds the quote and
+mints every Yjs position itself. Finding it is the concurrency check, and a
+better one than a digest — it tests whether the sentence is still there, which
+is what matters, and a browser cannot compute a canonical block digest without
+re-serialising the document. The two ends must agree on which blocks the source
+addresses; they need not agree on the offset, so a divergence surfaces as a
+refusal rather than a comment landing on the wrong sentence.
 
 **Hard-fail at boot.** A missing token, an unusable CLI or a `WORKING_DIR` that
 is not there are all detectable in seconds by trying, and discovering them when
@@ -139,6 +161,22 @@ failed tool chips; without that a boundary the agent keeps hitting is invisible.
 `transform`. They compose rather than override, so an element positioned by
 script must not also carry them.
 
+**A gate on a message is not a gate on a button.** `chat:send` checks
+`config.agent`; accepting a comment reached `Chat.instruct` directly and opened
+a session under `AGENT=off`. Anything that can start a turn has to check, and
+the check lives in `instruct` now so the next one cannot miss it.
+
+**Rebasing used to happen only inside `edit_plan`.** So a block a person moved
+kept its anchors broken until the agent next happened to edit, and everything
+restored from disk was expressed in a history the new document did not have.
+It now runs on the snapshot debounce, on an epoch rotation, and before `open`
+returns — and the flush broadcasts only when the snapshot actually moved,
+because a recovery nobody is told about is the same as no recovery.
+
+**`CSS.highlights` is a document-wide registry**, shared with Lexical's remote
+cursors. Ours are named `plan-comment*`, its are `lexical-cursor-*`; a
+collision would silently unpaint somebody's selection.
+
 **`bun run <script>` does not exit when what it started dies.** It sits there
 with no child. `scripts/dev.ts` spawns both processes directly for this reason,
 and gives each its own process group so the whole tree can be taken down.
@@ -176,7 +214,10 @@ That line exists because a dropped tool is otherwise undetectable. If the agent
 starts claiming it cannot do something, read it before anything else.
 
 `DEV_QUESTIONS=1` makes a room ask a sample questionnaire on open, which
-exercises the whole question path without an agent.
+exercises the whole question path without an agent. `DEV_COMMENTS=1` marks a
+real phrase in whatever the room already holds, which does the same for
+passages — anchoring, carrying across edits, freezing into a decision — before
+any of it has a sidecar to be driven from.
 
 ## Origins
 

--- a/apps/server/src/agent/planner.ts
+++ b/apps/server/src/agent/planner.ts
@@ -106,10 +106,20 @@ which blocks changed — read again and retry rather than forcing the edit.
 Every successful \`edit_plan\` returns \`anchors_pending\`, and you MUST clear it
 with \`anchor_plan\` before you reply or end the turn, quoting that result's
 revision and block digests. A question's own text maps to \`subject\`; the prose
-its answer caused maps to \`result\`. Link only blocks that would have to change
-if that answer changed — not the goal, not the architecture, not everything
-written after it. An empty list is a real answer: it records that you looked
-and there is deliberately nothing related.
+its answer caused maps to \`result\`. An accepted comment takes \`thread\` instead,
+and its blocks are the prose your revision produced. Link only blocks that would
+have to change if that decision changed — not the goal, not the architecture,
+not everything written after it. An empty list is a real answer: it records that
+you looked and there is deliberately nothing related.
+
+People comment on passages of the plan, and when the room accepts a thread you
+are asked to act on it. An accepted comment is an instruction: revise the prose
+it marks so their point is addressed, then anchor what you produced. Take the
+whole thread rather than its last line — the disagreement in it is usually the
+part that matters. \`read_plan\` lists every accepted comment and whether it has
+been actioned, so if several are outstanding you can deal with them together.
+Comments still under discussion never reach you; nothing is asked of you until
+the room has accepted it.
 
 Other people are editing the same document while you work, and their edits are
 as real as yours. Rewrite what a decision invalidates; do not rewrite what

--- a/apps/server/src/agent/tools.ts
+++ b/apps/server/src/agent/tools.ts
@@ -11,6 +11,7 @@
  * by accident.
  */
 
+import * as Comments from "../comments/service";
 import * as edit from "../plan/edit";
 import * as Questions from "../questions/service";
 
@@ -56,6 +57,25 @@ export function toolbox(context: Context): Tool[] {
 					revision: context.plan.revision,
 					source: edit.source(context.plan),
 					blocks: edit.outline(context.plan),
+					/*
+					 * Accepted threads only.
+					 *
+					 * An open one is a conversation the room is still having, and
+					 * acting on feedback nobody has accepted would make the accept
+					 * button decorative. A dismissed one was decided against and
+					 * never reaches here at all.
+					 */
+					comments: [...context.plan.threads.values()]
+						.filter(thread => thread.status === "accepted")
+						.map(thread => ({
+							id: thread.id,
+							quote: thread.quote,
+							accepted_by: thread.resolver,
+							// False means this one still needs acting on and
+							// anchoring; it is the same list `anchors_pending` gives.
+							actioned: !!thread.result && !thread.result.pending,
+							comments: thread.notes.map(note => `@${note.handle}: ${note.text}`),
+						})),
 					questions: [...context.plan.records.values()].map(record => ({
 						id: record.id,
 						status: record.status,
@@ -143,13 +163,18 @@ export function toolbox(context: Context): Tool[] {
 					// rewritten.
 					Questions.rebase(context.plan);
 					Questions.invalidate(context.plan, "plan_changed");
+					Comments.rebase(context.plan);
+					Comments.invalidate(context.plan, "plan_changed");
 					context.anchors();
 
 					return {
 						ok: true,
 						revision: context.plan.revision,
 						blocks: outcome.blocks,
-						anchors_pending: Questions.outstanding(context.plan),
+						anchors_pending: [
+							...Questions.outstanding(context.plan),
+							...Comments.outstanding(context.plan),
+						],
 					};
 				}),
 		},
@@ -215,13 +240,14 @@ export function toolbox(context: Context): Tool[] {
 		},
 		{
 			name: "anchor_plan",
-			description:
-				"Say which passages of the plan each question concerns and each answer produced. "
-				+ "Call it immediately after every successful `edit_plan`, using that result's "
-				+ "revision and block digests. A question's text maps to `subject`; the prose its "
-				+ "answer caused maps to `result`. Link only blocks that would have to change if "
-				+ "that answer changed. An empty list means reviewed and deliberately unrelated, "
-				+ "which is a real answer and clears the review.",
+			description: "Say which passages of the plan each decision concerns and produced. Call it "
+				+ "immediately after every successful `edit_plan`, using that result's revision and "
+				+ "block digests. For a question, give `widget`, `question` and `relation`: its text "
+				+ "maps to `subject`, and the prose its answer caused maps to `result`. For an "
+				+ "accepted comment, give `thread` instead — the blocks are the prose your revision "
+				+ "produced. Link only blocks that would have to change if that decision changed. An "
+				+ "empty list means reviewed and deliberately unrelated, which is a real answer and "
+				+ "clears the review.",
 			parameters: {
 				type: "object",
 				properties: {
@@ -233,9 +259,18 @@ export function toolbox(context: Context): Tool[] {
 						items: {
 							type: "object",
 							properties: {
-								widget: { type: "string", description: "The questionnaire id." },
+								widget: {
+									type: "string",
+									description: "The questionnaire id. Give with `question` and `relation`.",
+								},
 								question: { type: "string", description: "The question id." },
 								relation: { type: "string", enum: ["subject", "result"] },
+								thread: {
+									type: "string",
+									description:
+										"An accepted comment thread's id, instead of widget/question/relation. "
+										+ "The blocks are the prose your revision produced.",
+								},
 								blocks: {
 									type: "array",
 									items: {
@@ -249,7 +284,10 @@ export function toolbox(context: Context): Tool[] {
 									},
 								},
 							},
-							required: ["widget", "question", "relation", "blocks"],
+							// Only `blocks` is always required: the rest depend on which
+							// kind of decision is being anchored, the way `edit_plan`'s
+							// operations already work. `relate` names what is missing.
+							required: ["blocks"],
 							additionalProperties: false,
 						},
 					},
@@ -262,9 +300,10 @@ export function toolbox(context: Context): Tool[] {
 					let args = raw as {
 						revision: number;
 						anchors: Array<{
-							widget: string;
-							question: string;
-							relation: "subject" | "result";
+							widget?: string;
+							question?: string;
+							relation?: "subject" | "result";
+							thread?: string;
 							blocks: Array<{ index: number; digest: string }>;
 						}>;
 					};
@@ -280,13 +319,17 @@ export function toolbox(context: Context): Tool[] {
 
 					let failures: string[] = [];
 					for (let update of args.anchors) {
-						let failure = Questions.relate(
-							context.plan,
-							update.widget,
-							update.question,
-							update.relation,
-							update.blocks,
-						);
+						let failure = update.thread
+							? Comments.relate(context.plan, update.thread, update.blocks)
+							: update.widget && update.question && update.relation
+							? Questions.relate(
+								context.plan,
+								update.widget,
+								update.question,
+								update.relation,
+								update.blocks,
+							)
+							: "give either `thread`, or all of `widget`, `question` and `relation`.";
 						if (failure) failures.push(failure);
 					}
 
@@ -295,7 +338,13 @@ export function toolbox(context: Context): Tool[] {
 
 					return failures.length > 0
 						? { ok: false, reason: "invalid", errors: failures }
-						: { ok: true, anchors_pending: Questions.outstanding(context.plan) };
+						: {
+							ok: true,
+							anchors_pending: [
+								...Questions.outstanding(context.plan),
+								...Comments.outstanding(context.plan),
+							],
+						};
 				}),
 		},
 	];

--- a/apps/server/src/agent/tools.ts
+++ b/apps/server/src/agent/tools.ts
@@ -165,6 +165,14 @@ export function toolbox(context: Context): Tool[] {
 					Questions.invalidate(context.plan, "plan_changed");
 					Comments.rebase(context.plan);
 					Comments.invalidate(context.plan, "plan_changed");
+
+					// After invalidating, so it is not immediately undone. If
+					// this turn was started by accepting a comment, what it
+					// just wrote is what that decision produced — unless the
+					// agent says otherwise with `anchor_plan`, which wins.
+					let acting = context.plan.chat.acting;
+					if (acting) Comments.attribute(context.plan, acting, outcome.touched);
+
 					context.anchors();
 
 					return {

--- a/apps/server/src/chat/queue.test.ts
+++ b/apps/server/src/chat/queue.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Turns that something other than a message started.
+ *
+ * Accepting a comment is an instruction, so it starts a turn the same way a
+ * message does — through the same queue, with the same ceiling. What differs is
+ * that a button press is not a thing anybody said, so the transcript has to be
+ * told why the agent began moving, and that the work may already be done by the
+ * time the turn comes up.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import * as Chat from "./service";
+
+import type { Server } from "bun";
+import type { Config } from "../config";
+import type { Plan } from "../plan/service";
+import type { SocketData } from "../wire";
+
+type Sent = { kind: string; [key: string]: unknown };
+
+function room(options: { agent?: boolean; busy?: boolean } = {}) {
+	let sent: Sent[] = [];
+	let chat = Chat.create();
+	chat.busy = options.busy ?? false;
+
+	let server = {
+		publish(_topic: string, data: string) {
+			sent.push(JSON.parse(data) as Sent);
+		},
+	} as unknown as Server<SocketData>;
+
+	let context: Chat.Room = {
+		chat,
+		config: { agent: options.agent ?? true } as Config,
+		plan: { chat } as Plan,
+		room: "test",
+		server,
+	};
+
+	return { chat, context, sent };
+}
+
+/** What the transcript gained, in order. */
+function said(sent: Sent[]): string[] {
+	return sent
+		.filter(frame => frame.kind === "chat:message")
+		.map(frame => (frame.entry as { text: string }).text);
+}
+
+describe("instructing the agent without a message", () => {
+	/**
+	 * An agent that starts editing for no visible reason is worse than a noisy
+	 * log, so the reason goes in the one place the room reads chronologically.
+	 */
+	it("says why the turn started", () => {
+		let { context, sent } = room({ busy: true });
+		Chat.instruct(context, "ana", "do the thing", '@ana accepted a comment on "x".');
+
+		expect(said(sent)[0]).toBe('@ana accepted a comment on "x".');
+	});
+
+	it("queues behind a running turn rather than interrupting it", () => {
+		let { chat, context, sent } = room({ busy: true });
+		Chat.instruct(context, "ana", "do the thing", "@ana accepted a comment.");
+
+		expect(chat.waiting).toHaveLength(1);
+		expect(chat.waiting[0]).toMatchObject({ handle: "ana", text: "do the thing" });
+		expect(sent.some(frame => frame.kind === "chat:queue")).toBe(true);
+	});
+
+	it("refuses to grow a queue nobody is going to read", () => {
+		let { chat, context, sent } = room({ busy: true });
+		for (let i = 0; i < 25; i++) {
+			Chat.instruct(context, "ana", `turn ${i}`, `notice ${i}`);
+		}
+
+		expect(chat.waiting.length).toBeLessThanOrEqual(20);
+		expect(said(sent)).toContain("The queue is full. Wait for the current turn to finish.");
+	});
+
+	/**
+	 * `AGENT=off` runs the room without one. The decision that got here is
+	 * already recorded; only the turn is impossible. Saying so beats a session
+	 * failing to open — which is what happened before this check existed,
+	 * because `chat:send` was gated and a button press was not.
+	 */
+	it("records the decision but does not reach for an agent that is off", () => {
+		let { chat, context, sent } = room({ agent: false, busy: false });
+		Chat.instruct(context, "ana", "do the thing", "@ana accepted a comment.");
+
+		expect(chat.busy).toBe(false);
+		expect(chat.waiting).toHaveLength(0);
+		expect(said(sent)).toEqual([
+			"@ana accepted a comment.",
+			"The agent is not running, so the plan has not been revised.",
+		]);
+	});
+
+	it("still says nothing was revised when the agent is off and busy", () => {
+		let { chat, context, sent } = room({ agent: false, busy: true });
+		Chat.instruct(context, "ana", "do the thing", "@ana accepted a comment.");
+
+		// The gate comes before the queue: queueing a turn that can never run
+		// would leave it there until someone withdrew it.
+		expect(chat.waiting).toHaveLength(0);
+		expect(said(sent)).toHaveLength(2);
+	});
+});
+
+/** Queue some turns, as `instruct` would have while another was running. */
+function waiting(chat: Chat.Chat, entries: Array<{ text: string; spent?: () => boolean }>): void {
+	for (let [index, entry] of entries.entries()) {
+		chat.waiting.push({ id: `w${index}`, handle: "ana", ...entry });
+	}
+}
+
+describe("draining the queue", () => {
+	it("takes them in the order they arrived", () => {
+		let { chat } = room();
+		waiting(chat, [{ text: "first" }, { text: "second" }]);
+
+		expect(Chat.pending(chat)?.text).toBe("first");
+		expect(Chat.pending(chat)?.text).toBe("second");
+		expect(Chat.pending(chat)).toBeUndefined();
+	});
+
+	/**
+	 * Four accepted comments should not cost four passes over the plan when the
+	 * agent dealt with all of them in the first. Only something that queued
+	 * behind a turn can be spent, which is why the question is asked here.
+	 */
+	it("drops a turn whose work another one already did", () => {
+		let { chat } = room();
+		waiting(chat, [
+			{ text: "thread one", spent: () => true },
+			{ text: "thread two", spent: () => true },
+			{ text: "thread three", spent: () => false },
+		]);
+
+		expect(Chat.pending(chat)?.text).toBe("thread three");
+		expect(chat.waiting).toHaveLength(0);
+	});
+
+	it("drops the whole queue when everything in it is spent", () => {
+		let { chat } = room();
+		waiting(chat, [{ text: "one", spent: () => true }, { text: "two", spent: () => true }]);
+
+		expect(Chat.pending(chat)).toBeUndefined();
+	});
+
+	/** An ordinary message is never spent: nobody else can have said it for you. */
+	it("keeps a message, which has no work anybody else could have done", () => {
+		let { chat } = room();
+		waiting(chat, [{ text: "what about auth?" }]);
+
+		expect(Chat.pending(chat)?.text).toBe("what about auth?");
+	});
+
+	/**
+	 * `spent` is a function, so it is asked at the moment the turn would run
+	 * rather than when it was queued — which is the only moment the answer is
+	 * knowable. It also means `JSON.stringify` drops it, keeping the wire shape
+	 * exactly what clients expect.
+	 */
+	it("asks when the turn would run, not when it was queued", () => {
+		let { chat } = room();
+		let done = false;
+		waiting(chat, [{ text: "thread", spent: () => done }]);
+
+		done = true;
+		expect(Chat.pending(chat)).toBeUndefined();
+	});
+
+	it("keeps `spent` off the wire", () => {
+		let { context, sent } = room({ busy: true });
+		Chat.instruct(context, "ana", "do the thing", "notice", () => false);
+
+		let queue = sent.findLast(frame => frame.kind === "chat:queue");
+		expect(queue?.waiting).toEqual([{
+			id: expect.any(String),
+			handle: "ana",
+			text: "do the thing",
+		}]);
+	});
+});

--- a/apps/server/src/chat/queue.test.ts
+++ b/apps/server/src/chat/queue.test.ts
@@ -115,6 +115,37 @@ function waiting(chat: Chat.Chat, entries: Array<{ text: string; spent?: () => b
 	}
 }
 
+describe("what a turn is acting on", () => {
+	/**
+	 * `edit_plan` reads this to record the prose a turn wrote as what the
+	 * decision that started it produced. A turn nobody started by accepting a
+	 * comment is acting on nothing, and must attribute nothing.
+	 */
+	it("carries the thread through the queue to the turn", () => {
+		let { chat, context } = room({ busy: true });
+		Chat.instruct(context, "ana", "do the thing", "notice", { thread: "t1" });
+
+		expect(chat.waiting[0]).toMatchObject({ thread: "t1" });
+	});
+
+	it("keeps the thread off the wire", () => {
+		let { context, sent } = room({ busy: true });
+		Chat.instruct(context, "ana", "do the thing", "notice", { thread: "t1" });
+
+		let queue = sent.findLast(frame => frame.kind === "chat:queue");
+		expect(queue?.waiting).toEqual([{
+			id: expect.any(String),
+			handle: "ana",
+			text: "do the thing",
+		}]);
+	});
+
+	it("says a room with no turn running is acting on nothing", () => {
+		let { chat } = room();
+		expect(chat.acting).toBeUndefined();
+	});
+});
+
 describe("draining the queue", () => {
 	it("takes them in the order they arrived", () => {
 		let { chat } = room();
@@ -174,7 +205,7 @@ describe("draining the queue", () => {
 
 	it("keeps `spent` off the wire", () => {
 		let { context, sent } = room({ busy: true });
-		Chat.instruct(context, "ana", "do the thing", "notice", () => false);
+		Chat.instruct(context, "ana", "do the thing", "notice", { spent: () => false });
 
 		let queue = sent.findLast(frame => frame.kind === "chat:queue");
 		expect(queue?.waiting).toEqual([{

--- a/apps/server/src/chat/service.ts
+++ b/apps/server/src/chat/service.ts
@@ -213,8 +213,20 @@ export function instruct(
 	said: string,
 	spent?: () => boolean,
 ): void {
-	let { chat, room, server } = context;
+	let { chat, config, room, server } = context;
 	notice(context, said);
+
+	// `AGENT=off` runs the room without one. The decision that got here is
+	// still a decision and is already recorded; only the turn is impossible,
+	// and saying so beats a session failing to open.
+	if (!config.agent) {
+		return void say(chat, server, room, {
+			id: ulid(),
+			author: { kind: "system" },
+			text: "The agent is not running, so the plan has not been revised.",
+			ts: now(),
+		});
+	}
 
 	if (chat.busy) {
 		if (chat.waiting.length >= MAX_QUEUE) {

--- a/apps/server/src/chat/service.ts
+++ b/apps/server/src/chat/service.ts
@@ -380,16 +380,25 @@ async function run(context: Room, handle: string, text: string): Promise<void> {
 		state(chat, server, room);
 	}
 
-	let next = chat.waiting.shift();
-	// A turn whose work is already done is dropped rather than run. Four
-	// accepted comments should not cost four passes over the plan when the
-	// agent dealt with all of them in the first.
-	while (next?.spent?.()) next = chat.waiting.shift();
-
+	let next = pending(chat);
 	if (next) {
 		queued(chat, server, room);
 		await run(context, next.handle, next.text);
 	}
+}
+
+/**
+ * The next queued turn worth running.
+ *
+ * A turn whose work is already done is dropped rather than run: four accepted
+ * comments should not cost four passes over the plan when the agent dealt with
+ * all of them in the first. Only something that queued behind a turn can be
+ * spent, which is why the question is asked here and not when it was accepted.
+ */
+export function pending(chat: Chat): Waiting | undefined {
+	let next = chat.waiting.shift();
+	while (next?.spent?.()) next = chat.waiting.shift();
+	return next;
 }
 
 /**

--- a/apps/server/src/chat/service.ts
+++ b/apps/server/src/chat/service.ts
@@ -37,9 +37,19 @@ import type { Socket, SocketData } from "../wire";
 /** Beyond this the queue is a backlog nobody is going to read. */
 const MAX_QUEUE = 20;
 
+/**
+ * A queued message, with what the queue needs and clients do not.
+ *
+ * `spent` is asked, just before the turn would run, whether somebody else has
+ * already done the work. It is a function rather than a flag because the answer
+ * is only knowable at that moment — and `JSON.stringify` drops it, so the wire
+ * shape stays exactly `Wire.Waiting`.
+ */
+type Waiting = Wire.Waiting & { spent?: () => boolean };
+
 export type Chat = {
 	entries: Wire.Entry[];
-	waiting: Wire.Waiting[];
+	waiting: Waiting[];
 	/** The Copilot session, once somebody has prompted. */
 	agent?: Agent.Agent;
 	/** In flight while the session is being opened, so a second prompt waits. */
@@ -175,6 +185,47 @@ export function send(context: Room, ws: Socket, msg: Request<Wire.Send>): void {
 			});
 		}
 		chat.waiting.push({ id: ulid(), handle, text });
+		return queued(chat, server, room);
+	}
+
+	void run(context, handle, text);
+}
+
+/** Say something in the transcript without asking the agent for anything. */
+export function notice(context: Room, text: string): void {
+	let { chat, room, server } = context;
+	say(chat, server, room, { id: ulid(), author: { kind: "system" }, text, ts: now() });
+}
+
+/**
+ * Start a turn from something other than a message.
+ *
+ * Accepting a comment is an instruction in a way prose is not — the `@ai` rule
+ * exists to separate conversation from instruction, and a button press is
+ * already the latter. What it is not is a thing anybody said, so the transcript
+ * gets a system entry explaining why the agent started moving; an agent that
+ * begins editing for no visible reason is worse than a noisy log.
+ */
+export function instruct(
+	context: Room,
+	handle: string,
+	text: string,
+	said: string,
+	spent?: () => boolean,
+): void {
+	let { chat, room, server } = context;
+	notice(context, said);
+
+	if (chat.busy) {
+		if (chat.waiting.length >= MAX_QUEUE) {
+			return void say(chat, server, room, {
+				id: ulid(),
+				author: { kind: "system" },
+				text: "The queue is full. Wait for the current turn to finish.",
+				ts: now(),
+			});
+		}
+		chat.waiting.push({ id: ulid(), handle, text, ...(spent ? { spent } : {}) });
 		return queued(chat, server, room);
 	}
 
@@ -318,6 +369,11 @@ async function run(context: Room, handle: string, text: string): Promise<void> {
 	}
 
 	let next = chat.waiting.shift();
+	// A turn whose work is already done is dropped rather than run. Four
+	// accepted comments should not cost four passes over the plan when the
+	// agent dealt with all of them in the first.
+	while (next?.spent?.()) next = chat.waiting.shift();
+
 	if (next) {
 		queued(chat, server, room);
 		await run(context, next.handle, next.text);

--- a/apps/server/src/chat/service.ts
+++ b/apps/server/src/chat/service.ts
@@ -45,7 +45,17 @@ const MAX_QUEUE = 20;
  * is only knowable at that moment — and `JSON.stringify` drops it, so the wire
  * shape stays exactly `Wire.Waiting`.
  */
-type Waiting = Wire.Waiting & { spent?: () => boolean };
+type Waiting = Wire.Waiting & {
+	spent?: () => boolean;
+	/** The comment thread this turn was started to act on, if one was. */
+	thread?: string;
+};
+
+/** What a turn other than a message needs to say about itself. */
+export type Instruction = {
+	spent?: () => boolean;
+	thread?: string;
+};
 
 export type Chat = {
 	entries: Wire.Entry[];
@@ -57,6 +67,13 @@ export type Chat = {
 	busy: boolean;
 	/** Whose message the running turn is answering. */
 	turn?: string;
+	/**
+	 * The comment thread the running turn is acting on.
+	 *
+	 * Read by `edit_plan`, so the prose a turn writes can be recorded as what
+	 * that decision produced even when the agent forgets to say so itself.
+	 */
+	acting?: string;
 	/** The entry the agent is currently writing into. */
 	writing?: string;
 	/** Detaches the event handler when a turn ends. */
@@ -113,8 +130,19 @@ function state(chat: Chat, server: Server<SocketData>, room: string): void {
 	});
 }
 
+/**
+ * The queue as clients see it.
+ *
+ * `spent` is a function and disappears on its own; `thread` is a string and
+ * would not. Both are how the queue decides what to do, not anything a reader
+ * of the transcript has business knowing.
+ */
+function visible(chat: Chat): Wire.Waiting[] {
+	return chat.waiting.map(({ handle, id, text }) => ({ handle, id, text }));
+}
+
 function queued(chat: Chat, server: Server<SocketData>, room: string): void {
-	broadcast(server, room, { kind: "chat:queue", ts: 0, waiting: chat.waiting });
+	broadcast(server, room, { kind: "chat:queue", ts: 0, waiting: visible(chat) });
 }
 
 function say(
@@ -135,7 +163,7 @@ export function greet(chat: Chat, ws: Socket): void {
 		ts: 0,
 		entries: chat.entries,
 		busy: chat.busy,
-		queued: chat.waiting,
+		queued: visible(chat),
 	});
 }
 
@@ -211,7 +239,7 @@ export function instruct(
 	handle: string,
 	text: string,
 	said: string,
-	spent?: () => boolean,
+	about: Instruction = {},
 ): void {
 	let { chat, config, room, server } = context;
 	notice(context, said);
@@ -237,11 +265,11 @@ export function instruct(
 				ts: now(),
 			});
 		}
-		chat.waiting.push({ id: ulid(), handle, text, ...(spent ? { spent } : {}) });
+		chat.waiting.push({ id: ulid(), handle, text, ...about });
 		return queued(chat, server, room);
 	}
 
-	void run(context, handle, text);
+	void run(context, handle, text, about.thread);
 }
 
 /** Withdraw a queued message. Only whoever wrote it may. */
@@ -326,11 +354,12 @@ function settle(chat: Chat, server: Server<SocketData>, room: string): void {
 }
 
 /** Run one turn, then drain whatever queued up behind it. */
-async function run(context: Room, handle: string, text: string): Promise<void> {
+async function run(context: Room, handle: string, text: string, thread?: string): Promise<void> {
 	let { chat, room, server } = context;
 
 	chat.busy = true;
 	chat.turn = handle;
+	chat.acting = thread;
 	state(chat, server, room);
 
 	try {
@@ -377,13 +406,14 @@ async function run(context: Room, handle: string, text: string): Promise<void> {
 		settle(chat, server, room);
 		chat.busy = false;
 		chat.turn = undefined;
+		chat.acting = undefined;
 		state(chat, server, room);
 	}
 
 	let next = pending(chat);
 	if (next) {
 		queued(chat, server, room);
-		await run(context, next.handle, next.text);
+		await run(context, next.handle, next.text, next.thread);
 	}
 }
 

--- a/apps/server/src/comments.test.ts
+++ b/apps/server/src/comments.test.ts
@@ -31,8 +31,7 @@ async function document(source = SOURCE): Promise<Document> {
 
 /** A thread on a real passage, the way `comment:start` builds one. */
 function thread(doc: Document, handle = "ana"): { records: Store.Records; record: Record } {
-	let digest = room.digests(doc)[1]!;
-	let passage = room.passageAt(doc, [{ index: 1, digest }], QUOTE, 0, QUOTE.length);
+	let passage = room.passageAt(doc, [1], QUOTE, 0, QUOTE.length);
 
 	let record: Record = {
 		id: "01K0N4TR8K7JGM4R1J7PW4R8YJ",

--- a/apps/server/src/comments.test.ts
+++ b/apps/server/src/comments.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Commenting on the plan, and deciding about it.
+ *
+ * The properties worth holding onto: a thread is frozen the moment it resolves,
+ * only one resolution wins, accepting reaches both the record that owns the
+ * decision and the plan that shows it — or neither — and dismissing changes the
+ * plan not at all.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import * as room from "./plan/room";
+import * as Store from "./comments/store";
+import { compose } from "./comments/prompt";
+
+import type { Document } from "./plan/room";
+import type { Record } from "./comments/service";
+
+const SOURCE = `# Title
+
+The renderer caches tiles for 60 seconds.
+
+The second paragraph.
+`;
+
+const QUOTE = "caches tiles for 60 seconds";
+
+async function document(source = SOURCE): Promise<Document> {
+	return room.create(source);
+}
+
+/** A thread on a real passage, the way `comment:start` builds one. */
+function thread(doc: Document, handle = "ana"): { records: Store.Records; record: Record } {
+	let digest = room.digests(doc)[1]!;
+	let passage = room.passageAt(doc, [{ index: 1, digest }], QUOTE, 0, QUOTE.length);
+
+	let record: Record = {
+		id: "01K0N4TR8K7JGM4R1J7PW4R8YJ",
+		status: "open",
+		passage,
+		notes: [Store.note(handle, "60s is too long.")],
+	};
+
+	return { records: new Map([[record.id, record]]), record };
+}
+
+describe("a thread while it is open", () => {
+	it("collects what people say, in order", async () => {
+		let { records, record } = thread(await document());
+		let threads = Store.create();
+
+		expect(Store.reply(threads, records, record.id, "kris", "Agreed.").ok).toBe(true);
+
+		expect(records.get(record.id)!.notes.map(note => note.handle)).toEqual(["ana", "kris"]);
+	});
+
+	it("refuses a thread nobody started", async () => {
+		let { records } = thread(await document());
+		let outcome = Store.reply(Store.create(), records, "nope", "kris", "Hello?");
+
+		expect(outcome.ok).toBe(false);
+		if (!outcome.ok) expect(outcome.reason).toBe("missing");
+	});
+
+	it("stops taking comments once a thread is long enough to be a conversation", async () => {
+		let { records, record } = thread(await document());
+		let threads = Store.create();
+
+		for (let i = record.notes.length; i < Store.MAX_NOTES; i++) {
+			Store.reply(threads, records, record.id, "kris", `note ${i}`);
+		}
+		let outcome = Store.reply(threads, records, record.id, "kris", "one more");
+
+		expect(outcome.ok).toBe(false);
+		if (!outcome.ok) expect(outcome.reason).toBe("full");
+	});
+
+	/** Fifty unresolved threads says the room has stopped resolving things. */
+	it("refuses a new thread once too many are unresolved", async () => {
+		let { records } = thread(await document());
+		let sample = records.values().next().value!;
+		// One short of the cap, counting the thread already there.
+		for (let i = 1; i < Store.MAX_OPEN - 1; i++) {
+			records.set(`extra-${i}`, { ...sample, id: `extra-${i}` });
+		}
+
+		expect(Store.room(records)).toBeUndefined();
+		records.set("one-more", { ...sample, id: "one-more" });
+		expect(Store.room(records)?.reason).toBe("full");
+	});
+});
+
+describe("resolving a thread", () => {
+	it("freezes it, and refuses anything said afterwards", async () => {
+		let { records, record } = thread(await document());
+		let threads = Store.create();
+
+		let claimed = Store.claim(threads, records, record.id, "accept", "kris", QUOTE);
+		expect(claimed.ok).toBe(true);
+		if (!claimed.ok) return;
+		Store.commit(threads, records, claimed.claim);
+
+		expect(records.get(record.id)!.status).toBe("accepted");
+		expect(records.get(record.id)!.quote).toBe(QUOTE);
+
+		let late = Store.reply(threads, records, record.id, "ana", "Actually…");
+		expect(late.ok).toBe(false);
+		if (!late.ok) expect(late.reason).toBe("resolved");
+	});
+
+	/**
+	 * Arriving second is not a failure. The thing the caller wanted to know is
+	 * already decided, so they are told the outcome rather than an error.
+	 */
+	it("tells the loser of a race what happened, not that it failed", async () => {
+		let { records, record } = thread(await document());
+		let threads = Store.create();
+
+		let first = Store.claim(threads, records, record.id, "accept", "kris", QUOTE);
+		if (!first.ok) throw new Error("expected a claim");
+		Store.commit(threads, records, first.claim);
+
+		let second = Store.claim(threads, records, record.id, "dismiss", "ana", QUOTE);
+		expect(second.ok).toBe(false);
+		if (!second.ok && second.reason === "resolved") {
+			expect(second.status).toBe("accepted");
+			expect(second.resolver).toBe("kris");
+		} else {
+			throw new Error("expected the outcome, not an error");
+		}
+	});
+
+	it("refuses a rival while a resolution is in flight", async () => {
+		let { records, record } = thread(await document());
+		let threads = Store.create();
+
+		Store.claim(threads, records, record.id, "accept", "kris", QUOTE);
+		let rival = Store.claim(threads, records, record.id, "dismiss", "ana", QUOTE);
+
+		expect(rival.ok).toBe(false);
+		if (!rival.ok) expect(rival.reason).toBe("resolving");
+	});
+
+	/**
+	 * The durable half is the `<Decision>` node. If it cannot be written the
+	 * decision is not final, and the thread has to be left in a state every
+	 * client already knows how to render — which is the one it was in.
+	 */
+	it("leaves the thread open when the plan could not be told", async () => {
+		let { records, record } = thread(await document());
+		let threads = Store.create();
+
+		let claimed = Store.claim(threads, records, record.id, "accept", "kris", QUOTE);
+		if (!claimed.ok) throw new Error("expected a claim");
+		Store.rollback(threads, claimed.claim);
+
+		expect(records.get(record.id)!.status).toBe("open");
+		expect(Store.reply(threads, records, record.id, "ana", "Still talking.").ok).toBe(true);
+	});
+});
+
+describe("projecting a decision", () => {
+	it("puts an accepted thread into the plan, and leaves a dismissed one out", async () => {
+		let doc = await document();
+		let { record } = thread(doc);
+
+		room.insertDecision(doc, {
+			id: record.id,
+			quote: QUOTE,
+			by: "kris",
+			at: "2026-07-28T10:14:00Z",
+			notes: record.notes.map(note => ({ by: note.handle, text: note.text })),
+		});
+
+		let source = room.project(doc);
+		expect(source).toContain(`<Decision id="${record.id}"`);
+		expect(source).toContain('by="kris"');
+		expect(source).toContain("60s is too long.");
+		// And the prose it marks is untouched: a decision is recorded beside
+		// the plan, not written into the sentence it concerns.
+		expect(source).toContain("The renderer caches tiles for 60 seconds.");
+	});
+
+	it("survives the round trip back off disk", async () => {
+		let doc = await document();
+		let { record } = thread(doc);
+
+		room.insertDecision(doc, {
+			id: record.id,
+			quote: QUOTE,
+			by: "kris",
+			at: "2026-07-28T10:14:00Z",
+			notes: [{ by: "ana", text: "Line one.\nLine two." }],
+		});
+
+		// What `plan.mdx` would hold, read back as the server reads it on boot.
+		expect(() => room.validate(room.project(doc))).not.toThrow();
+	});
+});
+
+describe("a thread across a restart", () => {
+	/**
+	 * A restart is an epoch rotation: every stored position was expressed in a
+	 * history the new document does not have. The quote is the only way back,
+	 * and it has to happen before anybody joins — a client that resolves
+	 * nothing shows a thread with no highlight and no way to tell why.
+	 */
+	it("recovers its passage against a document it has never seen", async () => {
+		let doc = await document();
+		let { record } = thread(doc);
+
+		// The same source, under a fresh epoch, as `open` rebuilds it on boot.
+		let restarted = await room.replace(room.project(doc));
+		expect(room.locate(restarted, record.passage)).toBeUndefined();
+
+		let carried = room.rebasePassage(restarted, record.passage);
+		expect(carried.drifted).toBeUndefined();
+		expect(room.locate(restarted, carried)).toBeDefined();
+		expect(carried.quote).toBe(QUOTE);
+	});
+});
+
+describe("what the agent is told", () => {
+	it("quotes the passage and the whole thread", async () => {
+		let { record } = thread(await document());
+		let prompt = compose(record, QUOTE);
+
+		expect(prompt.startsWith("accepted a comment")).toBe(true);
+		expect(prompt).toContain(`> ${QUOTE}`);
+		expect(prompt).toContain("@ana: 60s is too long.");
+		expect(prompt).toContain(record.id);
+	});
+
+	/** A rewritten passage is more information, not less. */
+	it("says so when the prose has moved on, and quotes both", async () => {
+		let { record } = thread(await document());
+		let prompt = compose(record, QUOTE, "caches tiles for 10 seconds");
+
+		expect(prompt).toContain("has since been rewritten");
+		expect(prompt).toContain("> caches tiles for 10 seconds");
+	});
+});

--- a/apps/server/src/comments.test.ts
+++ b/apps/server/src/comments.test.ts
@@ -55,8 +55,13 @@ function thread(doc: Document, handle = "ana"): { records: Store.Records; record
 // -- a room, for the parts that need the service rather than the store -------
 
 let rooms: string[] = [];
+let opens: Plan[] = [];
 
 afterEach(async () => {
+	// Sinks are on a timer. Left running they write, and log, after the test
+	// that made them has finished and put `console.error` back.
+	for (let plan of opens) await Service.close(plan);
+	opens = [];
 	for (let dir of rooms) await rm(dir, { recursive: true, force: true });
 	rooms = [];
 });
@@ -88,6 +93,7 @@ async function opened(source = SOURCE, state?: object) {
 	} as unknown as Server<SocketData>;
 
 	let plan = await Service.open("test", dir, server);
+	opens.push(plan);
 	return {
 		broadcasts,
 		dir,
@@ -350,6 +356,10 @@ describe("opening a room whose sidecar is damaged", () => {
 			let ana = member("ana");
 			expect(() => mark(plan, server, ana)).not.toThrow();
 			expect(room.project(plan.document)).toContain(QUOTE);
+
+			// The damaged record would be carried forward again on the way out,
+			// logging after this test has put `console.error` back.
+			plan.sink.cancel();
 		} finally {
 			console.error = complain;
 		}
@@ -601,6 +611,64 @@ describe("what a thread owes the agent", () => {
 		let id = mark(plan, server, ana);
 
 		expect(Comments.relate(plan, id, [])).toContain("was not accepted");
+	});
+
+	/**
+	 * The agent is told to say what its revision produced, and when it does
+	 * that answer is the better one. But a thread whose result is never
+	 * anchored points at nothing for good — and by then the prose it was about
+	 * is gone, because rewriting it is what acceptance asked for.
+	 */
+	it("takes the blocks a turn wrote when the agent does not say", async () => {
+		let { id, plan } = await accepted();
+		expect(Comments.applied(plan, id)).toBe(false);
+
+		Comments.attribute(plan, id, [1, 2]);
+
+		expect(Comments.applied(plan, id)).toBe(true);
+		expect(plan.threads.get(id)?.result?.anchors).toHaveLength(2);
+	});
+
+	it("does not coarsen an answer the agent already gave", async () => {
+		let { id, plan } = await accepted();
+		let digest = room.digests(plan.document)[1]!;
+		Comments.relate(plan, id, [{ index: 1, digest }]);
+
+		// The agent picked one block; a later guess must not widen it to two.
+		Comments.attribute(plan, id, [1, 2]);
+
+		expect(plan.threads.get(id)?.result?.anchors).toHaveLength(1);
+	});
+
+	/** Once an edit has invalidated it, there is nothing left to preserve. */
+	it("takes over again once the plan has moved under the agent's answer", async () => {
+		let { id, plan } = await accepted();
+		let digest = room.digests(plan.document)[1]!;
+		Comments.relate(plan, id, [{ index: 1, digest }]);
+		Comments.invalidate(plan, "plan_changed");
+
+		Comments.attribute(plan, id, [1, 2]);
+
+		expect(Comments.applied(plan, id)).toBe(true);
+		expect(plan.threads.get(id)?.result?.anchors).toHaveLength(2);
+	});
+
+	it("attributes nothing to a thread nobody accepted", async () => {
+		let { plan, server } = await opened();
+		let ana = member("ana");
+		let id = mark(plan, server, ana);
+
+		Comments.attribute(plan, id, [1]);
+
+		expect(plan.threads.get(id)?.result).toBeUndefined();
+	});
+
+	it("attributes nothing when a turn wrote nothing", async () => {
+		let { id, plan } = await accepted();
+
+		Comments.attribute(plan, id, []);
+
+		expect(plan.threads.get(id)?.result).toBeUndefined();
 	});
 
 	/**

--- a/apps/server/src/comments.test.ts
+++ b/apps/server/src/comments.test.ts
@@ -71,10 +71,11 @@ type Sent = { kind: string; [key: string]: unknown };
  * open and the snapshot sink are all part of what the service does, and a
  * stubbed plan would test the parts around them instead of them.
  */
-async function opened(source = SOURCE) {
+async function opened(source = SOURCE, state?: object) {
 	let dir = await mkdtemp(join(tmpdir(), "chopin-comments-"));
 	rooms.push(dir);
 	await writeFile(join(dir, "plan.mdx"), source);
+	if (state) await writeFile(join(dir, "state.json"), JSON.stringify(state));
 
 	let broadcasts: Sent[] = [];
 	let broken: string | undefined;
@@ -313,6 +314,45 @@ describe("projecting a decision", () => {
 
 		// What `plan.mdx` would hold, read back as the server reads it on boot.
 		expect(() => room.validate(room.project(doc))).not.toThrow();
+	});
+});
+
+describe("opening a room whose sidecar is damaged", () => {
+	/**
+	 * `plan.mdx` is a file a person can edit between runs, and `state.json` sits
+	 * beside it. A record that cannot be carried onto the rebuilt document is a
+	 * decision nobody can point at — not a room nobody can open. Letting it
+	 * throw would fail `plan:open`, and a client whose open is refused sits
+	 * there locked with the chrome saying it is still loading.
+	 */
+	it("still opens when a thread record cannot be carried forward", async () => {
+		let damaged = {
+			revision: 1,
+			questions: [],
+			threads: [{
+				id: "01K0N4TR8K7JGM4R1J7PW4R8YJ",
+				status: "accepted",
+				// No blocks, no positions: whatever wrote this, it is not a passage.
+				passage: null,
+				notes: [{ id: "n1", handle: "ana", text: "Too long.", ts: 1 }],
+				quote: QUOTE,
+				resolver: "ana",
+				at: 2,
+			}],
+		};
+
+		let complain = console.error;
+		console.error = () => {};
+		try {
+			let { plan, server } = await opened(SOURCE, damaged);
+
+			// The room is open and usable: a new thread can still be marked.
+			let ana = member("ana");
+			expect(() => mark(plan, server, ana)).not.toThrow();
+			expect(room.project(plan.document)).toContain(QUOTE);
+		} finally {
+			console.error = complain;
+		}
 	});
 });
 

--- a/apps/server/src/comments.test.ts
+++ b/apps/server/src/comments.test.ts
@@ -7,14 +7,23 @@
  * plan not at all.
  */
 
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
+import * as Comments from "./comments/service";
 import * as room from "./plan/room";
+import * as Service from "./plan/service";
 import * as Store from "./comments/store";
 import { compose } from "./comments/prompt";
 
+import type { Server } from "bun";
+import type * as Chat from "./chat/service";
 import type { Document } from "./plan/room";
 import type { Record } from "./comments/service";
+import type { Plan } from "./plan/service";
+import type { Socket, SocketData } from "./wire";
 
 const SOURCE = `# Title
 
@@ -41,6 +50,116 @@ function thread(doc: Document, handle = "ana"): { records: Store.Records; record
 	};
 
 	return { records: new Map([[record.id, record]]), record };
+}
+
+// -- a room, for the parts that need the service rather than the store -------
+
+let rooms: string[] = [];
+
+afterEach(async () => {
+	for (let dir of rooms) await rm(dir, { recursive: true, force: true });
+	rooms = [];
+});
+
+/** Frames the room sent, and to whom. */
+type Sent = { kind: string; [key: string]: unknown };
+
+/**
+ * A room with a plan on disk.
+ *
+ * Built through `Service.open` rather than by hand: restoring, rebasing on
+ * open and the snapshot sink are all part of what the service does, and a
+ * stubbed plan would test the parts around them instead of them.
+ */
+async function opened(source = SOURCE) {
+	let dir = await mkdtemp(join(tmpdir(), "chopin-comments-"));
+	rooms.push(dir);
+	await writeFile(join(dir, "plan.mdx"), source);
+
+	let broadcasts: Sent[] = [];
+	let broken: string | undefined;
+	let server = {
+		publish(_topic: string, data: string) {
+			let frame = JSON.parse(data) as Sent;
+			if (frame.kind === broken) throw new Error("nobody is listening");
+			broadcasts.push(frame);
+		},
+	} as unknown as Server<SocketData>;
+
+	let plan = await Service.open("test", dir, server);
+	return {
+		broadcasts,
+		dir,
+		plan,
+		server,
+		/**
+		 * Make one kind of frame fail to relay.
+		 *
+		 * One kind rather than all of them: Bun's pub/sub does not throw for a
+		 * topic nobody is on, so breaking everything would be simulating a
+		 * failure that cannot happen and armouring the code against it. What
+		 * can be reasoned about is what happens if a particular relay is lost.
+		 */
+		breakRelay: (kind: string) => {
+			broken = kind;
+		},
+	};
+}
+
+/** A socket that records what was said to it, and what was said past it. */
+function member(handle: string) {
+	let replies: Sent[] = [];
+	let relayed: Sent[] = [];
+
+	let socket = {
+		data: { handle, client: `client-${handle}`, room: "test" },
+		send(raw: string) {
+			replies.push(JSON.parse(raw) as Sent);
+		},
+		publish(_topic: string, raw: string) {
+			relayed.push(JSON.parse(raw) as Sent);
+		},
+	} as unknown as Socket;
+
+	return { relayed, replies, socket };
+}
+
+let rid = 0;
+function ask<T extends object>(payload: T) {
+	return { ts: 0, rid: `r${++rid}`, ...payload } as T & { ts: number; rid: string };
+}
+
+/** Enough of a room for the handlers that start a turn. `AGENT=off` throughout. */
+function context(plan: Plan, server: Server<SocketData>): Chat.Room {
+	return { chat: plan.chat, config: { agent: false }, plan, room: "test", server } as Chat.Room;
+}
+
+/** Mark the sentence, the way a client's `comment:start` does. */
+function mark(
+	plan: Plan,
+	server: Server<SocketData>,
+	who: ReturnType<typeof member>,
+	text = "Too long.",
+): string {
+	Comments.start(
+		plan,
+		server,
+		"test",
+		who.socket,
+		ask({
+			kind: "comment:start" as const,
+			blocks: [1],
+			quote: QUOTE,
+			offset: 0,
+			length: QUOTE.length,
+			text,
+		}),
+	);
+
+	let reply = who.replies.findLast(frame => frame.kind === "comment:start");
+	let thread = reply?.thread as { id: string } | undefined;
+	if (!thread) throw new Error(`no thread was started: ${JSON.stringify(reply)}`);
+	return thread.id;
 }
 
 describe("a thread while it is open", () => {
@@ -216,6 +335,247 @@ describe("a thread across a restart", () => {
 		expect(carried.drifted).toBeUndefined();
 		expect(room.locate(restarted, carried)).toBeDefined();
 		expect(carried.quote).toBe(QUOTE);
+	});
+});
+
+describe("marking a passage over the wire", () => {
+	it("mints the thread and tells the rest of the room where it points", async () => {
+		let { broadcasts, plan, server } = await opened();
+		let ana = member("ana");
+		let id = mark(plan, server, ana);
+
+		expect(ana.replies[0]).toMatchObject({ kind: "comment:start", ok: true });
+		expect(ana.relayed[0]).toMatchObject({ kind: "comment:opened" });
+
+		// The passage never rides with the thread; it comes on plan:anchors,
+		// which has to follow immediately or the card has nothing to highlight.
+		expect(ana.replies[0]?.thread).not.toHaveProperty("passage");
+		let anchors = broadcasts.findLast(frame => frame.kind === "plan:anchors");
+		let pointed = (anchors?.threads as Array<{ thread: string }> | undefined)
+			?.find(each => each.thread === id);
+		expect(pointed).toMatchObject({ subject: { quote: QUOTE } });
+	});
+
+	/**
+	 * Finding the quote is the concurrency check. Naming a block that no longer
+	 * holds the phrase has to be refused rather than marking whatever is there.
+	 */
+	it("refuses a selection the plan has moved out from under", async () => {
+		let { plan, server } = await opened();
+		let ana = member("ana");
+
+		Comments.start(
+			plan,
+			server,
+			"test",
+			ana.socket,
+			ask({
+				kind: "comment:start" as const,
+				blocks: [0],
+				quote: QUOTE,
+				offset: 0,
+				length: QUOTE.length,
+				text: "Too long.",
+			}),
+		);
+
+		expect(ana.replies[0]).toMatchObject({ ok: false, reason: "invalid" });
+		expect(plan.threads.size).toBe(0);
+	});
+
+	it("refuses a comment with nothing in it", async () => {
+		let { plan, server } = await opened();
+		let ana = member("ana");
+
+		Comments.start(
+			plan,
+			server,
+			"test",
+			ana.socket,
+			ask({
+				kind: "comment:start" as const,
+				blocks: [1],
+				quote: QUOTE,
+				offset: 0,
+				length: QUOTE.length,
+				text: "   ",
+			}),
+		);
+
+		expect(ana.replies[0]).toMatchObject({ ok: false, reason: "invalid" });
+		expect(plan.threads.size).toBe(0);
+	});
+
+	it("keeps a dismissed thread off the wire for whoever joins next", async () => {
+		let { plan, server } = await opened();
+		let ana = member("ana");
+		let id = mark(plan, server, ana);
+		await Comments.dismiss(
+			context(plan, server),
+			ana.socket,
+			ask({ kind: "comment:dismiss" as const, id }),
+		);
+
+		let joiner = member("kris");
+		Comments.greet(plan, joiner.socket);
+
+		let sync = joiner.replies.find(frame => frame.kind === "comment:sync");
+		expect(sync?.threads).toEqual([]);
+		// The record survives; it is only hidden.
+		expect(plan.threads.get(id)?.status).toBe("dismissed");
+	});
+});
+
+describe("accepting, as the service orders it", () => {
+	async function accepted(options: { failPublish?: boolean } = {}) {
+		let { breakRelay, broadcasts, plan, server } = await opened();
+		let ana = member("ana");
+		let id = mark(plan, server, ana);
+		ana.replies.length = 0;
+
+		// The document delta, which is what carries the new node to clients.
+		if (options.failPublish) breakRelay("plan:update");
+		await Comments.accept(
+			context(plan, server),
+			ana.socket,
+			ask({ kind: "comment:accept" as const, id }),
+		);
+		return { ana, broadcasts, id, plan };
+	}
+
+	it("reaches the record and the plan together", async () => {
+		let { ana, id, plan } = await accepted();
+
+		expect(ana.replies.at(-1)).toMatchObject({ kind: "comment:accept", ok: true, resolver: "ana" });
+		expect(plan.threads.get(id)?.status).toBe("accepted");
+		expect(plan.threads.get(id)?.quote).toBe(QUOTE);
+		expect(room.project(plan.document)).toContain(`<Decision id="${id}"`);
+	});
+
+	/**
+	 * Once the document holds the decision, committing is no longer optional.
+	 * Rolling back on a failed relay would leave a `<Decision>` in a plan whose
+	 * record says the thread is open — and the next accept would append a
+	 * second node carrying the same id. A relay nobody received is recoverable.
+	 */
+	it("stands even when the room could not be told", async () => {
+		// The relay failing is the point, and it logs. Quietened so the run
+		// does not print a stack trace that reads like a real one.
+		let complain = console.error;
+		console.error = () => {};
+		let { id, plan } = await accepted({ failPublish: true }).finally(() => {
+			console.error = complain;
+		});
+
+		expect(plan.threads.get(id)?.status).toBe("accepted");
+		let source = room.project(plan.document);
+		expect(source.split(`id="${id}"`)).toHaveLength(2);
+	});
+
+	it("says nothing more can be added, and nobody can resolve it twice", async () => {
+		let { id, plan } = await accepted();
+		let kris = member("kris");
+
+		Comments.respond(plan, kris.socket, ask({ kind: "comment:reply" as const, id, text: "Wait." }));
+		expect(kris.replies.at(-1)).toMatchObject({ ok: false, reason: "resolved" });
+
+		let after = context(plan, {} as Server<SocketData>);
+		await Comments.dismiss(after, kris.socket, ask({ kind: "comment:dismiss" as const, id }));
+		expect(kris.replies.at(-1)).toMatchObject({
+			ok: false,
+			reason: "resolved",
+			status: "accepted",
+			resolver: "ana",
+		});
+	});
+
+	it("leaves the plan alone when the thread is dismissed instead", async () => {
+		let { plan, server } = await opened();
+		let ana = member("ana");
+		let id = mark(plan, server, ana);
+		await Comments.dismiss(
+			context(plan, server),
+			ana.socket,
+			ask({ kind: "comment:dismiss" as const, id }),
+		);
+
+		expect(plan.threads.get(id)?.status).toBe("dismissed");
+		expect(room.project(plan.document)).not.toContain("<Decision");
+	});
+});
+
+describe("what a thread owes the agent", () => {
+	async function accepted() {
+		let { plan, server } = await opened();
+		let ana = member("ana");
+		let id = mark(plan, server, ana);
+		await Comments.accept(
+			context(plan, server),
+			ana.socket,
+			ask({ kind: "comment:accept" as const, id }),
+		);
+		return { id, plan };
+	}
+
+	/** An open thread asks nothing of the agent; there is no decision yet. */
+	it("owes nothing while it is still being discussed", async () => {
+		let { plan, server } = await opened();
+		let ana = member("ana");
+		mark(plan, server, ana);
+
+		expect(Comments.outstanding(plan)).toEqual([]);
+		expect(Comments.anchors(plan)[0]?.result.pending).toBe(false);
+	});
+
+	it("owes a review the moment it is accepted, and stops when it is anchored", async () => {
+		let { id, plan } = await accepted();
+
+		expect(Comments.outstanding(plan)).toEqual([{ thread: id, reason: "missing" }]);
+		expect(Comments.applied(plan, id)).toBe(false);
+
+		let digest = room.digests(plan.document)[1]!;
+		expect(Comments.relate(plan, id, [{ index: 1, digest }])).toBeUndefined();
+
+		expect(Comments.outstanding(plan)).toEqual([]);
+		expect(Comments.applied(plan, id)).toBe(true);
+	});
+
+	/** An empty list is a real answer: reviewed, deliberately related to nothing. */
+	it("accepts that a revision produced nothing worth pointing at", async () => {
+		let { id, plan } = await accepted();
+
+		expect(Comments.relate(plan, id, [])).toBeUndefined();
+		expect(Comments.applied(plan, id)).toBe(true);
+	});
+
+	it("refuses to anchor against a block that has changed", async () => {
+		let { id, plan } = await accepted();
+
+		expect(Comments.relate(plan, id, [{ index: 1, digest: "sha256:stale" }]))
+			.toContain("has changed");
+	});
+
+	it("refuses to anchor a thread nobody accepted", async () => {
+		let { plan, server } = await opened();
+		let ana = member("ana");
+		let id = mark(plan, server, ana);
+
+		expect(Comments.relate(plan, id, [])).toContain("was not accepted");
+	});
+
+	/**
+	 * The prose a decision produced is the thing most likely to have been
+	 * rewritten, so an edit puts it back on the agent's list rather than
+	 * leaving a link to where it used to be.
+	 */
+	it("owes it again once the plan moves underneath", async () => {
+		let { id, plan } = await accepted();
+		let digest = room.digests(plan.document)[1]!;
+		Comments.relate(plan, id, [{ index: 1, digest }]);
+
+		Comments.invalidate(plan, "plan_changed");
+
+		expect(Comments.outstanding(plan)).toEqual([{ thread: id, reason: "plan_changed" }]);
 	});
 });
 

--- a/apps/server/src/comments.wire.test.ts
+++ b/apps/server/src/comments.wire.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Commenting, over an actual socket.
+ *
+ * The service tests drive the handlers directly, which says nothing about
+ * whether they are reachable. This spawns the real server: the frames have to
+ * be routed, a reply has to find the request that asked for it, and what one
+ * member does has to arrive at the other. It is also the only place the join
+ * sequence is exercised — a client learns about existing threads from
+ * `plan:open`, not from connecting.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { Subprocess } from "bun";
+
+const PORT = 8898;
+const ORIGIN = `127.0.0.1:${PORT}`;
+
+const SOURCE = `# Title
+
+The renderer caches tiles for 60 seconds.
+
+The second paragraph.
+`;
+
+const QUOTE = "caches tiles for 60 seconds";
+
+let server: Subprocess;
+let data: string;
+
+type Frame = { kind: string; rid?: string; [key: string]: unknown };
+
+/** A member, with the frames it has been sent and a way to ask for a reply. */
+async function member(room: string, handle: string): Promise<Member> {
+	let socket = new WebSocket(`ws://${ORIGIN}/ws?room=${room}&as=${handle}`);
+	let frames: Frame[] = [];
+	let waiting = new Map<string, (frame: Frame) => void>();
+	let n = 0;
+
+	socket.addEventListener("message", event => {
+		let frame = JSON.parse(String(event.data)) as Frame;
+		frames.push(frame);
+		let settle = frame.rid && waiting.get(frame.rid);
+		if (settle) {
+			waiting.delete(frame.rid!);
+			settle(frame);
+		}
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		socket.addEventListener("open", () => resolve());
+		socket.addEventListener("error", () => reject(new Error("refused")));
+	});
+
+	return {
+		frames,
+		socket,
+		ask(kind: string, payload: Record<string, unknown> = {}) {
+			let rid = `${handle}-${++n}`;
+			return new Promise<Frame>(resolve => {
+				waiting.set(rid, resolve);
+				socket.send(JSON.stringify({ kind, ts: 0, rid, ...payload }));
+			});
+		},
+		send(kind: string, payload: Record<string, unknown> = {}) {
+			socket.send(JSON.stringify({ kind, ts: 0, rid: `${handle}-${++n}`, ...payload }));
+		},
+	};
+}
+
+/** Frames arrive on their own schedule; wait for the one being asserted on. */
+async function until<T>(read: () => T | undefined, label: string): Promise<T> {
+	for (let i = 0; i < 200; i++) {
+		let value = read();
+		if (value !== undefined) return value;
+		await Bun.sleep(10);
+	}
+	throw new Error(`timed out waiting for ${label}`);
+}
+
+function seen(frames: Frame[], kind: string) {
+	return () => frames.findLast(frame => frame.kind === kind);
+}
+
+type Member = {
+	frames: Frame[];
+	socket: WebSocket;
+	ask(kind: string, payload?: Record<string, unknown>): Promise<Frame>;
+	send(kind: string, payload?: Record<string, unknown>): void;
+};
+
+/** Mark the sentence, and hand back the thread it made. */
+async function mark(who: Member, text = "Too long.") {
+	let reply = await who.ask("comment:start", {
+		blocks: [1],
+		quote: QUOTE,
+		offset: 0,
+		length: QUOTE.length,
+		text,
+	});
+	if (!reply.ok) throw new Error(`could not mark: ${JSON.stringify(reply)}`);
+	return (reply.thread as { id: string }).id;
+}
+
+beforeAll(async () => {
+	data = await mkdtemp(join(tmpdir(), "chopin-wire-"));
+	// Every room this file uses, seeded so there is prose worth marking.
+	for (let room of ["marking", "replies", "accepting", "joining"]) {
+		await mkdir(join(data, room), { recursive: true });
+		await writeFile(join(data, room, "plan.mdx"), SOURCE);
+	}
+
+	server = Bun.spawn(["bun", `${import.meta.dir}/main.ts`], {
+		env: {
+			...process.env,
+			PORT: String(PORT),
+			SERVER_HOST: "127.0.0.1",
+			AGENT: "off",
+			DATA_DIR: data,
+		},
+		stdout: "ignore",
+		stderr: "inherit",
+	});
+
+	for (let i = 0; i < 200; i++) {
+		try {
+			await fetch(`http://${ORIGIN}/`);
+			return;
+		} catch {
+			await Bun.sleep(20);
+		}
+	}
+	throw new Error("server did not start");
+});
+
+afterAll(async () => {
+	server.kill();
+	await rm(data, { recursive: true, force: true });
+});
+
+describe("marking a passage", () => {
+	it("answers the request that asked, and tells the other member", async () => {
+		let ana = await member("marking", "ana");
+		let kris = await member("marking", "kris");
+		await ana.ask("plan:open", {});
+		await kris.ask("plan:open", {});
+
+		let id = await mark(ana);
+
+		let opened = await until(seen(kris.frames, "comment:opened"), "comment:opened");
+		expect((opened.thread as { id: string }).id).toBe(id);
+		// The author already has it from the reply; echoing it would be a
+		// second copy of the same thread.
+		expect(ana.frames.filter(frame => frame.kind === "comment:opened")).toHaveLength(0);
+
+		ana.socket.close();
+		kris.socket.close();
+	});
+
+	it("says where it points on the anchors snapshot, not with the thread", async () => {
+		let ana = await member("marking", "ana");
+		await ana.ask("plan:open", {});
+		let id = await mark(ana);
+
+		let anchors = await until(
+			() => {
+				let frame = ana.frames.findLast(each => each.kind === "plan:anchors");
+				let threads = frame?.threads as Array<{ thread: string }> | undefined;
+				return threads?.some(each => each.thread === id) ? frame : undefined;
+			},
+			"plan:anchors carrying the thread",
+		);
+
+		let pointed = (anchors.threads as Array<{ thread: string; subject: { quote: string } }>)
+			.find(each => each.thread === id);
+		expect(pointed?.subject.quote).toBe(QUOTE);
+
+		ana.socket.close();
+	});
+
+	it("refuses a selection the plan no longer holds", async () => {
+		let ana = await member("marking", "ana");
+		await ana.ask("plan:open", {});
+
+		let reply = await ana.ask("comment:start", {
+			blocks: [0],
+			quote: QUOTE,
+			offset: 0,
+			length: QUOTE.length,
+			text: "Too long.",
+		});
+
+		expect(reply).toMatchObject({ ok: false, reason: "invalid" });
+		ana.socket.close();
+	});
+});
+
+describe("talking in a thread", () => {
+	it("carries a reply to everyone else", async () => {
+		let ana = await member("replies", "ana");
+		let kris = await member("replies", "kris");
+		await ana.ask("plan:open", {});
+		await kris.ask("plan:open", {});
+		let id = await mark(ana);
+
+		let reply = await kris.ask("comment:reply", { id, text: "Agreed." });
+		expect(reply.ok).toBe(true);
+
+		let said = await until(seen(ana.frames, "comment:said"), "comment:said");
+		expect(said.note as { handle: string; text: string }).toMatchObject({
+			handle: "kris",
+			text: "Agreed.",
+		});
+
+		ana.socket.close();
+		kris.socket.close();
+	});
+
+	it("relays who is writing, and who has stopped", async () => {
+		let ana = await member("replies", "ana");
+		let kris = await member("replies", "kris");
+		await ana.ask("plan:open", {});
+		await kris.ask("plan:open", {});
+		let id = await mark(ana);
+
+		kris.send("comment:typing", { id, writing: true });
+		let started = await until(seen(ana.frames, "comment:typing"), "typing");
+		expect(started).toMatchObject({ handle: "kris", writing: true });
+
+		kris.send("comment:typing", { id, writing: false });
+		await until(
+			() => {
+				let last = ana.frames.findLast(frame => frame.kind === "comment:typing");
+				return last?.writing === false ? last : undefined;
+			},
+			"typing stopped",
+		);
+
+		ana.socket.close();
+		kris.socket.close();
+	});
+});
+
+describe("resolving a thread", () => {
+	it("tells the whole room, including whoever did it", async () => {
+		let ana = await member("accepting", "ana");
+		let kris = await member("accepting", "kris");
+		await ana.ask("plan:open", {});
+		await kris.ask("plan:open", {});
+		let id = await mark(ana);
+
+		let accepted = await kris.ask("comment:accept", { id });
+		expect(accepted).toMatchObject({ ok: true, resolver: "kris" });
+
+		// A broadcast, not a relay: the resolver's own sidecar has to freeze too.
+		for (let each of [ana, kris]) {
+			let resolved = await until(seen(each.frames, "comment:resolved"), "comment:resolved");
+			expect(resolved).toMatchObject({ id, status: "accepted", resolver: "kris", quote: QUOTE });
+		}
+
+		ana.socket.close();
+		kris.socket.close();
+	});
+
+	it("says in the transcript why the agent would have moved", async () => {
+		let ana = await member("accepting", "ana");
+		await ana.ask("plan:open", {});
+		let id = await mark(ana, "Make it ten.");
+		await ana.ask("comment:accept", { id });
+
+		let lines = await until(
+			() => {
+				let said = ana.frames
+					.filter(frame => frame.kind === "chat:message")
+					.map(frame => (frame.entry as { author: { kind: string }; text: string }))
+					.filter(entry => entry.author.kind === "system")
+					.map(entry => entry.text);
+				return said.length >= 2 ? said : undefined;
+			},
+			"system transcript lines",
+		);
+
+		expect(lines[0]).toContain("accepted a comment");
+		expect(lines[0]).toContain(QUOTE);
+		// `AGENT=off` in this run, so the turn is skipped and says so rather
+		// than a session failing to open behind the scenes.
+		expect(lines[1]).toContain("agent is not running");
+
+		ana.socket.close();
+	});
+
+	it("refuses anything said after it is closed", async () => {
+		let ana = await member("accepting", "ana");
+		await ana.ask("plan:open", {});
+		let id = await mark(ana);
+		await ana.ask("comment:accept", { id });
+
+		let late = await ana.ask("comment:reply", { id, text: "One more thing." });
+		expect(late).toMatchObject({ ok: false, reason: "resolved" });
+
+		ana.socket.close();
+	});
+
+	/** Arriving second is not a failure: the outcome is what was wanted. */
+	it("tells the second resolver what happened rather than that it failed", async () => {
+		let ana = await member("accepting", "ana");
+		let kris = await member("accepting", "kris");
+		await ana.ask("plan:open", {});
+		await kris.ask("plan:open", {});
+		let id = await mark(ana);
+
+		await ana.ask("comment:accept", { id });
+		let second = await kris.ask("comment:dismiss", { id });
+
+		expect(second).toMatchObject({
+			ok: false,
+			reason: "resolved",
+			status: "accepted",
+			resolver: "ana",
+		});
+
+		ana.socket.close();
+		kris.socket.close();
+	});
+});
+
+describe("arriving late", () => {
+	/**
+	 * A client learns about existing threads from opening the plan, not from
+	 * connecting: the sidecar has to show what everyone else is already
+	 * looking at.
+	 */
+	it("is told about the threads already open", async () => {
+		let ana = await member("joining", "ana");
+		await ana.ask("plan:open", {});
+		let id = await mark(ana);
+
+		let kris = await member("joining", "kris");
+		await kris.ask("plan:open", {});
+
+		let sync = await until(seen(kris.frames, "comment:sync"), "comment:sync");
+		let threads = sync.threads as Array<{ id: string; notes: unknown[] }>;
+		expect(threads.map(thread => thread.id)).toContain(id);
+		expect(threads[0]?.notes).toHaveLength(1);
+
+		ana.socket.close();
+		kris.socket.close();
+	});
+
+	it("is not told about one that was dismissed", async () => {
+		let ana = await member("joining", "ana");
+		await ana.ask("plan:open", {});
+		let id = await mark(ana, "Never mind.");
+		await ana.ask("comment:dismiss", { id });
+
+		let kris = await member("joining", "kris");
+		await kris.ask("plan:open", {});
+
+		let sync = await until(seen(kris.frames, "comment:sync"), "comment:sync");
+		let threads = sync.threads as Array<{ id: string }>;
+		expect(threads.map(thread => thread.id)).not.toContain(id);
+
+		ana.socket.close();
+		kris.socket.close();
+	});
+});

--- a/apps/server/src/comments/inject.ts
+++ b/apps/server/src/comments/inject.ts
@@ -33,14 +33,14 @@ export function enabled(): boolean {
 export function mark(plan: Plan): void {
 	let digests = room.digests(plan.document);
 
-	for (let [index, digest] of digests.entries()) {
+	for (let index of digests.keys()) {
 		let text = passageOf(plan, index);
 		if (!text) continue;
 
 		try {
 			let passage = room.passageAt(
 				plan.document,
-				[{ index, digest }],
+				[index],
 				text.quote,
 				text.offset,
 				text.quote.length,

--- a/apps/server/src/comments/inject.ts
+++ b/apps/server/src/comments/inject.ts
@@ -1,0 +1,76 @@
+/**
+ * Marking a passage without a browser.
+ *
+ * Everything a comment does — anchoring a phrase, carrying it across edits,
+ * freezing it into a decision — happens on the server, and none of it is
+ * reachable until the sidecar exists. Building the client against a path that
+ * has never run once is how the anchoring bugs in this repo were made.
+ *
+ * Enabled only when `DEV_COMMENTS` is set. It marks a real phrase in whatever
+ * the room already holds, using the same request shape a client sends, so the
+ * path this exercises is the real one rather than a rehearsal of it.
+ */
+
+import { ulid } from "@chopin/dialect";
+
+import * as room from "../plan/room";
+import * as Store from "./store";
+
+import type { Plan } from "../plan/service";
+import type { Record } from "./service";
+
+export function enabled(): boolean {
+	return !!process.env.DEV_COMMENTS;
+}
+
+/**
+ * Mark the longest phrase the plan offers, and say something about it.
+ *
+ * The first block with enough prose to be worth marking, rather than a fixed
+ * index: a sample that only works against one document proves less than one
+ * that has to find its own footing.
+ */
+export function mark(plan: Plan): void {
+	let digests = room.digests(plan.document);
+
+	for (let [index, digest] of digests.entries()) {
+		let text = passageOf(plan, index);
+		if (!text) continue;
+
+		try {
+			let passage = room.passageAt(
+				plan.document,
+				[{ index, digest }],
+				text.quote,
+				text.offset,
+				text.quote.length,
+			);
+
+			let record: Record = {
+				id: ulid(),
+				status: "open",
+				passage,
+				notes: [Store.note("dev", `Is this still right? — "${text.quote}"`)],
+			};
+			plan.threads.set(record.id, record);
+			plan.sink.touch();
+
+			console.log(`[dev] marked block ${index}: ${JSON.stringify(text.quote)}`);
+			return;
+		} catch (err) {
+			console.error("[dev] could not mark that block:", err);
+		}
+	}
+
+	console.log("[dev] no block long enough to mark");
+}
+
+/** A phrase from a block, if it has one worth marking. */
+function passageOf(plan: Plan, index: number): { quote: string; offset: number } | undefined {
+	let text = room.blockText(plan.document, [index]);
+	let trimmed = text.trim();
+	if (trimmed.length < 20) return undefined;
+
+	let quote = trimmed.slice(0, Math.min(48, trimmed.length));
+	return { quote, offset: text.indexOf(quote) };
+}

--- a/apps/server/src/comments/prompt.ts
+++ b/apps/server/src/comments/prompt.ts
@@ -1,0 +1,51 @@
+/**
+ * What the agent is told when a thread is accepted.
+ *
+ * The body starts with a verb because `compose` puts `@handle:` in front of it,
+ * and a turn that reads "@ana: @ana accepted…" spends its first line saying the
+ * same thing twice.
+ *
+ * The thread is quoted whole rather than summarised. Somebody would have to
+ * write that summary, and the disagreement in a thread is usually the part
+ * worth acting on — an agent given only the conclusion cannot tell which
+ * objection the conclusion answered.
+ */
+
+import type { Record as Thread } from "./service";
+
+/** Enough context to act, without pretending block indices will still be valid. */
+export function compose(thread: Thread, quote: string, current?: string): string {
+	let lines = [
+		"accepted a comment on the plan.",
+		"",
+		"The passage it marks:",
+		"",
+		...quote.split("\n").map(line => `> ${line}`),
+	];
+
+	// A rewritten passage is more information, not less: the agent is told what
+	// was discussed and what stands there now, and can reconcile the two.
+	if (current !== undefined && current !== quote) {
+		lines.push(
+			"",
+			"That prose has since been rewritten. It now reads:",
+			"",
+			...current.split("\n").map(line => `> ${line}`),
+		);
+	}
+
+	lines.push(
+		"",
+		"The thread:",
+		"",
+		...thread.notes.map(note => `@${note.handle}: ${note.text}`),
+		"",
+		"Revise the plan so it reflects this, then record what your revision produced "
+			+ `with \`anchor_plan\`, using thread ${thread.id}.`,
+		"",
+		"Other accepted threads may be waiting too — `read_plan` lists them, and you can "
+			+ "deal with several in one pass.",
+	);
+
+	return lines.join("\n");
+}

--- a/apps/server/src/comments/service.ts
+++ b/apps/server/src/comments/service.ts
@@ -346,15 +346,16 @@ async function settle(
 	if (!claimed.ok) return answer(ws, msg.rid, kind, msg.id, claimed);
 
 	if (kind === "accept") {
+		let mutation: { update: Uint8Array; source: string } | undefined;
+
 		try {
-			let mutation = room.insertDecision(plan.document, {
+			mutation = room.insertDecision(plan.document, {
 				id: msg.id,
 				quote: quote.slice(0, limits.MAX_QUOTE),
 				by: ws.data.handle,
 				at: new Date(claimed.claim.result.at * 1_000).toISOString(),
 				notes: claimed.thread.notes.map(note => ({ by: note.handle, text: note.text })),
 			});
-			if (mutation) Service.publish(plan, server, roomId, mutation);
 		} catch (err) {
 			// The decision is not final if the plan could not be told about it.
 			Store.rollback(plan.comments, claimed.claim);
@@ -364,6 +365,22 @@ async function settle(
 				reason: "invalid",
 				message: err instanceof Error ? err.message : "could not record the decision",
 			});
+		}
+
+		/*
+		 * Past here the document holds the decision, so committing is no longer
+		 * optional. Rolling back on a failed broadcast would leave a
+		 * `<Decision>` in the plan whose record still says the thread is open —
+		 * and the next accept would append a second node carrying the same id.
+		 * A relay nobody received is recoverable; clients resync on the next
+		 * update. A record disagreeing with the document is not.
+		 */
+		if (mutation) {
+			try {
+				Service.publish(plan, server, roomId, mutation);
+			} catch (err) {
+				console.error("[comments] could not relay a decision:", err);
+			}
 		}
 	}
 

--- a/apps/server/src/comments/service.ts
+++ b/apps/server/src/comments/service.ts
@@ -178,6 +178,43 @@ export function applied(plan: Plan, id: string): boolean {
 	return !!record?.result && !record.result.pending;
 }
 
+/**
+ * Record what a turn wrote as the decision it was asked to act on.
+ *
+ * The agent is told to say this itself with `anchor_plan`, and when it does
+ * that answer is better than this one: it can pick out the two blocks of five
+ * that actually came from the decision. But a thread whose result is never
+ * anchored points at nothing for good, and the prose it was about is gone by
+ * then — rewriting it is what acceptance asked for. So the blocks a turn
+ * authored stand in until the agent says otherwise.
+ *
+ * Not pending: anchors derived from the change itself are as fresh as anchors
+ * get. Only applied when nothing trustworthy is already there, so a precise
+ * answer from a previous turn is never coarsened by a later guess.
+ */
+export function attribute(plan: Plan, thread: string, blocks: number[]): void {
+	let record = plan.threads.get(thread);
+	if (!record || record.status !== "accepted") return;
+	if (record.result && !record.result.pending) return;
+	if (blocks.length === 0) return;
+
+	try {
+		let current = room.digests(plan.document);
+		let anchors: Wired.Anchor[] = [];
+		for (let index of blocks) {
+			let hash = current[index];
+			if (hash) anchors.push(room.anchorAt(plan.document, index, hash));
+		}
+		if (anchors.length === 0) return;
+
+		plan.threads.set(thread, { ...record, result: { anchors, pending: false } });
+	} catch (err) {
+		// A decision that cannot be pointed at is worse than one pointed at
+		// coarsely, and both are better than a failed edit.
+		console.error(`[comments] could not attribute a revision to ${thread}:`, err);
+	}
+}
+
 /** Record the prose an accepted thread's revision produced. */
 export function relate(
 	plan: Plan,
@@ -406,9 +443,15 @@ async function settle(
 			resolver,
 			compose(next, quote),
 			`@${resolver} accepted a comment on "${excerpt(quote)}".`,
-			// Somebody else's turn may get to it first; running this one then
-			// would only have the agent read the plan and find nothing to do.
-			() => applied(plan, msg.id),
+			{
+				// Somebody else's turn may get to it first; running this one
+				// then would only have the agent read the plan and find
+				// nothing to do.
+				spent: () => applied(plan, msg.id),
+				// So the prose the turn writes can be recorded as what this
+				// decision produced, whether or not the agent says so.
+				thread: msg.id,
+			},
 		);
 	} else if (kind === "dismiss") {
 		Chat.notice(context, `@${resolver} dismissed a comment on "${excerpt(quote)}".`);

--- a/apps/server/src/comments/service.ts
+++ b/apps/server/src/comments/service.ts
@@ -1,0 +1,413 @@
+/**
+ * Comments, as a room offers them.
+ *
+ * A thread marks a phrase and collects what people said about it. Accepting one
+ * is the room deciding: the thread freezes, a `<Decision>` goes into the plan,
+ * and the agent is asked to revise the prose. Dismissing closes it without the
+ * agent.
+ *
+ * Accepting is two-phase for the same reason answering a questionnaire is — the
+ * record and the document both have to change, and nobody may be told it is
+ * final until both have. If the document write fails the claim is rolled back
+ * and the thread is still open, which every client already knows how to render.
+ *
+ * Where a thread points is not in these frames. A passage moves whenever the
+ * plan does, and `plan:anchors` already carries every such relationship as one
+ * authoritative snapshot, so putting it here too would be a second source of
+ * truth updated on a different schedule.
+ */
+
+import { limits, ulid } from "@chopin/dialect";
+
+import * as room from "../plan/room";
+import * as Store from "./store";
+import { broadcast, relay, reply, tell } from "../wire";
+
+import * as Chat from "../chat/service";
+import * as Service from "../plan/service";
+import { compose } from "./prompt";
+
+import type { Server } from "bun";
+// `Plan` is the room's plan here; the protocol namespace of the same name is
+// aliased so the two cannot be confused at a glance.
+import type { Comment as Wire, Plan as Wired, Request } from "@chopin/protocol";
+import type { Plan } from "../plan/service";
+import type { Socket, SocketData } from "../wire";
+
+export type { Threads } from "./store";
+
+export const create = Store.create;
+
+/** A comment thread as it is stored beside the plan, so it survives a restart. */
+export type Record = {
+	id: string;
+	status: Wire.Status;
+	/**
+	 * The phrase it marks.
+	 *
+	 * Rebased with the plan and never frozen: an accepted thread keeps its
+	 * prose highlighted, so it has to keep knowing where that prose is.
+	 */
+	passage: Wired.Passage;
+	notes: Wire.Note[];
+	/** The prose the agent's revision produced. Absent until it anchors it. */
+	result?: Wired.AnchorSet;
+	/** The marked text as it read when this resolved. Frozen; the passage is not. */
+	quote?: string;
+	resolver?: string;
+	/** Unix seconds. */
+	at?: number;
+};
+
+/** The thread as clients see it. The passage travels on `plan:anchors`. */
+function wire(record: Record): Wire.Thread {
+	return {
+		id: record.id,
+		status: record.status,
+		notes: record.notes,
+		...(record.quote !== undefined ? { quote: record.quote } : {}),
+		...(record.resolver ? { resolver: record.resolver } : {}),
+		...(record.at !== undefined ? { at: record.at } : {}),
+	};
+}
+
+/**
+ * What the passage reads as right now.
+ *
+ * Rebasing is how that question is answered: it resolves the positions and
+ * re-cuts the quote from the text they now cover. The rebased passage is kept,
+ * because having computed it there is no reason to store the older one. A
+ * drifted passage answers with what it last read, which is the best anyone can
+ * say about prose that is gone.
+ */
+function reading(plan: Plan, record: Record): { quote: string; record: Record } {
+	let passage = room.rebasePassage(plan.document, record.passage);
+	let next: Record = { ...record, passage };
+	plan.threads.set(record.id, next);
+	return { quote: passage.quote, record: next };
+}
+
+// -- relationships ---------------------------------------------------------
+
+/**
+ * A thread's relationships, with an entry for one that has never been anchored.
+ *
+ * An accepted thread with no result is pending: the agent owes a review. An
+ * open one is not — there is nothing outstanding until there is a decision.
+ */
+export function anchors(plan: Plan): Wired.ThreadAnchors[] {
+	let out: Wired.ThreadAnchors[] = [];
+
+	for (let record of plan.threads.values()) {
+		// Dismissed threads are not shown and never reach the agent, so there
+		// is nothing for anyone to point at.
+		if (record.status === "dismissed") continue;
+
+		let accepted = record.status === "accepted";
+		out.push({
+			thread: record.id,
+			subject: record.passage,
+			result: record.result ?? {
+				anchors: [],
+				pending: accepted,
+				...(accepted ? { reason: "missing" as const } : {}),
+			},
+		});
+	}
+
+	return out;
+}
+
+/** Bring every thread forward onto the document as it is now. */
+export function rebase(plan: Plan): void {
+	for (let [id, record] of plan.threads) {
+		if (record.status === "dismissed") continue;
+
+		let next: Record = {
+			...record,
+			passage: room.rebasePassage(plan.document, record.passage),
+		};
+
+		if (record.result) {
+			let moved = room.rebase(plan.document, record.result.anchors);
+			let lost = moved.some(anchor => anchor.orphaned);
+			next.result = {
+				...record.result,
+				anchors: moved,
+				...(lost ? { pending: true, reason: "orphaned" as const } : {}),
+			};
+		}
+
+		plan.threads.set(id, next);
+	}
+}
+
+/**
+ * Mark every result as needing review.
+ *
+ * The passage a decision produced is the thing most likely to have been
+ * rewritten, and a link to where it used to be is worse than an admission that
+ * nobody has checked.
+ */
+export function invalidate(plan: Plan, reason: Wired.AnchorReason): void {
+	for (let [id, record] of plan.threads) {
+		if (record.status !== "accepted" || !record.result) continue;
+		plan.threads.set(id, {
+			...record,
+			result: { ...record.result, pending: true, reason },
+		});
+	}
+}
+
+/** Everything the agent still owes a review on. */
+export function outstanding(plan: Plan): Array<{ thread: string; reason: Wired.AnchorReason }> {
+	let out: Array<{ thread: string; reason: Wired.AnchorReason }> = [];
+
+	for (let record of plan.threads.values()) {
+		if (record.status !== "accepted") continue;
+		if (record.result && !record.result.pending) continue;
+		out.push({ thread: record.id, reason: record.result?.reason ?? "missing" });
+	}
+
+	return out;
+}
+
+/** Whether an accepted thread has already been acted on and anchored. */
+export function applied(plan: Plan, id: string): boolean {
+	let record = plan.threads.get(id);
+	return !!record?.result && !record.result.pending;
+}
+
+/** Record the prose an accepted thread's revision produced. */
+export function relate(
+	plan: Plan,
+	thread: string,
+	blocks: Array<{ index: number; digest: string }>,
+): string | undefined {
+	let record = plan.threads.get(thread);
+	if (!record) return `no comment thread ${thread}`;
+	if (record.status !== "accepted") return `comment thread ${thread} was not accepted`;
+
+	let current = room.digests(plan.document);
+	let found: Wired.Anchor[] = [];
+
+	for (let block of blocks) {
+		let hash = current[block.index];
+		if (!hash) return `no block at index ${block.index}`;
+		if (hash !== block.digest) return `block ${block.index} has changed; read the plan again`;
+		found.push(room.anchorAt(plan.document, block.index, hash));
+	}
+
+	// An empty list is a real answer: reviewed, and deliberately related to
+	// nothing. It is not the same as never having looked.
+	plan.threads.set(thread, { ...record, result: { anchors: found, pending: false } });
+	return undefined;
+}
+
+// -- sockets ---------------------------------------------------------------
+
+/** Every thread worth showing, for somebody who has just arrived. */
+export function greet(plan: Plan, ws: Socket): void {
+	tell(ws, {
+		kind: "comment:sync",
+		ts: 0,
+		threads: [...plan.threads.values()]
+			.filter(record => record.status !== "dismissed")
+			.map(wire),
+	});
+}
+
+function said(text: string): string | undefined {
+	let value = text.trim();
+	if (!value) return undefined;
+	return value.length > limits.MAX_NOTE ? undefined : value;
+}
+
+/** Mark a phrase and say the first thing about it. */
+export function start(
+	plan: Plan,
+	server: Server<SocketData>,
+	roomId: string,
+	ws: Socket,
+	msg: Request<Wire.Start.Ask>,
+): void {
+	let refuse = (reason: "invalid" | "full", message: string) =>
+		reply(ws, msg.rid, { kind: "comment:start", ts: 0, ok: false, reason, message });
+
+	let full = Store.room(plan.threads);
+	if (full) return refuse("full", full.message);
+
+	let text = said(msg.text);
+	if (!text) return refuse("invalid", "A comment needs something in it.");
+
+	let passage: Wired.Passage;
+	try {
+		passage = room.passageAt(plan.document, msg.blocks, msg.quote, msg.offset, msg.length);
+	} catch (err) {
+		return refuse("invalid", err instanceof Error ? err.message : "could not mark that passage");
+	}
+
+	let record: Record = {
+		id: ulid(),
+		status: "open",
+		passage,
+		notes: [Store.note(ws.data.handle, text)],
+	};
+	plan.threads.set(record.id, record);
+	plan.sink.touch();
+
+	reply(ws, msg.rid, { kind: "comment:start", ts: 0, ok: true, thread: wire(record) });
+	relay(ws, { kind: "comment:opened", ts: 0, thread: wire(record) });
+	// The passage travels separately, and a card with nothing to highlight is
+	// what the room sees until it arrives — so it goes now, not on the next edit.
+	Service.anchors(plan, server, roomId);
+}
+
+/** Add to an open thread. */
+export function respond(plan: Plan, ws: Socket, msg: Request<Wire.Reply.Ask>): void {
+	let text = said(msg.text);
+	if (!text) {
+		return reply(ws, msg.rid, {
+			kind: "comment:reply",
+			ts: 0,
+			id: msg.id,
+			ok: false,
+			reason: "invalid",
+			message: "A comment needs something in it.",
+		});
+	}
+
+	let outcome = Store.reply(plan.comments, plan.threads, msg.id, ws.data.handle, text);
+	if (!outcome.ok) {
+		return reply(ws, msg.rid, { kind: "comment:reply", ts: 0, id: msg.id, ...outcome });
+	}
+
+	Store.typing(plan.comments, msg.id, ws.data.client, ws.data.handle, false);
+	plan.sink.touch();
+
+	reply(ws, msg.rid, { kind: "comment:reply", ts: 0, id: msg.id, ok: true, note: outcome.note });
+	relay(ws, { kind: "comment:said", ts: 0, id: msg.id, note: outcome.note });
+}
+
+/** Somebody is, or has stopped, writing a reply. */
+export function typing(plan: Plan, ws: Socket, msg: Wire.Typing.Input): void {
+	Store.typing(plan.comments, msg.id, ws.data.client, ws.data.handle, msg.writing);
+	relay(ws, {
+		kind: "comment:typing",
+		ts: 0,
+		id: msg.id,
+		writing: msg.writing,
+		client: ws.data.client,
+		handle: ws.data.handle,
+	});
+}
+
+/** Drop a departed member from every thread they were writing in. */
+export function away(plan: Plan, ws: Socket): void {
+	Store.away(plan.comments, ws.data.client);
+}
+
+type Resolution = "accept" | "dismiss";
+
+/** Both resolutions answer with the same shape; only the kind differs. */
+type Settled =
+	| { ok: true; resolver: string; at: number }
+	| { ok: false; reason: "missing" | "resolving" | "invalid"; message: string }
+	| { ok: false; reason: "resolved"; status: Wire.Status; resolver: string };
+
+function answer(ws: Socket, rid: string, kind: Resolution, id: string, body: Settled): void {
+	if (kind === "accept") {
+		return reply(ws, rid, { kind: "comment:accept", ts: 0, id, ...body });
+	}
+	reply(ws, rid, { kind: "comment:dismiss", ts: 0, id, ...body });
+}
+
+/**
+ * Close a thread.
+ *
+ * Accepting has a durable half — the `<Decision>` node — so it is claimed
+ * first, written, and only then committed. Dismissing has none: nothing about
+ * the plan changes, so there is nothing to roll back.
+ */
+async function settle(
+	context: Chat.Room,
+	ws: Socket,
+	msg: Request<Wire.Accept.Ask | Wire.Dismiss.Ask>,
+	kind: Resolution,
+): Promise<void> {
+	let { plan, room: roomId, server } = context;
+
+	let held = plan.threads.get(msg.id);
+	// Read the passage before claiming: a decision records the prose as it read
+	// when somebody decided about it, not as it reads after the agent acts.
+	let quote = held ? reading(plan, held).quote : "";
+
+	let claimed = Store.claim(plan.comments, plan.threads, msg.id, kind, ws.data.handle, quote);
+	if (!claimed.ok) return answer(ws, msg.rid, kind, msg.id, claimed);
+
+	if (kind === "accept") {
+		try {
+			let mutation = room.insertDecision(plan.document, {
+				id: msg.id,
+				quote: quote.slice(0, limits.MAX_QUOTE),
+				by: ws.data.handle,
+				at: new Date(claimed.claim.result.at * 1_000).toISOString(),
+				notes: claimed.thread.notes.map(note => ({ by: note.handle, text: note.text })),
+			});
+			if (mutation) Service.publish(plan, server, roomId, mutation);
+		} catch (err) {
+			// The decision is not final if the plan could not be told about it.
+			Store.rollback(plan.comments, claimed.claim);
+			console.error("[comments] could not project a decision:", err);
+			return answer(ws, msg.rid, kind, msg.id, {
+				ok: false,
+				reason: "invalid",
+				message: err instanceof Error ? err.message : "could not record the decision",
+			});
+		}
+	}
+
+	let next = Store.commit(plan.comments, plan.threads, claimed.claim);
+	plan.sink.touch();
+
+	let { at, resolver } = claimed.claim.result;
+	answer(ws, msg.rid, kind, msg.id, { ok: true, resolver, at });
+	broadcast(server, roomId, {
+		kind: "comment:resolved",
+		ts: 0,
+		id: msg.id,
+		status: claimed.claim.result.status,
+		resolver,
+		at,
+		quote,
+	});
+	Service.anchors(plan, server, roomId);
+
+	if (kind === "accept" && next) {
+		Chat.instruct(
+			context,
+			resolver,
+			compose(next, quote),
+			`@${resolver} accepted a comment on "${excerpt(quote)}".`,
+			// Somebody else's turn may get to it first; running this one then
+			// would only have the agent read the plan and find nothing to do.
+			() => applied(plan, msg.id),
+		);
+	} else if (kind === "dismiss") {
+		Chat.notice(context, `@${resolver} dismissed a comment on "${excerpt(quote)}".`);
+	}
+}
+
+/** Enough of the passage to recognise it in a line of transcript. */
+function excerpt(quote: string): string {
+	let value = quote.replace(/\s+/g, " ").trim();
+	return value.length > 60 ? `${value.slice(0, 60)}…` : value;
+}
+
+export function accept(context: Chat.Room, ws: Socket, msg: Request<Wire.Accept.Ask>) {
+	return settle(context, ws, msg, "accept");
+}
+
+export function dismiss(context: Chat.Room, ws: Socket, msg: Request<Wire.Dismiss.Ask>) {
+	return settle(context, ws, msg, "dismiss");
+}

--- a/apps/server/src/comments/store.ts
+++ b/apps/server/src/comments/store.ts
@@ -1,0 +1,247 @@
+/**
+ * The authority on what a comment thread says and whether it is still open.
+ *
+ * Thinner than the questionnaire store, because notes are append-only. Nobody
+ * is co-writing one sentence — they are each writing their own — so there is no
+ * shared draft, no CRDT, and no revision to be stale against.
+ *
+ * What is the same is the two-phase resolution. Accepting a thread has to
+ * change the plan document as well as this record, and nobody may be told it is
+ * final until both have happened. A claim reserves the outcome, the caller
+ * performs the durable half, and only then does the commit make it visible.
+ *
+ * The durable half of a thread lives in the plan's record map. This owns the
+ * parts that must not survive a restart: which resolutions are in flight, which
+ * threads resolved recently, and who is typing.
+ */
+
+import { ulid } from "@chopin/dialect";
+
+import type { Comment } from "@chopin/protocol";
+import type { Record as Thread } from "./service";
+
+/** How long a resolved thread is remembered, for a request that lost the race. */
+const CLOSED_TTL = 5 * 60 * 1_000;
+
+/**
+ * Unresolved threads a plan may hold.
+ *
+ * A ceiling on open ones rather than on the total: resolved threads are the
+ * record and are kept forever, while fifty unresolved ones say the room has
+ * stopped resolving things, which is worth refusing on.
+ */
+export const MAX_OPEN = 50;
+
+/** Notes in one thread, past which it is a conversation that belongs in chat. */
+export const MAX_NOTES = 50;
+
+export type Ended = {
+	status: "accepted" | "dismissed";
+	resolver: string;
+	at: number;
+	/** The marked prose as it read when this was decided. */
+	quote: string;
+};
+
+type Closed = { result: Ended; expires: number };
+
+export type Claim = { id: string; result: Ended };
+
+export type Threads = {
+	/** Resolutions in flight, so a rival claim is refused rather than raced. */
+	claims: Map<string, "accept" | "dismiss">;
+	/** Tombstones, so arriving second reads as "they got there first". */
+	closed: Map<string, Closed>;
+	/** Thread to client to handle. Relayed, never stored. */
+	typing: Map<string, Map<string, string>>;
+};
+
+export type Records = Map<string, Thread>;
+
+/** Why a thread cannot be added to or resolved right now. */
+export type Blocked =
+	| { ok: false; reason: "missing" | "resolving"; message: string }
+	| { ok: false; reason: "resolved"; status: Comment.Status; resolver: string };
+
+export type Refusal = Blocked | { ok: false; reason: "full"; message: string };
+
+export function create(): Threads {
+	return { claims: new Map(), closed: new Map(), typing: new Map() };
+}
+
+function sweep(threads: Threads): void {
+	let now = Date.now();
+	for (let [id, entry] of threads.closed) {
+		if (entry.expires <= now) threads.closed.delete(id);
+	}
+}
+
+function settled(entry: Closed): Blocked {
+	return {
+		ok: false,
+		reason: "resolved",
+		status: entry.result.status,
+		resolver: entry.result.resolver,
+	};
+}
+
+function now(): number {
+	return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Find an open thread, or say why there is not one.
+ *
+ * A tombstone answers before a missing record does, because a thread somebody
+ * resolved a moment ago is a different thing from one that never existed.
+ */
+function live(threads: Threads, records: Records, id: string): Thread | Blocked {
+	let ended = threads.closed.get(id);
+	if (ended) return settled(ended);
+
+	let record = records.get(id);
+	if (!record) return { ok: false, reason: "missing", message: "No such comment thread." };
+	if (record.status !== "open") {
+		return {
+			ok: false,
+			reason: "resolved",
+			status: record.status,
+			resolver: record.resolver ?? "system",
+		};
+	}
+	if (threads.claims.has(id)) {
+		return { ok: false, reason: "resolving", message: "That thread is being resolved." };
+	}
+
+	return record;
+}
+
+function refused(value: Thread | Blocked): value is Blocked {
+	return "ok" in value && value.ok === false;
+}
+
+export function note(handle: string, text: string): Comment.Note {
+	return { id: ulid(), handle, text, ts: now() };
+}
+
+/** Threads that have not been resolved. */
+export function open(records: Records): Thread[] {
+	return [...records.values()].filter(record => record.status === "open");
+}
+
+/** Whether another thread may be started at all. */
+export function room(records: Records): { ok: false; reason: "full"; message: string } | undefined {
+	if (open(records).length < MAX_OPEN) return undefined;
+	return {
+		ok: false,
+		reason: "full",
+		message: `This plan already has ${MAX_OPEN} unresolved comments. Resolve some first.`,
+	};
+}
+
+/** Add to an open thread. */
+export function reply(
+	threads: Threads,
+	records: Records,
+	id: string,
+	handle: string,
+	text: string,
+): { ok: true; note: Comment.Note; thread: Thread } | Refusal {
+	let record = live(threads, records, id);
+	if (refused(record)) return record;
+
+	if (record.notes.length >= MAX_NOTES) {
+		return {
+			ok: false,
+			reason: "full",
+			message: `A thread holds at most ${MAX_NOTES} comments.`,
+		};
+	}
+
+	let added = note(handle, text);
+	let next: Thread = { ...record, notes: [...record.notes, added] };
+	records.set(id, next);
+	return { ok: true, note: added, thread: next };
+}
+
+/**
+ * Reserve a resolution.
+ *
+ * The quote is frozen here rather than at commit, so the decision records the
+ * prose as it read when somebody decided about it — not as it reads after
+ * whatever the agent does next.
+ */
+export function claim(
+	threads: Threads,
+	records: Records,
+	id: string,
+	kind: "accept" | "dismiss",
+	resolver: string,
+	quote: string,
+): { ok: true; claim: Claim; thread: Thread } | Blocked {
+	let record = live(threads, records, id);
+	if (refused(record)) return record;
+
+	threads.claims.set(id, kind);
+	return {
+		ok: true,
+		thread: record,
+		claim: {
+			id,
+			result: {
+				status: kind === "accept" ? "accepted" : "dismissed",
+				resolver,
+				at: now(),
+				quote,
+			},
+		},
+	};
+}
+
+/** Make a claimed resolution final. */
+export function commit(threads: Threads, records: Records, entry: Claim): Thread | undefined {
+	let record = records.get(entry.id);
+	if (!record) return undefined;
+
+	threads.claims.delete(entry.id);
+	threads.typing.delete(entry.id);
+	sweep(threads);
+	threads.closed.set(entry.id, { result: entry.result, expires: Date.now() + CLOSED_TTL });
+
+	let next: Thread = {
+		...record,
+		status: entry.result.status,
+		resolver: entry.result.resolver,
+		at: entry.result.at,
+		quote: entry.result.quote,
+	};
+	records.set(entry.id, next);
+	return next;
+}
+
+/** Undo a claim whose durable half failed. The thread stays open. */
+export function rollback(threads: Threads, entry: Claim): void {
+	threads.claims.delete(entry.id);
+}
+
+/** Note that somebody is, or has stopped, writing a reply. */
+export function typing(
+	threads: Threads,
+	id: string,
+	client: string,
+	handle: string,
+	writing: boolean,
+): void {
+	if (!writing) {
+		threads.typing.get(id)?.delete(client);
+		return;
+	}
+	let entry = threads.typing.get(id);
+	if (!entry) threads.typing.set(id, entry = new Map());
+	entry.set(client, handle);
+}
+
+/** Drop a departed client from every thread it was writing in. */
+export function away(threads: Threads, client: string): void {
+	for (let entry of threads.typing.values()) entry.delete(client);
+}

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -11,11 +11,13 @@ import { join } from "node:path";
 
 import * as Agent from "./agent/client";
 import * as Chat from "./chat/service";
+import * as Comments from "./comments/service";
 import { proxy, serve } from "./client";
 import { describe, load, problem } from "./config";
 import { uid } from "./ids";
 import * as Service from "./plan/service";
 import * as Inject from "./questions/inject";
+import * as Marks from "./comments/inject";
 import * as Questions from "./questions/service";
 import * as Rooms from "./rooms";
 import { broadcast, fail, relay, tell, topic } from "./wire";
@@ -59,6 +61,7 @@ function plan(room: Rooms.Room, server: Server<SocketData>): Promise<Service.Pla
 			room.plan = opened;
 			room.opening = undefined;
 			if (Inject.enabled()) Inject.ask(opened, server, room.id);
+			if (Marks.enabled()) Marks.mark(opened);
 			return opened;
 		})
 		.catch(err => {
@@ -125,6 +128,7 @@ async function receive(ws: Socket, raw: string): Promise<void> {
 				// Anything still unanswered, so a joiner sees the sidecar the
 				// others are already looking at, and everything said so far.
 				Questions.greet(opened, ws);
+				Comments.greet(opened, ws);
 				Chat.greet(opened.chat, ws);
 			} catch (err) {
 				fail(ws, frame.rid, err instanceof Error ? err.message : "cannot open plan");
@@ -175,6 +179,26 @@ async function receive(ws: Socket, raw: string): Promise<void> {
 		case "question:cancel":
 			if (room.plan) await Questions.cancel(room.plan, server, room.id, ws, frame);
 			return;
+
+		case "comment:start":
+			if (room.plan) Comments.start(room.plan, server, room.id, ws, frame);
+			return;
+
+		case "comment:reply":
+			if (room.plan) Comments.respond(room.plan, ws, frame);
+			return;
+
+		case "comment:typing":
+			if (room.plan) Comments.typing(room.plan, ws, frame);
+			return;
+
+		case "comment:accept":
+			if (room.plan) await Comments.accept(conversation(room), ws, frame);
+			return;
+
+		case "comment:dismiss":
+			if (room.plan) await Comments.dismiss(conversation(room), ws, frame);
+			return;
 	}
 }
 
@@ -222,6 +246,7 @@ const server = Bun.serve<SocketData>({
 			if (room.plan) {
 				Service.departed(room.plan, ws);
 				Questions.away(room.plan, ws);
+				Comments.away(room.plan, ws);
 			}
 			if (room.members.size > 0) presence(server, room);
 			else evict(room);

--- a/apps/server/src/plan/edit.test.ts
+++ b/apps/server/src/plan/edit.test.ts
@@ -171,6 +171,44 @@ describe("refusing a batch", () => {
 		expect(outcome).toMatchObject({ ok: false, reason: "invalid" });
 	});
 
+	it("refuses to author a decision, which is accepted rather than written", () => {
+		let outcome = edit.apply(subject, 1, [{
+			op: "insert",
+			index: 0,
+			source: '<Decision id="01K0N4TR8K7JGM4R1J7PW4R8YJ" quote="q" by="ana" at="t">\n'
+				+ '<Note by="ana" text="n" />\n</Decision>\n',
+		}]);
+
+		expect(outcome).toMatchObject({ ok: false, reason: "invalid" });
+	});
+
+	/**
+	 * A decision is what the room settled, and the record it projects has no
+	 * way to hear that the plan no longer shows it. `detach_question` exists
+	 * because removing a questionnaire had to be deliberate; a decision is less
+	 * removable than a question, not more.
+	 */
+	it("refuses to delete or rewrite a decision while tidying around it", async () => {
+		let held = await plan();
+		room.insertDecision(held.document, {
+			id: "01K0N4TR8K7JGM4R1J7PW4R8YJ",
+			quote: "First paragraph.",
+			by: "ana",
+			at: "2026-07-28T10:14:00Z",
+			notes: [{ by: "ana", text: "Tighten this." }],
+		});
+		let at = edit.outline(held).findIndex(block => block.type === "Decision");
+		expect(at).toBeGreaterThan(-1);
+
+		expect(edit.apply(held, 1, [{ op: "delete", index: at }]))
+			.toMatchObject({ ok: false, reason: "invalid" });
+		expect(edit.apply(held, 1, [{ op: "replace", index: at, source: "Gone.\n" }]))
+			.toMatchObject({ ok: false, reason: "invalid" });
+
+		// Still there, and still saying what it said.
+		expect(room.project(held.document)).toContain("Tighten this.");
+	});
+
 	it("refuses an index the plan does not have", () => {
 		expect(edit.apply(subject, 1, [{ op: "delete", index: 9 }]))
 			.toMatchObject({ ok: false, reason: "invalid" });

--- a/apps/server/src/plan/edit.test.ts
+++ b/apps/server/src/plan/edit.test.ts
@@ -97,6 +97,48 @@ describe("applying a batch", () => {
 	});
 });
 
+describe("reporting what a batch wrote", () => {
+	/**
+	 * Which blocks a turn authored is what lets a decision be pointed at the
+	 * prose it produced, even when the agent forgets to say so. Object identity
+	 * is what tells them apart: a node carried over from the parsed base is the
+	 * same object, a staged one is not.
+	 */
+	it("names the blocks it authored and not the ones it left alone", () => {
+		let outcome = edit.apply(subject, 1, [{ op: "replace", index: 1, source: "Rewritten.\n" }]);
+
+		expect(outcome).toMatchObject({ ok: true, touched: [1] });
+	});
+
+	it("names each of several", () => {
+		let outcome = edit.apply(subject, 1, [
+			{ op: "replace", index: 1, source: "One.\n" },
+			{ op: "replace", index: 2, source: "Two.\n" },
+		]);
+
+		expect(outcome).toMatchObject({ ok: true, touched: [1, 2] });
+	});
+
+	it("names an insertion where it landed", () => {
+		let outcome = edit.apply(subject, 1, [{ op: "insert", index: 0, source: "Added.\n" }]);
+
+		expect(outcome).toMatchObject({ ok: true, touched: [1] });
+	});
+
+	/** Moving a block writes nothing: it is the same prose, further down. */
+	it("names nothing when a batch only moves blocks", () => {
+		let outcome = edit.apply(subject, 1, [{ op: "move", index: 2, to: 0 }]);
+
+		expect(outcome).toMatchObject({ ok: true, touched: [] });
+	});
+
+	it("names nothing when a batch only deletes", () => {
+		let outcome = edit.apply(subject, 1, [{ op: "delete", index: 2 }]);
+
+		expect(outcome).toMatchObject({ ok: true, touched: [] });
+	});
+});
+
 describe("refusing a batch", () => {
 	it("refuses one aimed at a revision that has moved, and says what changed", () => {
 		let outcome = edit.apply(subject, 0, [{ op: "delete", index: 0 }]);

--- a/apps/server/src/plan/edit.ts
+++ b/apps/server/src/plan/edit.ts
@@ -213,6 +213,7 @@ function step(
 		case "replace": {
 			let target = addressed(base, operation.index);
 			if (typeof target === "string") return target;
+			if (decision(target)) return protects(operation.index);
 			let index = children.indexOf(target);
 			if (index < 0) return changed(operation.index);
 			let parsed = fragment(operation.source);
@@ -226,6 +227,7 @@ function step(
 		case "delete": {
 			let target = addressed(base, operation.index);
 			if (typeof target === "string") return target;
+			if (decision(target)) return protects(operation.index);
 			let index = children.indexOf(target);
 			if (index < 0) return changed(operation.index);
 			return children.filter((_, position) => position !== index);
@@ -285,8 +287,21 @@ function repeated(children: RootContent[]): string | undefined {
 	return found;
 }
 
-/** Components only the `ask` tool may create. */
-const QUESTION_COMPONENTS = new Set(["Questionnaire", "Question", "Option", "Answer"]);
+/**
+ * Components the agent may not author.
+ *
+ * Each is a projection of something a record owns — a questionnaire's answer, a
+ * thread the room accepted — so writing one by hand would create a second
+ * account of a decision that is already settled somewhere else.
+ */
+const RESERVED_COMPONENTS = new Set([
+	"Questionnaire",
+	"Question",
+	"Option",
+	"Answer",
+	"Decision",
+	"Note",
+]);
 
 /** Parse an operation's source as a run of top-level blocks. */
 function fragment(value: string): RootContent[] | string {
@@ -322,8 +337,10 @@ function identify(root: Root): string | undefined {
 		if (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") {
 			let spec = lookup(node.name);
 			if (spec) {
-				if (QUESTION_COMPONENTS.has(spec.name)) {
-					refused = `\`${spec.name}\` is created by asking a question, not by editing the plan.`;
+				if (RESERVED_COMPONENTS.has(spec.name)) {
+					refused = spec.name === "Decision" || spec.name === "Note"
+						? `\`${spec.name}\` is written when the room accepts a comment, not by editing the plan.`
+						: `\`${spec.name}\` is created by asking a question, not by editing the plan.`;
 					return;
 				}
 				stamp(node, spec);
@@ -369,6 +386,10 @@ function changed(index: number): string {
 	return `block ${index} is already changed by another operation in this batch.`;
 }
 
+function protects(index: number): string {
+	return `block ${index} is a decision the room accepted; it cannot be edited or removed.`;
+}
+
 /** The questionnaire id a node carries, when it is one. */
 function questionnaire(node: RootContent): string | undefined {
 	if (node.type !== "mdxJsxFlowElement" || node.name !== "Questionnaire") return undefined;
@@ -377,6 +398,18 @@ function questionnaire(node: RootContent): string | undefined {
 		if (typeof attribute.value === "string") return attribute.value;
 	}
 	return undefined;
+}
+
+/**
+ * Whether a block is an accepted decision.
+ *
+ * `detach_question` exists because taking a questionnaire out of the plan had
+ * to be a deliberate, recorded act rather than a side effect of tidying. A
+ * decision is less removable than a question, not more: it is what the room
+ * settled, and the record it projects has no way to hear that it is gone.
+ */
+function decision(node: RootContent): boolean {
+	return node.type === "mdxJsxFlowElement" && node.name === "Decision";
 }
 
 function describe(node: RootContent, index: number): Block {

--- a/apps/server/src/plan/edit.ts
+++ b/apps/server/src/plan/edit.ts
@@ -54,6 +54,14 @@ export type Result =
 		ok: true;
 		revision: number;
 		blocks: Block[];
+		/**
+		 * Indices of the blocks this batch authored.
+		 *
+		 * Told apart by object identity: a node carried over from the parsed
+		 * base is the same object, a staged one is not. That is the property
+		 * reconciliation already relies on, so it costs nothing to report.
+		 */
+		touched: number[];
 		/** Questionnaires this batch took out of the plan. */
 		detached: string[];
 		/** The change to relay, absent when the batch was a no-op. */
@@ -171,12 +179,15 @@ export function apply(plan: Plan, revision: number, operations: Operation[]): Re
 		return { ok: false, reason: "invalid", message: reason(err) };
 	}
 
+	let carried = new Set(root.children);
+
 	return {
 		ok: true,
 		detached: detach,
 		mutation,
 		revision: plan.revision,
 		blocks: outline(plan),
+		touched: children.flatMap((node, index) => carried.has(node) ? [] : [index]),
 	};
 }
 

--- a/apps/server/src/plan/passages.test.ts
+++ b/apps/server/src/plan/passages.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Keeping a comment pointed at the right phrase.
+ *
+ * A passage is a block run plus a range inside it, and the range is held twice
+ * over: Yjs relative positions, which stretch as somebody types inside the
+ * phrase, and the quoted text, which finds it again when they cannot be
+ * resolved. The cases worth pinning are the ones where each layer is the only
+ * one left — an edit inside the phrase, a block that moved, an epoch rotation —
+ * and the ones where neither is, which must say so rather than guess.
+ *
+ * This also pins arithmetic that `@lexical/yjs` does not export. If a version
+ * bump changes how a text node's characters are indexed inside its parent,
+ * these fail rather than the highlight quietly landing a word to the left.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { $getNodeByKey, $getRoot, $isElementNode, $isParagraphNode } from "lexical";
+
+import * as edit from "./edit";
+import * as room from "./room";
+
+import type { Document } from "./room";
+import type { Plan as Room } from "./service";
+
+const SOURCE = `# Title
+
+The renderer caches tiles for 60 seconds.
+
+The second paragraph.
+
+The third paragraph.
+`;
+
+async function plan(source = SOURCE): Promise<Room> {
+	return { document: await room.create(source), revision: 1, outlines: new Map() } as Room;
+}
+
+/**
+ * Mark a phrase, the way the client's request does.
+ *
+ * The offset is a hint the server searches near, so zero is honest here: it is
+ * exactly as much as a client that miscounted would supply.
+ */
+function mark(document: Document, indices: number[], quote: string, offset = 0) {
+	let digests = room.digests(document);
+	let blocks = indices.map(index => ({ index, digest: digests[index]! }));
+	return room.passageAt(document, blocks, quote, offset, quote.length);
+}
+
+/**
+ * Edit a block's text the way a keystroke does.
+ *
+ * Not `edit_plan replace`, which swaps the whole block and takes its
+ * collaborative identity with it. A person typing splices the text node, which
+ * is the case the relative positions exist to survive.
+ */
+function retype(document: Document, index: number, find: string, replacement: string): void {
+	document.editor.update(() => {
+		let blocks = $getRoot().getChildren().filter(
+			node => !($isParagraphNode(node) && node.getChildrenSize() === 0),
+		);
+		let block = blocks[index];
+		if (!$isElementNode(block)) throw new Error("not an element");
+
+		for (let leaf of block.getAllTextNodes()) {
+			let text = leaf.getTextContent();
+			let at = text.indexOf(find);
+			if (at === -1) continue;
+			leaf.setTextContent(text.slice(0, at) + replacement + text.slice(at + find.length));
+			return;
+		}
+		throw new Error(`no "${find}" in block ${index}`);
+	}, { discrete: true });
+}
+
+/** What the passage covers now, read back out of the document itself. */
+function reads(document: Document, passage: ReturnType<typeof mark>): string | undefined {
+	let points = room.locate(document, passage);
+	if (!points) return undefined;
+
+	let text: string | undefined;
+	document.editor.getEditorState().read(() => {
+		let anchor = $getNodeByKey(points.anchorKey);
+		// Single-node ranges only: enough to prove the arithmetic, and a
+		// cross-node reconstruction here would just reimplement the thing
+		// under test.
+		if (anchor && points.anchorKey === points.focusKey) {
+			text = anchor.getTextContent().slice(points.anchorOffset, points.focusOffset);
+		}
+	});
+	return text;
+}
+
+const QUOTE = "caches tiles for 60 seconds";
+
+describe("marking a passage", () => {
+	it("names a phrase, and can find it again", async () => {
+		let subject = await plan();
+		let passage = mark(subject.document, [1], QUOTE);
+
+		expect(passage.quote).toBe(QUOTE);
+		expect(passage.length).toBe(QUOTE.length);
+		expect(passage.blocks).toHaveLength(1);
+		expect(room.locate(subject.document, passage)).toBeDefined();
+		expect(reads(subject.document, passage)).toBe(QUOTE);
+	});
+
+	it("refuses a block whose digest has moved on", async () => {
+		let subject = await plan();
+		expect(() =>
+			room.passageAt(subject.document, [{ index: 1, digest: "sha256:stale" }], QUOTE, 0, 3)
+		)
+			.toThrow(/has changed/);
+	});
+
+	it("refuses a phrase that is not in the blocks named", async () => {
+		let subject = await plan();
+		let digest = room.digests(subject.document)[1]!;
+		expect(() => room.passageAt(subject.document, [{ index: 1, digest }], "not here", 0, 8))
+			.toThrow(/not in those blocks/);
+	});
+
+	it("spans a run of blocks", async () => {
+		let subject = await plan();
+		let passage = mark(subject.document, [1, 2], "60 seconds.\nThe second");
+
+		expect(passage.blocks).toHaveLength(2);
+		expect(room.locate(subject.document, passage)).toBeDefined();
+	});
+});
+
+describe("a passage as the plan changes", () => {
+	/** The property the quote alone cannot give. */
+	it("stretches when text is typed inside the phrase", async () => {
+		let subject = await plan();
+		let passage = mark(subject.document, [1], QUOTE);
+
+		retype(subject.document, 1, "60 seconds", "60 whole seconds");
+
+		let rebased = room.rebasePassage(subject.document, passage);
+		expect(rebased.drifted).toBeUndefined();
+		// The range grew with the sentence rather than snapping off it.
+		expect(rebased.quote).toBe("caches tiles for 60 whole seconds");
+		expect(reads(subject.document, rebased)).toBe("caches tiles for 60 whole seconds");
+	});
+
+	it("survives an insertion above it", async () => {
+		let subject = await plan();
+		let passage = mark(subject.document, [1], QUOTE);
+
+		edit.apply(subject, 1, [{ op: "insert", index: 0, source: "Inserted.\n" }]);
+
+		let rebased = room.rebasePassage(subject.document, passage);
+		expect(rebased.drifted).toBeUndefined();
+		expect(rebased.quote).toBe(QUOTE);
+		expect(reads(subject.document, rebased)).toBe(QUOTE);
+	});
+
+	/**
+	 * A move rebuilds the block's collaborative identity, so both the block
+	 * position and the range inside it die at once. The digest recovers the
+	 * block and the quote recovers the range — the two layers, both needed.
+	 */
+	it("recovers a block that moved, by digest and quote", async () => {
+		let subject = await plan();
+		let passage = mark(subject.document, [1], QUOTE);
+
+		edit.apply(subject, 1, [{ op: "move", index: 1, to: 0 }]);
+
+		let rebased = room.rebasePassage(subject.document, passage);
+		expect(rebased.drifted).toBeUndefined();
+		expect(reads(subject.document, rebased)).toBe(QUOTE);
+	});
+
+	/** A rotation throws away the history the positions were expressed in. */
+	it("recovers across an epoch rotation, by quote", async () => {
+		let subject = await plan();
+		let passage = mark(subject.document, [1], QUOTE);
+
+		let rotated = await room.replace(room.project(subject.document));
+		expect(rotated.epoch).not.toBe(subject.document.epoch);
+		expect(room.locate(rotated, passage)).toBeUndefined();
+
+		let rebased = room.rebasePassage(rotated, passage);
+		expect(rebased.drifted).toBeUndefined();
+		expect(rebased.blocks[0]!.epoch).toBe(rotated.epoch);
+		expect(reads(rotated, rebased)).toBe(QUOTE);
+	});
+
+	it("drifts when the phrase is rewritten away", async () => {
+		let subject = await plan();
+		let passage = mark(subject.document, [1], QUOTE);
+
+		edit.apply(subject, 1, [{ op: "replace", index: 1, source: "Something else entirely.\n" }]);
+
+		expect(room.rebasePassage(subject.document, passage).drifted).toBe(true);
+	});
+
+	it("drifts when the block it marks is deleted", async () => {
+		let subject = await plan();
+		let passage = mark(subject.document, [1], QUOTE);
+
+		edit.apply(subject, 1, [{ op: "delete", index: 1 }]);
+
+		expect(room.rebasePassage(subject.document, passage).drifted).toBe(true);
+	});
+
+	/**
+	 * Two identical phrases in one block give no way to tell which was meant.
+	 * The same rule as two identical blocks, and for the same reason: marking
+	 * the wrong sentence is worse than admitting the mark is lost.
+	 */
+	it("refuses to choose between the same phrase twice over", async () => {
+		let subject = await plan("# Title\n\nSay it. Say it.\n");
+		let passage = mark(subject.document, [1], "Say it.");
+
+		// Rotate so only the quote is left, and put the two occurrences the
+		// same distance from where the mark was made.
+		edit.apply(subject, 1, [{ op: "replace", index: 1, source: "Say it. x Say it.\n" }]);
+		let rotated = await room.replace(room.project(subject.document));
+
+		expect(room.rebasePassage(rotated, { ...passage, offset: 5 }).drifted).toBe(true);
+	});
+
+	it("keeps a drifted passage drifted rather than re-finding it", async () => {
+		let subject = await plan();
+		let passage = mark(subject.document, [1], QUOTE);
+
+		let drifted = room.rebasePassage(subject.document, { ...passage, drifted: true });
+		// It is kept, on the current epoch, and still says what it marked.
+		expect(drifted.quote).toBe(QUOTE);
+	});
+});
+
+describe("reading a passage back", () => {
+	it("reports the current text of the blocks it covers", async () => {
+		let subject = await plan();
+		let passage = mark(subject.document, [1], QUOTE);
+
+		expect(room.passageText(subject.document, passage))
+			.toBe("The renderer caches tiles for 60 seconds.");
+	});
+});

--- a/apps/server/src/plan/passages.test.ts
+++ b/apps/server/src/plan/passages.test.ts
@@ -42,9 +42,7 @@ async function plan(source = SOURCE): Promise<Room> {
  * exactly as much as a client that miscounted would supply.
  */
 function mark(document: Document, indices: number[], quote: string, offset = 0) {
-	let digests = room.digests(document);
-	let blocks = indices.map(index => ({ index, digest: digests[index]! }));
-	return room.passageAt(document, blocks, quote, offset, quote.length);
+	return room.passageAt(document, indices, quote, offset, quote.length);
 }
 
 /**
@@ -105,18 +103,20 @@ describe("marking a passage", () => {
 		expect(reads(subject.document, passage)).toBe(QUOTE);
 	});
 
-	it("refuses a block whose digest has moved on", async () => {
+	it("refuses a block that is not there", async () => {
 		let subject = await plan();
-		expect(() =>
-			room.passageAt(subject.document, [{ index: 1, digest: "sha256:stale" }], QUOTE, 0, 3)
-		)
-			.toThrow(/has changed/);
+		expect(() => room.passageAt(subject.document, [9], QUOTE, 0, 3))
+			.toThrow(/no block at index/);
 	});
 
+	/**
+	 * Finding the quote is the concurrency check. If the plan moved so that the
+	 * blocks named no longer hold the phrase, marking whatever sits there now
+	 * would be worse than refusing and asking for the selection again.
+	 */
 	it("refuses a phrase that is not in the blocks named", async () => {
 		let subject = await plan();
-		let digest = room.digests(subject.document)[1]!;
-		expect(() => room.passageAt(subject.document, [{ index: 1, digest }], "not here", 0, 8))
+		expect(() => room.passageAt(subject.document, [1], "not here", 0, 8))
 			.toThrow(/not in those blocks/);
 	});
 

--- a/apps/server/src/plan/room.ts
+++ b/apps/server/src/plan/room.ts
@@ -837,6 +837,17 @@ export function locate(
 	}
 }
 
+/** The plain text of a run of blocks, addressed the way the agent addresses them. */
+export function blockText(target: Document, indices: number[]): string {
+	let text = "";
+	target.editor.getEditorState().read(() => {
+		let all = addressable();
+		let nodes = indices.map(index => all[index]).filter(node => !!node);
+		if (nodes.length === indices.length) text = runOf(nodes).text;
+	});
+	return text;
+}
+
 /** The current text of the blocks a passage covers, for saying what it now reads. */
 export function passageText(target: Document, passage: Passage): string | undefined {
 	let nodes = runNodes(target, passage.blocks);

--- a/apps/server/src/plan/room.ts
+++ b/apps/server/src/plan/room.ts
@@ -18,6 +18,7 @@ import { createYjsBinding, syncLexicalUpdateToYjs, syncYjsChangesToLexical } fro
 import * as Y from "yjs";
 
 import {
+	$createDecisionNode,
 	$createPlanNodes,
 	$createQuestionnaireNode,
 	$exportPlan,
@@ -31,15 +32,17 @@ import {
 	serialize,
 	ulid,
 } from "@chopin/dialect";
-import { $getRoot, $isParagraphNode, $nodesOfType } from "lexical";
+import { $getAnchorAndFocusForUserState } from "@lexical/yjs";
+import { $getNodeByKey, $getRoot, $isElementNode, $isParagraphNode, $nodesOfType } from "lexical";
 
 import type { Binding, Provider } from "@lexical/yjs";
 import type { LexicalEditor, LexicalNode } from "lexical";
 import type { Root, RootContent } from "mdast";
-import type { Questionnaire, Registry } from "@chopin/dialect";
+import type { Decision, Questionnaire, Registry } from "@chopin/dialect";
 import type { Plan } from "@chopin/protocol";
 
 type Anchor = Plan.Anchor;
+type Passage = Plan.Passage;
 
 /** Awareness is relayed, never interpreted here, so a no-op provider suffices. */
 const PROVIDER = {
@@ -383,6 +386,21 @@ export function insertQuestionnaire(
 }
 
 /**
+ * Append an accepted comment thread to the plan.
+ *
+ * At the end rather than beside the prose it concerns: the node renders as
+ * nothing, so its position only affects how `plan.mdx` reads, and decisions
+ * gathered in one place read as the record they are. Written once and never
+ * revised — what marks the prose is the passage, which keeps moving.
+ */
+export function insertDecision(target: Document, value: Decision): Mutation | undefined {
+	return mutate(target, () => {
+		$getRoot().append($createDecisionNode(value));
+		return true;
+	});
+}
+
+/**
  * Write a resolved answer into the document.
  *
  * The sidecar record is authoritative; this only makes the plan read correctly
@@ -587,4 +605,293 @@ export function rebase(target: Document, anchors: Anchor[]): Anchor[] {
 			? anchorForKey(target, matches[0], anchor.digest)
 			: { ...anchor, epoch: target.epoch, orphaned: true as const };
 	});
+}
+
+// -- passages --------------------------------------------------------------
+
+/**
+ * A phrase of the plan, to the character.
+ *
+ * An anchor names a whole block, which is the right grain for a decision and
+ * the wrong one for a remark about a single sentence. A passage is therefore
+ * the block run plus a range inside it, and the range is expressed twice for
+ * the same reason the block is: relative positions, so it stretches as somebody
+ * types inside the phrase, and the quoted text, which finds it again when they
+ * cannot be resolved.
+ *
+ * The quote is a bounded locator, not the whole phrase, so `length` carries the
+ * real extent — find the prefix, then run on. That is what lets a passage be
+ * longer than the bound instead of being refused for it.
+ */
+
+/** Blocks are one string; this joins them. Only consistency matters. */
+const RUN = "\n";
+
+/** One text node's place in a block run's plain text. */
+type Span = { key: string; start: number; length: number };
+
+/**
+ * A block run as one string, with where each of its text nodes sits in it.
+ *
+ * Call inside a read. Blocks with no text — a decorator, a rule — contribute
+ * nothing but still take their separator, so a run can span across one.
+ */
+function runOf(nodes: LexicalNode[]): { text: string; spans: Span[] } {
+	let spans: Span[] = [];
+	let text = "";
+
+	for (let [i, node] of nodes.entries()) {
+		if (i > 0) text += RUN;
+		if (!$isElementNode(node)) continue;
+		for (let leaf of node.getAllTextNodes()) {
+			let value = leaf.getTextContent();
+			spans.push({ key: leaf.getKey(), start: text.length, length: value.length });
+			text += value;
+		}
+	}
+
+	return { text, spans };
+}
+
+/** Where an index in the run's text sits, as a Lexical text point. */
+function place(spans: Span[], index: number): { key: string; offset: number } | undefined {
+	for (let span of spans) {
+		// An index inside a separator lands at the start of the block after it.
+		if (index <= span.start + span.length) {
+			return { key: span.key, offset: Math.max(0, index - span.start) };
+		}
+	}
+	let last = spans.at(-1);
+	return last ? { key: last.key, offset: last.length } : undefined;
+}
+
+/** The run index of a Lexical text point, if the point is in this run. */
+function indexOfPoint(spans: Span[], key: string | null, offset: number): number | undefined {
+	if (!key) return undefined;
+	for (let span of spans) {
+		if (span.key === key) return span.start + Math.min(offset, span.length);
+	}
+	return undefined;
+}
+
+/**
+ * Where the quote is now, or nothing if that cannot be said.
+ *
+ * The recorded offset breaks ties, because a phrase can legitimately appear
+ * twice in one paragraph. Two occurrences equally near it recover neither —
+ * the rule `rebase` applies to two identical blocks, for the same reason.
+ */
+function seek(text: string, quote: string, offset: number): number | undefined {
+	if (!quote) return undefined;
+
+	let found: number[] = [];
+	for (let at = text.indexOf(quote); at !== -1; at = text.indexOf(quote, at + 1)) found.push(at);
+	if (found.length === 0) return undefined;
+	if (found.length === 1) return found[0];
+
+	let best = found.reduce((a, b) => Math.abs(a - offset) <= Math.abs(b - offset) ? a : b);
+	let near = Math.abs(best - offset);
+	return found.filter(at => Math.abs(at - offset) === near).length === 1 ? best : undefined;
+}
+
+/** The parts of a collab text node this needs, named structurally. */
+type CollabText = { _parent?: { getSharedType(): unknown }; getOffset(): number };
+
+/**
+ * A Yjs position for a point inside a block's text.
+ *
+ * `@lexical/yjs` computes this for every remote cursor and does not export it,
+ * so the arithmetic is repeated here: a text node's characters live in its
+ * parent's `XmlText`, one slot past the node's own entry, which is the `+ 1`.
+ * The inverse *is* exported, so this is the only half that is ours to keep
+ * right — and it is pinned by `passages.test.ts` rather than by inspection.
+ */
+function positionAt(target: Document, key: string, offset: number): string {
+	let collab = target.binding.collabNodeMap.get(key) as CollabText | undefined;
+	let type = collab?._parent?.getSharedType();
+	if (!collab || !(type instanceof Y.XmlText)) {
+		throw new Error("passage names text with no collaborative identity");
+	}
+
+	let base = collab.getOffset();
+	if (base === -1) throw new Error("passage names text that is no longer in the document");
+
+	return Buffer.from(
+		Y.encodeRelativePosition(Y.createRelativePositionFromTypeIndex(type, base + 1 + offset)),
+	).toString("base64");
+}
+
+/** The nodes a passage's blocks name, if every one of them still resolves. */
+function runNodes(target: Document, blocks: Anchor[]): LexicalNode[] | undefined {
+	let keys = blocks.map(block => resolveAnchor(target, block));
+	if (keys.some(key => !key)) return undefined;
+
+	let nodes: LexicalNode[] = [];
+	target.editor.getEditorState().read(() => {
+		for (let key of keys) {
+			let node = $getNodeByKey(key!);
+			if (node) nodes.push(node);
+		}
+	});
+
+	return nodes.length === blocks.length ? nodes : undefined;
+}
+
+/** Build a passage over a resolved run, from a range in its text. */
+function cut(
+	target: Document,
+	blocks: Anchor[],
+	run: { text: string; spans: Span[] },
+	from: number,
+	to: number,
+): Passage {
+	let start = place(run.spans, from);
+	let end = place(run.spans, to);
+	if (!start || !end) throw new Error("passage names a run with no text in it");
+
+	return {
+		blocks,
+		start: positionAt(target, start.key, start.offset),
+		end: positionAt(target, end.key, end.offset),
+		quote: run.text.slice(from, to).slice(0, limits.MAX_QUOTE),
+		offset: from,
+		length: to - from,
+	};
+}
+
+/**
+ * Mark a phrase, from what the client could prove it read.
+ *
+ * Block digests are a precondition, as they are for anchoring a decision: if
+ * one does not match, the plan moved between reading and marking, and placing
+ * the passage against prose that has since changed would be worse than saying
+ * so. The offset is a hint rather than a coordinate — the quote is searched
+ * for near it — so the client's idea of where text begins never has to agree
+ * with this one exactly.
+ */
+export function passageAt(
+	target: Document,
+	blocks: Array<{ index: number; digest: string }>,
+	quote: string,
+	offset: number,
+	length: number,
+): Passage {
+	if (blocks.length === 0) throw new Error("a passage must name at least one block");
+
+	let current = digests(target);
+	let anchors: Anchor[] = [];
+	for (let block of blocks) {
+		let hash = current[block.index];
+		if (!hash) throw new Error(`no block at index ${block.index}`);
+		if (hash !== block.digest) {
+			throw new Error(`block ${block.index} has changed; read the plan again`);
+		}
+		anchors.push(anchorAt(target, block.index, hash));
+	}
+
+	let nodes = runNodes(target, anchors);
+	if (!nodes) throw new Error("a block in the passage has no collaborative identity");
+
+	let run = { text: "", spans: [] as Span[] };
+	target.editor.getEditorState().read(() => {
+		run = runOf(nodes);
+	});
+
+	let from = seek(run.text, quote, offset);
+	if (from === undefined) throw new Error("the quoted text is not in those blocks");
+
+	return cut(target, anchors, run, from, Math.min(from + length, run.text.length));
+}
+
+/** The Lexical points a passage names, if it still names any. */
+export function locate(
+	target: Document,
+	passage: Passage,
+): { anchorKey: string; anchorOffset: number; focusKey: string; focusOffset: number } | undefined {
+	if (passage.drifted) return undefined;
+	if (passage.blocks[0]?.epoch !== target.epoch) return undefined;
+
+	try {
+		let state = {
+			anchorPos: Y.decodeRelativePosition(Buffer.from(passage.start, "base64")),
+			focusPos: Y.decodeRelativePosition(Buffer.from(passage.end, "base64")),
+			color: "",
+			focusing: false,
+			name: "",
+			awarenessData: {},
+		};
+
+		let found: ReturnType<typeof $getAnchorAndFocusForUserState> | undefined;
+		target.editor.getEditorState().read(() => {
+			found = $getAnchorAndFocusForUserState(target.binding, state);
+		});
+		if (!found) return undefined;
+
+		let { anchorKey, anchorOffset, focusKey, focusOffset } = found;
+		if (!anchorKey || !focusKey) return undefined;
+		return { anchorKey, anchorOffset: anchorOffset ?? 0, focusKey, focusOffset: focusOffset ?? 0 };
+	} catch {
+		// A position from a history this document no longer holds. The quote is
+		// the fallback, and `rebasePassage` is about to try it.
+		return undefined;
+	}
+}
+
+/** The current text of the blocks a passage covers, for saying what it now reads. */
+export function passageText(target: Document, passage: Passage): string | undefined {
+	let nodes = runNodes(target, passage.blocks);
+	if (!nodes) return undefined;
+
+	let text = "";
+	target.editor.getEditorState().read(() => {
+		text = runOf(nodes).text;
+	});
+	return text;
+}
+
+/**
+ * Bring a passage forward onto the document as it is now.
+ *
+ * Same ladder as an anchor, one level finer. The blocks are rebased first,
+ * because a range means nothing without them. Positions that still resolve are
+ * kept and the quote refreshed from what they now cover, so the fallback keeps
+ * describing the prose rather than a memory of it. Positions that do not are
+ * re-derived by finding the quote. Anything left over is marked drifted and
+ * kept: a comment pointing at the wrong sentence is worse than one admitting
+ * its sentence is gone, and the thread is still worth reading either way.
+ */
+export function rebasePassage(target: Document, passage: Passage): Passage {
+	let resolvable = !passage.drifted && passage.blocks[0]?.epoch === target.epoch;
+	let blocks = rebase(target, passage.blocks);
+	let nodes = blocks.some(block => block.orphaned) ? undefined : runNodes(target, blocks);
+	if (!nodes) return { ...passage, blocks, drifted: true };
+
+	let run = { text: "", spans: [] as Span[] };
+	target.editor.getEditorState().read(() => {
+		run = runOf(nodes);
+	});
+
+	if (resolvable) {
+		let points = locate(target, { ...passage, blocks: passage.blocks });
+		let from = points && indexOfPoint(run.spans, points.anchorKey, points.anchorOffset);
+		let to = points && indexOfPoint(run.spans, points.focusKey, points.focusOffset);
+
+		if (from !== undefined && to !== undefined) {
+			try {
+				return cut(target, blocks, run, Math.min(from, to), Math.max(from, to));
+			} catch {
+				// The points resolved but no longer sit in text we can address.
+				// Fall through to the quote.
+			}
+		}
+	}
+
+	let found = seek(run.text, passage.quote, passage.offset);
+	if (found === undefined) return { ...passage, blocks, drifted: true };
+
+	try {
+		return cut(target, blocks, run, found, Math.min(found + passage.length, run.text.length));
+	} catch {
+		return { ...passage, blocks, drifted: true };
+	}
 }

--- a/apps/server/src/plan/room.ts
+++ b/apps/server/src/plan/room.ts
@@ -760,18 +760,22 @@ function cut(
 }
 
 /**
- * Mark a phrase, from what the client could prove it read.
+ * Mark a phrase, from what the client read.
  *
- * Block digests are a precondition, as they are for anchoring a decision: if
- * one does not match, the plan moved between reading and marking, and placing
- * the passage against prose that has since changed would be worse than saying
- * so. The offset is a hint rather than a coordinate — the quote is searched
- * for near it — so the client's idea of where text begins never has to agree
- * with this one exactly.
+ * Finding the quote is the concurrency check. A digest would only prove the
+ * blocks are byte-identical, which is both stricter than needed and impossible
+ * for a client to compute without re-serialising the document; the quote tests
+ * whether the sentence somebody selected is still there, which is the thing
+ * that matters. If the plan moved underneath, it is not found and this refuses
+ * rather than marking whatever sits at that index now.
+ *
+ * The offset is a hint rather than a coordinate — the quote is searched for
+ * near it — so the client's idea of where text begins never has to agree with
+ * this one exactly.
  */
 export function passageAt(
 	target: Document,
-	blocks: Array<{ index: number; digest: string }>,
+	blocks: number[],
 	quote: string,
 	offset: number,
 	length: number,
@@ -780,13 +784,10 @@ export function passageAt(
 
 	let current = digests(target);
 	let anchors: Anchor[] = [];
-	for (let block of blocks) {
-		let hash = current[block.index];
-		if (!hash) throw new Error(`no block at index ${block.index}`);
-		if (hash !== block.digest) {
-			throw new Error(`block ${block.index} has changed; read the plan again`);
-		}
-		anchors.push(anchorAt(target, block.index, hash));
+	for (let index of blocks) {
+		let hash = current[index];
+		if (!hash) throw new Error(`no block at index ${index}`);
+		anchors.push(anchorAt(target, index, hash));
 	}
 
 	let nodes = runNodes(target, anchors);

--- a/apps/server/src/plan/room.ts
+++ b/apps/server/src/plan/room.ts
@@ -411,6 +411,7 @@ export function projectAnswer(
 	target: Document,
 	id: string,
 	answers: Record<string, string>,
+	settled?: { by: string; at: string },
 ): Mutation | undefined {
 	return mutate(target, () => {
 		let found = false;
@@ -420,6 +421,9 @@ export function projectAnswer(
 			let value = node.getQuestionnaire();
 			node.setQuestionnaire({
 				...value,
+				// Who settled it, on the questionnaire rather than on each
+				// answer: it resolves as a unit, so this is one fact.
+				...(settled ? { by: settled.by, at: settled.at } : {}),
 				questions: value.questions.map(question => {
 					let answer = answers[question.id];
 					return answer === undefined ? question : { ...question, answer };

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -16,6 +16,7 @@ import * as presence from "./presence";
 import * as room from "./room";
 import * as snapshot from "./snapshot";
 import * as Chat from "../chat/service";
+import * as Comments from "../comments/service";
 import * as Questions from "../questions/service";
 import { broadcast, relay, reply, tell } from "../wire";
 
@@ -61,6 +62,8 @@ export type Plan = {
 	sink: Sink;
 	/** Open questionnaires and their shared answer drafts. */
 	questions: Questions.Questions;
+	/** Resolutions in flight and who is typing. Nothing durable. */
+	comments: Comments.Threads;
 	/** The conversation driving the agent. */
 	chat: Chat.Chat;
 	/**
@@ -70,6 +73,14 @@ export type Plan = {
 	 * this owns it. An agent rewriting the prose cannot change what was decided.
 	 */
 	records: Map<string, Questions.Record>;
+	/**
+	 * Every comment thread this plan has ever held.
+	 *
+	 * Beside the document for the same reason a questionnaire record is: a
+	 * comment must not be undoable with the plan, and the agent must not be
+	 * able to rewrite what somebody said about its work.
+	 */
+	threads: Map<string, Comments.Record>;
 	/** Bumped on every committed change; the agent's concurrency token. */
 	revision: number;
 	/**
@@ -124,6 +135,7 @@ export async function open(id: string, dir: string, server: Server<SocketData>):
 		document,
 		presence: presence.create(),
 		questions: Questions.create(),
+		comments: Comments.create(),
 		chat: Chat.restore(
 			(stored?.state.transcript ?? []) as never[],
 			stored?.state.session,
@@ -132,6 +144,9 @@ export async function open(id: string, dir: string, server: Server<SocketData>):
 		records: new Map(
 			(stored?.state.questions ?? []).map(record => [record.id, record as Questions.Record]),
 		),
+		threads: new Map(
+			(stored?.state.threads ?? []).map(record => [record.id, record as Comments.Record]),
+		),
 		revision: stored?.state.revision ?? 0,
 		queue: [],
 		timer: undefined,
@@ -139,11 +154,25 @@ export async function open(id: string, dir: string, server: Server<SocketData>):
 		meters: new WeakMap(),
 		sink: snapshot.sink({
 			dir,
+			// Anchors and passages are expressed against the document, so they
+			// are brought forward before being written rather than left to the
+			// agent's next edit — which is what used to recover a moved block.
+			//
+			// A recovery nobody is told about is invisible: the highlight stays
+			// dark until something else happens to broadcast. So the snapshot
+			// is compared, and the room hears only when it actually moved.
+			onFlush: () => {
+				let before = signature(plan);
+				Questions.rebase(plan);
+				Comments.rebase(plan);
+				if (signature(plan) !== before) anchors(plan, server, id);
+			},
 			read: () => ({
 				source: room.project(plan.document),
 				state: {
 					revision: plan.revision,
 					questions: [...plan.records.values()],
+					threads: [...plan.threads.values()],
 					transcript: plan.chat.entries,
 					...(plan.chat.resume ? { session: plan.chat.resume } : {}),
 				},
@@ -160,7 +189,19 @@ export async function open(id: string, dir: string, server: Server<SocketData>):
 		}),
 	};
 
+	// A restart is an epoch rotation: every position restored from disk was
+	// expressed in a history this document does not have. Recovering them now
+	// rather than on the first write is what lets the client that joins one
+	// millisecond later resolve anything at all.
+	Questions.rebase(plan);
+	Comments.rebase(plan);
+
 	return plan;
+}
+
+/** Cheap identity of the whole relationship snapshot, for spotting a change. */
+function signature(plan: Plan): string {
+	return JSON.stringify([Questions.anchors(plan), Comments.anchors(plan)]);
 }
 
 /** Everything a joining client needs to start from. */
@@ -176,8 +217,7 @@ export function greet(plan: Plan, ws: Socket, msg: Request<Wire.Open.Ask>): void
 		update: encode(room.sync(plan.document, resume)),
 		revision: plan.revision,
 		anchors: Questions.anchors(plan),
-		// Filled once the room holds comment threads.
-		threads: [],
+		threads: Comments.anchors(plan),
 		limits: room.LIMITS,
 		...(hello ? { awareness: encode(hello) } : {}),
 	});
@@ -257,6 +297,11 @@ async function commit(plan: Plan): Promise<void> {
 		// Cursors describe positions in a history that no longer exists.
 		presence.destroy(plan.presence);
 		plan.presence = presence.create();
+		// So do anchors and passages, and unlike a cursor nobody re-announces
+		// them. Without this every highlight in the room stays dark until the
+		// agent happens to edit.
+		Questions.rebase(plan);
+		Comments.rebase(plan);
 
 		for (let item of batch) {
 			tell(item.ws, { kind: "plan:reset", ts: 0, epoch: rebuilt.epoch, reason: "rebuilt" });
@@ -325,8 +370,7 @@ export function anchors(
 		ts: 0,
 		epoch: plan.document.epoch,
 		widgets: Questions.anchors(plan),
-		// Filled once the room holds comment threads.
-		threads: [],
+		threads: Comments.anchors(plan),
 	});
 }
 

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -193,8 +193,16 @@ export async function open(id: string, dir: string, server: Server<SocketData>):
 	// expressed in a history this document does not have. Recovering them now
 	// rather than on the first write is what lets the client that joins one
 	// millisecond later resolve anything at all.
-	Questions.rebase(plan);
-	Comments.rebase(plan);
+	//
+	// Guarded because this is the last thing between a room and being open. A
+	// plan whose highlights are stale is worth having; one that refuses to open
+	// because a decision could not be placed is not.
+	try {
+		Questions.rebase(plan);
+		Comments.rebase(plan);
+	} catch (err) {
+		console.error(`[plan] could not carry anchors into ${id}:`, err);
+	}
 
 	return plan;
 }
@@ -300,8 +308,16 @@ async function commit(plan: Plan): Promise<void> {
 		// So do anchors and passages, and unlike a cursor nobody re-announces
 		// them. Without this every highlight in the room stays dark until the
 		// agent happens to edit.
-		Questions.rebase(plan);
-		Comments.rebase(plan);
+		//
+		// Guarded because the `plan:reset` below is what tells everyone to
+		// re-open. A throw here would strand the whole room on an epoch that no
+		// longer exists, to save some highlights that are already stale.
+		try {
+			Questions.rebase(plan);
+			Comments.rebase(plan);
+		} catch (err) {
+			console.error("[plan] could not carry anchors onto the rebuilt document:", err);
+		}
 
 		for (let item of batch) {
 			tell(item.ws, { kind: "plan:reset", ts: 0, epoch: rebuilt.epoch, reason: "rebuilt" });

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -176,6 +176,8 @@ export function greet(plan: Plan, ws: Socket, msg: Request<Wire.Open.Ask>): void
 		update: encode(room.sync(plan.document, resume)),
 		revision: plan.revision,
 		anchors: Questions.anchors(plan),
+		// Filled once the room holds comment threads.
+		threads: [],
 		limits: room.LIMITS,
 		...(hello ? { awareness: encode(hello) } : {}),
 	});
@@ -323,6 +325,8 @@ export function anchors(
 		ts: 0,
 		epoch: plan.document.epoch,
 		widgets: Questions.anchors(plan),
+		// Filled once the room holds comment threads.
+		threads: [],
 	});
 }
 

--- a/apps/server/src/plan/snapshot.ts
+++ b/apps/server/src/plan/snapshot.ts
@@ -33,6 +33,12 @@ export type State = {
 	 * The copy projected into the prose is for reading.
 	 */
 	questions: QuestionRecord[];
+	/**
+	 * Comment threads and the decisions they became.
+	 *
+	 * Optional, so a plan written before this existed still loads.
+	 */
+	threads?: ThreadRecord[];
 	/** The conversation, so a restart resumes rather than forgets. */
 	transcript?: unknown[];
 	/** The Copilot session to resume into. */
@@ -46,6 +52,18 @@ export type QuestionRecord = {
 	status: "open" | "answered" | "cancelled";
 	answers?: { [question: string]: string };
 	resolver?: string;
+};
+
+/** Structural too, for the same reason. */
+export type ThreadRecord = {
+	id: string;
+	status: "open" | "accepted" | "dismissed";
+	passage: unknown;
+	notes: unknown[];
+	result?: unknown;
+	quote?: string;
+	resolver?: string;
+	at?: number;
 };
 
 export type Stored = {
@@ -66,6 +84,15 @@ export type SinkOptions = {
 	dir: string;
 	/** Read the current state at write time, not at schedule time. */
 	read: () => Stored;
+	/**
+	 * Run just before reading, to bring derived state up to date.
+	 *
+	 * Anchors and passages are the case: they have to be carried forward onto
+	 * the document as it is now, and the debounce is the right rhythm for it —
+	 * often enough that a block somebody moved recovers within two seconds,
+	 * rarely enough that it is not in the path of a keystroke.
+	 */
+	onFlush?: () => void;
 	onWrite?: (state: "saving" | "saved" | "error", message?: string) => void;
 };
 
@@ -132,6 +159,14 @@ export function sink(options: SinkOptions): Sink {
 		dirty = false;
 
 		writing = writing.then(async () => {
+			try {
+				options.onFlush?.();
+			} catch (err) {
+				// Derived state failing to refresh must not cost the write; a
+				// stale anchor is recoverable, an unwritten plan is not.
+				console.error("[plan] could not refresh derived state:", err);
+			}
+
 			let stored = options.read();
 
 			// An empty plan is not worth a directory. Room names come from URLs,

--- a/apps/server/src/plan/snapshot.ts
+++ b/apps/server/src/plan/snapshot.ts
@@ -52,6 +52,7 @@ export type QuestionRecord = {
 	status: "open" | "answered" | "cancelled";
 	answers?: { [question: string]: string };
 	resolver?: string;
+	at?: number;
 };
 
 /** Structural too, for the same reason. */

--- a/apps/server/src/questions.test.ts
+++ b/apps/server/src/questions.test.ts
@@ -309,6 +309,62 @@ describe("the plan document", () => {
 		expect(room.project(document)).toContain("On disk as MDX");
 	});
 
+	/**
+	 * On the questionnaire rather than on each answer: it resolves as a unit,
+	 * so every answer would repeat the same handle and the same moment. The
+	 * plan carrying it is what lets a late joiner see who decided, and what
+	 * lets it survive a restart.
+	 */
+	it("records who settled it, on the questionnaire", async () => {
+		let document = await room.create();
+		let value = definition();
+		let ID = ids(value);
+
+		room.insertQuestionnaire(document, {
+			id: ID.storage,
+			questions: value.questions.map(question => ({
+				id: question.id,
+				header: question.header,
+				prompt: question.question,
+				multiple: question.multiple,
+				options: question.options,
+			})),
+		});
+
+		room.projectAnswer(document, ID.storage, { [ID.storage]: "On disk as MDX" }, {
+			by: "ana",
+			at: "2026-07-28T10:14:00.000Z",
+		});
+
+		let source = room.project(document);
+		expect(source).toContain('by="ana"');
+		expect(source).toContain('at="2026-07-28T10:14:00.000Z"');
+		// Once, on the container — not repeated onto the answer.
+		expect(source.split('by="ana"')).toHaveLength(2);
+		expect(() => room.validate(source)).not.toThrow();
+	});
+
+	it("leaves the plan without provenance when none was given", async () => {
+		let document = await room.create();
+		let value = definition();
+		let ID = ids(value);
+
+		room.insertQuestionnaire(document, {
+			id: ID.storage,
+			questions: value.questions.map(question => ({
+				id: question.id,
+				header: question.header,
+				prompt: question.question,
+				multiple: question.multiple,
+				options: question.options,
+			})),
+		});
+
+		room.projectAnswer(document, ID.storage, { [ID.storage]: "On disk as MDX" });
+
+		expect(room.project(document)).not.toContain("by=");
+	});
+
 	it("takes a cancelled questionnaire out of the plan", async () => {
 		let document = await room.create();
 		let value = definition();

--- a/apps/server/src/questions/service.ts
+++ b/apps/server/src/questions/service.ts
@@ -63,6 +63,8 @@ export type Record = {
 	/** Question id to the answer as it reads, for projection into the plan. */
 	answers?: { [question: string]: string };
 	resolver?: string;
+	/** When it was settled, Unix seconds. Absent on one settled before we recorded it. */
+	at?: number;
 	/** Where in the prose each question and its answer live. */
 	anchors?: Wired.WidgetAnchors;
 };
@@ -200,8 +202,13 @@ export async function submit(
 		? decide({ status: "answered", answers: claimed.answers }, record.definition)
 		: {};
 
+	// Stamped once and used in both places, so the record and the plan cannot
+	// disagree about when the room decided.
+	let at = Math.floor(Date.now() / 1_000);
+	let settled = { by: ws.data.handle, at: new Date(at * 1_000).toISOString() };
+
 	try {
-		let mutation = room.projectAnswer(plan.document, msg.id, answers);
+		let mutation = room.projectAnswer(plan.document, msg.id, answers, settled);
 		if (mutation) Service.publish(plan, server, roomId, mutation);
 	} catch (err) {
 		// The decision is not final if the plan could not be told about it.
@@ -218,7 +225,13 @@ export async function submit(
 
 	Store.commit(plan.questions, claimed.claim);
 	if (record) {
-		plan.records.set(msg.id, { ...record, status: "answered", answers, resolver: ws.data.handle });
+		plan.records.set(msg.id, {
+			...record,
+			status: "answered",
+			answers,
+			resolver: ws.data.handle,
+			at,
+		});
 	}
 	plan.sink.touch();
 

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -4,6 +4,7 @@ import {
 	Decisions,
 	PlanEditor,
 	QuestionnaireStore,
+	ThreadStore,
 	useQuestionnaires,
 } from "@chopin/editor";
 
@@ -105,6 +106,7 @@ function Room({ handle }: { handle: string }) {
 	let user = useMemo(() => cursor(handle), [handle]);
 	// Written from inside the editor, read by the decisions pane beside it.
 	let [questions] = useState(() => new QuestionnaireStore());
+	let [threads] = useState(() => new ThreadStore());
 	let [reveal, setReveal] = useState<{ widget: string; token: number }>();
 	let unanswered = useQuestionnaires(questions).filter(entry =>
 		entry.value.questions.some(question => question.answer === undefined)
@@ -125,6 +127,7 @@ function Room({ handle }: { handle: string }) {
 		let off = [
 			socket.on<Session.Hello>("session:hello", frame => setMembers(frame.members)),
 			socket.on<Session.Presence>("session:presence", frame => setMembers(frame.members)),
+			threads.listen(socket),
 		];
 
 		return () => {
@@ -132,7 +135,7 @@ function Room({ handle }: { handle: string }) {
 			socket.dispose();
 			setWire(undefined);
 		};
-	}, [room, handle]);
+	}, [room, handle, threads]);
 
 	return (
 		<Workspace
@@ -160,10 +163,19 @@ function Room({ handle }: { handle: string }) {
 					connected={status === "connected"}
 					reveal={reveal}
 					store={questions}
+					threads={threads}
 					wire={wire}
 				/>
 			}
-			plan={<PlanEditor connection={status} questions={questions} user={user} wire={wire} />}
+			plan={
+				<PlanEditor
+					connection={status}
+					questions={questions}
+					threads={threads}
+					user={user}
+					wire={wire}
+				/>
+			}
 		/>
 	);
 }

--- a/apps/web/src/theme.test.ts
+++ b/apps/web/src/theme.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Whether a highlight can be seen.
+ *
+ * Nothing else can check this. There is no DOM in the test runtime and no
+ * `CSS.highlights` to register against, so a mark painted in page-white looks
+ * exactly like a mark that failed to paint — which is how an invisible palette
+ * shipped twice, once because a percentage was calibrated against a token that
+ * was already pale, and once because the visible part of the old rule was an
+ * outline rather than the wash it was copied from.
+ *
+ * So this does the arithmetic instead: resolve each tone against the theme it
+ * names, composite it over the page, and insist the result is far enough from
+ * the background to be a mark at all. It also checks the colour recorded beside
+ * each declaration, because that comment is what the next person will calibrate
+ * against and a stale one is worse than none.
+ *
+ * It lives here rather than beside the stylesheet because the app owns the
+ * palette; the editor only names tokens, and a package must not read an app.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+type Oklch = { l: number; c: number; h: number };
+
+const THEME = readFileSync(join(import.meta.dir, "theme.css"), "utf8");
+const STYLES = readFileSync(
+	join(import.meta.dir, "../../../packages/editor/src/styles.css"),
+	"utf8",
+);
+
+/** A colour token, as the theme declares it. */
+function token(name: string): Oklch {
+	let found = new RegExp(`--color-${name}:\\s*oklch\\(([\\d.]+)\\s+([\\d.]+)\\s+([\\d.]+)\\)`)
+		.exec(THEME);
+	if (!found) throw new Error(`no --color-${name} in the theme`);
+	return { l: Number(found[1]), c: Number(found[2]), h: Number(found[3]) };
+}
+
+/**
+ * A colour at `alpha`, over an opaque backdrop.
+ *
+ * The backdrop is achromatic, so its chroma contributes nothing and the mix is
+ * linear in both channels.
+ */
+function over(colour: Oklch, alpha: number, backdrop: Oklch): Oklch {
+	return {
+		l: alpha * colour.l + (1 - alpha) * backdrop.l,
+		c: alpha * colour.c,
+		h: colour.h,
+	};
+}
+
+function hex({ c, h, l }: Oklch): string {
+	let radians = (h * Math.PI) / 180;
+	let a = c * Math.cos(radians);
+	let b = c * Math.sin(radians);
+
+	let long = (l + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+	let medium = (l - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+	let short = (l - 0.0894841775 * a - 1.291485548 * b) ** 3;
+
+	let channels = [
+		4.0767416621 * long - 3.3077115913 * medium + 0.2309699292 * short,
+		-1.2684380046 * long + 2.6097574011 * medium - 0.3413193965 * short,
+		-0.0041960863 * long - 0.7034186147 * medium + 1.707614701 * short,
+	];
+
+	return `#${
+		channels
+			.map(value => {
+				let encoded = value <= 0.0031308
+					? 12.92 * value
+					: 1.055 * Math.pow(Math.max(value, 0), 1 / 2.4) - 0.055;
+				return Math.round(Math.min(1, Math.max(0, encoded)) * 255)
+					.toString(16)
+					.padStart(2, "0");
+			})
+			.join("")
+	}`;
+}
+
+type Mark = { name: string; token: string; percent: number; recorded: string };
+
+/** Every highlight the stylesheet declares, with the colour written beside it. */
+function marks(): Mark[] {
+	let pattern =
+		/\/\* (#[0-9a-f]{6}) \*\/\s*\n\s*background-color: color-mix\(in oklch, var\(--color-([a-z]+)\) (\d+)%/g;
+	let named = /::highlight\((plan-[a-z-]+)\)/g;
+
+	let names = [...STYLES.matchAll(named)].map(match => match[1]!);
+	let found = [...STYLES.matchAll(pattern)].map((match, index) => ({
+		name: names[index] ?? `#${index}`,
+		recorded: match[1]!,
+		token: match[2]!,
+		percent: Number(match[3]),
+	}));
+
+	if (found.length === 0) throw new Error("no highlight declarations found");
+	return found;
+}
+
+/**
+ * How far a mark has to be from the page to be one.
+ *
+ * The invisible tone that prompted this rendered `#f9fbff`, a lightness of
+ * 0.979 against a page of 1.0. Anything that close is not a highlight, whatever
+ * the stylesheet says it is.
+ */
+const PERCEPTIBLE = 0.05;
+
+describe("marking prose", () => {
+	let page = token("background");
+
+	it("declares every highlight against a token the theme has", () => {
+		for (let mark of marks()) expect(() => token(mark.token)).not.toThrow();
+	});
+
+	it("paints each one far enough from the page to be seen", () => {
+		for (let mark of marks()) {
+			let painted = over(token(mark.token), mark.percent / 100, page);
+			let distance = page.l - painted.l;
+
+			// Asserted as an object so a failure names the mark and what it
+			// renders as, rather than reporting a bare number nobody can place.
+			expect({ mark: mark.name, renders: hex(painted), visible: distance > PERCEPTIBLE })
+				.toEqual({ mark: mark.name, renders: hex(painted), visible: true });
+		}
+	});
+
+	/** The recorded colour is what the next person will calibrate against. */
+	it("records beside each one the colour it actually renders", () => {
+		for (let mark of marks()) {
+			expect({ mark: mark.name, hex: mark.recorded }).toEqual({
+				mark: mark.name,
+				hex: hex(over(token(mark.token), mark.percent / 100, page)),
+			});
+		}
+	});
+
+	it("keeps the pointer stronger than the standing marks it covers", () => {
+		let found = marks();
+		let lightness = (name: string) => {
+			let mark = found.find(each => each.name === name);
+			if (!mark) throw new Error(`no ${name}`);
+			return over(token(mark.token), mark.percent / 100, page).l;
+		};
+
+		// Darker is stronger against a white page.
+		expect(lightness("plan-related")).toBeLessThan(lightness("plan-decision"));
+		expect(lightness("plan-related")).toBeLessThan(lightness("plan-comment"));
+	});
+});

--- a/apps/web/src/theme.test.ts
+++ b/apps/web/src/theme.test.ts
@@ -138,17 +138,4 @@ describe("marking prose", () => {
 			});
 		}
 	});
-
-	it("keeps the pointer stronger than the standing marks it covers", () => {
-		let found = marks();
-		let lightness = (name: string) => {
-			let mark = found.find(each => each.name === name);
-			if (!mark) throw new Error(`no ${name}`);
-			return over(token(mark.token), mark.percent / 100, page).l;
-		};
-
-		// Darker is stronger against a white page.
-		expect(lightness("plan-related")).toBeLessThan(lightness("plan-decision"));
-		expect(lightness("plan-related")).toBeLessThan(lightness("plan-comment"));
-	});
 });

--- a/apps/web/src/wire.test.ts
+++ b/apps/web/src/wire.test.ts
@@ -108,3 +108,52 @@ describe("status", () => {
 		await expect(pending).rejects.toThrow();
 	});
 });
+
+/**
+ * Frames are fanned out in a loop, and a loop with no isolation means the first
+ * handler to throw silences every handler after it — for the rest of the
+ * session, in silence. The same shape as Lexical's update listeners, and just
+ * as hard to notice: a broken sidecar would stop the transcript arriving.
+ */
+describe("fanning a frame out", () => {
+	/** Sends every frame straight back, so a real one reaches the listeners. */
+	function echo(): number {
+		let server = Bun.serve({
+			port: 0,
+			hostname: "127.0.0.1",
+			fetch(req, self) {
+				return self.upgrade(req) ? undefined : new Response("no", { status: 400 });
+			},
+			websocket: {
+				message(ws, raw) {
+					ws.send(String(raw));
+				},
+			},
+		});
+		servers.push(server);
+		return server.port!;
+	}
+
+	it("keeps delivering after one listener throws", async () => {
+		let seen: Status[] = [];
+		let wire = connect(echo(), seen);
+		await until(() => seen.includes("connected"), "connected");
+
+		let reached: string[] = [];
+		wire.on("session:ping", () => {
+			throw new Error("this listener is broken");
+		});
+		wire.on("session:ping", () => reached.push("second"));
+
+		let complain = console.error;
+		console.error = () => {};
+		try {
+			wire.send("session:ping");
+			await until(() => reached.length > 0, "the listener behind the broken one");
+		} finally {
+			console.error = complain;
+		}
+
+		expect(reached).toEqual(["second"]);
+	});
+});

--- a/apps/web/src/wire.ts
+++ b/apps/web/src/wire.ts
@@ -76,6 +76,17 @@ export class Wire {
 		return this.#status ?? "connecting";
 	}
 
+	/**
+	 * Whether a request can be carried right now.
+	 *
+	 * Not the same as the reported status: `connected` is published from the
+	 * socket's open event, and a caller may be asking before that has run.
+	 * This reads the socket itself, which is what `ask` will do a moment later.
+	 */
+	get connected(): boolean {
+		return this.#socket?.readyState === WebSocket.OPEN;
+	}
+
 	#set(status: Status, reason?: string): void {
 		if (this.#status === status) return;
 		this.#status = status;

--- a/apps/web/src/wire.ts
+++ b/apps/web/src/wire.ts
@@ -161,7 +161,21 @@ export class Wire {
 			}
 		}
 
-		for (let listener of this.#listeners.get(frame.kind) ?? []) listener(frame as never);
+		/*
+		 * One listener at a time.
+		 *
+		 * Frames are fanned out in a loop, so without this the first handler to
+		 * throw silences every handler registered after it for that kind — the
+		 * same failure Lexical's update listeners have, and just as quiet. A
+		 * broken sidecar must not stop the transcript from arriving.
+		 */
+		for (let listener of this.#listeners.get(frame.kind) ?? []) {
+			try {
+				listener(frame as never);
+			} catch (err) {
+				console.error(`[wire] ${frame.kind} listener failed:`, err);
+			}
+		}
 	}
 
 	/** Reject everything still waiting; a reply cannot survive its connection. */

--- a/bun.lock
+++ b/bun.lock
@@ -112,6 +112,7 @@
         "yjs": "catalog:mdx",
       },
       "devDependencies": {
+        "@lexical/headless": "catalog:mdx",
         "@types/bun": "catalog:bun",
         "@types/react": "catalog:react",
         "@types/react-dom": "catalog:react",

--- a/packages/dialect/src/dialect.test.ts
+++ b/packages/dialect/src/dialect.test.ts
@@ -173,6 +173,34 @@ describe("components", () => {
 		);
 	});
 
+	it("accepts an accepted comment thread", () => {
+		accepts(
+			`<Decision id="${ID}" quote="Cached for 60 seconds." by="ana" at="2026-07-28T10:14:00Z">\n`
+				+ `<Note by="ana" text="Too long." />\n`
+				+ `</Decision>`,
+		);
+	});
+
+	it("requires a decision to say who accepted it and when", () => {
+		expect(codes(`<Decision id="${ID}" quote="q"><Note by="a" text="t" /></Decision>`))
+			.toContain("missing-attribute");
+	});
+
+	it("keeps a note out of the prose", () => {
+		expect(codes(`<Note by="ana" text="Loose." />`)).toContain("bad-parent");
+	});
+
+	/** A note's text is an attribute, so children are a hand-edit gone wrong. */
+	it("rejects a note written with its text between the tags", () => {
+		expect(
+			codes(
+				`<Decision id="${ID}" quote="q" by="a" at="t">\n`
+					+ `<Note by="ana">\n\nToo long.\n\n</Note>\n`
+					+ `</Decision>`,
+			),
+		).toContain("unexpected-children");
+	});
+
 	it("requires ULID ids", () => {
 		expect(codes(`<Callout id="nope" type="note">x</Callout>`)).toContain("bad-id");
 	});

--- a/packages/dialect/src/dialect.ts
+++ b/packages/dialect/src/dialect.ts
@@ -123,6 +123,45 @@ export const COMPONENTS: Readonly<Record<string, Component>> = Object.freeze({
 		},
 	}),
 
+	/**
+	 * An accepted comment thread.
+	 *
+	 * The record beside the plan owns it; this exists so the source carries the
+	 * decision when read alone. Only accepted threads are projected — an open
+	 * one is a conversation, not yet part of the plan — and the projection is
+	 * written once and never revised, which is what makes it history.
+	 */
+	Decision: component({
+		name: "Decision",
+		kind: "flow",
+		content: { type: "components", names: ["Note"] },
+		forbids: ["Questionnaire", "Decision", "Tabs", "Callout"],
+		attributes: {
+			quote: { type: "text", required: true, max: limits.MAX_QUOTE },
+			by: { type: "text", required: true, max: limits.MAX_HANDLE },
+			at: { type: "text", required: true, max: limits.MAX_TIMESTAMP },
+		},
+	}),
+
+	/**
+	 * One comment in an accepted thread.
+	 *
+	 * The text is an attribute rather than children, following `Answer`: a flow
+	 * component's children are parsed as blocks, so prose written between the
+	 * tags comes back wrapped in a paragraph and flattens on the way out. An
+	 * attribute round-trips exactly, which the plan's round-trip check requires.
+	 */
+	Note: plain({
+		name: "Note",
+		kind: "flow",
+		content: { type: "empty" },
+		parent: ["Decision"],
+		attributes: {
+			by: { type: "text", required: true, max: limits.MAX_HANDLE },
+			text: { type: "text", required: true, max: limits.MAX_NOTE },
+		},
+	}),
+
 	Tabs: component({
 		name: "Tabs",
 		kind: "flow",

--- a/packages/dialect/src/dialect.ts
+++ b/packages/dialect/src/dialect.ts
@@ -79,11 +79,27 @@ function plain(spec: Spec): Component {
 export const CALLOUT_TYPES = ["note", "tip", "important", "warning", "danger"] as const;
 
 export const COMPONENTS: Readonly<Record<string, Component>> = Object.freeze({
+	/**
+	 * A questionnaire, and who settled it.
+	 *
+	 * The provenance sits here rather than on each `Answer` because a
+	 * questionnaire resolves as a unit — every question is answered by the same
+	 * person at the same moment — so repeating it per answer would be one fact
+	 * written several times. `Decision` carries its provenance the same way, on
+	 * the container, with the content on the children.
+	 *
+	 * Both are optional: a questionnaire has neither until it is answered, and
+	 * one settled before this was recorded has neither for good.
+	 */
 	Questionnaire: component({
 		name: "Questionnaire",
 		kind: "flow",
 		content: { type: "components", names: ["Question"] },
 		forbids: ["Questionnaire", "Tabs", "Callout"],
+		attributes: {
+			by: { type: "text", required: false, max: limits.MAX_HANDLE },
+			at: { type: "text", required: false, max: limits.MAX_TIMESTAMP },
+		},
 	}),
 
 	Question: component({

--- a/packages/dialect/src/index.ts
+++ b/packages/dialect/src/index.ts
@@ -72,6 +72,9 @@ export {
 } from "./nodes/questionnaire";
 export type { Option, Question, Questionnaire } from "./nodes/questionnaire";
 
+export { $createDecisionNode, $isDecisionNode, DecisionNode } from "./nodes/decision";
+export type { Decision, Note } from "./nodes/decision";
+
 export { render, setRenderer } from "./nodes/render";
 export type { Renderer } from "./nodes/render";
 

--- a/packages/dialect/src/limits.ts
+++ b/packages/dialect/src/limits.ts
@@ -34,3 +34,15 @@ export const MAX_QUESTION_PROMPT = 1_000;
 export const MAX_OPTION_LABEL = 200;
 export const MAX_OPTION_DESCRIPTION = 1_000;
 export const MAX_CUSTOM_ANSWER = 4_000;
+
+/**
+ * Accepted comment threads, projected into the plan as `<Decision>`.
+ *
+ * `MAX_QUOTE` bounds a locator, not the passage: a thread records the extent it
+ * marked separately, so a long selection is truncated here rather than refused.
+ */
+export const MAX_QUOTE = 500;
+export const MAX_NOTE = 4_000;
+export const MAX_HANDLE = 80;
+/** ISO 8601, with room for an offset. */
+export const MAX_TIMESTAMP = 40;

--- a/packages/dialect/src/nodes/decision.test.ts
+++ b/packages/dialect/src/nodes/decision.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import { createHeadlessEditor } from "@lexical/headless";
+import { $getRoot, $isElementNode } from "lexical";
+
+import { exportPlan, importPlan } from "../convert";
+import { registry } from "../registry";
+import { $isDecisionNode } from "./decision";
+
+import type { LexicalEditor } from "lexical";
+
+const REGISTRY = registry();
+
+const ID = "01K0N4TR8K7JGM4R1J7PW4R8YJ";
+
+function editor(): LexicalEditor {
+	return createHeadlessEditor({
+		nodes: REGISTRY.nodes,
+		onError(err) {
+			throw err;
+		},
+	});
+}
+
+function through(source: string): string {
+	let instance = editor();
+	importPlan(instance, source, { registry: REGISTRY });
+	return exportPlan(instance, { registry: REGISTRY });
+}
+
+const ACCEPTED = `<Decision id="${ID}" quote="The renderer caches tiles for 60 seconds." `
+	+ `by="krzysztof" at="2026-07-28T10:14:00Z">\n`
+	+ `<Note by="krzysztof" text="60s is too long, the data changes every 10s." />\n`
+	+ `<Note by="ana" text="Agreed, and it should be configurable." />\n`
+	+ `</Decision>\n`;
+
+describe("decision", () => {
+	it("round-trips an accepted thread", () => {
+		let out = through(ACCEPTED);
+		expect(through(out)).toBe(out);
+		expect(out).toContain(`id="${ID}"`);
+		expect(out).toContain('by="krzysztof"');
+		expect(out).toContain('at="2026-07-28T10:14:00Z"');
+		expect(out).toContain('quote="The renderer caches tiles for 60 seconds."');
+	});
+
+	it("keeps the thread in the order it was said", () => {
+		let instance = editor();
+		importPlan(instance, ACCEPTED, { registry: REGISTRY });
+
+		instance.getEditorState().read(() => {
+			let node = $getRoot().getFirstChild();
+			if (!$isDecisionNode(node)) throw new Error("expected decision");
+			expect(node.getDecision().notes.map(note => note.by)).toEqual(["krzysztof", "ana"]);
+		});
+	});
+
+	it("gives a note no identity of its own", () => {
+		let note = through(ACCEPTED).split("\n").find(line => line.includes("<Note"));
+		// It is addressed through its Decision, exactly as an Answer is
+		// addressed through its Question.
+		expect(note).not.toContain("id=");
+	});
+
+	it("imports as one atomic node", () => {
+		let instance = editor();
+		importPlan(instance, ACCEPTED, { registry: REGISTRY });
+
+		instance.getEditorState().read(() => {
+			let node = $getRoot().getFirstChild();
+			expect($isDecisionNode(node)).toBe(true);
+			if (!$isDecisionNode(node)) return;
+
+			// A decorator, not an element: an accepted thread is frozen, so
+			// there is no editable subtree inside it.
+			expect($isElementNode(node)).toBe(false);
+			expect(node.getDecision().id).toBe(ID);
+		});
+	});
+
+	it("carries a note through unchanged when it spans lines and quotes things", () => {
+		// The text is an attribute rather than children precisely so this
+		// survives: a flow component's children parse as blocks, and prose
+		// written between the tags would come back wrapped in a paragraph.
+		let text = 'line one\nline two\n\nand "quoted" & <angled>';
+		let source = `<Decision id="${ID}" quote="q" by="ana" at="2026-07-28T10:14:00Z">\n`
+			+ `<Note by="ana" text="${text.replaceAll('"', "&#x22;")}" />\n`
+			+ `</Decision>\n`;
+
+		let instance = editor();
+		importPlan(instance, source, { registry: REGISTRY });
+
+		instance.getEditorState().read(() => {
+			let node = $getRoot().getFirstChild();
+			if (!$isDecisionNode(node)) throw new Error("expected decision");
+			expect(node.getDecision().notes[0]!.text).toBe(text);
+		});
+
+		expect(through(through(source))).toBe(through(source));
+	});
+});

--- a/packages/dialect/src/nodes/decision.ts
+++ b/packages/dialect/src/nodes/decision.ts
@@ -1,0 +1,199 @@
+/**
+ * Accepted comment threads.
+ *
+ * Atomic, for the same reason a questionnaire is: the record beside the plan
+ * owns the thread, and an accepted one is frozen, so there is nothing inside
+ * for two people to edit. Modelling it as a decorator keeps it movable as one
+ * unit while making its contents unwritable by construction.
+ *
+ * Nothing renders it in the prose. The sidecar shows the card, and the passage
+ * the decision concerns is marked in the text itself — this node exists so the
+ * source carries the decision when read on its own.
+ */
+
+import { $applyNodeReplacement, $getState, $setState, createState, DecoratorNode } from "lexical";
+
+import { render } from "./render";
+import { attribute, attributes, identity, isFlow, PRIORITY } from "./shared";
+
+import type { LexicalExportVisitor, MdastImportVisitor } from "@mdxeditor/editor";
+import type {
+	ElementNode,
+	LexicalNode,
+	LexicalUpdateJSON,
+	SerializedLexicalNode,
+	Spread,
+} from "lexical";
+import type { MdxJsxFlowElement } from "mdast-util-mdx-jsx";
+import type { Jsx } from "./shared";
+
+export type Note = {
+	/** Handle of whoever wrote it. Unverified, as everywhere else. */
+	by: string;
+	text: string;
+};
+
+export type Decision = {
+	id: string;
+	/**
+	 * The prose the thread marked, as it read when the thread was accepted.
+	 *
+	 * A bounded locator, not the whole passage: the record holds the extent.
+	 * Frozen here on purpose — the anchor keeps moving with the plan, this says
+	 * what was actually being discussed.
+	 */
+	quote: string;
+	/** Who accepted it. */
+	by: string;
+	/** When, ISO 8601. */
+	at: string;
+	notes: Note[];
+};
+
+const EMPTY: Decision = { id: "", quote: "", by: "", at: "", notes: [] };
+
+function parse(value: unknown): Decision {
+	if (!value || typeof value !== "object") return EMPTY;
+	let raw = value as Partial<Decision>;
+	return {
+		id: typeof raw.id === "string" ? raw.id : "",
+		quote: typeof raw.quote === "string" ? raw.quote : "",
+		by: typeof raw.by === "string" ? raw.by : "",
+		at: typeof raw.at === "string" ? raw.at : "",
+		notes: Array.isArray(raw.notes) ? raw.notes : [],
+	};
+}
+
+export const decisionState = createState("plan-decision", {
+	parse,
+	isEqual: (a: Decision, b: Decision) => JSON.stringify(a) === JSON.stringify(b),
+});
+
+type Serialized = Spread<{ planDecision: Decision }, SerializedLexicalNode>;
+
+export class DecisionNode extends DecoratorNode<unknown> {
+	static override getType(): string {
+		return "plan-decision";
+	}
+
+	static override clone(node: DecisionNode): DecisionNode {
+		return new DecisionNode(node.__key);
+	}
+
+	static override importJSON(serialized: Serialized): DecisionNode {
+		return $createDecisionNode().updateFromJSON(serialized);
+	}
+
+	getDecision(): Decision {
+		return $getState(this, decisionState);
+	}
+
+	setDecision(value: Decision): this {
+		return $setState(this.getWritable(), decisionState, value);
+	}
+
+	getId(): string {
+		return this.getDecision().id;
+	}
+
+	override exportJSON(): Serialized {
+		return { ...super.exportJSON(), planDecision: this.getDecision() };
+	}
+
+	override updateFromJSON(serialized: LexicalUpdateJSON<Serialized>): this {
+		return super.updateFromJSON(serialized).setDecision(parse(serialized.planDecision));
+	}
+
+	override createDOM(): HTMLElement {
+		let dom = document.createElement("div");
+		dom.dataset.planDecision = this.getId();
+		return dom;
+	}
+
+	override updateDOM(): boolean {
+		return false;
+	}
+
+	/**
+	 * `DecoratorNode` defaults to inline; a decision is a block. Without this
+	 * Lexical wraps it in a paragraph on insert and the node is lost.
+	 */
+	override isInline(): boolean {
+		return false;
+	}
+
+	override isKeyboardSelectable(): boolean {
+		return true;
+	}
+
+	override decorate(): unknown {
+		return render(this);
+	}
+}
+
+export function $createDecisionNode(value: Decision = EMPTY): DecisionNode {
+	return $applyNodeReplacement(new DecisionNode().setDecision(value));
+}
+
+export function $isDecisionNode(node: LexicalNode | null | undefined): node is DecisionNode {
+	return node instanceof DecisionNode;
+}
+
+// -- MDX conversion --------------------------------------------------------
+
+/** Read a validated `<Decision>` element into plain data. */
+export function fromElement(node: Jsx): Decision {
+	let notes: Note[] = [];
+
+	for (let child of node.children) {
+		if (child.type !== "mdxJsxFlowElement" || child.name !== "Note") continue;
+		notes.push({
+			by: attribute(child, "by") ?? "",
+			text: attribute(child, "text") ?? "",
+		});
+	}
+
+	return {
+		id: attribute(node, "id") ?? "",
+		quote: attribute(node, "quote") ?? "",
+		by: attribute(node, "by") ?? "",
+		at: attribute(node, "at") ?? "",
+		notes,
+	};
+}
+
+/** Write plain data back out as a `<Decision>` element. */
+export function toElement(value: Decision): MdxJsxFlowElement {
+	return {
+		type: "mdxJsxFlowElement",
+		name: "Decision",
+		attributes: identity(value.id, { quote: value.quote, by: value.by, at: value.at }),
+		children: value.notes.map(note => ({
+			type: "mdxJsxFlowElement" as const,
+			name: "Note",
+			// A projection of a thread the record owns: addressed through its
+			// Decision, so it carries no identity of its own.
+			attributes: attributes({ by: note.by, text: note.text }),
+			children: [],
+		})),
+	};
+}
+
+// -- visitors --------------------------------------------------------------
+
+/** Import the whole subtree as one atomic node; nothing inside is editable. */
+export const MdastDecisionVisitor: MdastImportVisitor<MdxJsxFlowElement> = {
+	testNode: isFlow("Decision"),
+	visitNode({ mdastNode, lexicalParent }) {
+		(lexicalParent as ElementNode).append($createDecisionNode(fromElement(mdastNode)));
+	},
+	priority: PRIORITY,
+};
+
+export const LexicalDecisionVisitor: LexicalExportVisitor<DecisionNode, MdxJsxFlowElement> = {
+	testLexicalNode: $isDecisionNode,
+	visitLexicalNode({ lexicalNode, mdastParent, actions }) {
+		actions.appendToParent(mdastParent, toElement(lexicalNode.getDecision()));
+	},
+	priority: PRIORITY,
+};

--- a/packages/dialect/src/nodes/questionnaire.test.ts
+++ b/packages/dialect/src/nodes/questionnaire.test.ts
@@ -107,6 +107,40 @@ describe("questionnaire", () => {
 		});
 	});
 
+	/**
+	 * On the questionnaire rather than on each answer: it resolves as a unit,
+	 * so every answer would otherwise repeat the same handle and the same
+	 * moment. `<Decision>` records its provenance the same way.
+	 */
+	it("round-trips who settled it and when", () => {
+		let source = OPEN
+			.replace(
+				`<Questionnaire id="${ID}">`,
+				`<Questionnaire id="${ID}" by="ana" at="2026-07-28T10:14:00Z">`,
+			)
+			.replace("</Question>", `<Answer value="Canary" />\n</Question>`);
+
+		let out = through(source);
+		expect(through(out)).toBe(out);
+		expect(out).toContain('by="ana"');
+		expect(out).toContain('at="2026-07-28T10:14:00Z"');
+
+		let instance = editor();
+		importPlan(instance, source, { registry: REGISTRY });
+		instance.getEditorState().read(() => {
+			let node = $getRoot().getFirstChild();
+			if (!$isQuestionnaireNode(node)) throw new Error("expected questionnaire");
+			expect(node.getQuestionnaire()).toMatchObject({ by: "ana", at: "2026-07-28T10:14:00Z" });
+		});
+	});
+
+	/** One answered before any of this was recorded has neither, for good. */
+	it("carries no provenance when none was recorded", () => {
+		let out = through(OPEN);
+		expect(out).not.toContain("by=");
+		expect(out).not.toContain("at=");
+	});
+
 	it("omits optional option descriptions", () => {
 		let out = through(OPEN);
 		let blue = out.split("\n").find(line => line.includes("Blue-green"));

--- a/packages/dialect/src/nodes/questionnaire.ts
+++ b/packages/dialect/src/nodes/questionnaire.ts
@@ -47,6 +47,16 @@ export type Question = {
 export type Questionnaire = {
 	id: string;
 	questions: Question[];
+	/**
+	 * Who settled it, and when.
+	 *
+	 * On the questionnaire rather than on each answer: it resolves as a unit,
+	 * so this is one fact about one moment. Absent until it is answered, and
+	 * absent for good on one answered before this was written down.
+	 */
+	by?: string;
+	/** ISO 8601. */
+	at?: string;
 };
 
 const EMPTY: Questionnaire = { id: "", questions: [] };
@@ -57,6 +67,8 @@ function parse(value: unknown): Questionnaire {
 	return {
 		id: typeof raw.id === "string" ? raw.id : "",
 		questions: Array.isArray(raw.questions) ? raw.questions : [],
+		...(typeof raw.by === "string" ? { by: raw.by } : {}),
+		...(typeof raw.at === "string" ? { at: raw.at } : {}),
 	};
 }
 
@@ -178,7 +190,15 @@ export function fromElement(node: Jsx): Questionnaire {
 		questions.push(question);
 	}
 
-	return { id: attribute(node, "id") ?? "", questions };
+	let by = attribute(node, "by");
+	let at = attribute(node, "at");
+
+	return {
+		id: attribute(node, "id") ?? "",
+		questions,
+		...(by ? { by } : {}),
+		...(at ? { at } : {}),
+	};
 }
 
 /** Write plain data back out as a `<Questionnaire>` element. */
@@ -186,7 +206,7 @@ export function toElement(value: Questionnaire): MdxJsxFlowElement {
 	return {
 		type: "mdxJsxFlowElement",
 		name: "Questionnaire",
-		attributes: identity(value.id),
+		attributes: identity(value.id, { by: value.by, at: value.at }),
 		children: value.questions.map(question => ({
 			type: "mdxJsxFlowElement",
 			name: "Question",

--- a/packages/dialect/src/registry.test.ts
+++ b/packages/dialect/src/registry.test.ts
@@ -106,6 +106,10 @@ A reference[^01K0N4V4E7Y6P4MJ5WD8XZF3B2] and <Var name="x" /> inline.
 Inside.
 
 </Callout>
+
+<Decision id="01K0N4X2M5R8T3VQ7YB6ZC4DEF" quote="Cached for 60 seconds." by="ana" at="2026-07-28T10:14:00Z">
+  <Note by="ana" text="Too long; the data changes every 10s." />
+</Decision>
 `;
 
 function types(node: Nodes, seen = new Set<string>()): Set<string> {

--- a/packages/dialect/src/registry.ts
+++ b/packages/dialect/src/registry.ts
@@ -38,6 +38,7 @@ import { CONTAINER_EXPORT_VISITORS, CONTAINER_IMPORT_VISITORS } from "./nodes/co
 import { CONTAINER_NODES } from "./nodes/containers";
 import { CONTENT_EXPORT_VISITORS, CONTENT_IMPORT_VISITORS } from "./nodes/content-visitors";
 import { CONTENT_NODES } from "./nodes/content";
+import { DecisionNode, LexicalDecisionVisitor, MdastDecisionVisitor } from "./nodes/decision";
 import {
 	LexicalQuestionnaireVisitor,
 	MdastQuestionnaireVisitor,
@@ -149,6 +150,22 @@ export const questionnairePlugin = realmPlugin({
 	},
 });
 
+/**
+ * Accepted comment threads.
+ *
+ * Atomic for the same reason a questionnaire is, and never revised once
+ * written: the node is the plan's copy of a decision the record owns.
+ */
+export const decisionPlugin = realmPlugin({
+	init(realm) {
+		realm.pubIn({
+			[addLexicalNode$]: [DecisionNode],
+			[addImportVisitor$]: MdastDecisionVisitor,
+			[addExportVisitor$]: LexicalDecisionVisitor,
+		});
+	},
+});
+
 /** Underline, mapped to Lexical's native text format rather than a wrapper node. */
 export const underlinePlugin = realmPlugin({
 	init(realm) {
@@ -232,6 +249,7 @@ export function plugins({ core: withCore = true } = {}): RealmPlugin[] {
 		containersPlugin(),
 		contentPlugin(),
 		questionnairePlugin(),
+		decisionPlugin(),
 		underlinePlugin(),
 		markdownPlugin(),
 	];

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -36,6 +36,7 @@
 		"react-dom": "catalog:react"
 	},
 	"devDependencies": {
+		"@lexical/headless": "catalog:mdx",
 		"@types/bun": "catalog:bun",
 		"@types/react": "catalog:react",
 		"@types/react-dom": "catalog:react"

--- a/packages/editor/src/card.test.ts
+++ b/packages/editor/src/card.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Saying who settled something, and when.
+ *
+ * The two records keep the moment in different shapes — a comment thread in
+ * Unix seconds, a questionnaire in the ISO string the plan carries — because
+ * one is read off the wire and the other out of the document. The card should
+ * not care, and a reader should not be able to tell which they are looking at.
+ *
+ * Only the formatting is tested. What the card looks like is layout, and
+ * happy-dom returns zero for every measurement.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { when } from "./card";
+
+describe("saying when", () => {
+	it("reads a comment's seconds and a questionnaire's ISO string the same way", () => {
+		let seconds = Date.UTC(2026, 6, 28, 10, 14) / 1_000;
+		let iso = new Date(seconds * 1_000).toISOString();
+
+		expect(when(seconds)).toBe(when(iso));
+	});
+
+	it("says the month, the day and the time", () => {
+		let stamp = when(Date.UTC(2026, 6, 28, 10, 14) / 1_000);
+
+		expect(stamp).toContain("28");
+		expect(stamp).toMatch(/\d{1,2}:\d{2}/);
+	});
+
+	/**
+	 * A record written before this was recorded has nothing to say. Rendering
+	 * "Invalid Date" beside a decision would be worse than saying nothing.
+	 */
+	it("says nothing rather than something wrong", () => {
+		expect(when("")).toBe("");
+		expect(when("not a date")).toBe("");
+		expect(when(Number.NaN)).toBe("");
+	});
+});

--- a/packages/editor/src/card.tsx
+++ b/packages/editor/src/card.tsx
@@ -1,0 +1,106 @@
+/**
+ * The shape every sidecar card has.
+ *
+ * A question the room answered and a comment the room accepted are the same
+ * kind of thing — something settled, with a record of who settled it — and used
+ * to look nothing alike: one had a header and no provenance, the other
+ * provenance and no header. Two components rendering similar chrome by
+ * convention is how that happens, so the chrome lives here instead and neither
+ * card draws its own.
+ *
+ * The header names the kind, always, so a mixed list can be scanned by what
+ * things are. The footer's verb carries the status, because "accepted by" and
+ * "answered by" already say it and a separate label would say it twice.
+ *
+ * Controls stay in each body rather than being hoisted into the footer:
+ * `QuestionView` owns its submit and cancel and cannot give them up, so moving
+ * the comment's would trade one asymmetry for another. Both still sit at the
+ * bottom of the card.
+ */
+
+import type { ComponentProps, ReactNode } from "react";
+
+export type SidecarCardProps = {
+	/** What this is: a comment, a question. Not what has happened to it. */
+	label: string;
+	/** Provenance once it is settled; nothing while it is still open. */
+	footer?: ReactNode;
+	children: ReactNode;
+	/** True while the reader is pointing at it, which also marks its prose. */
+	focused?: boolean;
+	/**
+	 * False when the body already insets itself.
+	 *
+	 * `QuestionView` pads its own content and belongs to another package, so
+	 * the shell would otherwise inset it twice. The escape hatch is narrower
+	 * than letting each card space itself, which is how they drifted apart.
+	 */
+	padded?: boolean;
+};
+
+export function SidecarCard(
+	{ children, focused, footer, label, padded = true, ...rest }:
+		& SidecarCardProps
+		& Omit<ComponentProps<"article">, "children">,
+) {
+	return (
+		<article
+			className={`flex flex-col overflow-hidden rounded-lg border bg-card ${
+				focused ? "border-ring" : "border-border"
+			}`}
+			{...rest}
+		>
+			<header className="flex items-center gap-2 border-b border-border bg-muted px-3 py-2">
+				<span className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+					{label}
+				</span>
+			</header>
+
+			<div className={`flex flex-col gap-2 ${padded ? "px-3 py-2.5" : ""}`}>{children}</div>
+
+			{footer && (
+				<footer className="flex items-center gap-2 border-t border-border px-3 py-2">
+					{footer}
+				</footer>
+			)}
+		</article>
+	);
+}
+
+/**
+ * When something happened, at the precision a reader cares about.
+ *
+ * Takes either shape the two records keep it in: Unix seconds for a comment
+ * thread, an ISO string for a questionnaire read back out of the plan.
+ */
+export function when(at: number | string): string {
+	let date = typeof at === "number" ? new Date(at * 1_000) : new Date(at);
+	if (Number.isNaN(date.getTime())) return "";
+
+	return date.toLocaleString(undefined, {
+		month: "short",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}
+
+export type ProvenanceProps = {
+	/** What was done: accepted, answered. The status, said as a verb. */
+	verb: string;
+	by?: string;
+	at?: number | string;
+};
+
+/** Who settled something, and when — as much of it as was recorded. */
+export function Provenance({ at, by, verb }: ProvenanceProps) {
+	if (!by) return null;
+	let stamp = at === undefined ? "" : when(at);
+
+	return (
+		<span className="text-[10px] text-muted-foreground">
+			{verb} by @{by}
+			{stamp && ` · ${stamp}`}
+		</span>
+	);
+}

--- a/packages/editor/src/collaboration.tsx
+++ b/packages/editor/src/collaboration.tsx
@@ -173,7 +173,19 @@ function Collaboration(options: CollaborationOptions) {
 		addEventListener("beforeunload", leave);
 		addEventListener("pagehide", leave);
 
-		void provider.connect();
+		/*
+		 * A failed open used to be invisible.
+		 *
+		 * `connect` resolves once the document has arrived and `sync` has been
+		 * emitted; anything that threw on the way left the editor locked with
+		 * the status chip saying "Loading" forever, and the rejection went
+		 * nowhere. Saying so is not a fix for whatever threw, but it is the
+		 * difference between a bug somebody can report and one they cannot.
+		 */
+		provider.connect().catch((err: unknown) => {
+			console.error("[plan] could not open the document:", err);
+			provider.fail(err instanceof Error ? err.message : "the plan could not be opened");
+		});
 
 		return () => {
 			removeEventListener("beforeunload", leave);

--- a/packages/editor/src/comments.tsx
+++ b/packages/editor/src/comments.tsx
@@ -16,20 +16,12 @@ import { useEffect, useRef, useState } from "react";
 
 import { limits } from "@chopin/dialect";
 
+import { Provenance, SidecarCard, when } from "./card";
 import { cursor } from "./cursor";
 
 import type { KeyboardEvent } from "react";
 import type { Comment } from "@chopin/protocol";
 import type { ThreadView } from "./threads";
-
-function when(ts: number): string {
-	return new Date(ts * 1_000).toLocaleString(undefined, {
-		month: "short",
-		day: "numeric",
-		hour: "2-digit",
-		minute: "2-digit",
-	});
-}
 
 function Who({ handle }: { handle: string }) {
 	return (
@@ -233,11 +225,28 @@ export function ThreadCard({
 	let open = thread.status === "open";
 
 	return (
-		<article
-			className={`flex flex-col gap-2 overflow-hidden rounded-lg border bg-card p-3 ${
-				focused ? "border-ring" : "border-border"
-			}`}
+		<SidecarCard
 			data-plan-sidecar-thread={thread.id}
+			focused={focused}
+			footer={open ? undefined : (
+				<>
+					<Provenance at={thread.at} by={thread.resolver} verb="Accepted" />
+					{!applied && (
+						<>
+							<span className="ml-auto text-[10px] text-warning">Not yet applied</span>
+							<button
+								className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+								disabled={busy}
+								onClick={onRetry}
+								type="button"
+							>
+								Ask again
+							</button>
+						</>
+					)}
+				</>
+			)}
+			label="Comment"
 			onBlur={onBlur}
 			onFocus={onFocus}
 			onMouseEnter={onFocus}
@@ -255,47 +264,25 @@ export function ThreadCard({
 				</p>
 			)}
 
-			{open
-				? (
-					<>
-						<Composer
-							busy={busy}
-							label="Reply"
-							onSend={onReply}
-							onTyping={onTyping}
-							placeholder="Reply…"
-						/>
-						<div className="flex items-center gap-2 border-t border-border pt-2">
-							<Confirm busy={busy} label="Accept" onConfirm={onAccept} tone="primary" />
-							<Confirm busy={busy} label="Dismiss" onConfirm={onDismiss} tone="quiet" />
-							<span className="ml-auto text-[10px] text-muted-foreground">
-								Accepting asks the agent to revise the plan
-							</span>
-						</div>
-					</>
-				)
-				: (
-					<footer className="flex items-center gap-2 border-t border-border pt-2">
-						<span className="text-[10px] text-muted-foreground">
-							Accepted by @{thread.resolver}
-							{thread.at !== undefined && ` · ${when(thread.at)}`}
+			{open && (
+				<>
+					<Composer
+						busy={busy}
+						label="Reply"
+						onSend={onReply}
+						onTyping={onTyping}
+						placeholder="Reply…"
+					/>
+					<div className="flex items-center gap-2 border-t border-border pt-2">
+						<Confirm busy={busy} label="Accept" onConfirm={onAccept} tone="primary" />
+						<Confirm busy={busy} label="Dismiss" onConfirm={onDismiss} tone="quiet" />
+						<span className="ml-auto text-[10px] text-muted-foreground">
+							Accepting asks the agent to revise the plan
 						</span>
-						{!applied && (
-							<>
-								<span className="ml-auto text-[10px] text-warning">Not yet applied</span>
-								<button
-									className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
-									disabled={busy}
-									onClick={onRetry}
-									type="button"
-								>
-									Ask again
-								</button>
-							</>
-						)}
-					</footer>
-				)}
-		</article>
+					</div>
+				</>
+			)}
+		</SidecarCard>
 	);
 }
 
@@ -308,7 +295,7 @@ export type DraftCardProps = {
 
 export function DraftCard({ busy, onCancel, onSend, quote }: DraftCardProps) {
 	return (
-		<article className="flex flex-col gap-2 overflow-hidden rounded-lg border border-ring bg-card p-3">
+		<SidecarCard focused label="Comment">
 			<Quote text={quote} />
 			<Composer
 				autoFocus
@@ -318,6 +305,6 @@ export function DraftCard({ busy, onCancel, onSend, quote }: DraftCardProps) {
 				onSend={onSend}
 				placeholder="Comment on this passage…"
 			/>
-		</article>
+		</SidecarCard>
 	);
 }

--- a/packages/editor/src/comments.tsx
+++ b/packages/editor/src/comments.tsx
@@ -1,0 +1,323 @@
+/**
+ * A comment thread, as a card in the sidecar.
+ *
+ * Four states, and the difference between them is who can still act. A draft
+ * has a passage but no thread yet. An open thread takes replies from anyone.
+ * An accepted one is frozen — that is what accepting means — and reads as a
+ * decision. A dismissed one is not rendered at all.
+ *
+ * Accept and dismiss both confirm on a second click, because neither can be
+ * undone: accepting freezes the thread, puts a decision in the plan and starts
+ * a turn. That is the same two-click shape `QuestionView` uses for cancelling,
+ * so it is an interaction people have already met here.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import { limits } from "@chopin/dialect";
+
+import { cursor } from "./cursor";
+
+import type { KeyboardEvent } from "react";
+import type { Comment } from "@chopin/protocol";
+import type { ThreadView } from "./threads";
+
+function when(ts: number): string {
+	return new Date(ts * 1_000).toLocaleString(undefined, {
+		month: "short",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}
+
+function Who({ handle }: { handle: string }) {
+	return (
+		<span
+			className="text-xs font-semibold"
+			style={{ color: cursor(handle).color }}
+		>
+			@{handle}
+		</span>
+	);
+}
+
+function Note({ note }: { note: Comment.Note }) {
+	return (
+		<li className="flex flex-col gap-0.5">
+			<div className="flex items-baseline gap-2">
+				<Who handle={note.handle} />
+				<span className="text-[10px] text-muted-foreground">{when(note.ts)}</span>
+			</div>
+			<p className="m-0 text-sm whitespace-pre-wrap text-foreground">{note.text}</p>
+		</li>
+	);
+}
+
+/** The prose the thread marks, as a quotation the card can be read without. */
+function Quote({ drifted, text }: { drifted?: boolean; text: string }) {
+	return (
+		<div className="flex flex-col gap-1">
+			<blockquote className="m-0 border-l-2 border-border pl-2 text-xs text-muted-foreground italic">
+				{text}
+			</blockquote>
+			{drifted && (
+				<p className="m-0 text-[10px] text-warning">
+					The text this refers to has changed.
+				</p>
+			)}
+		</div>
+	);
+}
+
+/**
+ * A textarea that submits on Enter.
+ *
+ * Shift-Enter is a newline, which is the convention every chat surface uses and
+ * the one the composer next door already follows.
+ */
+function Composer({
+	autoFocus,
+	busy,
+	label,
+	onCancel,
+	onSend,
+	onTyping,
+	placeholder,
+}: {
+	autoFocus?: boolean;
+	busy?: boolean;
+	label: string;
+	onCancel?: () => void;
+	onSend: (text: string) => void;
+	onTyping?: (writing: boolean) => void;
+	placeholder: string;
+}) {
+	let [text, setText] = useState("");
+	let ref = useRef<HTMLTextAreaElement>(null);
+
+	useEffect(() => {
+		if (autoFocus) ref.current?.focus();
+	}, [autoFocus]);
+
+	// Whoever is typing stops being told about the moment this goes away, so
+	// an unmount does not leave a caret blinking in somebody else's sidecar.
+	useEffect(() => () => onTyping?.(false), [onTyping]);
+
+	let send = () => {
+		let value = text.trim();
+		if (!value || busy) return;
+		setText("");
+		onTyping?.(false);
+		onSend(value);
+	};
+
+	let key = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+		if (event.key === "Escape" && onCancel) return onCancel();
+		if (event.key !== "Enter" || event.shiftKey) return;
+		event.preventDefault();
+		send();
+	};
+
+	return (
+		<div className="flex flex-col gap-1.5">
+			<textarea
+				ref={ref}
+				className="min-h-16 w-full resize-y rounded-md border border-input bg-background px-2 py-1.5 text-sm outline-none focus-visible:border-ring"
+				disabled={busy}
+				maxLength={limits.MAX_NOTE}
+				onChange={event => {
+					setText(event.target.value);
+					onTyping?.(event.target.value.length > 0);
+				}}
+				onKeyDown={key}
+				placeholder={placeholder}
+				value={text}
+			/>
+			<div className="flex items-center gap-2">
+				<button
+					className="rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground hover:bg-primary-hover disabled:opacity-50"
+					disabled={!text.trim() || busy}
+					onClick={send}
+					type="button"
+				>
+					{label}
+				</button>
+				{onCancel && (
+					<button
+						className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+						onClick={onCancel}
+						type="button"
+					>
+						Cancel
+					</button>
+				)}
+			</div>
+		</div>
+	);
+}
+
+/** A button that asks again before doing something that cannot be undone. */
+function Confirm({
+	busy,
+	label,
+	onConfirm,
+	tone,
+}: {
+	busy?: boolean;
+	label: string;
+	onConfirm: () => void;
+	tone: "primary" | "quiet";
+}) {
+	let [asked, setAsked] = useState(false);
+
+	useEffect(() => {
+		if (!asked) return;
+		let timer = setTimeout(() => setAsked(false), 4_000);
+		return () => clearTimeout(timer);
+	}, [asked]);
+
+	let style = tone === "primary"
+		? "bg-primary text-primary-foreground hover:bg-primary-hover"
+		: "text-muted-foreground hover:text-foreground";
+
+	return (
+		<button
+			className={`rounded-md px-2 py-1 text-xs font-medium disabled:opacity-50 ${style}`}
+			disabled={busy}
+			onClick={() => {
+				if (!asked) return setAsked(true);
+				setAsked(false);
+				onConfirm();
+			}}
+			type="button"
+		>
+			{asked ? "Sure?" : label}
+		</button>
+	);
+}
+
+export type ThreadCardProps = {
+	view: ThreadView;
+	quote: string;
+	writing?: string[];
+	focused?: boolean;
+	busy?: boolean;
+	/** True once the agent has said what an accepted thread produced. */
+	applied?: boolean;
+	onReply: (text: string) => void;
+	onAccept: () => void;
+	onDismiss: () => void;
+	onRetry: () => void;
+	onTyping: (writing: boolean) => void;
+	onFocus: () => void;
+	onBlur: () => void;
+};
+
+export function ThreadCard({
+	applied,
+	busy,
+	focused,
+	onAccept,
+	onBlur,
+	onDismiss,
+	onFocus,
+	onReply,
+	onRetry,
+	onTyping,
+	quote,
+	view,
+	writing,
+}: ThreadCardProps) {
+	let { thread } = view;
+	let open = thread.status === "open";
+
+	return (
+		<article
+			className={`flex flex-col gap-2 overflow-hidden rounded-lg border bg-card p-3 ${
+				focused ? "border-ring" : "border-border"
+			}`}
+			data-plan-sidecar-thread={thread.id}
+			onBlur={onBlur}
+			onFocus={onFocus}
+			onMouseEnter={onFocus}
+			onMouseLeave={onBlur}
+		>
+			<Quote drifted={view.drifted} text={quote} />
+
+			<ul className="m-0 flex list-none flex-col gap-2 p-0">
+				{thread.notes.map(note => <Note key={note.id} note={note} />)}
+			</ul>
+
+			{writing && writing.length > 0 && (
+				<p className="m-0 text-[10px] text-muted-foreground">
+					{writing.join(", ")} {writing.length === 1 ? "is" : "are"} writing…
+				</p>
+			)}
+
+			{open
+				? (
+					<>
+						<Composer
+							busy={busy}
+							label="Reply"
+							onSend={onReply}
+							onTyping={onTyping}
+							placeholder="Reply…"
+						/>
+						<div className="flex items-center gap-2 border-t border-border pt-2">
+							<Confirm busy={busy} label="Accept" onConfirm={onAccept} tone="primary" />
+							<Confirm busy={busy} label="Dismiss" onConfirm={onDismiss} tone="quiet" />
+							<span className="ml-auto text-[10px] text-muted-foreground">
+								Accepting asks the agent to revise the plan
+							</span>
+						</div>
+					</>
+				)
+				: (
+					<footer className="flex items-center gap-2 border-t border-border pt-2">
+						<span className="text-[10px] text-muted-foreground">
+							Accepted by @{thread.resolver}
+							{thread.at !== undefined && ` · ${when(thread.at)}`}
+						</span>
+						{!applied && (
+							<>
+								<span className="ml-auto text-[10px] text-warning">Not yet applied</span>
+								<button
+									className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+									disabled={busy}
+									onClick={onRetry}
+									type="button"
+								>
+									Ask again
+								</button>
+							</>
+						)}
+					</footer>
+				)}
+		</article>
+	);
+}
+
+export type DraftCardProps = {
+	quote: string;
+	busy?: boolean;
+	onSend: (text: string) => void;
+	onCancel: () => void;
+};
+
+export function DraftCard({ busy, onCancel, onSend, quote }: DraftCardProps) {
+	return (
+		<article className="flex flex-col gap-2 overflow-hidden rounded-lg border border-ring bg-card p-3">
+			<Quote text={quote} />
+			<Composer
+				autoFocus
+				busy={busy}
+				label="Comment"
+				onCancel={onCancel}
+				onSend={onSend}
+				placeholder="Comment on this passage…"
+			/>
+		</article>
+	);
+}

--- a/packages/editor/src/decisions.tsx
+++ b/packages/editor/src/decisions.tsx
@@ -1,36 +1,41 @@
 /**
- * The decisions pane.
+ * The sidecar.
  *
- * Every question the plan has asked, open ones first. This is the only place a
- * questionnaire is answered: the plan node itself renders nothing, because a
- * form sitting inline in prose competes with the prose, and because a decision
- * is worth keeping visible after it has been made.
+ * Everything the plan is waiting on, and everything it has settled: questions
+ * the agent asked, and comments the room made on the prose. Both are decisions
+ * in the same sense, so they share one list rather than two tabs — an accepted
+ * comment *is* a decision, and would otherwise have to pick a side.
  *
- * Answering is collaborative. Everyone here is editing one draft, so what you
- * type appears under the other person's cursor, and whoever submits it is
- * recorded as having decided.
+ * Outstanding items come first, in document order, because one of those is
+ * blocking somebody. Everything resolved collapses behind a disclosure: it is
+ * the record, worth keeping and not worth scrolling past. A dismissed thread is
+ * not shown at all; the transcript is where it left its trace.
  *
- * A decision also knows where it lives. Hovering a question lights up the
- * passage it concerns; hovering its answer lights up the prose that answer
- * produced. The highlight is written to the DOM rather than the document — it
- * is one reader's pointer, not a fact about the plan, and putting it in the
- * document would send it to everybody else and make it undoable.
+ * An item also knows where it lives. Hovering a question lights the passage it
+ * concerns; hovering a comment lights the phrase it marks. The highlight is
+ * written to the DOM rather than the document — it is one reader's pointer, not
+ * a fact about the plan, and putting it in the document would send it to
+ * everybody else and make it undoable.
  */
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
+import { DraftCard, ThreadCard } from "./comments";
 import { useQuestionnaires } from "./questionnaires";
+import { useThreads } from "./threads";
 import { QuestionnaireCard } from "./widgets/questionnaire";
 
 import type { Transport } from "@chopin/question/react";
 import type { QuestionnaireEntry, QuestionnaireStore } from "./questionnaires";
+import type { ThreadStore } from "./threads";
 
 export type DecisionsProps = {
 	store: QuestionnaireStore;
+	threads: ThreadStore;
 	wire?: Transport;
 	connected?: boolean;
 	/**
-	 * A questionnaire to bring into view.
+	 * An item to bring into view.
 	 *
 	 * Carries a token as well as an id so asking for the same one twice still
 	 * scrolls — naming it again means "show me", not "it is already open".
@@ -42,9 +47,11 @@ function undecided(entry: QuestionnaireEntry): boolean {
 	return entry.value.questions.some(question => question.answer === undefined);
 }
 
-export function Decisions({ connected, reveal, store, wire }: DecisionsProps) {
+export function Decisions({ connected, reveal, store, threads, wire }: DecisionsProps) {
 	let entries = useQuestionnaires(store);
+	let state = useThreads(threads);
 	let content = useRef<HTMLDivElement>(null);
+	let [history, setHistory] = useState(false);
 
 	// Leaving the pane should not leave the prose lit. A highlight belongs to
 	// the pointer that asked for it.
@@ -58,8 +65,44 @@ export function Decisions({ connected, reveal, store, wire }: DecisionsProps) {
 		target?.scrollIntoView({ block: "center", behavior: "smooth" });
 	}, [entries, reveal]);
 
-	// Undecided first: one of those is blocking somebody, the rest are history.
-	let ordered = [...entries].sort((a, b) => Number(undecided(b)) - Number(undecided(a)));
+	let open = state.threads.filter(view => view.thread.status === "open");
+	let accepted = state.threads.filter(view => view.thread.status === "accepted");
+	let waiting = entries.filter(undecided);
+	let settled = entries.filter(entry => !undecided(entry));
+
+	let outstanding = waiting.length + open.length;
+	let resolved = settled.length + accepted.length;
+
+	let card = (view: (typeof state.threads)[number]) => (
+		<ThreadCard
+			applied={view.applied}
+			busy={!connected}
+			focused={state.focused === view.thread.id}
+			key={view.thread.id}
+			onAccept={() => threads.accept(view.thread.id)}
+			onBlur={() => threads.focus(undefined)}
+			onDismiss={() => threads.dismiss(view.thread.id)}
+			onFocus={() => threads.focus(view.thread.id)}
+			onReply={text => threads.reply(view.thread.id, text)}
+			onRetry={() => threads.retry(view.thread.id)}
+			onTyping={writing => threads.announce(view.thread.id, writing)}
+			quote={view.quote}
+			view={view}
+			writing={state.writing[view.thread.id]}
+		/>
+	);
+
+	let question = (entry: QuestionnaireEntry) => (
+		<QuestionnaireCard
+			connected={connected}
+			key={entry.id}
+			onRelationEnter={(q, relation) => store.highlight(entry.id, q, relation)}
+			onRelationLeave={() => store.clear()}
+			relations={store.counts(entry.id)}
+			value={entry.value}
+			wire={wire}
+		/>
+	);
 
 	return (
 		<div className="plan-decisions">
@@ -67,34 +110,58 @@ export function Decisions({ connected, reveal, store, wire }: DecisionsProps) {
 				<span className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
 					Decisions
 				</span>
-				{entries.length > 0 && (
-					<span className="text-xs text-muted-foreground">{entries.length}</span>
-				)}
+				{outstanding > 0 && <span className="text-xs text-muted-foreground">{outstanding}</span>}
 			</header>
 
 			<div className="min-h-0 flex-1 overflow-auto p-3" ref={content}>
-				{ordered.length === 0
+				{state.draft && (
+					<div className="mb-3">
+						<DraftCard
+							busy={!connected}
+							onCancel={() => threads.draft(undefined)}
+							onSend={text => threads.start(text)}
+							quote={state.draft.quote}
+						/>
+					</div>
+				)}
+
+				{state.error && (
+					<p className="mb-3 rounded-md border border-destructive px-2 py-1.5 text-xs text-destructive">
+						{state.error} Select the passage again.
+					</p>
+				)}
+
+				{outstanding === 0 && resolved === 0 && !state.draft
 					? (
 						<p className="m-0 text-xs text-muted-foreground">
-							Questions the agent asks appear here, and stay as a record of what was decided.
+							Select any of the plan to comment on it. Questions the agent asks appear here too, and
+							both stay as a record of what was decided.
 						</p>
 					)
 					: (
 						<div className="flex flex-col gap-3">
-							{ordered.map(entry => (
-								<QuestionnaireCard
-									connected={connected}
-									key={entry.id}
-									onRelationEnter={(question, relation) =>
-										store.highlight(entry.id, question, relation)}
-									onRelationLeave={() => store.clear()}
-									relations={store.counts(entry.id)}
-									value={entry.value}
-									wire={wire}
-								/>
-							))}
+							{waiting.map(question)}
+							{open.map(card)}
 						</div>
 					)}
+
+				{resolved > 0 && (
+					<div className={outstanding > 0 || state.draft ? "mt-3" : ""}>
+						<button
+							className="w-full rounded-md px-1 py-1 text-left text-xs text-muted-foreground hover:text-foreground"
+							onClick={() => setHistory(value => !value)}
+							type="button"
+						>
+							{history ? "▾" : "▸"} {resolved} resolved
+						</button>
+						{history && (
+							<div className="mt-2 flex flex-col gap-3">
+								{accepted.map(card)}
+								{settled.map(question)}
+							</div>
+						)}
+					</div>
+				)}
 			</div>
 		</div>
 	);

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -12,5 +12,7 @@ export { QuestionnaireObserver, QuestionnaireStore, useQuestionnaires } from "./
 export type { QuestionnaireEntry } from "./questionnaires";
 export { PlanStatus } from "./status";
 export type { PlanStatusProps } from "./status";
+export { ThreadObserver, ThreadStore, useThreads } from "./threads";
+export type { Draft, ThreadState, ThreadView } from "./threads";
 export type { Connection, Transport, Unsubscribe } from "./transport";
 export { QuestionnaireCard, register as registerPlanWidgets } from "./widgets";

--- a/packages/editor/src/marks.test.ts
+++ b/packages/editor/src/marks.test.ts
@@ -40,47 +40,44 @@ afterEach(() => {
 
 describe("sharing the registry", () => {
 	it("keeps what each store asked for", () => {
-		paint(editor, "questions", [{ tone: "related", points: points("q") }]);
-		paint(editor, "comments", [{ tone: "comment", points: points("c") }]);
+		paint(editor, "questions", [points("q")]);
+		paint(editor, "comments", [points("c")]);
 
-		expect(union().get("related")).toEqual([points("q")]);
-		expect(union().get("comment")).toEqual([points("c")]);
+		expect(union()).toEqual([points("q"), points("c")]);
 	});
 
 	/** The bug this exists for: repainting one used to wipe the other. */
 	it("does not drop one store's marks when the other repaints", () => {
-		paint(editor, "comments", [{ tone: "comment", points: points("c") }]);
-		paint(editor, "questions", [{ tone: "related", points: points("q") }]);
-		paint(editor, "questions", [{ tone: "related", points: points("q2") }]);
+		paint(editor, "comments", [points("c")]);
+		paint(editor, "questions", [points("q")]);
+		paint(editor, "questions", [points("q2")]);
 
-		expect(union().get("comment")).toEqual([points("c")]);
-		expect(union().get("related")).toEqual([points("q2")]);
+		expect(union()).toEqual([points("c"), points("q2")]);
 	});
 
 	it("removes only its own when a store asks for nothing", () => {
-		paint(editor, "comments", [{ tone: "comment", points: points("c") }]);
-		paint(editor, "questions", [{ tone: "related", points: points("q") }]);
+		paint(editor, "comments", [points("c")]);
+		paint(editor, "questions", [points("q")]);
 
 		paint(editor, "questions", []);
 
-		expect(union().get("related")).toBeUndefined();
-		expect(union().get("comment")).toEqual([points("c")]);
+		expect(union()).toEqual([points("c")]);
 	});
 
-	it("gathers marks of one tone from both stores", () => {
-		paint(editor, "questions", [{ tone: "related", points: points("q") }]);
-		paint(editor, "comments", [{ tone: "related", points: points("c") }]);
+	it("marks both at once when a reader points at one of each", () => {
+		paint(editor, "questions", [points("q")]);
+		paint(editor, "comments", [points("c1"), points("c2")]);
 
-		expect(union().get("related")).toEqual([points("q"), points("c")]);
+		expect(union()).toEqual([points("q"), points("c1"), points("c2")]);
 	});
 
 	it("takes everything down when the editor goes away", () => {
-		paint(editor, "questions", [{ tone: "related", points: points("q") }]);
-		paint(editor, "comments", [{ tone: "comment", points: points("c") }]);
+		paint(editor, "questions", [points("q")]);
+		paint(editor, "comments", [points("c")]);
 
 		clear();
 
-		expect([...union().keys()]).toEqual([]);
+		expect(union()).toEqual([]);
 	});
 
 	/**
@@ -97,7 +94,7 @@ describe("sharing the registry", () => {
 		let complain = console.error;
 		console.error = () => {};
 		try {
-			expect(() => paint(broken, "comments", [{ tone: "comment", points: points("c") }]))
+			expect(() => paint(broken, "comments", [points("c")]))
 				.not.toThrow();
 		} finally {
 			console.error = complain;

--- a/packages/editor/src/marks.test.ts
+++ b/packages/editor/src/marks.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Two stores, one registry.
+ *
+ * `CSS.highlights` is document-wide and painting sets it wholesale, so the
+ * question sidecar and the comment sidecar cannot each own it — the second to
+ * repaint would erase the first. What is worth pinning is that they coexist:
+ * declaring what one wants marked never drops what the other asked for.
+ *
+ * The registration itself is not tested. There is no `CSS.highlights` in the
+ * test runtime and no layout to measure, which is the same reason the toolbar's
+ * placement has no test either.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { clear, paint, union } from "./marks";
+
+import type { LexicalEditor } from "lexical";
+import type { Points } from "./passage";
+
+/**
+ * Enough of an editor for painting to run through.
+ *
+ * Reads pass straight through; there is no DOM, so the fallback finds no
+ * elements and does nothing, which is what we want it to do here.
+ */
+let editor = {
+	getEditorState: () => ({ read: (fn: () => void) => fn() }),
+	getElementByKey: () => null,
+	getRootElement: () => null,
+} as unknown as LexicalEditor;
+
+function points(key: string): Points {
+	return { anchorKey: key, anchorOffset: 0, focusKey: key, focusOffset: 1 };
+}
+
+afterEach(() => {
+	clear();
+});
+
+describe("sharing the registry", () => {
+	it("keeps what each store asked for", () => {
+		paint(editor, "questions", [{ tone: "related", points: points("q") }]);
+		paint(editor, "comments", [{ tone: "comment", points: points("c") }]);
+
+		expect(union().get("related")).toEqual([points("q")]);
+		expect(union().get("comment")).toEqual([points("c")]);
+	});
+
+	/** The bug this exists for: repainting one used to wipe the other. */
+	it("does not drop one store's marks when the other repaints", () => {
+		paint(editor, "comments", [{ tone: "comment", points: points("c") }]);
+		paint(editor, "questions", [{ tone: "related", points: points("q") }]);
+		paint(editor, "questions", [{ tone: "related", points: points("q2") }]);
+
+		expect(union().get("comment")).toEqual([points("c")]);
+		expect(union().get("related")).toEqual([points("q2")]);
+	});
+
+	it("removes only its own when a store asks for nothing", () => {
+		paint(editor, "comments", [{ tone: "comment", points: points("c") }]);
+		paint(editor, "questions", [{ tone: "related", points: points("q") }]);
+
+		paint(editor, "questions", []);
+
+		expect(union().get("related")).toBeUndefined();
+		expect(union().get("comment")).toEqual([points("c")]);
+	});
+
+	it("gathers marks of one tone from both stores", () => {
+		paint(editor, "questions", [{ tone: "related", points: points("q") }]);
+		paint(editor, "comments", [{ tone: "related", points: points("c") }]);
+
+		expect(union().get("related")).toEqual([points("q"), points("c")]);
+	});
+
+	it("takes everything down when the editor goes away", () => {
+		paint(editor, "questions", [{ tone: "related", points: points("q") }]);
+		paint(editor, "comments", [{ tone: "comment", points: points("c") }]);
+
+		clear();
+
+		expect([...union().keys()]).toEqual([]);
+	});
+
+	/**
+	 * Reached from a Lexical update listener, where a throw skips every
+	 * listener after it — including the one that syncs the document.
+	 */
+	it("never throws, whatever the editor does", () => {
+		let broken = {
+			getEditorState() {
+				throw new Error("the editor is gone");
+			},
+		} as unknown as LexicalEditor;
+
+		let complain = console.error;
+		console.error = () => {};
+		try {
+			expect(() => paint(broken, "comments", [{ tone: "comment", points: points("c") }]))
+				.not.toThrow();
+		} finally {
+			console.error = complain;
+		}
+	});
+});

--- a/packages/editor/src/marks.ts
+++ b/packages/editor/src/marks.ts
@@ -1,0 +1,123 @@
+/**
+ * Marking commented prose.
+ *
+ * Through the CSS Custom Highlight API, which is what Lexical already uses for
+ * remote selections. Ranges live in a document-wide registry keyed by name and
+ * are styled by `::highlight()` rules, so nothing is inserted into the tree:
+ * the dialect has no mark node, and adding one would put one reader's pointer
+ * into everybody's document and make it undoable.
+ *
+ * The names cannot collide with Lexical's, which are `lexical-cursor-<id>`.
+ *
+ * Overlapping ranges in one highlight paint once rather than stacking, which is
+ * what makes two comments on the same sentence look like one mark. Telling them
+ * apart is the sidecar's job, and clicking is resolved to the innermost.
+ *
+ * Where the API is missing the whole passage cannot be marked, so the blocks it
+ * covers are outlined instead — the same `data-plan-related` treatment a
+ * decision's prose already gets. Less precise, and honest about it, which beats
+ * hand-positioning rectangles over text that scrolls.
+ */
+
+import { createDOMRange } from "@lexical/selection";
+import { $getNodeByKey } from "lexical";
+
+import type { LexicalEditor } from "lexical";
+import type { Points } from "./passage";
+
+/** What a marked passage is: open comment, the one in focus, or decided. */
+export type Tone = "open" | "current" | "decided";
+
+const NAMES: Record<Tone, string> = {
+	open: "plan-comment",
+	current: "plan-comment-current",
+	decided: "plan-decision",
+};
+
+export type Marked = { tone: Tone; points: Points };
+
+function available(): boolean {
+	return typeof CSS !== "undefined" && !!CSS.highlights && typeof Highlight === "function";
+}
+
+/** Build the DOM range a passage covers. Call inside a read. */
+function $rangeOf(editor: LexicalEditor, points: Points): Range | null {
+	let anchor = $getNodeByKey(points.anchorKey);
+	let focus = $getNodeByKey(points.focusKey);
+	if (!anchor || !focus) return null;
+
+	return createDOMRange(editor, anchor, points.anchorOffset, focus, points.focusOffset);
+}
+
+/**
+ * Repaint every mark.
+ *
+ * Wholesale rather than incremental: the registry is small, the ranges are
+ * invalidated by any edit anywhere, and a diff would be a second model of what
+ * is on screen for no gain.
+ */
+export function paint(editor: LexicalEditor, marks: Marked[]): void {
+	if (!available()) return fallback(editor, marks);
+
+	let ranges = new Map<Tone, Range[]>();
+	editor.getEditorState().read(() => {
+		for (let mark of marks) {
+			let range = $rangeOf(editor, mark.points);
+			if (!range) continue;
+			ranges.set(mark.tone, [...ranges.get(mark.tone) ?? [], range]);
+		}
+	});
+
+	for (let [tone, name] of Object.entries(NAMES) as Array<[Tone, string]>) {
+		let list = ranges.get(tone);
+		if (!list || list.length === 0) CSS.highlights.delete(name);
+		else CSS.highlights.set(name, new Highlight(...list));
+	}
+}
+
+/** Take every mark down. Called when the editor goes away. */
+export function clear(editor?: LexicalEditor): void {
+	if (available()) {
+		for (let name of Object.values(NAMES)) CSS.highlights.delete(name);
+	}
+	if (editor) outline(editor, []);
+}
+
+/** Blocks currently outlined by the fallback, so they can be un-outlined. */
+const outlined = new WeakMap<LexicalEditor, string[]>();
+
+function fallback(editor: LexicalEditor, marks: Marked[]): void {
+	let keys: string[] = [];
+	for (let mark of marks) {
+		if (mark.tone === "decided") continue;
+		for (let key of [mark.points.anchorKey, mark.points.focusKey]) {
+			let block = blockOf(editor, key);
+			if (block && !keys.includes(block)) keys.push(block);
+		}
+	}
+	outline(editor, keys);
+}
+
+function blockOf(editor: LexicalEditor, key: string): string | undefined {
+	let found: string | undefined;
+	editor.getEditorState().read(() => {
+		let node = $getNodeByKey(key);
+		while (node) {
+			let parent = node.getParent();
+			if (!parent || parent.getKey() === "root") break;
+			node = parent;
+		}
+		found = node?.getKey();
+	});
+	return found;
+}
+
+function outline(editor: LexicalEditor, keys: string[]): void {
+	for (let key of outlined.get(editor) ?? []) {
+		editor.getElementByKey(key)?.removeAttribute("data-plan-related");
+	}
+	for (let key of keys) {
+		editor.getElementByKey(key)?.setAttribute("data-plan-related", "");
+	}
+	outlined.set(editor, keys);
+}

--- a/packages/editor/src/marks.ts
+++ b/packages/editor/src/marks.ts
@@ -40,8 +40,14 @@ function available(): boolean {
 	return typeof CSS !== "undefined" && !!CSS.highlights && typeof Highlight === "function";
 }
 
-/** Build the DOM range a passage covers. Call inside a read. */
-function $rangeOf(editor: LexicalEditor, points: Points): Range | null {
+/**
+ * Build the DOM range a passage covers. Call inside a read.
+ *
+ * Exported so hit-testing builds its range the same way painting does. Points
+ * may name a text offset or a child index — a phrase or a whole block — and
+ * `createDOMRange` handles both, which hand-rolling from `firstChild` does not.
+ */
+export function $rangeOf(editor: LexicalEditor, points: Points): Range | null {
 	let anchor = $getNodeByKey(points.anchorKey);
 	let focus = $getNodeByKey(points.focusKey);
 	if (!anchor || !focus) return null;

--- a/packages/editor/src/marks.ts
+++ b/packages/editor/src/marks.ts
@@ -57,21 +57,29 @@ function $rangeOf(editor: LexicalEditor, points: Points): Range | null {
  * is on screen for no gain.
  */
 export function paint(editor: LexicalEditor, marks: Marked[]): void {
-	if (!available()) return fallback(editor, marks);
+	try {
+		if (!available()) return fallback(editor, marks);
 
-	let ranges = new Map<Tone, Range[]>();
-	editor.getEditorState().read(() => {
-		for (let mark of marks) {
-			let range = $rangeOf(editor, mark.points);
-			if (!range) continue;
-			ranges.set(mark.tone, [...ranges.get(mark.tone) ?? [], range]);
+		let ranges = new Map<Tone, Range[]>();
+		editor.getEditorState().read(() => {
+			for (let mark of marks) {
+				let range = $rangeOf(editor, mark.points);
+				if (!range) continue;
+				ranges.set(mark.tone, [...ranges.get(mark.tone) ?? [], range]);
+			}
+		});
+
+		for (let [tone, name] of Object.entries(NAMES) as Array<[Tone, string]>) {
+			let list = ranges.get(tone);
+			if (!list || list.length === 0) CSS.highlights.delete(name);
+			else CSS.highlights.set(name, new Highlight(...list));
 		}
-	});
-
-	for (let [tone, name] of Object.entries(NAMES) as Array<[Tone, string]>) {
-		let list = ranges.get(tone);
-		if (!list || list.length === 0) CSS.highlights.delete(name);
-		else CSS.highlights.set(name, new Highlight(...list));
+	} catch (err) {
+		// This is reached from a Lexical update listener, and Lexical runs
+		// those in one unisolated loop — a throw here would skip the listener
+		// that syncs the document. Losing a highlight is the cheapest possible
+		// outcome and the only acceptable one.
+		console.error("[plan] could not mark commented prose:", err);
 	}
 }
 

--- a/packages/editor/src/marks.ts
+++ b/packages/editor/src/marks.ts
@@ -1,5 +1,5 @@
 /**
- * Marking commented prose.
+ * Marking prose the sidecar refers to.
  *
  * Through the CSS Custom Highlight API, which is what Lexical already uses for
  * remote selections. Ranges live in a document-wide registry keyed by name and
@@ -7,46 +7,87 @@
  * the dialect has no mark node, and adding one would put one reader's pointer
  * into everybody's document and make it undoable.
  *
- * The names cannot collide with Lexical's, which are `lexical-cursor-<id>`.
+ * One mechanism for both features, deliberately. Questions used to outline a
+ * block through a DOM attribute while comments washed a range, so the same
+ * fact — this prose is what that decision produced — looked like two different
+ * things depending on which half of the sidecar it came from. `::highlight()`
+ * cannot draw an outline, so the wash is what they can both be.
  *
- * Overlapping ranges in one highlight paint once rather than stacking, which is
- * what makes two comments on the same sentence look like one mark. Telling them
- * apart is the sidecar's job, and clicking is resolved to the innermost.
+ * The registry is document-wide, so it is owned here rather than by either
+ * store. Each declares what it wants marked and the union is painted; neither
+ * can erase the other by repainting itself.
  *
- * Where the API is missing the whole passage cannot be marked, so the blocks it
- * covers are outlined instead — the same `data-plan-related` treatment a
- * decision's prose already gets. Less precise, and honest about it, which beats
+ * Names cannot collide with Lexical's, which are `lexical-cursor-<id>`.
+ *
+ * Overlapping ranges in one highlight paint once, which is what makes two
+ * comments on the same sentence look like one mark. Telling them apart is the
+ * sidecar's job, and clicking is resolved to the innermost.
+ *
+ * Where the API is missing the prose cannot be washed, so the blocks it covers
+ * are outlined instead. Less precise, and honest about it, which beats
  * hand-positioning rectangles over text that scrolls.
  */
 
-import { createDOMRange } from "@lexical/selection";
 import { $getNodeByKey } from "lexical";
+
+import { createDOMRange } from "@lexical/selection";
 
 import type { LexicalEditor } from "lexical";
 import type { Points } from "./passage";
 
-/** What a marked passage is: open comment, the one in focus, or decided. */
-export type Tone = "open" | "current" | "decided";
+/**
+ * What a mark says.
+ *
+ * `related` is the reader's pointer and belongs to whichever card they are
+ * touching, so it is shared: hovering a question and hovering a comment light
+ * their prose the same way. The other two are standing marks, and say what is
+ * true of the prose rather than what the reader is doing.
+ */
+export type Tone = "comment" | "decision" | "related";
 
-const NAMES: Record<Tone, string> = {
-	open: "plan-comment",
-	current: "plan-comment-current",
-	decided: "plan-decision",
-};
+/** Which store a mark came from. */
+export type Owner = "questions" | "comments";
 
 export type Marked = { tone: Tone; points: Points };
+
+const NAMES: Record<Tone, string> = {
+	comment: "plan-comment",
+	decision: "plan-decision",
+	related: "plan-related",
+};
+
+/**
+ * Which mark wins where two cover the same words.
+ *
+ * Set explicitly rather than left to registration order: the pointer has to
+ * beat a standing mark, and a rule that depends on the order a `Map` happened
+ * to be built in is a rule nobody can see.
+ */
+const PRIORITY: Record<Tone, number> = { decision: 0, comment: 1, related: 2 };
+
+/** What each store wants marked, most recently declared. */
+const wanted = new Map<Owner, Marked[]>();
+
+/**
+ * Everything to paint, by tone.
+ *
+ * Pure, and exported for that reason: whether two stores can coexist in one
+ * registry is the part of this worth testing, and it is the part that does not
+ * need a browser.
+ */
+export function union(): Map<Tone, Points[]> {
+	let out = new Map<Tone, Points[]>();
+	for (let marks of wanted.values()) {
+		for (let mark of marks) out.set(mark.tone, [...out.get(mark.tone) ?? [], mark.points]);
+	}
+	return out;
+}
 
 function available(): boolean {
 	return typeof CSS !== "undefined" && !!CSS.highlights && typeof Highlight === "function";
 }
 
-/**
- * Build the DOM range a passage covers. Call inside a read.
- *
- * Exported so hit-testing builds its range the same way painting does. Points
- * may name a text offset or a child index — a phrase or a whole block — and
- * `createDOMRange` handles both, which hand-rolling from `firstChild` does not.
- */
+/** Build the DOM range a passage covers. Call inside a read. */
 export function $rangeOf(editor: LexicalEditor, points: Points): Range | null {
 	let anchor = $getNodeByKey(points.anchorKey);
 	let focus = $getNodeByKey(points.focusKey);
@@ -56,41 +97,49 @@ export function $rangeOf(editor: LexicalEditor, points: Points): Range | null {
 }
 
 /**
- * Repaint every mark.
+ * Declare what one store wants marked, and repaint.
  *
  * Wholesale rather than incremental: the registry is small, the ranges are
  * invalidated by any edit anywhere, and a diff would be a second model of what
  * is on screen for no gain.
  */
-export function paint(editor: LexicalEditor, marks: Marked[]): void {
+export function paint(editor: LexicalEditor, owner: Owner, marks: Marked[]): void {
 	try {
-		if (!available()) return fallback(editor, marks);
+		wanted.set(owner, marks);
+		if (!available()) return fallback(editor);
 
 		let ranges = new Map<Tone, Range[]>();
 		editor.getEditorState().read(() => {
-			for (let mark of marks) {
-				let range = $rangeOf(editor, mark.points);
-				if (!range) continue;
-				ranges.set(mark.tone, [...ranges.get(mark.tone) ?? [], range]);
+			for (let [tone, places] of union()) {
+				for (let points of places) {
+					let range = $rangeOf(editor, points);
+					if (range) ranges.set(tone, [...ranges.get(tone) ?? [], range]);
+				}
 			}
 		});
 
 		for (let [tone, name] of Object.entries(NAMES) as Array<[Tone, string]>) {
 			let list = ranges.get(tone);
-			if (!list || list.length === 0) CSS.highlights.delete(name);
-			else CSS.highlights.set(name, new Highlight(...list));
+			if (!list || list.length === 0) {
+				CSS.highlights.delete(name);
+				continue;
+			}
+			let highlight = new Highlight(...list);
+			highlight.priority = PRIORITY[tone];
+			CSS.highlights.set(name, highlight);
 		}
 	} catch (err) {
 		// This is reached from a Lexical update listener, and Lexical runs
 		// those in one unisolated loop — a throw here would skip the listener
 		// that syncs the document. Losing a highlight is the cheapest possible
 		// outcome and the only acceptable one.
-		console.error("[plan] could not mark commented prose:", err);
+		console.error("[plan] could not mark prose:", err);
 	}
 }
 
 /** Take every mark down. Called when the editor goes away. */
 export function clear(editor?: LexicalEditor): void {
+	wanted.clear();
 	if (available()) {
 		for (let name of Object.values(NAMES)) CSS.highlights.delete(name);
 	}
@@ -100,29 +149,42 @@ export function clear(editor?: LexicalEditor): void {
 /** Blocks currently outlined by the fallback, so they can be un-outlined. */
 const outlined = new WeakMap<LexicalEditor, string[]>();
 
-function fallback(editor: LexicalEditor, marks: Marked[]): void {
+function fallback(editor: LexicalEditor): void {
 	let keys: string[] = [];
-	for (let mark of marks) {
-		if (mark.tone === "decided") continue;
-		for (let key of [mark.points.anchorKey, mark.points.focusKey]) {
-			let block = blockOf(editor, key);
+	for (let [tone, places] of union()) {
+		// A standing mark on every decided passage would outline half the plan;
+		// without the API the pointer is the only one worth drawing.
+		if (tone !== "related") continue;
+		for (let points of places) {
+			let block = blockOf(editor, points.anchorKey);
 			if (block && !keys.includes(block)) keys.push(block);
 		}
 	}
 	outline(editor, keys);
 }
 
+/**
+ * The block a key sits in.
+ *
+ * Guarded per key: one that cannot be resolved is one outline nobody gets, and
+ * abandoning the rest of the marks over it would be a worse answer than
+ * drawing the ones that do resolve.
+ */
 function blockOf(editor: LexicalEditor, key: string): string | undefined {
 	let found: string | undefined;
-	editor.getEditorState().read(() => {
-		let node = $getNodeByKey(key);
-		while (node) {
-			let parent = node.getParent();
-			if (!parent || parent.getKey() === "root") break;
-			node = parent;
-		}
-		found = node?.getKey();
-	});
+	try {
+		editor.getEditorState().read(() => {
+			let node = $getNodeByKey(key);
+			while (node) {
+				let parent = node.getParent();
+				if (!parent || parent.getKey() === "root") break;
+				node = parent;
+			}
+			found = node?.getKey();
+		});
+	} catch {
+		return undefined;
+	}
 	return found;
 }
 

--- a/packages/editor/src/marks.ts
+++ b/packages/editor/src/marks.ts
@@ -1,5 +1,5 @@
 /**
- * Marking prose the sidecar refers to.
+ * Marking the prose a sidecar card refers to.
  *
  * Through the CSS Custom Highlight API, which is what Lexical already uses for
  * remote selections. Ranges live in a document-wide registry keyed by name and
@@ -7,21 +7,24 @@
  * the dialect has no mark node, and adding one would put one reader's pointer
  * into everybody's document and make it undoable.
  *
- * One mechanism for both features, deliberately. Questions used to outline a
- * block through a DOM attribute while comments washed a range, so the same
- * fact — this prose is what that decision produced — looked like two different
- * things depending on which half of the sidecar it came from. `::highlight()`
- * cannot draw an outline, so the wash is what they can both be.
+ * One mark, and only while somebody is pointing at the card that owns it.
+ * Standing marks were tried and taken out again: a plan accumulates decisions,
+ * so anything painted permanently ends up painted over most of the prose, and
+ * a document that is mostly highlighted says nothing at all. Which prose a
+ * comment or a decision concerns is the sidecar's to answer, and it answers on
+ * demand.
+ *
+ * One mechanism for both halves of the sidecar, too. Questions used to outline
+ * a block through a DOM attribute while comments washed a range, so the same
+ * fact — this is the prose that card refers to — read as two different things
+ * depending on which card it came from. `::highlight()` cannot draw an outline,
+ * so the wash is what they can both be.
  *
  * The registry is document-wide, so it is owned here rather than by either
  * store. Each declares what it wants marked and the union is painted; neither
  * can erase the other by repainting itself.
  *
- * Names cannot collide with Lexical's, which are `lexical-cursor-<id>`.
- *
- * Overlapping ranges in one highlight paint once, which is what makes two
- * comments on the same sentence look like one mark. Telling them apart is the
- * sidecar's job, and clicking is resolved to the innermost.
+ * The name cannot collide with Lexical's, which are `lexical-cursor-<id>`.
  *
  * Where the API is missing the prose cannot be washed, so the blocks it covers
  * are outlined instead. Less precise, and honest about it, which beats
@@ -35,52 +38,23 @@ import { createDOMRange } from "@lexical/selection";
 import type { LexicalEditor } from "lexical";
 import type { Points } from "./passage";
 
-/**
- * What a mark says.
- *
- * `related` is the reader's pointer and belongs to whichever card they are
- * touching, so it is shared: hovering a question and hovering a comment light
- * their prose the same way. The other two are standing marks, and say what is
- * true of the prose rather than what the reader is doing.
- */
-export type Tone = "comment" | "decision" | "related";
-
 /** Which store a mark came from. */
 export type Owner = "questions" | "comments";
 
-export type Marked = { tone: Tone; points: Points };
-
-const NAMES: Record<Tone, string> = {
-	comment: "plan-comment",
-	decision: "plan-decision",
-	related: "plan-related",
-};
-
-/**
- * Which mark wins where two cover the same words.
- *
- * Set explicitly rather than left to registration order: the pointer has to
- * beat a standing mark, and a rule that depends on the order a `Map` happened
- * to be built in is a rule nobody can see.
- */
-const PRIORITY: Record<Tone, number> = { decision: 0, comment: 1, related: 2 };
+const NAME = "plan-related";
 
 /** What each store wants marked, most recently declared. */
-const wanted = new Map<Owner, Marked[]>();
+const wanted = new Map<Owner, Points[]>();
 
 /**
- * Everything to paint, by tone.
+ * Everything to paint.
  *
  * Pure, and exported for that reason: whether two stores can coexist in one
  * registry is the part of this worth testing, and it is the part that does not
  * need a browser.
  */
-export function union(): Map<Tone, Points[]> {
-	let out = new Map<Tone, Points[]>();
-	for (let marks of wanted.values()) {
-		for (let mark of marks) out.set(mark.tone, [...out.get(mark.tone) ?? [], mark.points]);
-	}
-	return out;
+export function union(): Points[] {
+	return [...wanted.values()].flat();
 }
 
 function available(): boolean {
@@ -103,31 +77,21 @@ export function $rangeOf(editor: LexicalEditor, points: Points): Range | null {
  * invalidated by any edit anywhere, and a diff would be a second model of what
  * is on screen for no gain.
  */
-export function paint(editor: LexicalEditor, owner: Owner, marks: Marked[]): void {
+export function paint(editor: LexicalEditor, owner: Owner, places: Points[]): void {
 	try {
-		wanted.set(owner, marks);
+		wanted.set(owner, places);
 		if (!available()) return fallback(editor);
 
-		let ranges = new Map<Tone, Range[]>();
+		let ranges: Range[] = [];
 		editor.getEditorState().read(() => {
-			for (let [tone, places] of union()) {
-				for (let points of places) {
-					let range = $rangeOf(editor, points);
-					if (range) ranges.set(tone, [...ranges.get(tone) ?? [], range]);
-				}
+			for (let points of union()) {
+				let range = $rangeOf(editor, points);
+				if (range) ranges.push(range);
 			}
 		});
 
-		for (let [tone, name] of Object.entries(NAMES) as Array<[Tone, string]>) {
-			let list = ranges.get(tone);
-			if (!list || list.length === 0) {
-				CSS.highlights.delete(name);
-				continue;
-			}
-			let highlight = new Highlight(...list);
-			highlight.priority = PRIORITY[tone];
-			CSS.highlights.set(name, highlight);
-		}
+		if (ranges.length === 0) CSS.highlights.delete(NAME);
+		else CSS.highlights.set(NAME, new Highlight(...ranges));
 	} catch (err) {
 		// This is reached from a Lexical update listener, and Lexical runs
 		// those in one unisolated loop — a throw here would skip the listener
@@ -140,9 +104,7 @@ export function paint(editor: LexicalEditor, owner: Owner, marks: Marked[]): voi
 /** Take every mark down. Called when the editor goes away. */
 export function clear(editor?: LexicalEditor): void {
 	wanted.clear();
-	if (available()) {
-		for (let name of Object.values(NAMES)) CSS.highlights.delete(name);
-	}
+	if (available()) CSS.highlights.delete(NAME);
 	if (editor) outline(editor, []);
 }
 
@@ -151,14 +113,9 @@ const outlined = new WeakMap<LexicalEditor, string[]>();
 
 function fallback(editor: LexicalEditor): void {
 	let keys: string[] = [];
-	for (let [tone, places] of union()) {
-		// A standing mark on every decided passage would outline half the plan;
-		// without the API the pointer is the only one worth drawing.
-		if (tone !== "related") continue;
-		for (let points of places) {
-			let block = blockOf(editor, points.anchorKey);
-			if (block && !keys.includes(block)) keys.push(block);
-		}
+	for (let points of union()) {
+		let block = blockOf(editor, points.anchorKey);
+		if (block && !keys.includes(block)) keys.push(block);
 	}
 	outline(editor, keys);
 }

--- a/packages/editor/src/passage.test.ts
+++ b/packages/editor/src/passage.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Turning a selection into something the server can check.
+ *
+ * The client sends block indices, the digests it read them at, and the text it
+ * selected — never a position. So the thing worth pinning is that its idea of
+ * which blocks a selection covers, and what text that is, matches the server's:
+ * the offset is only a hint, but the block indices have to be exact and the
+ * quote has to be findable.
+ *
+ * Resolution and painting are not tested here. Both need real layout, and
+ * happy-dom returns zero for every measurement.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createHeadlessEditor } from "@lexical/headless";
+import { $getRoot, $isElementNode, $setSelection } from "lexical";
+
+import { importPlan, registry } from "@chopin/dialect";
+
+import { $describe } from "./passage";
+
+import type { LexicalEditor, TextNode } from "lexical";
+
+const REGISTRY = registry();
+
+const SOURCE = `# Title
+
+The renderer caches tiles for 60 seconds.
+
+The second paragraph.
+`;
+
+function editor(source = SOURCE): LexicalEditor {
+	let instance = createHeadlessEditor({
+		nodes: REGISTRY.nodes,
+		onError(err) {
+			throw err;
+		},
+	});
+	importPlan(instance, source, { registry: REGISTRY });
+	return instance;
+}
+
+/** The addressable blocks, the way both ends count them. */
+function $blocks() {
+	return $getRoot().getChildren();
+}
+
+/** Select from one offset in a block's text to another, possibly across blocks. */
+function select(
+	instance: LexicalEditor,
+	from: { block: number; at: number },
+	to: { block: number; at: number },
+) {
+	let marked;
+	instance.update(() => {
+		let all = $blocks();
+		let start = all[from.block];
+		let end = all[to.block];
+		if (!$isElementNode(start) || !$isElementNode(end)) throw new Error("not elements");
+
+		let anchor = start.getAllTextNodes()[0] as TextNode;
+		let focus = end.getAllTextNodes()[0] as TextNode;
+
+		let selection = anchor.select(from.at, from.at);
+		selection.focus.set(focus.getKey(), to.at, "text");
+		$setSelection(selection);
+		marked = $describe(selection);
+	}, { discrete: true });
+	return marked as ReturnType<typeof $describe>;
+}
+
+describe("describing a selection", () => {
+	it("names the block it sits in, and the text it covers", () => {
+		let instance = editor();
+		let marked = select(instance, { block: 1, at: 13 }, { block: 1, at: 40 });
+
+		expect(marked?.blocks).toEqual([1]);
+		expect(marked?.quote).toBe("caches tiles for 60 seconds");
+		expect(marked?.length).toBe("caches tiles for 60 seconds".length);
+	});
+
+	it("names every block in a run when the selection crosses one", () => {
+		let instance = editor();
+		let marked = select(instance, { block: 1, at: 30 }, { block: 2, at: 10 });
+
+		expect(marked?.blocks).toEqual([1, 2]);
+		// Blocks join with a newline, which is how the server reads a run too.
+		expect(marked?.quote).toBe("60 seconds.\nThe second");
+	});
+
+	it("reads the same span whichever way it was dragged", () => {
+		let instance = editor();
+		let forward = select(instance, { block: 1, at: 13 }, { block: 1, at: 40 });
+		let backward = select(instance, { block: 1, at: 40 }, { block: 1, at: 13 });
+
+		expect(backward?.quote).toBe(forward?.quote);
+		expect(backward?.offset).toBe(forward?.offset);
+	});
+
+	it("describes nothing for a caret", () => {
+		let instance = editor();
+		expect(select(instance, { block: 1, at: 5 }, { block: 1, at: 5 })).toBeUndefined();
+	});
+
+	/** The extent is carried separately, so a long phrase is marked, not refused. */
+	it("bounds the quote it sends but not the passage it marks", () => {
+		let long = `# Title\n\n${"word ".repeat(400)}\n`;
+		let instance = editor(long);
+		let marked = select(instance, { block: 1, at: 0 }, { block: 1, at: 1_500 });
+
+		expect(marked!.quote.length).toBeLessThanOrEqual(500);
+		expect(marked!.length).toBe(1_500);
+	});
+});

--- a/packages/editor/src/passage.ts
+++ b/packages/editor/src/passage.ts
@@ -1,0 +1,215 @@
+/**
+ * Where a comment's phrase is, in this editor.
+ *
+ * The server owns a passage and keeps it pointed at the right prose. Resolving
+ * one has to happen here anyway, for the reason anchors do: a Lexical key is
+ * per-editor, so the server's key for a text node means nothing in this
+ * browser. The position is the shared thing, and every client resolves it for
+ * itself.
+ *
+ * Going the other way — turning a selection into something the server can
+ * verify — deliberately produces no positions at all. Block indices, the
+ * digests they were read at, and the selected text are all things the server
+ * can check against its own copy, so a client cannot place a comment anywhere
+ * the prose does not agree it belongs.
+ */
+
+import { $getAnchorAndFocusForUserState } from "@lexical/yjs";
+import { $getRoot, $isElementNode, $isParagraphNode, $isRangeSelection } from "lexical";
+import * as Y from "yjs";
+
+import { limits } from "@chopin/dialect";
+
+import type { Binding } from "@lexical/yjs";
+import type { BaseSelection, LexicalNode } from "lexical";
+import type { Plan } from "@chopin/protocol";
+
+/**
+ * Blocks join with a newline, matching how the server reads a run.
+ *
+ * The two have to agree on which blocks the source addresses — empty paragraphs
+ * are skipped at both ends — because an index that means a different block
+ * would mark the wrong prose. They do not have to agree on the offset: the
+ * server searches for the quote near it. A divergence in this convention
+ * therefore shows up as `passageAt` refusing the request, which is loud, rather
+ * than as a comment silently landing somewhere else.
+ */
+const RUN = "\n";
+
+/** A resolved passage, as points in this editor's tree. */
+export type Points = {
+	anchorKey: string;
+	anchorOffset: number;
+	focusKey: string;
+	focusOffset: number;
+};
+
+/** What `comment:start` sends: everything the server can verify for itself. */
+export type Marked = {
+	blocks: number[];
+	quote: string;
+	offset: number;
+	length: number;
+};
+
+type Span = { key: string; start: number; length: number };
+
+/** The blocks the source addresses, in order. Call inside a read. */
+function $addressable(): LexicalNode[] {
+	return $getRoot().getChildren().filter(
+		node => !($isParagraphNode(node) && node.getChildrenSize() === 0),
+	);
+}
+
+/** A block run as one string, with where each text node sits in it. */
+function $runOf(nodes: LexicalNode[]): { text: string; spans: Span[] } {
+	let spans: Span[] = [];
+	let text = "";
+
+	for (let [i, node] of nodes.entries()) {
+		if (i > 0) text += RUN;
+		if (!$isElementNode(node)) continue;
+		for (let leaf of node.getAllTextNodes()) {
+			let value = leaf.getTextContent();
+			spans.push({ key: leaf.getKey(), start: text.length, length: value.length });
+			text += value;
+		}
+	}
+
+	return { text, spans };
+}
+
+function indexOfPoint(spans: Span[], key: string, offset: number): number | undefined {
+	for (let span of spans) {
+		if (span.key === key) return span.start + Math.min(offset, span.length);
+	}
+	return undefined;
+}
+
+/** The top-level block a node sits in. Call inside a read. */
+function $blockOf(node: LexicalNode): LexicalNode {
+	let current = node;
+	while (true) {
+		let parent = current.getParent();
+		if (!parent || parent.getKey() === "root") return current;
+		current = parent;
+	}
+}
+
+/**
+ * Describe a selection as something the server can check.
+ *
+ * Returns nothing for a collapsed selection, or one whose blocks are not
+ * addressable — there is no phrase to mark in either case.
+ */
+export function $describe(selection: BaseSelection | null): Marked | undefined {
+	if (!$isRangeSelection(selection) || selection.isCollapsed()) return undefined;
+
+	let all = $addressable();
+	let first = all.indexOf($blockOf(selection.anchor.getNode()));
+	let last = all.indexOf($blockOf(selection.focus.getNode()));
+	if (first === -1 || last === -1) return undefined;
+	if (first > last) [first, last] = [last, first];
+
+	let blocks = [];
+	for (let index = first; index <= last; index++) blocks.push(index);
+
+	let run = $runOf(blocks.map(index => all[index]!));
+	let from = indexOfPoint(run.spans, selection.anchor.key, selection.anchor.offset);
+	let to = indexOfPoint(run.spans, selection.focus.key, selection.focus.offset);
+	if (from === undefined || to === undefined) return undefined;
+	if (from > to) [from, to] = [to, from];
+	if (from === to) return undefined;
+
+	return {
+		blocks,
+		// A bounded locator, not the phrase: `length` carries the real extent,
+		// so a long selection is marked rather than refused for being long.
+		quote: run.text.slice(from, to).slice(0, limits.MAX_QUOTE),
+		offset: from,
+		length: to - from,
+	};
+}
+
+/**
+ * The points a passage names here, or nothing if it names none.
+ *
+ * The inverse of the arithmetic the server had to reimplement. This half is
+ * exported by `@lexical/yjs`, so it is theirs to keep correct.
+ */
+export function locate(binding: Binding, passage: Plan.Passage): Points | undefined {
+	if (passage.drifted) return undefined;
+
+	try {
+		let found = $getAnchorAndFocusForUserState(binding, {
+			anchorPos: decode(passage.start),
+			focusPos: decode(passage.end),
+			color: "",
+			focusing: false,
+			name: "",
+			awarenessData: {},
+		});
+
+		let { anchorKey, anchorOffset, focusKey, focusOffset } = found;
+		if (!anchorKey || !focusKey) return undefined;
+		return { anchorKey, anchorOffset, focusKey, focusOffset };
+	} catch {
+		// A position from a history this document no longer holds. The server
+		// rebases these; `$recover` is what covers the gap until it has.
+		return undefined;
+	}
+}
+
+/**
+ * Find the phrase by reading, when its positions cannot be resolved.
+ *
+ * A block that moved loses its collaborative identity, and with it every
+ * position inside it, until the server's next rebase — up to two seconds in
+ * which the highlight would otherwise blink out. The server does the durable
+ * version of this; here it only has to last until the next snapshot arrives.
+ */
+export function $recover(passage: Plan.Passage, keys: string[]): Points | undefined {
+	if (passage.drifted || keys.length === 0) return undefined;
+
+	let nodes: LexicalNode[] = [];
+	let all = $addressable();
+	for (let key of keys) {
+		let node = all.find(candidate => candidate.getKey() === key);
+		if (!node) return undefined;
+		nodes.push(node);
+	}
+
+	let run = $runOf(nodes);
+	let at = run.text.indexOf(passage.quote);
+	// Two occurrences of the same phrase recover neither, which is the rule
+	// the server applies for the same reason: the wrong sentence is worse.
+	if (at === -1 || run.text.indexOf(passage.quote, at + 1) !== -1) return undefined;
+
+	let from = place(run.spans, at);
+	let to = place(run.spans, Math.min(at + passage.length, run.text.length));
+	if (!from || !to) return undefined;
+
+	return {
+		anchorKey: from.key,
+		anchorOffset: from.offset,
+		focusKey: to.key,
+		focusOffset: to.offset,
+	};
+}
+
+function place(spans: Span[], index: number): { key: string; offset: number } | undefined {
+	for (let span of spans) {
+		if (index <= span.start + span.length) {
+			return { key: span.key, offset: Math.max(0, index - span.start) };
+		}
+	}
+	let last = spans.at(-1);
+	return last ? { key: last.key, offset: last.length } : undefined;
+}
+
+function decode(value: string): Y.RelativePosition {
+	let binary = atob(value);
+	let out = new Uint8Array(binary.length);
+	for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+	return Y.decodeRelativePosition(out);
+}

--- a/packages/editor/src/passage.ts
+++ b/packages/editor/src/passage.ts
@@ -15,7 +15,13 @@
  */
 
 import { $getAnchorAndFocusForUserState } from "@lexical/yjs";
-import { $getRoot, $isElementNode, $isParagraphNode, $isRangeSelection } from "lexical";
+import {
+	$getNodeByKey,
+	$getRoot,
+	$isElementNode,
+	$isParagraphNode,
+	$isRangeSelection,
+} from "lexical";
 import * as Y from "yjs";
 
 import { limits } from "@chopin/dialect";
@@ -53,6 +59,22 @@ export type Marked = {
 };
 
 type Span = { key: string; start: number; length: number };
+
+/**
+ * A whole block, as points. Call inside a read.
+ *
+ * Child indices rather than text offsets: what a decision produced is block
+ * granular, and `createDOMRange` reads an element point as a child index. A
+ * block with nothing in it has no range worth marking.
+ */
+export function $blockPoints(key: string): Points | undefined {
+	let node = $getNodeByKey(key);
+	if (!$isElementNode(node)) return undefined;
+
+	let size = node.getChildrenSize();
+	if (size === 0) return undefined;
+	return { anchorKey: key, anchorOffset: 0, focusKey: key, focusOffset: size };
+}
 
 /** The blocks the source addresses, in order. Call inside a read. */
 function $addressable(): LexicalNode[] {

--- a/packages/editor/src/places.test.ts
+++ b/packages/editor/src/places.test.ts
@@ -12,7 +12,7 @@
  * returns zero for every measurement.
  */
 
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { createHeadlessEditor } from "@lexical/headless";
 import { createYjsBinding, syncLexicalUpdateToYjs } from "@lexical/yjs";
 import { $getRoot, $isParagraphNode } from "lexical";
@@ -20,11 +20,13 @@ import * as Y from "yjs";
 
 import { importPlan, registry } from "@chopin/dialect";
 
+import { clear, union } from "./marks";
 import { ThreadStore } from "./threads";
 
 import type { Binding, Provider } from "@lexical/yjs";
 import type { LexicalEditor, LexicalNode } from "lexical";
 import type { Comment, Plan } from "@chopin/protocol";
+import type { Tone } from "./marks";
 
 const REGISTRY = registry();
 
@@ -40,6 +42,11 @@ beforeAll(() => {
 });
 afterAll(() => {
 	console.error = complain;
+});
+
+// The highlight registry is document-wide, so it outlives a single store.
+afterEach(() => {
+	clear();
 });
 
 const SOURCE = `# Title
@@ -165,6 +172,11 @@ function store(editor: LexicalEditor, binding: Binding): ThreadStore {
 	return subject;
 }
 
+/** The tones the sidecar is currently asking for. */
+function marked(): Tone[] {
+	return [...union().keys()];
+}
+
 describe("an accepted thread after the agent has acted", () => {
 	it("points at the prose the decision produced", () => {
 		let { binding, editor } = room();
@@ -248,6 +260,43 @@ describe("an accepted thread after the agent has acted", () => {
 		let view = subject.snapshot().threads[0]!;
 		expect(view.places).toHaveLength(1);
 		expect(view.drifted).toBe(false);
+	});
+
+	/**
+	 * Pointing at a card is the same act whichever half of the sidecar it is
+	 * in, so it gets the same mark. What differs is only what is true when
+	 * nobody is pointing.
+	 */
+	it("takes the shared pointer tone when the reader is on its card", () => {
+		let { binding, editor } = room();
+		let subject = store(editor, binding);
+		let value = thread();
+
+		subject.sync([value]);
+		subject.anchors([{
+			thread: value.id,
+			subject: rewritten(),
+			result: { anchors: [anchor(editor, binding, 2)], pending: false },
+		}]);
+
+		expect(marked()).toEqual(["decision"]);
+		subject.focus(value.id);
+		expect(marked()).toEqual(["related"]);
+	});
+
+	it("marks a live comment as waiting on somebody", () => {
+		let { binding, editor } = room();
+		let subject = store(editor, binding);
+		let value = thread({ status: "open", quote: undefined });
+
+		subject.sync([value]);
+		subject.anchors([{
+			thread: value.id,
+			subject: { ...rewritten(), blocks: [anchor(editor, binding, 1)], drifted: undefined },
+			result: { anchors: [], pending: false },
+		}]);
+
+		expect(marked()).toEqual(["comment"]);
 	});
 
 	it("points nowhere when neither end resolves", () => {

--- a/packages/editor/src/places.test.ts
+++ b/packages/editor/src/places.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Where an accepted thread points once the agent has acted.
+ *
+ * The prose a thread was about is usually the prose it asked to have
+ * rewritten, so after the turn the subject is gone by design. Treating that as
+ * the thread having lost its place gets it backwards: what was discussed is
+ * kept as a frozen quote, and what the decision produced is where it now
+ * lives.
+ *
+ * Real Lexical and real Yjs, because the whole question is whether positions
+ * resolve. Painting is still not tested — that needs layout, and happy-dom
+ * returns zero for every measurement.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { createHeadlessEditor } from "@lexical/headless";
+import { createYjsBinding, syncLexicalUpdateToYjs } from "@lexical/yjs";
+import { $getRoot, $isParagraphNode } from "lexical";
+import * as Y from "yjs";
+
+import { importPlan, registry } from "@chopin/dialect";
+
+import { ThreadStore } from "./threads";
+
+import type { Binding, Provider } from "@lexical/yjs";
+import type { LexicalEditor, LexicalNode } from "lexical";
+import type { Comment, Plan } from "@chopin/protocol";
+
+const REGISTRY = registry();
+
+/*
+ * A headless editor refuses `getElementByKey`, so painting cannot work here and
+ * says so on every refresh. That it says so rather than throwing is the guard
+ * doing its job; these tests are about where a thread points, not what that
+ * looks like, so the complaint is quietened rather than worked around.
+ */
+let complain = console.error;
+beforeAll(() => {
+	console.error = () => {};
+});
+afterAll(() => {
+	console.error = complain;
+});
+
+const SOURCE = `# Title
+
+The renderer caches tiles for 60 seconds.
+
+The second paragraph.
+`;
+
+const QUOTE = "caches tiles for 60 seconds";
+
+/** Awareness is never read here, so a no-op provider suffices. */
+const PROVIDER = {
+	awareness: {
+		getLocalState: () => null,
+		getStates: () => new Map(),
+		off() {},
+		on() {},
+		setLocalState() {},
+		setLocalStateField() {},
+	},
+	connect() {},
+	disconnect() {},
+	off() {},
+	on() {},
+} as unknown as Provider;
+
+function room(): { editor: LexicalEditor; binding: Binding } {
+	let editor = createHeadlessEditor({
+		nodes: REGISTRY.nodes,
+		onError(err) {
+			throw err;
+		},
+	});
+
+	let doc = new Y.Doc();
+	let binding = createYjsBinding({ editor, id: "plan", doc, docMap: new Map([["plan", doc]]) });
+
+	editor.registerUpdateListener(
+		({ dirtyElements, dirtyLeaves, editorState, normalizedNodes, prevEditorState, tags }) => {
+			if (tags.has("skip-collab")) return;
+			syncLexicalUpdateToYjs(
+				binding,
+				PROVIDER,
+				prevEditorState,
+				editorState,
+				dirtyElements,
+				dirtyLeaves,
+				normalizedNodes,
+				tags,
+			);
+		},
+	);
+
+	importPlan(editor, SOURCE, { registry: REGISTRY });
+	return { editor, binding };
+}
+
+/** The blocks the source addresses, the way both ends count them. */
+function blocks(editor: LexicalEditor): LexicalNode[] {
+	let found: LexicalNode[] = [];
+	editor.getEditorState().read(() => {
+		found = $getRoot().getChildren().filter(
+			node => !($isParagraphNode(node) && node.getChildrenSize() === 0),
+		);
+	});
+	return found;
+}
+
+function encode(value: Uint8Array): string {
+	let binary = "";
+	for (let byte of value) binary += String.fromCharCode(byte);
+	return btoa(binary);
+}
+
+/**
+ * An anchor on the block at `index`, minted the way the server mints one.
+ *
+ * Index 0 of the block's own shared type: the position is the block's
+ * collaborative identity, not a place inside it.
+ */
+function anchor(editor: LexicalEditor, binding: Binding, index: number): Plan.Anchor {
+	let key = blocks(editor)[index]!.getKey();
+	let type = binding.collabNodeMap.get(key)?.getSharedType();
+	if (!type) throw new Error(`block ${index} has no collaborative identity`);
+
+	return {
+		epoch: "e1",
+		position: encode(Y.encodeRelativePosition(Y.createRelativePositionFromTypeIndex(type, 0, -1))),
+		digest: `sha256:${index}`,
+	};
+}
+
+/** A subject that cannot be resolved, which is what the agent leaves behind. */
+function rewritten(): Plan.Passage {
+	return {
+		blocks: [{ epoch: "e1", position: "", digest: "sha256:gone", orphaned: true }],
+		start: "",
+		end: "",
+		quote: QUOTE,
+		offset: 0,
+		length: QUOTE.length,
+		drifted: true,
+	};
+}
+
+function thread(over: Partial<Comment.Thread> = {}): Comment.Thread {
+	return {
+		id: "01K0N4TR8K7JGM4R1J7PW4R8YJ",
+		status: "accepted",
+		notes: [{ id: "n1", handle: "ana", text: "Too long.", ts: 1 }],
+		quote: QUOTE,
+		resolver: "kris",
+		at: 2,
+		...over,
+	};
+}
+
+function store(editor: LexicalEditor, binding: Binding): ThreadStore {
+	let subject = new ThreadStore();
+	subject.attach(editor);
+	subject.bind(binding);
+	return subject;
+}
+
+describe("an accepted thread after the agent has acted", () => {
+	it("points at the prose the decision produced", () => {
+		let { binding, editor } = room();
+		let subject = store(editor, binding);
+		let value = thread();
+
+		subject.sync([value]);
+		subject.anchors([{
+			thread: value.id,
+			subject: rewritten(),
+			result: { anchors: [anchor(editor, binding, 2)], pending: false },
+		}]);
+
+		let view = subject.snapshot().threads[0]!;
+		expect(view.places).toHaveLength(1);
+		// Its own text is gone, and it has not lost its place: it moved to what
+		// accepting it caused to be written.
+		expect(view.drifted).toBe(false);
+		expect(view.quote).toBe(QUOTE);
+	});
+
+	it("points at every block the revision produced", () => {
+		let { binding, editor } = room();
+		let subject = store(editor, binding);
+		let value = thread();
+
+		subject.sync([value]);
+		subject.anchors([{
+			thread: value.id,
+			subject: rewritten(),
+			result: {
+				anchors: [anchor(editor, binding, 1), anchor(editor, binding, 2)],
+				pending: false,
+			},
+		}]);
+
+		expect(subject.snapshot().threads[0]?.places).toHaveLength(2);
+	});
+
+	/**
+	 * Pending means nobody has checked this since the plan moved, so it is not
+	 * somewhere worth sending a reader — and the subject is gone, so there is
+	 * nowhere else either.
+	 */
+	it("points nowhere while the result is waiting to be reviewed", () => {
+		let { binding, editor } = room();
+		let subject = store(editor, binding);
+		let value = thread();
+
+		subject.sync([value]);
+		subject.anchors([{
+			thread: value.id,
+			subject: rewritten(),
+			result: {
+				anchors: [anchor(editor, binding, 2)],
+				pending: true,
+				reason: "plan_changed",
+			},
+		}]);
+
+		let view = subject.snapshot().threads[0]!;
+		expect(view.places).toHaveLength(0);
+		expect(view.drifted).toBe(true);
+		expect(view.applied).toBe(false);
+	});
+
+	/** Before the agent runs there is no result, and the phrase is still there. */
+	it("points at the phrase until there is a result to point at instead", () => {
+		let { binding, editor } = room();
+		let subject = store(editor, binding);
+		let value = thread({ status: "open", quote: undefined });
+
+		subject.sync([value]);
+		subject.anchors([{
+			thread: value.id,
+			// Not rewritten: the block is still the one the comment marked.
+			subject: { ...rewritten(), blocks: [anchor(editor, binding, 1)], drifted: undefined },
+			result: { anchors: [], pending: false },
+		}]);
+
+		let view = subject.snapshot().threads[0]!;
+		expect(view.places).toHaveLength(1);
+		expect(view.drifted).toBe(false);
+	});
+
+	it("points nowhere when neither end resolves", () => {
+		let { binding, editor } = room();
+		let subject = store(editor, binding);
+		let value = thread();
+
+		subject.sync([value]);
+		subject.anchors([{
+			thread: value.id,
+			subject: rewritten(),
+			result: { anchors: [], pending: false },
+		}]);
+
+		let view = subject.snapshot().threads[0]!;
+		expect(view.places).toHaveLength(0);
+		expect(view.drifted).toBe(true);
+		// Still readable: the conversation is the durable part of a comment.
+		expect(view.thread.notes).toHaveLength(1);
+	});
+});

--- a/packages/editor/src/places.test.ts
+++ b/packages/editor/src/places.test.ts
@@ -26,7 +26,6 @@ import { ThreadStore } from "./threads";
 import type { Binding, Provider } from "@lexical/yjs";
 import type { LexicalEditor, LexicalNode } from "lexical";
 import type { Comment, Plan } from "@chopin/protocol";
-import type { Tone } from "./marks";
 
 const REGISTRY = registry();
 
@@ -172,9 +171,9 @@ function store(editor: LexicalEditor, binding: Binding): ThreadStore {
 	return subject;
 }
 
-/** The tones the sidecar is currently asking for. */
-function marked(): Tone[] {
-	return [...union().keys()];
+/** How many passages the sidecar is currently asking to have marked. */
+function marked(): number {
+	return union().length;
 }
 
 describe("an accepted thread after the agent has acted", () => {
@@ -263,11 +262,12 @@ describe("an accepted thread after the agent has acted", () => {
 	});
 
 	/**
-	 * Pointing at a card is the same act whichever half of the sidecar it is
-	 * in, so it gets the same mark. What differs is only what is true when
-	 * nobody is pointing.
+	 * Nothing is painted at rest. A plan accumulates decisions, so a standing
+	 * mark ends up covering most of the document — which tells a reader
+	 * nothing. Where a thread points is still known; it is only drawn when
+	 * somebody asks by pointing at the card.
 	 */
-	it("takes the shared pointer tone when the reader is on its card", () => {
+	it("marks nothing until the reader points at its card", () => {
 		let { binding, editor } = room();
 		let subject = store(editor, binding);
 		let value = thread();
@@ -279,24 +279,34 @@ describe("an accepted thread after the agent has acted", () => {
 			result: { anchors: [anchor(editor, binding, 2)], pending: false },
 		}]);
 
-		expect(marked()).toEqual(["decision"]);
+		// It knows where it is either way.
+		expect(subject.snapshot().threads[0]?.places).toHaveLength(1);
+		expect(marked()).toBe(0);
+
 		subject.focus(value.id);
-		expect(marked()).toEqual(["related"]);
+		expect(marked()).toBe(1);
+
+		subject.focus(undefined);
+		expect(marked()).toBe(0);
 	});
 
-	it("marks a live comment as waiting on somebody", () => {
+	it("marks every block a decision produced, not just the first", () => {
 		let { binding, editor } = room();
 		let subject = store(editor, binding);
-		let value = thread({ status: "open", quote: undefined });
+		let value = thread();
 
 		subject.sync([value]);
 		subject.anchors([{
 			thread: value.id,
-			subject: { ...rewritten(), blocks: [anchor(editor, binding, 1)], drifted: undefined },
-			result: { anchors: [], pending: false },
+			subject: rewritten(),
+			result: {
+				anchors: [anchor(editor, binding, 1), anchor(editor, binding, 2)],
+				pending: false,
+			},
 		}]);
+		subject.focus(value.id);
 
-		expect(marked()).toEqual(["comment"]);
+		expect(marked()).toBe(2);
 	});
 
 	it("points nowhere when neither end resolves", () => {

--- a/packages/editor/src/plan-editor.tsx
+++ b/packages/editor/src/plan-editor.tsx
@@ -25,6 +25,7 @@ import type { MDXEditorMethods } from "@mdxeditor/editor";
 import type { Plan } from "@chopin/protocol";
 import type { PlanProvider } from "./provider";
 import type { QuestionnaireStore } from "./questionnaires";
+import type { ThreadStore } from "./threads";
 import type { Connection, Transport } from "./transport";
 
 /**
@@ -60,6 +61,8 @@ export type PlanEditorProps = {
 	 * editor, while the observer that finds them has to run inside it.
 	 */
 	questions?: QuestionnaireStore;
+	/** The same arrangement for comment threads. */
+	threads?: ThreadStore;
 	className?: string;
 };
 
@@ -71,7 +74,7 @@ export type PlanState = {
 };
 
 export function PlanEditor(
-	{ busy, className, connection, questions, user, wire }: PlanEditorProps,
+	{ busy, className, connection, questions, threads, user, wire }: PlanEditorProps,
 ) {
 	let ref = useRef<MDXEditorMethods>(null);
 	let scroller = useRef<HTMLDivElement>(null);
@@ -94,11 +97,16 @@ export function PlanEditor(
 	// the server's key for a block means nothing in this browser.
 	let onBinding = useCallback((value: Binding | undefined) => {
 		questions?.bind(value);
-	}, [questions]);
+		threads?.bind(value);
+	}, [questions, threads]);
 
-	let onAnchors = useCallback((widgets: Plan.WidgetAnchors[]) => {
-		questions?.anchors(widgets);
-	}, [questions]);
+	let onAnchors = useCallback(
+		(snapshot: { widgets: Plan.WidgetAnchors[]; threads: Plan.ThreadAnchors[] }) => {
+			questions?.anchors(snapshot.widgets);
+			threads?.anchors(snapshot.threads);
+		},
+		[questions, threads],
+	);
 
 	let onProvider = useCallback((value: PlanProvider | undefined) => {
 		provider.current = value;
@@ -141,10 +149,10 @@ export function PlanEditor(
 					 * it has no reason to throw.
 					 */
 					collaborationPlugin({ wire, user, onReset, onProvider, onBinding, onAnchors }),
-					widgetsPlugin({ questions }),
+					widgetsPlugin({ questions, threads }),
 				]
 				: [],
-		[wire, user, onReset, onProvider, onBinding, onAnchors, questions],
+		[wire, user, onReset, onProvider, onBinding, onAnchors, questions, threads],
 	);
 
 	useEffect(() => {

--- a/packages/editor/src/plan-editor.tsx
+++ b/packages/editor/src/plan-editor.tsx
@@ -71,6 +71,8 @@ export type PlanState = {
 	synced: boolean;
 	/** Why the document was last replaced, if it was. */
 	reset?: Plan.Reset["reason"];
+	/** Why it could not be opened at all, if it could not. */
+	failed?: string;
 };
 
 export function PlanEditor(
@@ -113,6 +115,15 @@ export function PlanEditor(
 		setPresence(value);
 		if (!value) return;
 		value.on("sync", synced => setState(prev => ({ ...prev, synced })));
+		value.on("status", ({ message, status }) => {
+			// A failure is sticky until something opens the document; anything
+			// else clears it, so a reconnect that works stops saying it failed.
+			setState(prev => ({
+				...prev,
+				...(status === "failed" ? { failed: message ?? "the plan could not be opened" } : {}),
+				...(status === "connected" ? { failed: undefined } : {}),
+			}));
+		});
 	}, []);
 
 	let offline = connection !== undefined && connection !== "connected";
@@ -207,7 +218,13 @@ export function PlanEditor(
 					</div>
 					<PlanPresence provider={presence} />
 					{/* In the document column, so it tracks the prose, not the pane. */}
-					<PlanStatus wire={wire} connection={connection} synced={state.synced} busy={busy} />
+					<PlanStatus
+						wire={wire}
+						connection={connection}
+						synced={state.synced}
+						failed={state.failed}
+						busy={busy}
+					/>
 				</div>
 			</div>
 		</div>

--- a/packages/editor/src/plan-editor.tsx
+++ b/packages/editor/src/plan-editor.tsx
@@ -126,6 +126,23 @@ export function PlanEditor(
 		});
 	}, []);
 
+	/*
+	 * Open the document whenever the connection says it can carry the request.
+	 *
+	 * The provider is created when the editor mounts, and a socket comes up on
+	 * its own schedule; nothing makes the two coincide. Opening only on mount
+	 * meant a handshake that had not finished yet cost the plan entirely, and a
+	 * reconnect went unnoticed — leaving the editor unlocked over a document
+	 * quietly missing whatever arrived while it was away.
+	 *
+	 * Keyed on both, so it does not matter which turns up first, and so every
+	 * later reconnection re-syncs.
+	 */
+	useEffect(() => {
+		if (connection !== undefined && connection !== "connected") return;
+		void presence?.resume();
+	}, [presence, connection]);
+
 	let offline = connection !== undefined && connection !== "connected";
 	let locked = offline || !!busy || !state.synced;
 

--- a/packages/editor/src/provider.test.ts
+++ b/packages/editor/src/provider.test.ts
@@ -41,19 +41,34 @@ function reply(): Plan.Open.Reply {
 	};
 }
 
-/** A transport that answers `plan:open` and records what was sent. */
-function wire(): Transport & { sent: string[] } {
+/**
+ * A transport that answers `plan:open` and records what was asked of it.
+ *
+ * `connected` is settable, because the thing being tested is what happens when
+ * a socket has not finished its handshake by the time something mounts against
+ * it — and refuses the request the way the real one does.
+ */
+function wire(open = true): Transport & { sent: string[]; asked: object[]; up: boolean } {
 	let sent: string[] = [];
+	let asked: object[] = [];
+
 	return {
 		sent,
+		asked,
+		up: open,
+		get connected(): boolean {
+			return this.up;
+		},
 		on(): Unsubscribe {
 			return () => {};
 		},
 		send(kind: string) {
 			sent.push(kind);
 		},
-		ask<T>(kind: string): Promise<T> {
+		ask<T>(kind: string, payload: Record<string, unknown> = {}): Promise<T> {
+			if (!this.up) return Promise.reject(new Error("not connected"));
 			sent.push(kind);
+			asked.push(payload);
 			if (kind === "plan:open") return Promise.resolve(reply() as T);
 			return Promise.resolve(undefined as T);
 		},
@@ -121,6 +136,84 @@ describe("opening the plan", () => {
 	 * Whoever started it says so instead, and the chrome stops claiming the
 	 * plan is still loading.
 	 */
+	/**
+	 * The bug this exists for.
+	 *
+	 * A socket comes up on its own schedule and the editor mounts on React's;
+	 * nothing makes the two coincide. Opening against a handshake that has not
+	 * finished used to reject once and never be tried again, leaving the editor
+	 * locked for the session with the chrome still claiming to be loading.
+	 */
+	it("waits rather than failing when the socket is not up yet", async () => {
+		let transport = wire(false);
+		let synced: boolean[] = [];
+		let provider = new PlanProvider({ wire: transport, doc: new Y.Doc() });
+		provider.on("sync", value => synced.push(value));
+
+		await expect(provider.connect()).resolves.toBeUndefined();
+
+		expect(transport.sent).toEqual([]);
+		expect(synced).not.toContain(true);
+	});
+
+	it("opens as soon as the socket comes up", async () => {
+		let transport = wire(false);
+		let synced: boolean[] = [];
+		let provider = new PlanProvider({ wire: transport, doc: new Y.Doc() });
+		provider.on("sync", value => synced.push(value));
+		await provider.connect();
+
+		transport.up = true;
+		await provider.resume();
+
+		expect(transport.sent).toEqual(["plan:open"]);
+		expect(synced).toContain(true);
+	});
+
+	it("stays quiet on a connection that never comes up", async () => {
+		let transport = wire(false);
+		let provider = new PlanProvider({ wire: transport, doc: new Y.Doc() });
+		await provider.connect();
+
+		await provider.resume();
+		await provider.resume();
+
+		expect(transport.sent).toEqual([]);
+	});
+
+	/**
+	 * The second half of the same gap. `#open` is the only thing that asks for
+	 * what was missed and the only thing that replays the outbox, so a
+	 * reconnect that does not re-open leaves the editor unlocked over a
+	 * document quietly short of everybody else's edits.
+	 */
+	it("asks again after a reconnect, for only what it missed", async () => {
+		let transport = wire();
+		let provider = new PlanProvider({ wire: transport, doc: new Y.Doc() });
+		await provider.connect();
+
+		await provider.resume();
+
+		expect(transport.sent).toEqual(["plan:open", "plan:open"]);
+		// The second carries what it already has, so the server replies with
+		// the difference rather than the whole document.
+		expect(transport.asked[1]).toMatchObject({
+			epoch: "01K0N4TR8K7JGM4R1J7PW4R8YJ",
+			vector: expect.any(String),
+		});
+	});
+
+	it("does not ask twice while an open is already in flight", async () => {
+		let transport = wire();
+		let provider = new PlanProvider({ wire: transport, doc: new Y.Doc() });
+		await provider.connect();
+		transport.sent.length = 0;
+
+		await Promise.all([provider.resume(), provider.resume(), provider.resume()]);
+
+		expect(transport.sent).toEqual(["plan:open"]);
+	});
+
 	it("can be told it failed, so the chrome does not say loading forever", () => {
 		let states: Array<{ status: string; message?: string }> = [];
 		let provider = new PlanProvider({ wire: wire(), doc: new Y.Doc() });

--- a/packages/editor/src/provider.test.ts
+++ b/packages/editor/src/provider.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Opening the document, when something beside it is broken.
+ *
+ * A plan is the point of the room; anchors decorate it. Resolving them used to
+ * happen between applying the document and declaring it synced, so anything
+ * that threw while working out where a decision pointed skipped the emit — and
+ * because `connect` is started and forgotten, the editor stayed locked for the
+ * rest of the session with nothing said about it anywhere.
+ *
+ * These pin the ordering and the guard. Painting is not tested: it needs real
+ * layout, and happy-dom returns zero for every measurement.
+ */
+
+import { describe, expect, it } from "bun:test";
+import * as Y from "yjs";
+
+import { PlanProvider } from "./provider";
+
+import type { Plan } from "@chopin/protocol";
+import type { Transport, Unsubscribe } from "./transport";
+
+/** base64 of an empty Yjs update, which is what an empty plan opens with. */
+function emptyUpdate(): string {
+	let update = Y.encodeStateAsUpdate(new Y.Doc());
+	let binary = "";
+	for (let byte of update) binary += String.fromCharCode(byte);
+	return btoa(binary);
+}
+
+function reply(): Plan.Open.Reply {
+	return {
+		kind: "plan:open",
+		ts: 0,
+		epoch: "01K0N4TR8K7JGM4R1J7PW4R8YJ",
+		seq: 1,
+		update: emptyUpdate(),
+		revision: 1,
+		anchors: [],
+		threads: [],
+		limits: { source: 1_000, update: 1_000, depth: 10 },
+	};
+}
+
+/** A transport that answers `plan:open` and records what was sent. */
+function wire(): Transport & { sent: string[] } {
+	let sent: string[] = [];
+	return {
+		sent,
+		on(): Unsubscribe {
+			return () => {};
+		},
+		send(kind: string) {
+			sent.push(kind);
+		},
+		ask<T>(kind: string): Promise<T> {
+			sent.push(kind);
+			if (kind === "plan:open") return Promise.resolve(reply() as T);
+			return Promise.resolve(undefined as T);
+		},
+	};
+}
+
+function quietly<T>(run: () => T): T {
+	let complain = console.error;
+	console.error = () => {};
+	try {
+		return run();
+	} finally {
+		console.error = complain;
+	}
+}
+
+describe("opening the plan", () => {
+	it("declares the document synced", async () => {
+		let synced: boolean[] = [];
+		let provider = new PlanProvider({ wire: wire(), doc: new Y.Doc() });
+		provider.on("sync", value => synced.push(value));
+
+		await provider.connect();
+
+		expect(synced).toContain(true);
+	});
+
+	/**
+	 * The ordering that matters: a throw from anchors resolution must arrive
+	 * after the document is usable, not instead of it.
+	 */
+	it("stays usable when working out where decisions point throws", async () => {
+		let synced: boolean[] = [];
+		let provider = new PlanProvider({
+			wire: wire(),
+			doc: new Y.Doc(),
+			onAnchors() {
+				throw new Error("could not resolve");
+			},
+		});
+		provider.on("sync", value => synced.push(value));
+
+		await quietly(async () => {
+			await expect(provider.connect()).resolves.toBeUndefined();
+		});
+
+		expect(synced).toContain(true);
+	});
+
+	it("hands over the anchors it was given", async () => {
+		let seen: Array<{ widgets: unknown[]; threads: unknown[] }> = [];
+		let provider = new PlanProvider({
+			wire: wire(),
+			doc: new Y.Doc(),
+			onAnchors: snapshot => seen.push(snapshot),
+		});
+
+		await provider.connect();
+
+		expect(seen).toHaveLength(1);
+	});
+
+	/**
+	 * `connect` is started and forgotten, so a rejection has nowhere to go.
+	 * Whoever started it says so instead, and the chrome stops claiming the
+	 * plan is still loading.
+	 */
+	it("can be told it failed, so the chrome does not say loading forever", () => {
+		let states: Array<{ status: string; message?: string }> = [];
+		let provider = new PlanProvider({ wire: wire(), doc: new Y.Doc() });
+		provider.on("status", value => states.push(value));
+
+		provider.fail("the plan could not be opened");
+
+		expect(states).toContainEqual({
+			status: "failed",
+			message: "the plan could not be opened",
+		});
+	});
+});

--- a/packages/editor/src/provider.ts
+++ b/packages/editor/src/provider.ts
@@ -21,7 +21,7 @@ type Listener<T> = (value: T) => void;
 
 type Events = {
 	sync: boolean;
-	status: { status: string };
+	status: { status: string; message?: string };
 	update: unknown;
 	reload: Y.Doc;
 };
@@ -154,7 +154,7 @@ export class PlanProvider implements Provider {
 			this.#wire.on<Plan.Reset>("plan:reset", event => this.#reset(event)),
 			this.#wire.on<Plan.Anchors>("plan:anchors", event => {
 				if (event.epoch === this.#epoch) {
-					this.#options.onAnchors?.({ widgets: event.widgets, threads: event.threads });
+					this.#anchors({ widgets: event.widgets, threads: event.threads });
 				}
 			}),
 		);
@@ -163,6 +163,18 @@ export class PlanProvider implements Provider {
 		this.awareness.on("update", this.#announce);
 
 		await this.#open(generation);
+	}
+
+	/**
+	 * Say the document could not be opened.
+	 *
+	 * Called by whoever started the connection, because it is the only place
+	 * the rejection can be seen: `connect` is fired and forgotten, so a throw
+	 * on the way in otherwise leaves the editor locked and the chrome claiming
+	 * it is still loading.
+	 */
+	fail(message: string): void {
+		this.#emit("status", { status: "failed", message });
 	}
 
 	disconnect(): void {
@@ -204,7 +216,6 @@ export class PlanProvider implements Provider {
 
 		// Server state never originates locally, so it must not be echoed back.
 		Y.applyUpdate(this.#doc, decode(reply.update), this);
-		this.#options.onAnchors?.({ widgets: reply.anchors, threads: reply.threads });
 
 		if (reply.awareness) {
 			applyAwarenessUpdate(this.awareness, decode(reply.awareness), this);
@@ -220,6 +231,31 @@ export class PlanProvider implements Provider {
 		this.#synced = true;
 		this.#emit("status", { status: "connected" });
 		this.#emit("sync", true);
+
+		// After the document is open, never before it.
+		//
+		// Anchors decorate the prose; they are not a precondition for having
+		// it. Resolving them here used to sit between applying the update and
+		// declaring the document synced, so anything that threw while working
+		// out where a decision pointed skipped the emit — and the editor stayed
+		// locked for the rest of the session, with the rejection swallowed by
+		// the `void connect()` that started it.
+		this.#anchors({ widgets: reply.anchors, threads: reply.threads });
+	}
+
+	/**
+	 * Hand the relationship snapshot on, whatever it does with it.
+	 *
+	 * Guarded because the alternative is a highlight failing to paint and
+	 * taking the document with it. A reader losing an outline is a nuisance; a
+	 * room that cannot be edited is not.
+	 */
+	#anchors(snapshot: { widgets: Plan.WidgetAnchors[]; threads: Plan.ThreadAnchors[] }): void {
+		try {
+			this.#options.onAnchors?.(snapshot);
+		} catch (err) {
+			console.error("[plan] could not resolve where decisions point:", err);
+		}
 	}
 
 	/**

--- a/packages/editor/src/provider.ts
+++ b/packages/editor/src/provider.ts
@@ -88,6 +88,8 @@ export class PlanProvider implements Provider {
 	#epoch: string | undefined;
 	#synced = false;
 	#connected = false;
+	/** An open is in flight, so a second `resume` would ask for it twice. */
+	#opening = false;
 	#counter = 0;
 	#generation = 0;
 
@@ -140,10 +142,41 @@ export class PlanProvider implements Provider {
 		}
 	}
 
+	/**
+	 * Open the document, or bring it back up to date.
+	 *
+	 * Safe to call whenever the transport says it can carry a request: on the
+	 * first connection, and again after every reconnect.
+	 *
+	 * The provider used to open exactly once, when the editor mounted, and a
+	 * transport comes up on its own schedule — so if the socket had not
+	 * finished its handshake by then the plan never opened at all, and nothing
+	 * tried again. The same gap swallowed a reconnect: `#open` is the only
+	 * thing that asks for the updates missed while the connection was down and
+	 * the only thing that replays the outbox, so without it the editor came
+	 * back unlocked and quietly short of everybody else's edits.
+	 *
+	 * `#open` handles both cases already. It sends the epoch and state vector,
+	 * so a resume fetches only the difference rather than the whole document.
+	 */
+	async resume(): Promise<void> {
+		// Not attached yet, already opening, or the transport cannot carry it —
+		// in the last case it will say when it can, and this runs again.
+		if (!this.#connected || this.#opening) return;
+		if (this.#wire.connected === false) return;
+
+		this.#opening = true;
+		try {
+			await this.#open(this.#generation);
+		} finally {
+			this.#opening = false;
+		}
+	}
+
 	async connect(): Promise<void> {
 		if (this.#connected) return;
 		this.#connected = true;
-		let generation = ++this.#generation;
+		this.#generation++;
 
 		// Subscribe before opening: an update published between the reply being
 		// built and this handler being attached would otherwise be lost.
@@ -162,7 +195,7 @@ export class PlanProvider implements Provider {
 		this.#doc.on("update", this.#local);
 		this.awareness.on("update", this.#announce);
 
-		await this.#open(generation);
+		await this.resume();
 	}
 
 	/**

--- a/packages/editor/src/provider.ts
+++ b/packages/editor/src/provider.ts
@@ -45,8 +45,15 @@ export type PlanProviderOptions = {
 	doc: Y.Doc;
 	/** Told when the server rotates the epoch and local state must be discarded. */
 	onReset?: (reason: Plan.Reset["reason"]) => void;
-	/** Authoritative snapshot of which prose each decision relates to. */
-	onAnchors?: (widgets: Plan.WidgetAnchors[]) => void;
+	/**
+	 * Authoritative snapshot of which prose each decision and comment names.
+	 *
+	 * The whole snapshot rather than one half: the two arrive together because
+	 * they describe the same document at the same moment, and splitting them
+	 * into two callbacks would let a consumer act on one while holding a stale
+	 * copy of the other.
+	 */
+	onAnchors?: (snapshot: { widgets: Plan.WidgetAnchors[]; threads: Plan.ThreadAnchors[] }) => void;
 };
 
 /**
@@ -146,7 +153,9 @@ export class PlanProvider implements Provider {
 			this.#wire.on<Plan.Awareness>("plan:awareness", event => this.#presence(event)),
 			this.#wire.on<Plan.Reset>("plan:reset", event => this.#reset(event)),
 			this.#wire.on<Plan.Anchors>("plan:anchors", event => {
-				if (event.epoch === this.#epoch) this.#options.onAnchors?.(event.widgets);
+				if (event.epoch === this.#epoch) {
+					this.#options.onAnchors?.({ widgets: event.widgets, threads: event.threads });
+				}
 			}),
 		);
 
@@ -195,7 +204,7 @@ export class PlanProvider implements Provider {
 
 		// Server state never originates locally, so it must not be echoed back.
 		Y.applyUpdate(this.#doc, decode(reply.update), this);
-		this.#options.onAnchors?.(reply.anchors);
+		this.#options.onAnchors?.({ widgets: reply.anchors, threads: reply.threads });
 
 		if (reply.awareness) {
 			applyAwarenessUpdate(this.awareness, decode(reply.awareness), this);

--- a/packages/editor/src/questionnaires.ts
+++ b/packages/editor/src/questionnaires.ts
@@ -18,11 +18,14 @@ import { useEffect } from "react";
 import { QuestionnaireNode } from "@chopin/dialect";
 
 import { counts, relate } from "./anchors";
+import { paint } from "./marks";
+import { $blockPoints } from "./passage";
 
 import type { Binding } from "@lexical/yjs";
 import type { LexicalEditor } from "lexical";
 import type { Plan } from "@chopin/protocol";
 import type { Related, Relation } from "./anchors";
+import type { Marked } from "./marks";
 import type { Questionnaire } from "@chopin/dialect";
 
 export type QuestionnaireEntry = {
@@ -49,7 +52,6 @@ export class QuestionnaireStore {
 	#binding: Binding | undefined;
 	#editor: LexicalEditor | undefined;
 	#related: Related[] = [];
-	#lit: string[] = [];
 
 	subscribe = (listener: () => void): () => void => {
 		this.#listeners.add(listener);
@@ -75,6 +77,7 @@ export class QuestionnaireStore {
 
 	/** The editor, so a node key can be turned into something on screen. */
 	attach(editor: LexicalEditor | undefined): void {
+		if (!editor && this.#editor) this.clear();
 		this.#editor = editor;
 	}
 
@@ -112,30 +115,37 @@ export class QuestionnaireStore {
 	/**
 	 * Mark the prose a relationship names.
 	 *
-	 * Written to the DOM rather than to the document. A highlight is one
+	 * Painted rather than written into the document. A highlight is one
 	 * reader's pointer, not a fact about the plan, and putting it in the
 	 * document would send it to everybody else and make it undoable.
+	 *
+	 * Through the same registry comments use, under the same tone, so pointing
+	 * at a question and pointing at a comment look like the same act. They used
+	 * to be an outlined block and a washed range respectively, which made one
+	 * fact — this is the prose that card refers to — read as two.
 	 */
 	highlight(widget: string, question: string, relation: Relation): void {
-		this.clear();
+		let editor = this.#editor;
+		if (!editor) return;
+
 		let found = this.#related.find(item =>
 			item.widget === widget && item.question === question && item.relation === relation
 		);
-		if (!found || found.pending) return;
+		if (!found || found.pending) return this.clear();
 
-		for (let key of found.keys) {
-			let element = this.#editor?.getElementByKey(key);
-			if (!element) continue;
-			element.setAttribute("data-plan-related", "");
-			this.#lit.push(key);
-		}
+		let marks: Marked[] = [];
+		editor.getEditorState().read(() => {
+			for (let key of found.keys) {
+				let points = $blockPoints(key);
+				if (points) marks.push({ tone: "related", points });
+			}
+		});
+
+		paint(editor, "questions", marks);
 	}
 
 	clear(): void {
-		for (let key of this.#lit) {
-			this.#editor?.getElementByKey(key)?.removeAttribute("data-plan-related");
-		}
-		this.#lit = [];
+		if (this.#editor) paint(this.#editor, "questions", []);
 	}
 }
 

--- a/packages/editor/src/questionnaires.ts
+++ b/packages/editor/src/questionnaires.ts
@@ -92,7 +92,15 @@ export class QuestionnaireStore {
 	 */
 	anchors(widgets: Plan.WidgetAnchors[]): void {
 		if (!this.#binding) return;
-		this.#related = relate(this.#binding, widgets);
+		try {
+			this.#related = relate(this.#binding, widgets);
+		} catch (err) {
+			// Where a decision points is decoration. This is called while the
+			// document is being opened, so letting it throw would cost the room
+			// the plan itself rather than a few outlines.
+			console.error("[plan] could not resolve what decisions relate to:", err);
+			return;
+		}
 		for (let listener of this.#listeners) listener();
 	}
 

--- a/packages/editor/src/questionnaires.ts
+++ b/packages/editor/src/questionnaires.ts
@@ -25,7 +25,7 @@ import type { Binding } from "@lexical/yjs";
 import type { LexicalEditor } from "lexical";
 import type { Plan } from "@chopin/protocol";
 import type { Related, Relation } from "./anchors";
-import type { Marked } from "./marks";
+import type { Points } from "./passage";
 import type { Questionnaire } from "@chopin/dialect";
 
 export type QuestionnaireEntry = {
@@ -133,15 +133,15 @@ export class QuestionnaireStore {
 		);
 		if (!found || found.pending) return this.clear();
 
-		let marks: Marked[] = [];
+		let places: Points[] = [];
 		editor.getEditorState().read(() => {
 			for (let key of found.keys) {
 				let points = $blockPoints(key);
-				if (points) marks.push({ tone: "related", points });
+				if (points) places.push(points);
 			}
 		});
 
-		paint(editor, "questions", marks);
+		paint(editor, "questions", places);
 	}
 
 	clear(): void {

--- a/packages/editor/src/status.tsx
+++ b/packages/editor/src/status.tsx
@@ -25,6 +25,8 @@ export type PlanStatusProps = {
 	connection?: Connection;
 	/** False until the shared document has arrived. */
 	synced: boolean;
+	/** Why it never arrived, when something went wrong opening it. */
+	failed?: string;
 	/** True while an agent turn owns the document. */
 	busy?: boolean;
 };
@@ -57,6 +59,20 @@ function describe(
 			tone: "warn",
 			level: "notice",
 			detail: "Editing resumes once connected.",
+		};
+	}
+
+	/*
+	 * Before "Loading", because a document that failed to open never stops
+	 * loading. Saying so is the difference between a room somebody reports as
+	 * broken and one they assume is slow.
+	 */
+	if (props.failed) {
+		return {
+			label: "Could not open the plan",
+			tone: "error",
+			level: "notice",
+			detail: `${props.failed}. Reloading may help.`,
 		};
 	}
 

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -53,50 +53,29 @@
 }
 
 /*
- * Prose the sidecar refers to.
+ * The prose a sidecar card refers to, while somebody is pointing at that card.
  *
- * Registered in `CSS.highlights`, so these paint over the text without putting
- * anything in the document. One vocabulary for both halves of the sidecar:
- * questions used to outline a block while comments washed a range, so the same
- * fact read as two different things depending on which card it came from.
+ * Registered in `CSS.highlights`, so it paints over the text without putting
+ * anything in the document. One mark for both halves of the sidecar: questions
+ * used to outline a block while comments washed a range, so the same fact —
+ * this is the prose that card refers to — read as two different things
+ * depending on which card it came from. `::highlight()` cannot draw an outline,
+ * so the wash is what they can both be.
  *
- * Only a handful of properties are allowed on `::highlight()` — no outline, no
- * box-shadow, no border-radius — which is why the wash is what they can both
- * be. Overlapping ranges paint once, so two comments on a sentence look like
- * one mark; the sidecar is what tells them apart.
- *
- * Colour says what is true of the prose, intensity says whether the reader is
- * pointing at it.
+ * Nothing is painted at rest. Standing marks for live comments and for decided
+ * prose were tried and taken out: a plan accumulates decisions, so anything
+ * permanent ends up covering most of the document, and a page that is mostly
+ * highlighted has told you nothing.
  *
  * `background-color`, not `background`: only a handful of longhands are
  * permitted here, and the shorthand works today solely because browsers expand
  * it before filtering. Not worth depending on.
  *
- * Each carries the colour it actually composites to over the page, because a
- * percentage of an already-pale token says nothing about whether anyone will
- * see it — `accent` is `oklch(0.85 0.09 250)`, so 14% of it renders `#f9fbff`,
- * which is white. `ring` is dark enough that a wash of it reads.
- */
-
-/* A live comment: the one place the plan says somebody is waiting. */
-::highlight(plan-comment) {
-	/* #f3d7b3 */
-	background-color: color-mix(in oklch, var(--color-warning) 38%, transparent);
-}
-
-/* Prose a decision produced. Quietest of the three: a record, not a request. */
-::highlight(plan-decision) {
-	/* #e2ecfa */
-	background-color: color-mix(in oklch, var(--color-ring) 16%, transparent);
-}
-
-/*
- * Whatever the reader is pointing at, question or comment alike.
- *
- * About the weight of the browser's own text selection, which is the right
- * strength for something standing in for an outline and a 4px bar. Shares its
- * hue with a decision, so pointing at one deepens the same colour rather than
- * swapping it for another.
+ * The colour it composites to over the page is recorded because a percentage
+ * of an already-pale token says nothing about whether anyone will see it —
+ * `accent` is `oklch(0.85 0.09 250)`, so 14% of it renders `#f9fbff`, which is
+ * white. `ring` is dark enough that a wash of it reads, at about the weight of
+ * the browser's own text selection.
  */
 ::highlight(plan-related) {
 	/* #b7cff2 */

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -47,7 +47,8 @@
 
 /* The node stays in the plan for exports and agent reads; its form is in the
    decisions pane, so inline it renders as nothing. */
-.plan .plan-content [data-plan-questionnaire] {
+.plan .plan-content [data-plan-questionnaire],
+.plan .plan-content [data-plan-decision] {
 	display: none;
 }
 

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -67,21 +67,40 @@
  *
  * Colour says what is true of the prose, intensity says whether the reader is
  * pointing at it.
+ *
+ * `background-color`, not `background`: only a handful of longhands are
+ * permitted here, and the shorthand works today solely because browsers expand
+ * it before filtering. Not worth depending on.
+ *
+ * Each carries the colour it actually composites to over the page, because a
+ * percentage of an already-pale token says nothing about whether anyone will
+ * see it — `accent` is `oklch(0.85 0.09 250)`, so 14% of it renders `#f9fbff`,
+ * which is white. `ring` is dark enough that a wash of it reads.
  */
 
 /* A live comment: the one place the plan says somebody is waiting. */
 ::highlight(plan-comment) {
-	background: color-mix(in oklch, var(--color-warning) 22%, transparent);
+	/* #f3d7b3 */
+	background-color: color-mix(in oklch, var(--color-warning) 38%, transparent);
 }
 
 /* Prose a decision produced. Quietest of the three: a record, not a request. */
 ::highlight(plan-decision) {
-	background: color-mix(in oklch, var(--color-accent) 14%, transparent);
+	/* #e2ecfa */
+	background-color: color-mix(in oklch, var(--color-ring) 16%, transparent);
 }
 
-/* Whatever the reader is pointing at, question or comment alike. */
+/*
+ * Whatever the reader is pointing at, question or comment alike.
+ *
+ * About the weight of the browser's own text selection, which is the right
+ * strength for something standing in for an outline and a 4px bar. Shares its
+ * hue with a decision, so pointing at one deepens the same colour rather than
+ * swapping it for another.
+ */
 ::highlight(plan-related) {
-	background: color-mix(in oklch, var(--color-accent) 40%, transparent);
+	/* #b7cff2 */
+	background-color: color-mix(in oklch, var(--color-ring) 40%, transparent);
 }
 
 /*

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -53,54 +53,50 @@
 }
 
 /*
- * Commented prose.
+ * Prose the sidecar refers to.
  *
  * Registered in `CSS.highlights`, so these paint over the text without putting
- * anything in the document. Ranges that overlap paint once — two comments on
- * one sentence look like one mark, and the sidecar is what tells them apart.
+ * anything in the document. One vocabulary for both halves of the sidecar:
+ * questions used to outline a block while comments washed a range, so the same
+ * fact read as two different things depending on which card it came from.
  *
- * A decided passage is quieter than an open one: it is a record of something
- * settled, not a thing waiting on anybody.
+ * Only a handful of properties are allowed on `::highlight()` — no outline, no
+ * box-shadow, no border-radius — which is why the wash is what they can both
+ * be. Overlapping ranges paint once, so two comments on a sentence look like
+ * one mark; the sidecar is what tells them apart.
+ *
+ * Colour says what is true of the prose, intensity says whether the reader is
+ * pointing at it.
  */
+
+/* A live comment: the one place the plan says somebody is waiting. */
 ::highlight(plan-comment) {
-	background: color-mix(in oklch, var(--color-warning) 26%, transparent);
+	background: color-mix(in oklch, var(--color-warning) 22%, transparent);
 }
 
+/* Prose a decision produced. Quietest of the three: a record, not a request. */
 ::highlight(plan-decision) {
-	background: color-mix(in oklch, var(--color-success) 16%, transparent);
+	background: color-mix(in oklch, var(--color-accent) 14%, transparent);
 }
 
-::highlight(plan-comment-current) {
-	background: color-mix(in oklch, var(--color-warning) 46%, transparent);
+/* Whatever the reader is pointing at, question or comment alike. */
+::highlight(plan-related) {
+	background: color-mix(in oklch, var(--color-accent) 40%, transparent);
 }
 
-/* Prose related to the sidecar item under pointer, focus, or being followed. */
+/*
+ * The same pointer, for a browser with no Highlight API.
+ *
+ * A block outline rather than a wash, because without the API there is no way
+ * to mark part of one — less precise, and honest about it. Standing marks are
+ * dropped entirely on this path: outlining every decided passage would box up
+ * half the plan.
+ */
 .plan .plan-content [data-plan-related] {
 	border-radius: var(--radius-sm);
 	outline: 1px solid color-mix(in oklch, var(--color-ring) 60%, transparent);
 	outline-offset: 3px;
-	box-shadow: inset 4px 0 var(--color-ring);
-	background: color-mix(in oklch, var(--color-accent) 16%, transparent);
-}
-
-/*
- * The passage a reader was just taken to. A decision can span several
- * passages, so the one they landed on has to be separable from its siblings —
- * otherwise clicking through them looks like nothing happened.
- */
-.plan .plan-content [data-plan-related="current"] {
-	outline-color: var(--color-ring);
-	background: color-mix(in oklch, var(--color-accent) 26%, transparent);
-	animation: plan-arrive 900ms ease-out;
-}
-
-@keyframes plan-arrive {
-	0% {
-		background: color-mix(in oklch, var(--color-accent) 45%, transparent);
-	}
-	100% {
-		background: color-mix(in oklch, var(--color-accent) 26%, transparent);
-	}
+	background: color-mix(in oklch, var(--color-accent) 20%, transparent);
 }
 
 @container (max-width: 46rem) {

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -52,6 +52,28 @@
 	display: none;
 }
 
+/*
+ * Commented prose.
+ *
+ * Registered in `CSS.highlights`, so these paint over the text without putting
+ * anything in the document. Ranges that overlap paint once — two comments on
+ * one sentence look like one mark, and the sidecar is what tells them apart.
+ *
+ * A decided passage is quieter than an open one: it is a record of something
+ * settled, not a thing waiting on anybody.
+ */
+::highlight(plan-comment) {
+	background: color-mix(in oklch, var(--color-warning) 26%, transparent);
+}
+
+::highlight(plan-decision) {
+	background: color-mix(in oklch, var(--color-success) 16%, transparent);
+}
+
+::highlight(plan-comment-current) {
+	background: color-mix(in oklch, var(--color-warning) 46%, transparent);
+}
+
 /* Prose related to the sidecar item under pointer, focus, or being followed. */
 .plan .plan-content [data-plan-related] {
 	border-radius: var(--radius-sm);

--- a/packages/editor/src/threads.test.ts
+++ b/packages/editor/src/threads.test.ts
@@ -1,0 +1,305 @@
+/**
+ * What the sidecar believes, as frames arrive.
+ *
+ * Two sources feed the store and they arrive separately: what a thread says
+ * comes over `comment:*`, where it points comes over `plan:anchors`. Joining
+ * them by id is the whole job, and the cases worth pinning are the ones where
+ * only one of them has turned up, or where the same fact turns up twice.
+ *
+ * Resolution and painting are not tested here. Both need a bound editor and
+ * real layout, and happy-dom returns zero for every measurement.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { ThreadStore } from "./threads";
+
+import type { Comment, Plan } from "@chopin/protocol";
+
+function note(handle: string, text: string, id = `${handle}-${text}`): Comment.Note {
+	return { id, handle, text, ts: 1 };
+}
+
+function thread(over: Partial<Comment.Thread> = {}): Comment.Thread {
+	return {
+		id: "01K0N4TR8K7JGM4R1J7PW4R8YJ",
+		status: "open",
+		notes: [note("ana", "Too long.")],
+		...over,
+	};
+}
+
+/** An anchors entry, with the shape the server sends but no live positions. */
+function anchors(id: string, over: Partial<Plan.ThreadAnchors> = {}): Plan.ThreadAnchors {
+	return {
+		thread: id,
+		subject: {
+			blocks: [],
+			start: "",
+			end: "",
+			quote: "caches tiles for 60 seconds",
+			offset: 0,
+			length: 27,
+		},
+		result: { anchors: [], pending: false },
+		...over,
+	};
+}
+
+function store(): ThreadStore {
+	return new ThreadStore();
+}
+
+describe("holding what threads say", () => {
+	it("shows a thread before its passage has arrived", () => {
+		let subject = store();
+		subject.sync([thread()]);
+
+		// The card renders on the next frame either way; waiting for the
+		// anchors snapshot would leave a gap where the comment does not exist.
+		expect(subject.snapshot().threads).toHaveLength(1);
+		expect(subject.snapshot().threads[0]?.quote).toBe("");
+	});
+
+	it("takes the quote from the passage until the thread freezes its own", () => {
+		let subject = store();
+		let value = thread();
+		subject.sync([value]);
+		subject.anchors([anchors(value.id)]);
+
+		expect(subject.snapshot().threads[0]?.quote).toBe("caches tiles for 60 seconds");
+
+		// Resolving freezes it: from here the record says what was discussed,
+		// and the passage is free to keep moving.
+		subject.resolved({
+			kind: "comment:resolved",
+			ts: 0,
+			id: value.id,
+			status: "accepted",
+			resolver: "kris",
+			at: 2,
+			quote: "caches tiles for 60 seconds",
+		});
+		subject.anchors([anchors(value.id, {
+			subject: { ...anchors(value.id).subject, quote: "caches tiles for 10 seconds" },
+		})]);
+
+		expect(subject.snapshot().threads[0]?.quote).toBe("caches tiles for 60 seconds");
+	});
+
+	it("adds what somebody said", () => {
+		let subject = store();
+		let value = thread();
+		subject.sync([value]);
+		subject.said(value.id, note("kris", "Agreed."));
+
+		expect(subject.snapshot().threads[0]?.thread.notes.map(each => each.handle))
+			.toEqual(["ana", "kris"]);
+	});
+
+	/**
+	 * The author adds a note from its own reply, and the broadcast arrives
+	 * afterwards carrying the same one. Without this it appears twice.
+	 */
+	it("does not say the same thing twice", () => {
+		let subject = store();
+		let value = thread();
+		subject.sync([value]);
+
+		let said = note("kris", "Agreed.", "n1");
+		subject.said(value.id, said);
+		subject.said(value.id, said);
+
+		expect(subject.snapshot().threads[0]?.thread.notes).toHaveLength(2);
+	});
+
+	it("ignores a note for a thread it has never heard of", () => {
+		let subject = store();
+		subject.said("missing", note("kris", "Hello?"));
+
+		expect(subject.snapshot().threads).toHaveLength(0);
+	});
+
+	it("never shows a dismissed thread", () => {
+		let subject = store();
+		let value = thread();
+		subject.sync([value]);
+		subject.resolved({
+			kind: "comment:resolved",
+			ts: 0,
+			id: value.id,
+			status: "dismissed",
+			resolver: "kris",
+			at: 2,
+			quote: "q",
+		});
+
+		expect(subject.snapshot().threads).toHaveLength(0);
+	});
+
+	it("replaces everything on a fresh sync", () => {
+		let subject = store();
+		subject.sync([thread({ id: "a" }), thread({ id: "b" })]);
+		subject.sync([thread({ id: "b" })]);
+
+		expect(subject.snapshot().threads.map(each => each.thread.id)).toEqual(["b"]);
+	});
+});
+
+describe("what an accepted thread still owes", () => {
+	function accepted() {
+		let subject = store();
+		let value = thread({ id: "t1", status: "accepted", resolver: "kris", at: 2, quote: "q" });
+		subject.sync([value]);
+		return { subject, value };
+	}
+
+	/**
+	 * Derived from the result anchor rather than tracked separately: `pending`
+	 * already means "nobody has reviewed this since the last change", which is
+	 * exactly the question the card asks.
+	 */
+	it("reads as unapplied until the agent has anchored what it produced", () => {
+		let { subject, value } = accepted();
+		subject.anchors([anchors(value.id, {
+			result: { anchors: [], pending: true, reason: "missing" },
+		})]);
+
+		expect(subject.snapshot().threads[0]?.applied).toBe(false);
+	});
+
+	it("reads as applied once it has", () => {
+		let { subject, value } = accepted();
+		subject.anchors([anchors(value.id)]);
+
+		expect(subject.snapshot().threads[0]?.applied).toBe(true);
+	});
+
+	/** An empty list is a real answer: reviewed, deliberately unrelated. */
+	it("counts a deliberate nothing as applied", () => {
+		let { subject, value } = accepted();
+		subject.anchors([anchors(value.id, { result: { anchors: [], pending: false } })]);
+
+		expect(subject.snapshot().threads[0]?.applied).toBe(true);
+	});
+});
+
+describe("who is writing", () => {
+	it("collects them per thread, and forgets them when they stop", () => {
+		let subject = store();
+		let value = thread();
+		subject.sync([value]);
+
+		subject.typing({
+			kind: "comment:typing",
+			ts: 0,
+			id: value.id,
+			writing: true,
+			client: "c1",
+			handle: "kris",
+		});
+		expect(subject.snapshot().writing[value.id]).toEqual(["kris"]);
+
+		subject.typing({
+			kind: "comment:typing",
+			ts: 0,
+			id: value.id,
+			writing: false,
+			client: "c1",
+			handle: "kris",
+		});
+		expect(subject.snapshot().writing[value.id]).toBeUndefined();
+	});
+
+	/** One person in two tabs is one name, not two. */
+	it("names a person once however many tabs they have open", () => {
+		let subject = store();
+		let value = thread();
+		subject.sync([value]);
+
+		for (let client of ["c1", "c2"]) {
+			subject.typing({
+				kind: "comment:typing",
+				ts: 0,
+				id: value.id,
+				writing: true,
+				client,
+				handle: "kris",
+			});
+		}
+
+		expect(subject.snapshot().writing[value.id]).toEqual(["kris"]);
+	});
+
+	it("stops showing anybody once the thread is resolved", () => {
+		let subject = store();
+		let value = thread();
+		subject.sync([value]);
+		subject.typing({
+			kind: "comment:typing",
+			ts: 0,
+			id: value.id,
+			writing: true,
+			client: "c1",
+			handle: "kris",
+		});
+
+		subject.resolved({
+			kind: "comment:resolved",
+			ts: 0,
+			id: value.id,
+			status: "accepted",
+			resolver: "ana",
+			at: 2,
+			quote: "q",
+		});
+
+		expect(subject.snapshot().writing[value.id]).toBeUndefined();
+	});
+});
+
+describe("drafting", () => {
+	it("holds the passage that was selected, so losing the selection costs nothing", () => {
+		let subject = store();
+		subject.draft({ blocks: [1], quote: "the phrase", offset: 3, length: 10 });
+
+		expect(subject.snapshot().draft).toMatchObject({ quote: "the phrase", blocks: [1] });
+	});
+
+	it("puts the draft away once the thread it became arrives", () => {
+		let subject = store();
+		subject.draft({ blocks: [1], quote: "the phrase", offset: 3, length: 10 });
+		subject.opened(thread());
+
+		expect(subject.snapshot().draft).toBeUndefined();
+		expect(subject.snapshot().threads).toHaveLength(1);
+	});
+});
+
+describe("publishing", () => {
+	it("tells nobody when nothing changed", () => {
+		let subject = store();
+		let value = thread();
+		subject.sync([value]);
+
+		let seen = 0;
+		subject.subscribe(() => seen++);
+		subject.sync([value]);
+
+		// Every keystroke in the plan re-runs this. Publishing regardless is
+		// what would re-render the pane on every character typed in the prose.
+		expect(seen).toBe(0);
+	});
+
+	it("tells subscribers when something did", () => {
+		let subject = store();
+		let value = thread();
+		subject.sync([value]);
+
+		let seen = 0;
+		subject.subscribe(() => seen++);
+		subject.said(value.id, note("kris", "Agreed."));
+
+		expect(seen).toBe(1);
+	});
+});

--- a/packages/editor/src/threads.test.ts
+++ b/packages/editor/src/threads.test.ts
@@ -276,6 +276,84 @@ describe("drafting", () => {
 	});
 });
 
+/** Silence the log the guards produce, so a pass does not look like a failure. */
+function quietly<T>(run: () => T): T {
+	let complain = console.error;
+	console.error = () => {};
+	try {
+		return run();
+	} finally {
+		console.error = complain;
+	}
+}
+
+describe("when resolution goes wrong", () => {
+	/**
+	 * A passage that cannot be worked out is a highlight nobody gets, not a
+	 * sidecar nobody gets. The card still carries the conversation, which is
+	 * the durable part of a comment; the anchor was only ever a convenience.
+	 *
+	 * `refresh` also runs as a Lexical update listener, and Lexical runs those
+	 * in one unisolated loop — so a throw escaping here would skip the listener
+	 * that syncs the document and cost the room its collaboration.
+	 */
+	/**
+	 * A snapshot entry the client cannot read.
+	 *
+	 * A missing `result` is the realistic shape: the two halves of a
+	 * relationship are written at different times by different actors, so a
+	 * partial one is a protocol skew rather than an impossibility.
+	 */
+	function malformed(id: string): Plan.ThreadAnchors {
+		return { thread: id, subject: anchors(id).subject } as Plan.ThreadAnchors;
+	}
+
+	it("still shows a thread whose relationship it cannot read", () => {
+		let subject = store();
+		let value = thread();
+		subject.sync([value]);
+
+		quietly(() => subject.anchors([malformed(value.id)]));
+
+		let view = subject.snapshot().threads[0];
+		expect(view?.thread.notes).toHaveLength(1);
+		// Unplaceable, so it reads the way a passage whose prose moved does.
+		expect(view?.drifted).toBe(true);
+	});
+
+	it("does not let one unreadable relationship hide the others", () => {
+		let subject = store();
+		subject.sync([thread({ id: "a" }), thread({ id: "b" }), thread({ id: "c" })]);
+
+		quietly(() => subject.anchors([anchors("a"), malformed("b"), anchors("c")]));
+
+		expect(subject.snapshot().threads.map(each => each.thread.id)).toEqual(["a", "b", "c"]);
+		expect(subject.snapshot().threads[0]?.drifted).toBe(false);
+		expect(subject.snapshot().threads[1]?.drifted).toBe(true);
+	});
+
+	/**
+	 * `refresh` runs as a Lexical update listener, and Lexical runs those in
+	 * one loop with no isolation: the first to throw skips every listener after
+	 * it, including the one that syncs the document. Nothing it does may
+	 * escape, whatever the editor is doing.
+	 */
+	it("never throws out of refresh, whatever the editor does", () => {
+		let subject = store();
+		subject.sync([thread()]);
+		subject.attach({
+			getEditorState() {
+				throw new Error("the editor is gone");
+			},
+		} as never);
+		subject.bind({} as never);
+
+		quietly(() => {
+			expect(() => subject.refresh()).not.toThrow();
+		});
+	});
+});
+
 describe("publishing", () => {
 	it("tells nobody when nothing changed", () => {
 		let subject = store();

--- a/packages/editor/src/threads.ts
+++ b/packages/editor/src/threads.ts
@@ -286,8 +286,22 @@ export class ThreadStore {
 	 *
 	 * Called on every editor update as well as on new data, because a passage
 	 * is expressed against the document and any edit can move it.
+	 *
+	 * Guarded as a whole, on top of the per-thread guard inside. This runs as a
+	 * Lexical update listener, and Lexical runs those in one loop with no
+	 * isolation: the first to throw skips every listener after it, including
+	 * the one that syncs the document. A comment failing to paint must not cost
+	 * the room its collaboration.
 	 */
 	refresh = (): void => {
+		try {
+			this.#rebuild();
+		} catch (err) {
+			console.error("[plan] could not refresh the comment sidecar:", err);
+		}
+	};
+
+	#rebuild(): void {
 		let editor = this.#editor;
 		let binding = this.#binding;
 
@@ -301,23 +315,47 @@ export class ThreadStore {
 
 		let build = () => {
 			for (let thread of live) {
-				let anchors = this.#anchors.get(thread.id);
-				// Nothing resolves before the editor exists; the card still
-				// renders, with the quote and no highlight.
-				let points = editor && binding && anchors
-					? this.#points(binding, anchors)
-					: undefined;
+				/*
+				 * One thread at a time, and the whole of it.
+				 *
+				 * A thread whose relationship cannot be read is a highlight
+				 * nobody gets, not a sidecar nobody gets — and certainly not a
+				 * document nobody gets. The card still renders with its quote
+				 * and its notes, which is the durable part of a comment; the
+				 * anchor was only ever a convenience for finding it again.
+				 *
+				 * The guard covers reading the snapshot as well as resolving
+				 * it, because a malformed entry is as likely as an unresolvable
+				 * one and would otherwise cost every other card too.
+				 */
+				try {
+					let anchors = this.#anchors.get(thread.id);
+					// Nothing resolves before the editor exists; the card still
+					// renders, with the quote and no highlight.
+					let points = editor && binding && anchors
+						? this.#points(binding, anchors)
+						: undefined;
 
-				views.push({
-					thread,
-					...(points ? { points } : {}),
-					drifted: !!anchors?.subject.drifted || (!!editor && !!anchors && !points),
-					applied: !!anchors && !anchors.result.pending,
-					quote: thread.quote ?? anchors?.subject.quote ?? "",
-					...(points && editor ? { at: order(editor, points.anchorKey) } : {}),
-				});
+					views.push({
+						thread,
+						...(points ? { points } : {}),
+						drifted: !!anchors?.subject.drifted || (!!editor && !!anchors && !points),
+						applied: !!anchors && !anchors.result.pending,
+						quote: thread.quote ?? anchors?.subject.quote ?? "",
+						...(points && editor ? { at: order(editor, points.anchorKey) } : {}),
+					});
 
-				if (points) marks.push({ tone: this.#tone(thread), points });
+					if (points) marks.push({ tone: this.#tone(thread), points });
+				} catch (err) {
+					console.error(`[plan] could not place comment ${thread.id}:`, err);
+					// Unplaceable, but still worth reading.
+					views.push({
+						thread,
+						drifted: true,
+						applied: false,
+						quote: thread.quote ?? "",
+					});
+				}
 			}
 		};
 
@@ -346,7 +384,7 @@ export class ThreadStore {
 		if (JSON.stringify(next) === JSON.stringify(this.#state)) return;
 		this.#state = next;
 		for (let listener of this.#listeners) listener();
-	};
+	}
 
 	#tone(thread: Comment.Thread): Tone {
 		if (this.#focused === thread.id) return "current";

--- a/packages/editor/src/threads.ts
+++ b/packages/editor/src/threads.ts
@@ -14,12 +14,11 @@
 
 import { useCallback, useSyncExternalStore } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { $getNodeByKey, $isElementNode } from "lexical";
 import { useEffect } from "react";
 
 import { resolve } from "./anchors";
 import { $rangeOf, clear as unpaint, paint } from "./marks";
-import { $recover, locate } from "./passage";
+import { $blockPoints, $recover, locate } from "./passage";
 
 import type { Binding } from "@lexical/yjs";
 import type { LexicalEditor } from "lexical";
@@ -379,7 +378,7 @@ export class ThreadStore {
 		else build();
 
 		views.sort((a, b) => (a.at ?? Infinity) - (b.at ?? Infinity));
-		if (editor) paint(editor, marks);
+		if (editor) paint(editor, "comments", marks);
 
 		let writing: { [thread: string]: string[] } = {};
 		for (let [id, entry] of this.#writing) {
@@ -402,9 +401,17 @@ export class ThreadStore {
 		for (let listener of this.#listeners) listener();
 	}
 
+	/**
+	 * What this thread's mark says.
+	 *
+	 * The pointer is shared with questions, so hovering either kind of card
+	 * lights its prose the same way. What differs is only what is true when
+	 * nobody is pointing: a live comment is waiting on somebody, a decision is
+	 * a record of something settled.
+	 */
 	#tone(thread: Comment.Thread): Tone {
-		if (this.#focused === thread.id) return "current";
-		return thread.status === "accepted" ? "decided" : "open";
+		if (this.#focused === thread.id) return "related";
+		return thread.status === "accepted" ? "decision" : "comment";
 	}
 
 	/** Positions first; reading is what covers the gap before the next rebase. */
@@ -470,22 +477,6 @@ function order(editor: LexicalEditor, key: string): number | undefined {
 	} catch {
 		return undefined;
 	}
-}
-
-/**
- * A whole block, as points. Call inside a read.
- *
- * Child indices rather than text offsets: the result of a decision is block
- * granular, and `createDOMRange` reads an element point as a child index. A
- * block with nothing in it has no range worth painting.
- */
-function $blockPoints(key: string): Points | undefined {
-	let node = $getNodeByKey(key);
-	if (!$isElementNode(node)) return undefined;
-
-	let size = node.getChildrenSize();
-	if (size === 0) return undefined;
-	return { anchorKey: key, anchorOffset: 0, focusKey: key, focusOffset: size };
 }
 
 /** Mounted inside the editor, so resolution re-runs as the document changes. */

--- a/packages/editor/src/threads.ts
+++ b/packages/editor/src/threads.ts
@@ -17,13 +17,12 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import { useEffect } from "react";
 
 import { resolve } from "./anchors";
-import { $rangeOf, clear as unpaint, paint } from "./marks";
+import { clear as unpaint, paint } from "./marks";
 import { $blockPoints, $recover, locate } from "./passage";
 
 import type { Binding } from "@lexical/yjs";
 import type { LexicalEditor } from "lexical";
 import type { Comment, Plan } from "@chopin/protocol";
-import type { Marked, Tone } from "./marks";
 import type { Marked as Selected, Points } from "./passage";
 import type { Transport } from "./transport";
 
@@ -262,35 +261,6 @@ export class ThreadStore {
 		this.refresh();
 	}
 
-	/** The thread whose passage covers a point, innermost first. */
-	at(node: Node, offset: number): string | undefined {
-		let editor = this.#editor;
-		if (!editor) return undefined;
-
-		let best: { id: string; length: number } | undefined;
-
-		editor.getEditorState().read(() => {
-			for (let view of this.#state.threads) {
-				for (let points of view.places) {
-					let range = $rangeOf(editor, points);
-					if (!range) continue;
-					try {
-						if (range.comparePoint(node, offset) !== 0) continue;
-					} catch {
-						continue;
-					}
-					let length = range.toString().length;
-					// The tighter range is the more specific thing that was
-					// clicked; the list is in document order, so a later tie is
-					// the newer thread.
-					if (!best || length <= best.length) best = { id: view.thread.id, length };
-				}
-			}
-		});
-
-		return best?.id;
-	}
-
 	/**
 	 * Re-resolve and repaint.
 	 *
@@ -316,7 +286,7 @@ export class ThreadStore {
 		let binding = this.#binding;
 
 		let views: ThreadView[] = [];
-		let marks: Marked[] = [];
+		let marks: Points[] = [];
 
 		// Dismissed threads are not shown at all — the transcript is where they
 		// left their trace — so they are dropped once here rather than in each
@@ -358,8 +328,10 @@ export class ThreadStore {
 						...(first && editor ? { at: order(editor, first.anchorKey) } : {}),
 					});
 
-					let tone = this.#tone(thread);
-					for (let points of places) marks.push({ tone, points });
+					// Only the card the reader is pointing at. A standing mark on
+					// every comment and every decision ends up painted over most
+					// of a mature plan, which says nothing.
+					if (this.#focused === thread.id) marks.push(...places);
 				} catch (err) {
 					console.error(`[plan] could not place comment ${thread.id}:`, err);
 					// Unplaceable, but still worth reading.
@@ -399,19 +371,6 @@ export class ThreadStore {
 		if (JSON.stringify(next) === JSON.stringify(this.#state)) return;
 		this.#state = next;
 		for (let listener of this.#listeners) listener();
-	}
-
-	/**
-	 * What this thread's mark says.
-	 *
-	 * The pointer is shared with questions, so hovering either kind of card
-	 * lights its prose the same way. What differs is only what is true when
-	 * nobody is pointing: a live comment is waiting on somebody, a decision is
-	 * a record of something settled.
-	 */
-	#tone(thread: Comment.Thread): Tone {
-		if (this.#focused === thread.id) return "related";
-		return thread.status === "accepted" ? "decision" : "comment";
 	}
 
 	/** Positions first; reading is what covers the gap before the next rebase. */

--- a/packages/editor/src/threads.ts
+++ b/packages/editor/src/threads.ts
@@ -1,0 +1,420 @@
+/**
+ * Which comment threads the plan holds, and where they point.
+ *
+ * Two sources feed this and they arrive separately on purpose. What a thread
+ * says comes over `comment:*`; where it points comes over `plan:anchors`, with
+ * every other relationship in the plan, because a passage moves whenever the
+ * document does. Joining them by id here is what keeps the server from having
+ * to send the same fact twice on two schedules.
+ *
+ * An external store rather than React state because resolution has to re-run
+ * on every editor update, and that update arrives from a Lexical listener which
+ * knows nothing about rendering.
+ */
+
+import { useCallback, useSyncExternalStore } from "react";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { useEffect } from "react";
+
+import { resolve } from "./anchors";
+import { clear as unpaint, paint } from "./marks";
+import { $recover, locate } from "./passage";
+
+import type { Binding } from "@lexical/yjs";
+import type { LexicalEditor } from "lexical";
+import type { Comment, Plan } from "@chopin/protocol";
+import type { Marked, Tone } from "./marks";
+import type { Marked as Selected, Points } from "./passage";
+import type { Transport } from "./transport";
+
+/** A thread being written but not yet sent. It has no id until the server gives it one. */
+export type Draft = Selected;
+
+export type ThreadView = {
+	thread: Comment.Thread;
+	/** Where it points, once the anchors snapshot has caught up. */
+	points?: Points;
+	/** The passage cannot be found: the prose it marked has changed. */
+	drifted: boolean;
+	/**
+	 * The agent has said what an accepted thread produced.
+	 *
+	 * Derived from the result anchor rather than tracked: `pending` already
+	 * means "nobody has reviewed this since the last change", which is exactly
+	 * the question the card is asking.
+	 */
+	applied: boolean;
+	/** The prose it marks, as it currently reads. Frozen once resolved. */
+	quote: string;
+	/** Position in the document, for ordering the pane. Undefined if unresolved. */
+	at?: number;
+};
+
+export type ThreadState = {
+	threads: ThreadView[];
+	draft?: Draft;
+	/** Who is writing a reply, by thread. */
+	writing: { [thread: string]: string[] };
+	focused?: string;
+	/** Why the last attempt to mark a passage was refused. */
+	error?: string;
+};
+
+const EMPTY: ThreadState = { threads: [], writing: {} };
+
+export class ThreadStore {
+	#state: ThreadState = EMPTY;
+	#listeners = new Set<() => void>();
+
+	#threads = new Map<string, Comment.Thread>();
+	#anchors = new Map<string, Plan.ThreadAnchors>();
+	#writing = new Map<string, Map<string, string>>();
+	#draft: Draft | undefined;
+	#focused: string | undefined;
+	#error: string | undefined;
+
+	#binding: Binding | undefined;
+	#editor: LexicalEditor | undefined;
+	#wire: Transport | undefined;
+
+	subscribe = (listener: () => void): () => void => {
+		this.#listeners.add(listener);
+		return () => this.#listeners.delete(listener);
+	};
+
+	snapshot = (): ThreadState => this.#state;
+
+	attach(editor: LexicalEditor | undefined): void {
+		this.#editor = editor;
+		if (!editor) unpaint();
+	}
+
+	bind(binding: Binding | undefined): void {
+		this.#binding = binding;
+	}
+
+	/**
+	 * Take the room's socket, and listen on it.
+	 *
+	 * Returns the disposer rather than owning the lifetime: the host knows when
+	 * the connection goes away, and a store that unsubscribed itself would have
+	 * to guess.
+	 */
+	listen(wire: Transport | undefined): () => void {
+		this.#wire = wire;
+		if (!wire) {
+			this.#threads.clear();
+			this.refresh();
+			return () => {};
+		}
+
+		let off = [
+			wire.on<Comment.Sync>("comment:sync", frame => this.sync(frame.threads)),
+			wire.on<Comment.Opened>("comment:opened", frame => this.opened(frame.thread)),
+			wire.on<Comment.Said>("comment:said", frame => this.said(frame.id, frame.note)),
+			wire.on<Comment.Resolved>("comment:resolved", frame => this.resolved(frame)),
+			wire.on<Comment.Typing.Output>("comment:typing", frame => this.typing(frame)),
+		];
+
+		return () => {
+			for (let stop of off) stop();
+			this.#wire = undefined;
+		};
+	}
+
+	// -- acting ----------------------------------------------------------------
+
+	/** Send the drafted comment. The thread arrives back as `comment:opened`. */
+	start(text: string): void {
+		let draft = this.#draft;
+		if (!draft || !this.#wire) return;
+
+		void this.#wire
+			.ask<Comment.Start.Reply>("comment:start", { ...draft, text })
+			.then(frame => {
+				if (frame.ok) return this.opened(frame.thread);
+				// The plan moved under the selection, or there are too many
+				// open threads. Either way the draft is no longer sendable.
+				this.#draft = undefined;
+				this.#error = frame.message;
+				this.refresh();
+			})
+			.catch(() => {});
+	}
+
+	reply(id: string, text: string): void {
+		void this.#wire
+			?.ask<Comment.Reply.Reply>("comment:reply", { id, text })
+			.then(frame => {
+				if (frame.ok) this.said(id, frame.note);
+			})
+			.catch(() => {});
+	}
+
+	accept(id: string): void {
+		void this.#wire?.ask("comment:accept", { id }).catch(() => {});
+	}
+
+	dismiss(id: string): void {
+		void this.#wire?.ask("comment:dismiss", { id }).catch(() => {});
+	}
+
+	/**
+	 * Ask the agent to have another go at an accepted thread.
+	 *
+	 * An ordinary chat message, because that is what it is: the decision was
+	 * already made and recorded, and what is missing is a turn. Inventing a
+	 * frame for "run that again" would be a second way to start one.
+	 */
+	retry(id: string): void {
+		let view = this.#state.threads.find(entry => entry.thread.id === id);
+		if (!view || !this.#wire) return;
+		this.#wire.send("chat:send", {
+			text: `@ai apply the accepted comment on "${view.quote}" — it has not been actioned yet.`,
+		});
+	}
+
+	announce(id: string, writing: boolean): void {
+		this.#wire?.send("comment:typing", { id, writing });
+	}
+
+	// -- what threads say ------------------------------------------------------
+
+	/** Replace everything, from `comment:sync`. */
+	sync(threads: Comment.Thread[]): void {
+		this.#threads = new Map(threads.map(thread => [thread.id, thread]));
+		this.refresh();
+	}
+
+	opened(thread: Comment.Thread): void {
+		this.#threads.set(thread.id, thread);
+		// The card that was being drafted is now a real thread.
+		this.#draft = undefined;
+		this.refresh();
+	}
+
+	said(id: string, note: Comment.Note): void {
+		let thread = this.#threads.get(id);
+		if (!thread) return;
+		// A note the sender already added, arriving as a broadcast, must not
+		// appear twice.
+		if (thread.notes.some(existing => existing.id === note.id)) return;
+		this.#threads.set(id, { ...thread, notes: [...thread.notes, note] });
+		this.refresh();
+	}
+
+	resolved(event: Comment.Resolved): void {
+		let thread = this.#threads.get(event.id);
+		if (!thread) return;
+		this.#threads.set(event.id, {
+			...thread,
+			status: event.status,
+			resolver: event.resolver,
+			at: event.at,
+			quote: event.quote,
+		});
+		this.#writing.delete(event.id);
+		this.refresh();
+	}
+
+	typing(event: Comment.Typing.Output): void {
+		let entry = this.#writing.get(event.id);
+		if (event.writing) {
+			if (!entry) this.#writing.set(event.id, entry = new Map());
+			entry.set(event.client, event.handle);
+		} else {
+			entry?.delete(event.client);
+		}
+		this.refresh();
+	}
+
+	// -- where they point ------------------------------------------------------
+
+	/** Take a new snapshot from the server. */
+	anchors(threads: Plan.ThreadAnchors[]): void {
+		this.#anchors = new Map(threads.map(entry => [entry.thread, entry]));
+		this.refresh();
+	}
+
+	// -- drafting --------------------------------------------------------------
+
+	/**
+	 * Start a comment on what is selected.
+	 *
+	 * The passage is captured now, not held as a live selection: clicking into
+	 * the composer destroys the selection that summoned it, and a draft that
+	 * forgot what it was about the moment you started typing would be useless.
+	 */
+	draft(value: Draft | undefined): void {
+		this.#draft = value;
+		this.#error = undefined;
+		this.refresh();
+	}
+
+	focus(id: string | undefined): void {
+		if (this.#focused === id) return;
+		this.#focused = id;
+		this.refresh();
+	}
+
+	/** The thread whose passage covers a point, innermost first. */
+	at(node: Node, offset: number): string | undefined {
+		let editor = this.#editor;
+		if (!editor) return undefined;
+
+		let best: { id: string; length: number } | undefined;
+		for (let view of this.#state.threads) {
+			if (!view.points) continue;
+			let range = domRange(editor, view.points);
+			if (!range) continue;
+			try {
+				if (range.comparePoint(node, offset) !== 0) continue;
+			} catch {
+				continue;
+			}
+			let length = range.toString().length;
+			// The tighter range is the more specific thing that was clicked;
+			// the list is in document order, so a later tie is the newer thread.
+			if (!best || length <= best.length) best = { id: view.thread.id, length };
+		}
+
+		return best?.id;
+	}
+
+	/**
+	 * Re-resolve and repaint.
+	 *
+	 * Called on every editor update as well as on new data, because a passage
+	 * is expressed against the document and any edit can move it.
+	 */
+	refresh = (): void => {
+		let editor = this.#editor;
+		let binding = this.#binding;
+
+		let views: ThreadView[] = [];
+		let marks: Marked[] = [];
+
+		if (editor && binding) {
+			editor.getEditorState().read(() => {
+				for (let thread of this.#threads.values()) {
+					if (thread.status === "dismissed") continue;
+
+					let anchors = this.#anchors.get(thread.id);
+					let points = anchors ? this.#points(binding, anchors) : undefined;
+					views.push({
+						thread,
+						...(points ? { points } : {}),
+						drifted: !!anchors?.subject.drifted || (!!anchors && !points),
+						applied: !!anchors && !anchors.result.pending,
+						quote: thread.quote ?? anchors?.subject.quote ?? "",
+						...(points ? { at: order(editor, points.anchorKey) } : {}),
+					});
+
+					if (points) marks.push({ tone: this.#tone(thread), points });
+				}
+			});
+		} else {
+			for (let thread of this.#threads.values()) {
+				if (thread.status === "dismissed") continue;
+				let anchors = this.#anchors.get(thread.id);
+				views.push({
+					thread,
+					drifted: false,
+					applied: !!anchors && !anchors.result.pending,
+					quote: thread.quote ?? anchors?.subject.quote ?? "",
+				});
+			}
+		}
+
+		views.sort((a, b) => (a.at ?? Infinity) - (b.at ?? Infinity));
+		if (editor) paint(editor, marks);
+
+		let writing: { [thread: string]: string[] } = {};
+		for (let [id, entry] of this.#writing) {
+			if (entry.size > 0) writing[id] = [...new Set(entry.values())];
+		}
+
+		let next: ThreadState = {
+			threads: views,
+			writing,
+			...(this.#draft ? { draft: this.#draft } : {}),
+			...(this.#focused ? { focused: this.#focused } : {}),
+			...(this.#error ? { error: this.#error } : {}),
+		};
+
+		// Every keystroke in the plan produces an update and almost none of
+		// them move a thread. Comparing before publishing is what keeps the
+		// pane from re-rendering on every character typed in the prose.
+		if (JSON.stringify(next) === JSON.stringify(this.#state)) return;
+		this.#state = next;
+		for (let listener of this.#listeners) listener();
+	};
+
+	#tone(thread: Comment.Thread): Tone {
+		if (this.#focused === thread.id) return "current";
+		return thread.status === "accepted" ? "decided" : "open";
+	}
+
+	/** Positions first; reading is what covers the gap before the next rebase. */
+	#points(binding: Binding, anchors: Plan.ThreadAnchors): Points | undefined {
+		let found = locate(binding, anchors.subject);
+		if (found) return found;
+
+		let keys = anchors.subject.blocks
+			.map(block => resolve(binding, block))
+			.filter((key): key is string => !!key);
+		if (keys.length !== anchors.subject.blocks.length) return undefined;
+
+		return $recover(anchors.subject, keys);
+	}
+}
+
+/** Where a node sits among the document's blocks, for ordering the pane. */
+function order(editor: LexicalEditor, key: string): number | undefined {
+	let element = editor.getElementByKey(key);
+	if (!element) return undefined;
+
+	let root = editor.getRootElement();
+	if (!root) return undefined;
+
+	let block = element.closest(".plan-content > *") ?? element;
+	let index = [...root.children].indexOf(block);
+	return index === -1 ? undefined : index;
+}
+
+function domRange(editor: LexicalEditor, points: Points): Range | undefined {
+	let anchor = editor.getElementByKey(points.anchorKey);
+	let focus = editor.getElementByKey(points.focusKey);
+	if (!anchor || !focus) return undefined;
+
+	let range = document.createRange();
+	try {
+		range.setStart(anchor.firstChild ?? anchor, points.anchorOffset);
+		range.setEnd(focus.firstChild ?? focus, points.focusOffset);
+	} catch {
+		return undefined;
+	}
+	return range;
+}
+
+/** Mounted inside the editor, so resolution re-runs as the document changes. */
+export function ThreadObserver({ store }: { store: ThreadStore }) {
+	let [editor] = useLexicalComposerContext();
+
+	useEffect(() => {
+		store.attach(editor);
+		store.refresh();
+		let off = editor.registerUpdateListener(store.refresh);
+		return () => {
+			off();
+			store.attach(undefined);
+		};
+	}, [editor, store]);
+
+	return null;
+}
+
+export function useThreads(store: ThreadStore): ThreadState {
+	let subscribe = useCallback((listener: () => void) => store.subscribe(listener), [store]);
+	return useSyncExternalStore(subscribe, store.snapshot, store.snapshot);
+}

--- a/packages/editor/src/threads.ts
+++ b/packages/editor/src/threads.ts
@@ -294,37 +294,35 @@ export class ThreadStore {
 		let views: ThreadView[] = [];
 		let marks: Marked[] = [];
 
-		if (editor && binding) {
-			editor.getEditorState().read(() => {
-				for (let thread of this.#threads.values()) {
-					if (thread.status === "dismissed") continue;
+		// Dismissed threads are not shown at all — the transcript is where they
+		// left their trace — so they are dropped once here rather than in each
+		// branch below, where one copy of the rule could outlive the other.
+		let live = [...this.#threads.values()].filter(thread => thread.status !== "dismissed");
 
-					let anchors = this.#anchors.get(thread.id);
-					let points = anchors ? this.#points(binding, anchors) : undefined;
-					views.push({
-						thread,
-						...(points ? { points } : {}),
-						drifted: !!anchors?.subject.drifted || (!!anchors && !points),
-						applied: !!anchors && !anchors.result.pending,
-						quote: thread.quote ?? anchors?.subject.quote ?? "",
-						...(points ? { at: order(editor, points.anchorKey) } : {}),
-					});
-
-					if (points) marks.push({ tone: this.#tone(thread), points });
-				}
-			});
-		} else {
-			for (let thread of this.#threads.values()) {
-				if (thread.status === "dismissed") continue;
+		let build = () => {
+			for (let thread of live) {
 				let anchors = this.#anchors.get(thread.id);
+				// Nothing resolves before the editor exists; the card still
+				// renders, with the quote and no highlight.
+				let points = editor && binding && anchors
+					? this.#points(binding, anchors)
+					: undefined;
+
 				views.push({
 					thread,
-					drifted: false,
+					...(points ? { points } : {}),
+					drifted: !!anchors?.subject.drifted || (!!editor && !!anchors && !points),
 					applied: !!anchors && !anchors.result.pending,
 					quote: thread.quote ?? anchors?.subject.quote ?? "",
+					...(points && editor ? { at: order(editor, points.anchorKey) } : {}),
 				});
+
+				if (points) marks.push({ tone: this.#tone(thread), points });
 			}
-		}
+		};
+
+		if (editor && binding) editor.getEditorState().read(build);
+		else build();
 
 		views.sort((a, b) => (a.at ?? Infinity) - (b.at ?? Infinity));
 		if (editor) paint(editor, marks);

--- a/packages/editor/src/threads.ts
+++ b/packages/editor/src/threads.ts
@@ -14,10 +14,11 @@
 
 import { useCallback, useSyncExternalStore } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $getNodeByKey, $isElementNode } from "lexical";
 import { useEffect } from "react";
 
 import { resolve } from "./anchors";
-import { clear as unpaint, paint } from "./marks";
+import { $rangeOf, clear as unpaint, paint } from "./marks";
 import { $recover, locate } from "./passage";
 
 import type { Binding } from "@lexical/yjs";
@@ -32,9 +33,14 @@ export type Draft = Selected;
 
 export type ThreadView = {
 	thread: Comment.Thread;
-	/** Where it points, once the anchors snapshot has caught up. */
-	points?: Points;
-	/** The passage cannot be found: the prose it marked has changed. */
+	/**
+	 * Where it points, once the anchors snapshot has caught up.
+	 *
+	 * The phrase it marks while it is live; the prose its acceptance produced
+	 * once the agent has said what that was, which may be several blocks.
+	 */
+	places: Points[];
+	/** Nowhere left to point: the prose is gone and nothing replaced it. */
 	drifted: boolean;
 	/**
 	 * The agent has said what an accepted thread produced.
@@ -263,20 +269,25 @@ export class ThreadStore {
 		if (!editor) return undefined;
 
 		let best: { id: string; length: number } | undefined;
-		for (let view of this.#state.threads) {
-			if (!view.points) continue;
-			let range = domRange(editor, view.points);
-			if (!range) continue;
-			try {
-				if (range.comparePoint(node, offset) !== 0) continue;
-			} catch {
-				continue;
+
+		editor.getEditorState().read(() => {
+			for (let view of this.#state.threads) {
+				for (let points of view.places) {
+					let range = $rangeOf(editor, points);
+					if (!range) continue;
+					try {
+						if (range.comparePoint(node, offset) !== 0) continue;
+					} catch {
+						continue;
+					}
+					let length = range.toString().length;
+					// The tighter range is the more specific thing that was
+					// clicked; the list is in document order, so a later tie is
+					// the newer thread.
+					if (!best || length <= best.length) best = { id: view.thread.id, length };
+				}
 			}
-			let length = range.toString().length;
-			// The tighter range is the more specific thing that was clicked;
-			// the list is in document order, so a later tie is the newer thread.
-			if (!best || length <= best.length) best = { id: view.thread.id, length };
-		}
+		});
 
 		return best?.id;
 	}
@@ -332,25 +343,30 @@ export class ThreadStore {
 					let anchors = this.#anchors.get(thread.id);
 					// Nothing resolves before the editor exists; the card still
 					// renders, with the quote and no highlight.
-					let points = editor && binding && anchors
-						? this.#points(binding, anchors)
-						: undefined;
+					let places = editor && binding && anchors ? this.#places(binding, anchors) : [];
+					let first = places[0];
 
 					views.push({
 						thread,
-						...(points ? { points } : {}),
-						drifted: !!anchors?.subject.drifted || (!!editor && !!anchors && !points),
+						places,
+						// Only when there is nowhere left to point. A thread
+						// whose subject was rewritten but whose result resolves
+						// has not lost its place; it has moved to the prose it
+						// produced, which is the whole point of accepting it.
+						drifted: !!editor && !!anchors && places.length === 0,
 						applied: !!anchors && !anchors.result.pending,
 						quote: thread.quote ?? anchors?.subject.quote ?? "",
-						...(points && editor ? { at: order(editor, points.anchorKey) } : {}),
+						...(first && editor ? { at: order(editor, first.anchorKey) } : {}),
 					});
 
-					if (points) marks.push({ tone: this.#tone(thread), points });
+					let tone = this.#tone(thread);
+					for (let points of places) marks.push({ tone, points });
 				} catch (err) {
 					console.error(`[plan] could not place comment ${thread.id}:`, err);
 					// Unplaceable, but still worth reading.
 					views.push({
 						thread,
+						places: [],
 						drifted: true,
 						applied: false,
 						quote: thread.quote ?? "",
@@ -392,45 +408,84 @@ export class ThreadStore {
 	}
 
 	/** Positions first; reading is what covers the gap before the next rebase. */
-	#points(binding: Binding, anchors: Plan.ThreadAnchors): Points | undefined {
-		let found = locate(binding, anchors.subject);
-		if (found) return found;
+	/**
+	 * Where a thread points, now.
+	 *
+	 * The result first, when the agent has said what the decision produced.
+	 * The prose a thread was about is usually the prose it asked to have
+	 * rewritten, so after the turn the subject is gone by design — treating
+	 * that as the thread having lost its place gets it exactly backwards. What
+	 * was discussed is kept as a frozen quote; what it produced is where the
+	 * decision now lives.
+	 *
+	 * Block-wide, because after a rewrite there is no phrase to point at,
+	 * only a passage of new prose.
+	 */
+	#places(binding: Binding, anchors: Plan.ThreadAnchors): Points[] {
+		let { result, subject } = anchors;
 
-		let keys = anchors.subject.blocks
+		// Pending means nobody has checked this since the plan moved, so it is
+		// not somewhere worth sending a reader.
+		if (result.anchors.length > 0 && !result.pending) {
+			let produced = result.anchors
+				.map(anchor => resolve(binding, anchor))
+				.flatMap(key => (key ? [$blockPoints(key)] : []))
+				.filter((points): points is Points => !!points);
+			if (produced.length > 0) return produced;
+		}
+
+		let found = locate(binding, subject) ?? this.#recover(binding, subject);
+		return found ? [found] : [];
+	}
+
+	/** The phrase, read out of the prose, when its positions cannot be resolved. */
+	#recover(binding: Binding, subject: Plan.Passage): Points | undefined {
+		let keys = subject.blocks
 			.map(block => resolve(binding, block))
 			.filter((key): key is string => !!key);
-		if (keys.length !== anchors.subject.blocks.length) return undefined;
+		if (keys.length !== subject.blocks.length) return undefined;
 
-		return $recover(anchors.subject, keys);
+		return $recover(subject, keys);
 	}
 }
 
-/** Where a node sits among the document's blocks, for ordering the pane. */
+/**
+ * Where a node sits among the document's blocks, for ordering the pane.
+ *
+ * Guarded on its own rather than left to the caller's: this reaches for the
+ * DOM, and an editor without one throws rather than returning nothing. Sort
+ * order is cosmetic, and losing it must not cost the thread its place.
+ */
 function order(editor: LexicalEditor, key: string): number | undefined {
-	let element = editor.getElementByKey(key);
-	if (!element) return undefined;
-
-	let root = editor.getRootElement();
-	if (!root) return undefined;
-
-	let block = element.closest(".plan-content > *") ?? element;
-	let index = [...root.children].indexOf(block);
-	return index === -1 ? undefined : index;
-}
-
-function domRange(editor: LexicalEditor, points: Points): Range | undefined {
-	let anchor = editor.getElementByKey(points.anchorKey);
-	let focus = editor.getElementByKey(points.focusKey);
-	if (!anchor || !focus) return undefined;
-
-	let range = document.createRange();
 	try {
-		range.setStart(anchor.firstChild ?? anchor, points.anchorOffset);
-		range.setEnd(focus.firstChild ?? focus, points.focusOffset);
+		let element = editor.getElementByKey(key);
+		if (!element) return undefined;
+
+		let root = editor.getRootElement();
+		if (!root) return undefined;
+
+		let block = element.closest(".plan-content > *") ?? element;
+		let index = [...root.children].indexOf(block);
+		return index === -1 ? undefined : index;
 	} catch {
 		return undefined;
 	}
-	return range;
+}
+
+/**
+ * A whole block, as points. Call inside a read.
+ *
+ * Child indices rather than text offsets: the result of a decision is block
+ * granular, and `createDOMRange` reads an element point as a child index. A
+ * block with nothing in it has no range worth painting.
+ */
+function $blockPoints(key: string): Points | undefined {
+	let node = $getNodeByKey(key);
+	if (!$isElementNode(node)) return undefined;
+
+	let size = node.getChildrenSize();
+	if (size === 0) return undefined;
+	return { anchorKey: key, anchorOffset: 0, focusKey: key, focusOffset: size };
 }
 
 /** Mounted inside the editor, so resolution re-runs as the document changes. */

--- a/packages/editor/src/toolbar/bubble.tsx
+++ b/packages/editor/src/toolbar/bubble.tsx
@@ -131,7 +131,9 @@ type Position = { top: number; left: number };
 /** How close to the window edge the bubble may sit. */
 const EDGE = 8;
 
-export function SelectionBubble({ disabled }: { disabled?: boolean }) {
+export function SelectionBubble(
+	{ disabled, onComment }: { disabled?: boolean; onComment?: () => void },
+) {
 	let [editor] = useLexicalComposerContext();
 	let [position, setPosition] = useState<Position>();
 	let [active, setActive] = useState<Set<TextFormatType>>(new Set());
@@ -366,6 +368,27 @@ export function SelectionBubble({ disabled }: { disabled?: boolean }) {
 						>
 							🔗
 						</button>
+
+						{onComment && (
+							<>
+								<span aria-hidden="true" className="mx-0.5 h-4 w-px bg-border" />
+								<button
+									type="button"
+									aria-label="Comment on this passage"
+									title="Comment on this passage"
+									/*
+									 * The passage is captured now, inside the click, because
+									 * the composer this opens takes focus — and the selection
+									 * goes with it. A draft that forgot what it was about the
+									 * moment you started typing would be no use.
+									 */
+									onClick={onComment}
+									className="size-7 rounded text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+								>
+									💬
+								</button>
+							</>
+						)}
 					</>
 				)}
 		</div>

--- a/packages/editor/src/toolbar/index.tsx
+++ b/packages/editor/src/toolbar/index.tsx
@@ -7,7 +7,11 @@
 
 import { readOnly$ } from "@mdxeditor/editor";
 import { useCellValue } from "@mdxeditor/gurx";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $getSelection } from "lexical";
 
+import { $describe } from "../passage";
+import { widgets$ } from "../widgets-plugin";
 import { SelectionBubble } from "./bubble";
 import { SlashMenu } from "./slash";
 
@@ -18,10 +22,25 @@ import { SlashMenu } from "./slash";
  */
 export function Toolbar() {
 	let disabled = useCellValue(readOnly$);
+	let options = useCellValue(widgets$);
+	let [editor] = useLexicalComposerContext();
+
+	let threads = options.threads;
+
+	// Commenting is offered only when there is somewhere for the comment to
+	// go, so the button cannot appear on a surface with no sidecar.
+	let comment = threads
+		? () => {
+			editor.getEditorState().read(() => {
+				let marked = $describe($getSelection());
+				if (marked) threads.draft(marked);
+			});
+		}
+		: undefined;
 
 	return (
 		<>
-			<SelectionBubble disabled={disabled} />
+			<SelectionBubble disabled={disabled} onComment={comment} />
 			<SlashMenu disabled={disabled} />
 		</>
 	);

--- a/packages/editor/src/transport.ts
+++ b/packages/editor/src/transport.ts
@@ -11,6 +11,18 @@ export type Transport = {
 	on<T>(kind: string, handler: (frame: T) => void): Unsubscribe;
 	send(kind: string, payload?: Record<string, unknown>): void;
 	ask<T>(kind: string, payload?: Record<string, unknown>): Promise<T>;
+	/**
+	 * Whether a request can be carried right now.
+	 *
+	 * A connection comes up on its own schedule, and whatever mounted against
+	 * it does not. Asking rather than assuming is what stops a document being
+	 * opened against a socket that has not finished its handshake — which
+	 * fails once and, without this, forever.
+	 *
+	 * Optional so a test can still drive the transport with three functions.
+	 * Absent means "assume it can", which is what a stub wants.
+	 */
+	readonly connected?: boolean;
 };
 
 /** Mirrors the client's connection states, for read-only and status chrome. */

--- a/packages/editor/src/widgets-plugin.tsx
+++ b/packages/editor/src/widgets-plugin.tsx
@@ -15,14 +15,18 @@ import { addComposerChild$, realmPlugin } from "@mdxeditor/editor";
 import { Cell } from "@mdxeditor/gurx";
 
 import { QuestionnaireObserver } from "./questionnaires";
+import { ThreadObserver } from "./threads";
 import { Toolbar } from "./toolbar";
 import { CalloutPlugin, PreviewPlugin, TabsPlugin } from "./widgets";
 
 import type { QuestionnaireStore } from "./questionnaires";
+import type { ThreadStore } from "./threads";
 
 export type WidgetsOptions = {
 	/** Watched from inside the editor; read from outside it. */
 	questions?: QuestionnaireStore;
+	/** The same arrangement for comments: observed here, rendered in the pane. */
+	threads?: ThreadStore;
 };
 
 /** Live host configuration. Read it; do not capture it. */
@@ -36,6 +40,10 @@ export const widgetsPlugin = realmPlugin<WidgetsOptions>({
 		if (params?.questions) {
 			let store = params.questions;
 			realm.pub(addComposerChild$, () => <QuestionnaireObserver store={store} />);
+		}
+		if (params?.threads) {
+			let store = params.threads;
+			realm.pub(addComposerChild$, () => <ThreadObserver store={store} />);
 		}
 		realm.pub(addComposerChild$, TabsPlugin);
 		realm.pub(addComposerChild$, PreviewPlugin);

--- a/packages/editor/src/widgets/decision.tsx
+++ b/packages/editor/src/widgets/decision.tsx
@@ -1,0 +1,14 @@
+/**
+ * Accepted comment threads, in the prose.
+ *
+ * Nothing. The card belongs in the sidecar, and what marks the prose is the
+ * passage the decision concerns — highlighted in the text itself — rather than
+ * a block wedged in beside it. The node stays in the document so `plan.mdx`
+ * carries the decision and the agent can read it back.
+ */
+
+import type { DecisionNode } from "@chopin/dialect";
+
+export function renderDecision(_node: DecisionNode) {
+	return null;
+}

--- a/packages/editor/src/widgets/index.ts
+++ b/packages/editor/src/widgets/index.ts
@@ -8,10 +8,11 @@
 
 import { setRenderer } from "@chopin/dialect";
 
+import { renderDecision } from "./decision";
 import { renderImage } from "./image";
 import { renderQuestionnaire } from "./questionnaire";
 
-import type { ImageNode, QuestionnaireNode } from "@chopin/dialect";
+import type { DecisionNode, ImageNode, QuestionnaireNode } from "@chopin/dialect";
 
 let registered = false;
 
@@ -22,6 +23,7 @@ export function register(): void {
 
 	setRenderer<ImageNode>("plan-image", renderImage);
 	setRenderer<QuestionnaireNode>("plan-questionnaire", renderQuestionnaire);
+	setRenderer<DecisionNode>("plan-decision", renderDecision);
 }
 
 export { CalloutPlugin } from "./callout";

--- a/packages/editor/src/widgets/questionnaire.tsx
+++ b/packages/editor/src/widgets/questionnaire.tsx
@@ -9,6 +9,8 @@
 
 import { QuestionView, useQuestionnaire } from "@chopin/question/react";
 
+import { Provenance, SidecarCard } from "../card";
+
 import type { Transport } from "@chopin/question/react";
 import type { Answer } from "@chopin/question";
 import type { Questionnaire, QuestionnaireNode } from "@chopin/dialect";
@@ -84,12 +86,8 @@ function Undecided(
 	let answerable = connected && !!state.definition;
 
 	return (
-		<div
-			className="overflow-hidden rounded-lg border border-border bg-card"
-			data-plan-sidecar-questionnaire={value.id}
-		>
+		<SidecarCard data-plan-sidecar-questionnaire={value.id} label="Question" padded={false}>
 			<QuestionView
-				aside={<Heading count={value.questions.length} label="Open question" />}
 				collaborators={state.collaborators}
 				definition={state.definition ?? definition(value)}
 				// A draft that has not synced cannot be edited without discarding
@@ -104,7 +102,7 @@ function Undecided(
 				submitting={state.submitting}
 				{...pointing}
 			/>
-		</div>
+		</SidecarCard>
 	);
 }
 
@@ -112,31 +110,23 @@ function Decided(
 	{ resolved, value, ...pointing }: { resolved: Answer[]; value: Questionnaire } & Pointing,
 ) {
 	return (
-		<div
-			className="overflow-hidden rounded-lg border border-border bg-card"
+		<SidecarCard
 			data-plan-sidecar-questionnaire={value.id}
+			// Read off the node, so a late joiner sees it too and it survives a
+			// restart. Absent on one settled before the plan recorded any.
+			footer={<Provenance at={value.at} by={value.by} verb="Answered" />}
+			label="Question"
+			padded={false}
 		>
 			<QuestionView
 				answers={resolved}
-				aside={<Heading count={value.questions.length} label="Decision" />}
 				definition={definition(value)}
 				disabled
 				drafts={{}}
 				status="answered"
 				{...pointing}
 			/>
-		</div>
-	);
-}
-
-function Heading({ count, label }: { count: number; label: string }) {
-	return (
-		<header className="flex items-center gap-2 border-b border-border bg-muted px-3 py-2">
-			<span className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
-				{label}
-			</span>
-			{count > 1 && <span className="text-xs text-muted-foreground">{count} questions</span>}
-		</header>
+		</SidecarCard>
 	);
 }
 

--- a/packages/protocol/comment.d.ts
+++ b/packages/protocol/comment.d.ts
@@ -72,15 +72,22 @@ export declare namespace Comment {
 	/**
 	 * Mark a passage and say the first thing about it.
 	 *
-	 * The client sends what it can prove rather than what it computed: block
-	 * indices with the digests it read them at, and the text it selected. The
-	 * server verifies the digests against its own copy and mints every Yjs
-	 * position itself, so a client cannot place a passage anywhere the prose
-	 * does not agree it belongs.
+	 * The client sends what it read, not where it thinks that is: block indices
+	 * and the selected text. The server finds the quote in those blocks and
+	 * mints every Yjs position itself, so a client cannot place a passage
+	 * anywhere the prose does not agree it belongs.
+	 *
+	 * The quote is the concurrency check, and a better one than a digest would
+	 * be — it tests whether the sentence somebody selected is still there,
+	 * which is the thing that actually matters, and a client cannot compute a
+	 * canonical block digest without re-serialising the whole document anyway.
+	 * If the plan moved underneath, the quote is not found and the request is
+	 * refused rather than marking whatever is at that index now.
 	 */
 	export namespace Start {
 		export type Ask = KIND<"comment:start"> & {
-			blocks: Array<{ index: number; digest: string }>;
+			/** Blocks the selection covers, first to last. */
+			blocks: number[];
 			/** Bounded prefix of the selected text. */
 			quote: string;
 			/** Where the selection began in the run's text. */

--- a/packages/protocol/comment.d.ts
+++ b/packages/protocol/comment.d.ts
@@ -1,0 +1,182 @@
+import type { Frame, Request } from "./index";
+
+type KIND<K extends string> = Frame & { kind: K };
+
+/**
+ * Comments on the plan.
+ *
+ * A thread marks a passage of prose and collects what people said about it.
+ * Accepting one is the room deciding: the thread freezes, becomes a decision
+ * recorded beside the plan and projected into it, and the agent is asked to
+ * revise the prose accordingly. Dismissing one closes it without the agent.
+ *
+ * A thread's notes are append-only, so unlike a questionnaire's answer there is
+ * no shared draft and no CRDT — nobody is co-writing one sentence, they are
+ * each writing their own.
+ *
+ * Where a thread points is deliberately absent from these frames. A passage
+ * moves whenever the plan does, and `plan:anchors` already exists to carry
+ * every such relationship as one authoritative snapshot; sending it here too
+ * would be a second source of truth updated on a different schedule.
+ */
+export declare namespace Comment {
+	export type Incoming =
+		| Request<Start.Ask>
+		| Request<Reply.Ask>
+		| Request<Accept.Ask>
+		| Request<Dismiss.Ask>
+		| Typing.Input;
+
+	export type Outgoing =
+		| Sync
+		| Opened
+		| Said
+		| Resolved
+		| Start.Reply
+		| Reply.Reply
+		| Accept.Reply
+		| Dismiss.Reply
+		| Typing.Output;
+
+	export type Status = "open" | "accepted" | "dismissed";
+
+	export type Note = {
+		id: string;
+		handle: string;
+		text: string;
+		/** Unix seconds. */
+		ts: number;
+	};
+
+	export type Thread = {
+		id: string;
+		status: Status;
+		notes: Note[];
+		/**
+		 * The marked prose, frozen at the moment the thread resolved.
+		 *
+		 * Absent while open, when the live text is the passage's and travels on
+		 * `plan:anchors`. Present afterwards because a decision has to say what
+		 * was actually being discussed, and the anchor keeps moving.
+		 */
+		quote?: string;
+		/** Who accepted or dismissed it. */
+		resolver?: string;
+		/** When they did, Unix seconds. */
+		at?: number;
+	};
+
+	/** Every thread the plan holds, sent when a client joins. */
+	export type Sync = KIND<"comment:sync"> & { threads: Thread[] };
+
+	/**
+	 * Mark a passage and say the first thing about it.
+	 *
+	 * The client sends what it can prove rather than what it computed: block
+	 * indices with the digests it read them at, and the text it selected. The
+	 * server verifies the digests against its own copy and mints every Yjs
+	 * position itself, so a client cannot place a passage anywhere the prose
+	 * does not agree it belongs.
+	 */
+	export namespace Start {
+		export type Ask = KIND<"comment:start"> & {
+			blocks: Array<{ index: number; digest: string }>;
+			/** Bounded prefix of the selected text. */
+			quote: string;
+			/** Where the selection began in the run's text. */
+			offset: number;
+			/** Characters selected. */
+			length: number;
+			/** The first note. */
+			text: string;
+		};
+
+		export type Reply =
+			& KIND<"comment:start">
+			& (
+				| { ok: true; thread: Thread }
+				| { ok: false; reason: "invalid" | "full"; message: string }
+			);
+	}
+
+	/** A new thread, announced to the room. Followed by a `plan:anchors`. */
+	export type Opened = KIND<"comment:opened"> & { thread: Thread };
+
+	export namespace Reply {
+		export type Ask = KIND<"comment:reply"> & { id: string; text: string };
+
+		export type Reply =
+			& KIND<"comment:reply">
+			& { id: string }
+			& (
+				| { ok: true; note: Note }
+				| { ok: false; reason: "missing" | "resolved" | "invalid" | "full"; message: string }
+			);
+	}
+
+	/** Something said on an open thread. */
+	export type Said = KIND<"comment:said"> & { id: string; note: Note };
+
+	/**
+	 * A refusal that is not a failure: somebody got there first.
+	 *
+	 * Carries the outcome rather than an error, because the thing the caller
+	 * wanted to know — what happened to this thread — is already decided.
+	 */
+	type Settled = {
+		ok: false;
+		reason: "resolved";
+		status: Status;
+		resolver: string;
+	};
+
+	export namespace Accept {
+		/** Take the thread as the room's decision, and ask the agent to act. */
+		export type Ask = KIND<"comment:accept"> & { id: string };
+
+		export type Reply =
+			& KIND<"comment:accept">
+			& { id: string }
+			& (
+				| { ok: true; resolver: string; at: number }
+				| { ok: false; reason: "missing" | "resolving" | "invalid"; message: string }
+				| Settled
+			);
+	}
+
+	export namespace Dismiss {
+		/** Close the thread without involving the agent. */
+		export type Ask = KIND<"comment:dismiss"> & { id: string };
+
+		export type Reply =
+			& KIND<"comment:dismiss">
+			& { id: string }
+			& (
+				| { ok: true; resolver: string; at: number }
+				| { ok: false; reason: "missing" | "resolving" | "invalid"; message: string }
+				| Settled
+			);
+	}
+
+	/** The thread is closed. Nobody may add to it. */
+	export type Resolved = KIND<"comment:resolved"> & {
+		id: string;
+		status: Status;
+		resolver: string;
+		at: number;
+		/** The marked prose as it read when this was decided. */
+		quote: string;
+	};
+
+	/**
+	 * Somebody is writing a reply.
+	 *
+	 * Relayed and never stored. There is no shared draft to protect here — this
+	 * only stops two people writing the same reply at once, so a lost frame
+	 * costs nothing and the state is allowed to lapse on its own.
+	 */
+	export namespace Typing {
+		export type Input = KIND<"comment:typing"> & { id: string; writing: boolean };
+		export type Output = Input & { client: string; handle: string };
+	}
+}

--- a/packages/protocol/comment.d.ts
+++ b/packages/protocol/comment.d.ts
@@ -102,6 +102,19 @@ export declare namespace Comment {
 	/** A new thread, announced to the room. Followed by a `plan:anchors`. */
 	export type Opened = KIND<"comment:opened"> & { thread: Thread };
 
+	/**
+	 * Why a thread cannot be added to or resolved right now.
+	 *
+	 * `resolved` carries the outcome rather than an error message, because the
+	 * thing the caller wanted to know — what happened to this thread — is
+	 * already decided, and being second to ask is not a failure. `resolving`
+	 * is the same race caught a moment earlier, while the durable half of
+	 * somebody else's resolution is still being written.
+	 */
+	type Blocked =
+		| { ok: false; reason: "missing" | "resolving"; message: string }
+		| { ok: false; reason: "resolved"; status: Status; resolver: string };
+
 	export namespace Reply {
 		export type Ask = KIND<"comment:reply"> & { id: string; text: string };
 
@@ -110,25 +123,13 @@ export declare namespace Comment {
 			& { id: string }
 			& (
 				| { ok: true; note: Note }
-				| { ok: false; reason: "missing" | "resolved" | "invalid" | "full"; message: string }
+				| { ok: false; reason: "invalid" | "full"; message: string }
+				| Blocked
 			);
 	}
 
 	/** Something said on an open thread. */
 	export type Said = KIND<"comment:said"> & { id: string; note: Note };
-
-	/**
-	 * A refusal that is not a failure: somebody got there first.
-	 *
-	 * Carries the outcome rather than an error, because the thing the caller
-	 * wanted to know — what happened to this thread — is already decided.
-	 */
-	type Settled = {
-		ok: false;
-		reason: "resolved";
-		status: Status;
-		resolver: string;
-	};
 
 	export namespace Accept {
 		/** Take the thread as the room's decision, and ask the agent to act. */
@@ -139,8 +140,8 @@ export declare namespace Comment {
 			& { id: string }
 			& (
 				| { ok: true; resolver: string; at: number }
-				| { ok: false; reason: "missing" | "resolving" | "invalid"; message: string }
-				| Settled
+				| { ok: false; reason: "invalid"; message: string }
+				| Blocked
 			);
 	}
 
@@ -153,8 +154,8 @@ export declare namespace Comment {
 			& { id: string }
 			& (
 				| { ok: true; resolver: string; at: number }
-				| { ok: false; reason: "missing" | "resolving" | "invalid"; message: string }
-				| Settled
+				| { ok: false; reason: "invalid"; message: string }
+				| Blocked
 			);
 	}
 

--- a/packages/protocol/index.d.ts
+++ b/packages/protocol/index.d.ts
@@ -73,6 +73,7 @@ export declare namespace Session {
 }
 
 export type { Chat } from "./chat";
+export type { Comment } from "./comment";
 export type { Plan } from "./plan";
 export type { Question } from "./question";
 
@@ -80,6 +81,7 @@ export type { Question } from "./question";
 export type Incoming =
 	| Session.Incoming
 	| import("./chat").Chat.Incoming
+	| import("./comment").Comment.Incoming
 	| import("./plan").Plan.Incoming
 	| import("./question").Question.Incoming;
 
@@ -87,5 +89,6 @@ export type Incoming =
 export type Outgoing =
 	| Session.Outgoing
 	| import("./chat").Chat.Outgoing
+	| import("./comment").Comment.Outgoing
 	| import("./plan").Plan.Outgoing
 	| import("./question").Question.Outgoing;

--- a/packages/protocol/plan.d.ts
+++ b/packages/protocol/plan.d.ts
@@ -74,10 +74,58 @@ export declare namespace Plan {
 		questions: { [question: string]: QuestionAnchors };
 	};
 
+	/**
+	 * A phrase of the plan, as a comment marks it.
+	 *
+	 * An anchor names a whole block, which is the right grain for a decision but
+	 * not for a remark about one sentence in it. So a passage is the block run
+	 * plus a range inside it, and the range is expressed twice for the same
+	 * reason an anchor is: `start` and `end` are Yjs relative positions, so the
+	 * highlight stretches as somebody types inside the phrase, and `quote` is
+	 * what finds it again when they cannot be resolved — after a move, or an
+	 * epoch rotation.
+	 *
+	 * `quote` is a bounded locator rather than the whole phrase. `length` is the
+	 * real extent, so a passage longer than the bound is still recoverable:
+	 * find the prefix, then run on.
+	 */
+	export type Passage = {
+		/** The blocks it covers, first to last. */
+		blocks: Anchor[];
+		/** base64 `Y.encodeRelativePosition` of the range's start, in the first block. */
+		start: string;
+		/** base64 `Y.encodeRelativePosition` of its end, in the last. */
+		end: string;
+		/** Bounded prefix of the marked text. */
+		quote: string;
+		/** Where the quote began, so a phrase repeated in one block is not guessed at. */
+		offset: number;
+		/** Characters the passage covers, across the whole run. */
+		length: number;
+		/** Neither the positions nor the quote resolve. Kept rather than dropped. */
+		drifted?: true;
+	};
+
+	/**
+	 * What an accepted comment thread marks, and what accepting it produced.
+	 *
+	 * The two halves have different authors, which is why they have different
+	 * shapes. `subject` is the passage a person selected, and the server keeps
+	 * it moving with the plan. `result` is the prose the agent's revision
+	 * produced, and only the agent can say what that is — so it is an ordinary
+	 * anchor set, reviewed and pending exactly like a question's.
+	 */
+	export type ThreadAnchors = {
+		thread: string;
+		subject: Passage;
+		result: AnchorSet;
+	};
+
 	/** Authoritative replacement snapshot of every relationship in the plan. */
 	export type Anchors = KIND<"plan:anchors"> & {
 		epoch: string;
 		widgets: WidgetAnchors[];
+		threads: ThreadAnchors[];
 	};
 
 	/**
@@ -119,6 +167,8 @@ export declare namespace Plan {
 			revision: number;
 			/** Which prose each decision relates to, as an authoritative snapshot. */
 			anchors: WidgetAnchors[];
+			/** Which prose each comment thread marks, on the same terms. */
+			threads: ThreadAnchors[];
 			limits: Limits;
 		};
 	}


### PR DESCRIPTION
Select part of the plan, comment on it, and reply to each other in the right sidecar. Anyone can **accept** a thread — it freezes read-only, becomes an anchored decision projected into `plan.mdx`, and starts an agent turn to revise the prose — or **dismiss** it, which closes it without the agent.

Sixteen commits. The first eight build the feature, one per phase, each independently green; the rest are fixes and refinements found by running it, several in code that predates this branch. **375 tests**, up from 230.

## How it hangs together

**The record owns the thread; the plan shows the accepted ones.** A thread lives in `data/<room>/state.json` beside the questionnaire records, not in the Yjs document — a comment must not be undoable with Ctrl-Z, and the agent must not be able to rewrite what somebody said about its work. On accept, and only then, a `<Decision>` node is appended so the source carries the decision when read alone.

**A passage is an anchor one level finer.** An anchor names a block, which is the right grain for a decision and the wrong one for a remark about one sentence. So a passage is the block run plus a range inside it, held twice over: Yjs relative positions, so the highlight stretches as somebody types inside the phrase, and the quoted text, which finds it again when they cannot resolve. Same recovery ladder as an anchor, same refusal at the bottom — two occurrences equally near the recorded offset recover neither.

**An accepted thread points at what it produced, not at what it was about.** The prose a thread marked is usually the prose it asked to have rewritten, so after the agent acts the subject is gone by design. What was discussed is frozen as a quote; where the decision now lives is the result anchor.

**Accepting is an address.** The `@ai` rule separates conversation from instruction, and a button press is already the latter, so accept starts a turn through the same queue a message does, with a system line in the transcript explaining why the agent began moving.

**A client sends what it read, not where it thinks that is.** `comment:start` carries block indices and the selected text; the server finds the quote and mints every Yjs position itself. Finding it *is* the concurrency check, and a better one than a digest — it tests whether the sentence is still there, and a browser cannot compute a canonical block digest without re-serialising the document.

## Decisions that changed while building

- **A note's text is an attribute, not children.** A flow component's children parse as blocks, so prose between the tags comes back wrapped in a paragraph and flattens on export — which `room.validate()` rejects the whole plan for. Attributes round-trip newlines, quotes and angle brackets exactly, and the delimiter is escaped, so a note cannot break out into a second component.
- **No block digests on `comment:start`**, for the reason above.
- **Provenance lives on the container, not the answer.** `<Questionnaire by at>` rather than `<Answer by at>`: a questionnaire resolves as a unit, so per-answer provenance would write one handle and one moment N times. `<Decision by at>` already works this way.

## Bugs found and fixed

Four were in code that predates this branch. The error surfacing added here is what made two of them visible at all.

| | |
|---|---|
| **`AGENT=off` opened a session anyway** | `chat:send` was gated; a button press was not. Found by running the server. |
| **Accept rolled back after the document had changed** | A failed relay left a `<Decision>` in the plan whose record said the thread was open — and the next accept would add a second node with the same id. |
| **The plan never opened if the socket was still shaking hands** | *Pre-existing.* `connect()` ran once on mount and `ask` refused; nothing retried, so the editor stayed locked with the chrome saying "Loading". This was the bug reported as "sometimes I can't reload". |
| **No re-sync after a reconnect** | *Pre-existing.* `#replay()` is reachable only from `#open()`, so a client came back unlocked over a document quietly missing whatever arrived while it was away. |
| **A comment could take the room down** | Resolving anchors ran between applying the document and declaring it synced, inside a promise nobody caught. Now it runs after, guarded. |
| **`Wire.#receive` fanned frames out unguarded** | *Pre-existing.* The first handler to throw silenced every handler after it for that kind. |
| **`ThreadStore.refresh` dropped dismissed threads in two branches** | The test only covered one; removing the check from the other left it green. |
| **An invisible palette, twice** | Washes calibrated against a value that was doing nothing — the old rule's visible part was an outline. Decided prose rendered `#f2f9ff`. |

## Adjacent fixes, deliberately in scope

**Rebasing only ever happened inside `edit_plan`**, so a block somebody moved kept its anchors broken until the agent next edited, and everything restored from disk was expressed in a history the new document did not have. It now runs on the snapshot debounce, on an epoch rotation, and before `open` returns — and broadcasts only when the snapshot actually moved. This closes the identical pre-existing gap for question anchors.

**A failed open now says so** instead of claiming to still be loading, which is the difference between a bug somebody can report and one they cannot.

## One vocabulary for the sidecar

Questions and comments used to look nothing alike: one outlined a block through a DOM attribute, the other washed a range; one had a header and no provenance, the other provenance and no header.

Now both draw through one `SidecarCard`, and one `CSS.highlights` registration marks prose — **only while the reader is pointing at a card**. Standing marks were tried and taken out: a plan accumulates decisions, so anything permanent ends up covering most of the document.

`::highlight()` accepts neither outline nor box-shadow, which is why the wash is what both could be.

## Risk

The forward half of the Yjs position arithmetic is not exported by `@lexical/yjs`, so it is repeated in `plan/room.ts`. `passages.test.ts` pins it — including the test proving a highlight *stretches* when you type inside the phrase, which is the whole justification for keeping relative positions.

## Testing

**230 → 375.** Beyond the unit level: service ordering and relationship bookkeeping against a real `Service.open` room; `Chat.instruct`'s queue, ceiling and `AGENT=off` gate; eleven socket-level tests against a spawned server; the client store's reducers; and a colour test that composites each highlight over the page and refuses anything indistinguishable from it — there is no DOM in the test runtime, so a mark painted white looks exactly like one that failed to paint.

**Every test was verified by breaking the code it covers.** That is how the `refresh` duplication and an over-narrow guard were found. The whole path was also driven by hand against a running server: two members, marking, replying, typing, accept, dismiss, stale-index refusal, restart recovery, and provenance reaching `plan.mdx`.

`DEV_COMMENTS=1` marks a real phrase on room open, so the server path is exercisable with no client and no agent.

## Known and deliberate

- A questionnaire answered before this branch shows no footer — its record has a resolver but the file has nothing and there is no timestamp to recover. Not backfilled on load: the plan is a file a person can edit between runs, and correcting it at startup is what we decided against for missing `<Decision>` nodes.
- Nothing marks the prose at rest, so the sidecar is the only place you learn a passage has a comment. If that matters, a gutter marker is the cheap middle ground.
- `--radius-sm` and `--radius-md` are used five times in `styles.css` and defined nowhere, so those `border-radius` declarations are silently dropped. Pre-existing, untouched.

## Not included

Editing or deleting a posted note, reactions, threads on the chat transcript, per-card vertical alignment to the anchor.
