### PR TITLE
Show what the agent changed, and where it is working

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -24,7 +24,7 @@ packages/dialect     4.5k   the MDX dialect and its Lexical schema
 packages/editor      6.6k   the browser editor, cursors, the sidecar, agent marks
 packages/question    1.8k   questionnaires: definition, shared answer, derivation
 packages/protocol    0.9k   the wire, as types, plus the addressing rule
-apps/server          9.3k   rooms, documents, questions, comments, the agent
+apps/server          9.5k   rooms, documents, questions, comments, the agent
 apps/web             1.4k   the three panes
 scripts/dev.ts              the development supervisor
 ```
@@ -132,13 +132,28 @@ instead. Once seen the clock runs whether or not the mark is still in view: two
 states and one timer, so nothing can go dark and light up again on a later
 scroll, which would read as a second edit that never happened.
 
-**Those marks are drawn only in `box-shadow`**, on blocks that already exist.
-An agent editing below the fold must not shift the sentence somebody is in the
-middle of typing, and a mark expiring ten seconds later must not shift it back,
-so nothing may take space and nothing may add an element. What the agent
-removed has no element at all, which is why a hole is drawn on the edge of the
-block still beside it and why the side is part of its address — and why what
-was removed can only be read in the list behind the chips.
+**Those marks take no space and add no element.** An agent editing below the
+fold must not shift the sentence somebody is in the middle of typing, and a
+mark expiring ten seconds later must not shift it back. What the agent removed
+has no element at all, which is why a hole is drawn in `box-shadow` on the edge
+of the block still beside it and why the side is part of its address — and why
+what was removed can only be read in the list behind the chips.
+
+**The agent's cursor and the agent's marks disagree about time, on purpose.**
+The cursor is presence: it says the agent is working _here, now_, so it is
+broadcast the moment an edit lands, it is not held back for anyone, and it goes
+shortly after the turn ends. A mark is a record: it waits until it has been
+read and may sit unseen indefinitely. So somebody who comes back after a long
+turn sees marks and no cursor, and somebody watching sees both — which looks
+like an inconsistency until you notice they answer different questions. The
+cursor cannot replace the marks, because a cursor off screen is simply not
+there, and that is the case the marks exist for.
+
+**The agent rides in the presence mirror's own local slot.** Everything else
+in `plan/presence.ts` is a reflection of some socket, which is what lets a
+disconnect clear it; the agent has no socket, so it goes where nothing can
+attribute it to one. That slot is also in the join snapshot, so somebody
+arriving mid-turn sees where the agent is.
 
 ## Things that fail silently
 
@@ -203,6 +218,13 @@ because a recovery nobody is told about is the same as no recovery.
 **`CSS.highlights` is a document-wide registry**, shared with Lexical's remote
 cursors. Ours is named `plan-related`, its are `lexical-cursor-*`; a collision
 would silently unpaint somebody's selection.
+
+**Awareness ignores an update whose clock has not advanced**, and ignoring it
+means not refreshing the timer either. A peer drops a state it has not heard
+about for thirty seconds, so a cursor that outlives that has to be repeated —
+and repeating it by re-encoding the same state does nothing at all. The state
+has to be set again. Get this wrong and the agent's cursor vanishes partway
+through a long turn with nothing anywhere to say why.
 
 **An `IntersectionObserver` threshold is a fraction of the element**, not of
 the viewport. A block taller than the window can never reach `0.2`, so gating

--- a/agents.md
+++ b/agents.md
@@ -149,6 +149,16 @@ like an inconsistency until you notice they answer different questions. The
 cursor cannot replace the marks, because a cursor off screen is simply not
 there, and that is the case the marks exist for.
 
+**It sits at the end of what the agent wrote, and says its name for longer.**
+An anchor names a block from its start, which is the stable end of one; a
+cursor is where an edit _finished_, so `room.endOf` is its own function rather
+than a flag on `anchorAt`. A caret at the top of a new block points at the
+first thing the reader already knows and looks like something about to be
+typed. The label keeps the same distinction: a person's caret is one of several
+and its owner is watching it, so a second names them and that is enough, while
+the agent's turns up unannounced in a document somebody else is reading and the
+naming is the entire point of drawing it.
+
 **The agent rides in the presence mirror's own local slot.** Everything else
 in `plan/presence.ts` is a reflection of some socket, which is what lets a
 disconnect clear it; the agent has no socket, so it goes where nothing can

--- a/agents.md
+++ b/agents.md
@@ -124,7 +124,7 @@ to run without one.
 
 **A mark for an agent edit waits to be seen.** The agent writes wherever it
 likes, including several screens away from whoever is reading, so a mark that
-spent its ten seconds off screen would have told nobody anything. Nothing
+spent its few seconds off screen would have told nobody anything. Nothing
 starts counting down until it has been in the viewport, which makes it an
 unread marker rather than a flash — and unread markers do not expire on a
 clock, so an unseen one waits indefinitely and the set is bounded by a cap
@@ -134,7 +134,7 @@ scroll, which would read as a second edit that never happened.
 
 **Those marks take no space and add no element.** An agent editing below the
 fold must not shift the sentence somebody is in the middle of typing, and a
-mark expiring ten seconds later must not shift it back. What the agent removed
+mark expiring a few seconds later must not shift it back. What the agent removed
 has no element at all, which is why a hole is drawn in `box-shadow` on the edge
 of the block still beside it and why the side is part of its address — and why
 what was removed can only be read in the list behind the chips.

--- a/agents.md
+++ b/agents.md
@@ -21,10 +21,10 @@ agent, which is what the tests use.
 
 ```
 packages/dialect     4.5k   the MDX dialect and its Lexical schema
-packages/editor      5.4k   the browser editor, cursors, the sidecar
+packages/editor      6.6k   the browser editor, cursors, the sidecar, agent marks
 packages/question    1.8k   questionnaires: definition, shared answer, derivation
 packages/protocol    0.9k   the wire, as types, plus the addressing rule
-apps/server          8.8k   rooms, documents, questions, comments, the agent
+apps/server          9.3k   rooms, documents, questions, comments, the agent
 apps/web             1.4k   the three panes
 scripts/dev.ts              the development supervisor
 ```
@@ -122,6 +122,24 @@ is not there are all detectable in seconds by trying, and discovering them when
 somebody types their first message is worse. `AGENT=off` is the deliberate way
 to run without one.
 
+**A mark for an agent edit waits to be seen.** The agent writes wherever it
+likes, including several screens away from whoever is reading, so a mark that
+spent its ten seconds off screen would have told nobody anything. Nothing
+starts counting down until it has been in the viewport, which makes it an
+unread marker rather than a flash — and unread markers do not expire on a
+clock, so an unseen one waits indefinitely and the set is bounded by a cap
+instead. Once seen the clock runs whether or not the mark is still in view: two
+states and one timer, so nothing can go dark and light up again on a later
+scroll, which would read as a second edit that never happened.
+
+**Those marks are drawn only in `box-shadow`**, on blocks that already exist.
+An agent editing below the fold must not shift the sentence somebody is in the
+middle of typing, and a mark expiring ten seconds later must not shift it back,
+so nothing may take space and nothing may add an element. What the agent
+removed has no element at all, which is why a hole is drawn on the edge of the
+block still beside it and why the side is part of its address — and why what
+was removed can only be read in the list behind the chips.
+
 ## Things that fail silently
 
 Every bug found in this project so far was invisible. These are the mechanisms.
@@ -183,8 +201,26 @@ returns — and the flush broadcasts only when the snapshot actually moved,
 because a recovery nobody is told about is the same as no recovery.
 
 **`CSS.highlights` is a document-wide registry**, shared with Lexical's remote
-cursors. Ours are named `plan-comment*`, its are `lexical-cursor-*`; a
-collision would silently unpaint somebody's selection.
+cursors. Ours is named `plan-related`, its are `lexical-cursor-*`; a collision
+would silently unpaint somebody's selection.
+
+**An `IntersectionObserver` threshold is a fraction of the element**, not of
+the viewport. A block taller than the window can never reach `0.2`, so gating
+anything on a ratio silently excludes exactly the blocks most worth noticing. A
+negative `rootMargin` is the way to say "meaningfully on screen" for a block of
+any size.
+
+**An element that crosses the viewport in one frame produces no entry.** Its
+ratio is zero on both sides of a `scrollIntoView` or a scrollbar drag, so an
+observer watching for a crossing sees nothing and whatever was derived from the
+last one it did see is stale. `changes.ts` re-reads rectangles after any scroll
+longer than the viewport for this reason.
+
+**A block's index moves when anything above it is inserted.** Comparing indices
+before and after an edit therefore reports most of the document as having moved
+whenever one paragraph is added at the top. What genuinely moved is knowable
+only from the operations that were asked for, which is why `edit.ts` derives
+what was written from object identity and what moved or went from the batch.
 
 **`bun run <script>` does not exit when what it started dies.** It sits there
 with no child. `scripts/dev.ts` spawns both processes directly for this reason,
@@ -206,9 +242,14 @@ because something above surprised somebody.
 
 Tests describe behaviour rather than implementation, and their names read as
 sentences about what the system does. Prefer a test that fails when the
-behaviour regresses over one that fails when the code is rearranged. A few
-places have no test on purpose — anything requiring layout, since happy-dom
-returns zero for every measurement and a test there would assert a fiction.
+behaviour regresses over one that fails when the code is rearranged.
+
+A few places have no test on purpose. **There is no DOM in the test runtime** —
+no happy-dom, no preload, `document` is undefined — so anything that reaches
+for an element, a rectangle or an observer cannot be covered at all. The answer
+is not to add one but to keep the part worth testing separable from the part
+that needs a browser: `trail.ts` is the whole of the mark lifecycle with no
+document in it, and `changes.ts` is the adapter that has one and is not tested.
 
 ## Diagnostics
 

--- a/apps/server/src/agent/tools.ts
+++ b/apps/server/src/agent/tools.ts
@@ -39,6 +39,8 @@ export type Context = {
 	publish: (mutation: { update: Uint8Array; source: string }) => void;
 	/** Relays the current relationship snapshot to everyone in the room. */
 	anchors: () => void;
+	/** Tells the room where this batch wrote, moved and removed. */
+	changes: (found: edit.Change[]) => void;
 };
 
 export function toolbox(context: Context): Tool[] {
@@ -152,6 +154,12 @@ export function toolbox(context: Context): Tool[] {
 					if (!outcome.ok) return outcome;
 
 					if (outcome.mutation) context.publish(outcome.mutation);
+
+					// After the update that created them, never before it. Both
+					// go to the same topic in order, so by the time this arrives
+					// the browser already holds the blocks it names.
+					context.changes(outcome.changes);
+
 					for (let id of outcome.detached) {
 						let record = context.plan.records.get(id);
 						if (record) context.plan.records.set(id, { ...record, status: "cancelled" });

--- a/apps/server/src/chat/service.ts
+++ b/apps/server/src/chat/service.ts
@@ -310,6 +310,7 @@ async function session(context: Room): Promise<Agent.Agent> {
 			room,
 			publish: mutation => Service.publish(plan, server, room, mutation),
 			anchors: () => Service.anchors(plan, server, room),
+			changes: found => Service.changes(plan, server, room, found),
 		});
 
 		let { agent, resumed } = await Agent.open(config, { tools }, chat.resume);

--- a/apps/server/src/chat/service.ts
+++ b/apps/server/src/chat/service.ts
@@ -37,6 +37,9 @@ import type { Socket, SocketData } from "../wire";
 /** Beyond this the queue is a backlog nobody is going to read. */
 const MAX_QUEUE = 20;
 
+/** How long the agent's cursor stays where it finished, after a turn ends. */
+const LINGER_MS = 10_000;
+
 /**
  * A queued message, with what the queue needs and clients do not.
  *
@@ -78,6 +81,8 @@ export type Chat = {
 	writing?: string;
 	/** Detaches the event handler when a turn ends. */
 	release?: () => void;
+	/** Pending removal of the agent's cursor, cancelled if it edits again. */
+	lingering?: ReturnType<typeof setTimeout>;
 	/** When each running tool call started, for its duration. */
 	timings: Map<string, number>;
 	/** Session id, persisted so a restart resumes the conversation. */
@@ -356,7 +361,7 @@ function settle(chat: Chat, server: Server<SocketData>, room: string): void {
 
 /** Run one turn, then drain whatever queued up behind it. */
 async function run(context: Room, handle: string, text: string, thread?: string): Promise<void> {
-	let { chat, room, server } = context;
+	let { chat, plan, room, server } = context;
 
 	chat.busy = true;
 	chat.turn = handle;
@@ -409,6 +414,21 @@ async function run(context: Room, handle: string, text: string, thread?: string)
 		chat.turn = undefined;
 		chat.acting = undefined;
 		state(chat, server, room);
+
+		/*
+		 * The agent's cursor outlives the turn by a moment.
+		 *
+		 * Somebody who looks over just as it finishes should still see where it
+		 * got to, and a caret that vanished on the same tick as the last token
+		 * would deny them that. Restarted rather than stacked: a queued turn
+		 * starting inside the linger must cancel this, or it would take down a
+		 * cursor the next turn had just placed.
+		 */
+		clearTimeout(chat.lingering);
+		chat.lingering = setTimeout(() => {
+			chat.lingering = undefined;
+			Service.release(plan, server, room);
+		}, LINGER_MS);
 	}
 
 	let next = pending(chat);
@@ -615,6 +635,10 @@ function attach(chat: Chat, activity: Wire.Activity): string {
 /** Let go of the session. The conversation is resumable by id. */
 export async function close(chat: Chat): Promise<void> {
 	chat.release?.();
+	// A cursor waiting to be taken down has nowhere to be taken down from, and
+	// a live timer would hold the loop open for its whole linger.
+	clearTimeout(chat.lingering);
+	chat.lingering = undefined;
 	await chat.agent?.session.disconnect().catch(() => {});
 	chat.agent = undefined;
 }

--- a/apps/server/src/chat/service.ts
+++ b/apps/server/src/chat/service.ts
@@ -38,7 +38,7 @@ import type { Socket, SocketData } from "../wire";
 const MAX_QUEUE = 20;
 
 /** How long the agent's cursor stays where it finished, after a turn ends. */
-const LINGER_MS = 10_000;
+const LINGER_MS = 5_000;
 
 /**
  * A queued message, with what the queue needs and clients do not.

--- a/apps/server/src/plan/anchors.test.ts
+++ b/apps/server/src/plan/anchors.test.ts
@@ -9,6 +9,9 @@
  */
 
 import { describe, expect, it } from "bun:test";
+import { $getAnchorAndFocusForUserState } from "@lexical/yjs";
+import { $getNodeByKey } from "lexical";
+import type * as Y from "yjs";
 
 import * as edit from "./edit";
 import * as room from "./room";
@@ -275,5 +278,86 @@ describe("pointing at what an edit did", () => {
 
 		expect(room.resolveAnchor(subject.document, value)).toBeDefined();
 		expect(block(subject, value)).toBe("Inserted.");
+	});
+});
+
+/**
+ * Where the agent leaves its cursor.
+ *
+ * At the end of what it wrote, not the start. A caret at the top of a new
+ * block points at the first thing the reader already knows about and reads as
+ * though the agent is about to type there — the opposite of what happened.
+ *
+ * Resolved through Lexical rather than inspected as a Yjs position, because
+ * the only question that matters is where a browser would draw it.
+ */
+describe("the agent's cursor", () => {
+	/** What `syncCursorPositions` would resolve the position to. */
+	function caret(subject: Room, position: Y.RelativePosition) {
+		let state = {
+			anchorPos: position,
+			focusPos: position,
+			color: "",
+			focusing: true,
+			name: "",
+			awarenessData: {},
+		};
+
+		let found: { key: string | null; offset: number } | undefined;
+		subject.document.editor.getEditorState().read(() => {
+			let { anchorKey, anchorOffset } = $getAnchorAndFocusForUserState(
+				subject.document.binding,
+				state,
+			);
+			found = { key: anchorKey, offset: anchorOffset };
+		});
+		return found!;
+	}
+
+	/** The text of the node a caret landed in, and how far into it it sits. */
+	function landed(subject: Room, position: Y.RelativePosition) {
+		let { key, offset } = caret(subject, position);
+		let text: string | undefined;
+		subject.document.editor.getEditorState().read(() => {
+			text = key ? $getNodeByKey(key)?.getTextContent() : undefined;
+		});
+		return { text, offset };
+	}
+
+	it("sits after the last character of the block, not before the first", async () => {
+		let subject = await plan();
+
+		expect(landed(subject, room.endOf(subject.document, 1)))
+			.toEqual({ text: "The first paragraph.", offset: "The first paragraph.".length });
+	});
+
+	it("is somewhere else entirely for a different block", async () => {
+		let subject = await plan();
+
+		expect(landed(subject, room.endOf(subject.document, 3)))
+			.toEqual({ text: "The third paragraph.", offset: "The third paragraph.".length });
+	});
+
+	it("lands at the end of what a batch just wrote", async () => {
+		let subject = await plan();
+		let outcome = edit.apply(subject, 1, [
+			{ op: "insert", index: 3, source: "Appended by the agent.\n" },
+		]);
+
+		expect(outcome.ok).toBe(true);
+		if (!outcome.ok) return;
+		let added = outcome.changes.find(change => change.kind === "added");
+		if (added?.kind !== "added") throw new Error("expected a written block");
+
+		expect(landed(subject, room.endOf(subject.document, added.index))).toEqual({
+			text: "Appended by the agent.",
+			offset: "Appended by the agent.".length,
+		});
+	});
+
+	/** A questionnaire is a map, not a sequence; there is no inside to end at. */
+	it("does not fall over on a block with no text in it", async () => {
+		let subject = await plan("---\n");
+		expect(() => room.endOf(subject.document, 0)).not.toThrow();
 	});
 });

--- a/apps/server/src/plan/anchors.test.ts
+++ b/apps/server/src/plan/anchors.test.ts
@@ -199,3 +199,81 @@ describe("digests", () => {
 		expect(new Set(first).size).toBe(4);
 	});
 });
+
+/**
+ * Turning what a batch did into places a browser can find.
+ *
+ * The edit engine reports indices, because only it knows what the operations
+ * meant; the anchors are minted afterwards, because only the live document
+ * knows where a block sits in the collaborative history. These pin the join
+ * between the two — an off-by-one here would mark the wrong prose, and mark it
+ * plausibly enough that nobody would question it.
+ */
+describe("pointing at what an edit did", () => {
+	/**
+	 * The block an anchor names, as the text in it.
+	 *
+	 * Both halves of the anchor have to agree for this to answer: the position
+	 * has to still resolve in this history, and the digest has to still match a
+	 * block. An anchor minted against the wrong index fails the second even
+	 * though it passes the first, which is the off-by-one worth catching.
+	 */
+	function block(subject: Room, value: Plan.Anchor): string | undefined {
+		if (!room.resolveAnchor(subject.document, value)) return undefined;
+		let index = room.digests(subject.document).indexOf(value.digest);
+		return index < 0 ? undefined : edit.outline(subject)[index]?.preview;
+	}
+
+	it("anchors a written block to the block that was written", async () => {
+		let subject = await plan();
+		let outcome = edit.apply(subject, 1, [{ op: "insert", index: 1, source: "Inserted.\n" }]);
+
+		expect(outcome.ok).toBe(true);
+		if (!outcome.ok) return;
+
+		let added = outcome.changes.find(change => change.kind === "added");
+		expect(added).toBeDefined();
+		if (added?.kind !== "added") return;
+
+		expect(block(subject, anchor(subject.document, added.index))).toBe("Inserted.");
+	});
+
+	it("anchors a hole to the block still beside it", async () => {
+		let subject = await plan();
+		let outcome = edit.apply(subject, 1, [{ op: "delete", index: 2 }]);
+
+		expect(outcome.ok).toBe(true);
+		if (!outcome.ok) return;
+
+		let hole = outcome.changes.find(change => change.kind === "removed");
+		if (hole?.kind !== "removed") throw new Error("expected a hole");
+
+		// The paragraph that followed what went, which is now in its place.
+		expect(hole.at.side).toBe("before");
+		expect(block(subject, anchor(subject.document, hole.at.index)))
+			.toBe("The third paragraph.");
+		expect(hole.blocks).toEqual([{ type: "paragraph", preview: "The second paragraph." }]);
+	});
+
+	/**
+	 * The reason these are anchors rather than the indices the engine reported.
+	 * Somebody typing a new block above them between the edit and the browser
+	 * painting it would leave every index off by one.
+	 */
+	it("still names the same blocks after somebody edits above them", async () => {
+		let subject = await plan();
+		let outcome = edit.apply(subject, 1, [{ op: "insert", index: 1, source: "Inserted.\n" }]);
+
+		expect(outcome.ok).toBe(true);
+		if (!outcome.ok) return;
+		let added = outcome.changes.find(change => change.kind === "added");
+		if (added?.kind !== "added") return;
+
+		let value = anchor(subject.document, added.index);
+		subject.revision = 2;
+		expect(edit.apply(subject, 2, [{ op: "insert", index: 0, source: "Above.\n" }]).ok).toBe(true);
+
+		expect(room.resolveAnchor(subject.document, value)).toBeDefined();
+		expect(block(subject, value)).toBe("Inserted.");
+	});
+});

--- a/apps/server/src/plan/edit.test.ts
+++ b/apps/server/src/plan/edit.test.ts
@@ -293,3 +293,150 @@ describe("reconciliation", () => {
 		expect(outcome.mutation!.source).toContain("Added.");
 	});
 });
+
+/**
+ * What a batch did, so a reader can be shown where.
+ *
+ * The two halves are derived differently on purpose, and the difference is
+ * what these pin: identity answers what was written, and cannot be fooled;
+ * the operations answer what moved or went, which identity cannot tell apart
+ * from a block merely pushed down by an insert above it.
+ */
+describe("reporting what a batch did", () => {
+	/** Every change, in the order the reader will meet them. */
+	function changes(outcome: edit.Result): edit.Change[] {
+		expect(outcome.ok).toBe(true);
+		return outcome.ok ? outcome.changes : [];
+	}
+
+	it("reports a block it wrote, with enough of it to recognise", () => {
+		let found = changes(
+			edit.apply(subject, 1, [{ op: "insert", index: 0, source: "Inserted.\n" }]),
+		);
+
+		expect(found).toEqual([
+			{ kind: "added", index: 1, type: "paragraph", preview: "Inserted." },
+		]);
+	});
+
+	/**
+	 * The case index comparison gets wrong. Everything below an insert shifts
+	 * down by one, and a diff that read position as movement would light up
+	 * the whole document for an edit that touched one block.
+	 */
+	it("does not report blocks an insert pushed down as having moved", () => {
+		let found = changes(
+			edit.apply(subject, 1, [{ op: "insert", index: 0, source: "Inserted.\n" }]),
+		);
+
+		expect(found.filter(change => change.kind === "moved")).toEqual([]);
+	});
+
+	it("reports a rewrite as what it wrote, and leaves no hole", () => {
+		let found = changes(
+			edit.apply(subject, 1, [{ op: "replace", index: 1, source: "Rewritten.\n" }]),
+		);
+
+		expect(found).toEqual([
+			{ kind: "added", index: 1, type: "paragraph", preview: "Rewritten." },
+		]);
+	});
+
+	it("names the hole a deletion left by the block that followed it", () => {
+		let found = changes(edit.apply(subject, 1, [{ op: "delete", index: 1 }]));
+
+		expect(found).toEqual([
+			{
+				kind: "removed",
+				at: { index: 1, side: "before" },
+				blocks: [{ type: "paragraph", preview: "First paragraph." }],
+			},
+		]);
+	});
+
+	it("names a hole at the end by the block before it", () => {
+		let found = changes(edit.apply(subject, 1, [{ op: "delete", index: 2 }]));
+
+		expect(found).toEqual([
+			{
+				kind: "removed",
+				at: { index: 1, side: "after" },
+				blocks: [{ type: "paragraph", preview: "Second paragraph." }],
+			},
+		]);
+	});
+
+	/** Three blocks deleted in a row is one hole in the prose, not three. */
+	it("collapses deletions that left the same space into one hole", () => {
+		let found = changes(
+			edit.apply(subject, 1, [{ op: "delete", index: 1 }, { op: "delete", index: 2 }]),
+		);
+
+		expect(found).toEqual([
+			{
+				kind: "removed",
+				at: { index: 0, side: "after" },
+				blocks: [
+					{ type: "paragraph", preview: "First paragraph." },
+					{ type: "paragraph", preview: "Second paragraph." },
+				],
+			},
+		]);
+	});
+
+	it("reports a move as one change, at both ends", () => {
+		let found = changes(edit.apply(subject, 1, [{ op: "move", index: 0, to: 2 }]));
+
+		expect(found).toEqual([
+			{
+				kind: "moved",
+				index: 2,
+				from: { index: 0, side: "before" },
+				type: "heading",
+				preview: "Title",
+			},
+		]);
+	});
+
+	it("reports nothing for a move that goes nowhere", () => {
+		expect(changes(edit.apply(subject, 1, [{ op: "move", index: 1, to: 1 }]))).toEqual([]);
+	});
+
+	/**
+	 * The exclusion that stops a hole pointing at the wrong prose.
+	 *
+	 * The deleted paragraph sat between the heading and the block after it,
+	 * and that block is the one this batch sends to the top. Naming the hole
+	 * by it would put the mark above the whole document, nowhere near where
+	 * the content was, so the search has to pass over anything that vacated
+	 * and settle on the heading instead.
+	 */
+	it("does not name a hole by a block that has itself gone elsewhere", () => {
+		let found = changes(
+			edit.apply(subject, 1, [{ op: "delete", index: 1 }, { op: "move", index: 2, to: 0 }]),
+		);
+
+		expect(room.project(subject.document)).toBe("Second paragraph.\n\n# Title\n");
+		// The heading, which ended up last — not the paragraph now at the top.
+		expect(found.find(change => change.kind === "removed"))
+			.toMatchObject({ at: { index: 1, side: "after" } });
+	});
+
+	/** A document marked from end to end says nothing at all. */
+	it("reports nothing when the whole plan was replaced", () => {
+		expect(changes(edit.apply(subject, 1, [{ op: "replace_root", source: "# New\n" }])))
+			.toEqual([]);
+	});
+
+	it("reads in document order", () => {
+		let found = changes(
+			edit.apply(subject, 1, [
+				{ op: "insert", index: 2, source: "Last.\n" },
+				{ op: "insert", index: 0, source: "Early.\n" },
+			]),
+		);
+
+		expect(found.map(change => change.kind === "removed" ? change.at.index : change.index))
+			.toEqual([1, 4]);
+	});
+});

--- a/apps/server/src/plan/edit.ts
+++ b/apps/server/src/plan/edit.ts
@@ -49,6 +49,29 @@ export type Operation =
 	| { op: "delete"; index: number }
 	| { op: "detach_question"; id: string };
 
+/** Enough of a block to recognise it in a list, without hashing it. */
+export type Excerpt = { type: string; preview: string };
+
+/**
+ * Where a gap sits, in post-edit indices.
+ *
+ * A block that has gone cannot be addressed, so the space it left is named by
+ * a block still beside it and the side the content was on.
+ */
+export type Spot = { index: number; side: "before" | "after" };
+
+/**
+ * One thing a batch did, as somewhere a reader can be pointed.
+ *
+ * A rewrite is `added` alone. Something is still there to look at, and a batch
+ * that also reported a gap would put a tombstone on the most common edit the
+ * agent makes.
+ */
+export type Change =
+	| ({ kind: "added"; index: number } & Excerpt)
+	| ({ kind: "moved"; index: number; from: Spot } & Excerpt)
+	| { kind: "removed"; at: Spot; blocks: Excerpt[] };
+
 export type Result =
 	| {
 		ok: true;
@@ -64,6 +87,21 @@ export type Result =
 		touched: number[];
 		/** Questionnaires this batch took out of the plan. */
 		detached: string[];
+		/**
+		 * What this batch did, in document order, for marking in the browser.
+		 *
+		 * Wider than `touched`, and not a superset of it: that answers which
+		 * blocks now hold the agent's prose, which is what attributing a
+		 * decision needs, and it is silent about a block that only moved or
+		 * one that has gone. This answers where a reader should be sent, so a
+		 * deletion is a place too and a rewrite is one change rather than a
+		 * disappearance and an arrival.
+		 *
+		 * Indices rather than anchors: turning one into the other needs the
+		 * live document, which is the service's to reach into, not this
+		 * module's. Empty when there is nothing worth pointing at.
+		 */
+		changes: Change[];
 		/** The change to relay, absent when the batch was a no-op. */
 		mutation: room.Mutation | undefined;
 	}
@@ -188,7 +226,131 @@ export function apply(plan: Plan, revision: number, operations: Operation[]): Re
 		revision: plan.revision,
 		blocks: outline(plan),
 		touched: children.flatMap((node, index) => carried.has(node) ? [] : [index]),
+		changes: describeChanges(root.children, children, operations),
 	};
+}
+
+/**
+ * What a batch did, as places a reader can be sent.
+ *
+ * Two derivations, deliberately different. What was *written* comes from
+ * object identity: a node reconciliation carried through is the same object,
+ * and the agent cannot misreport that. What *moved or went* comes from the
+ * operations, because identity cannot tell those apart — a node missing from
+ * the result may have been deleted or replaced, and a node at a new index may
+ * have moved or merely been pushed down by an insert above it.
+ *
+ * Both are exact here: a batch aborts on the first operation that fails, so
+ * reaching this point means every one of them applied.
+ */
+function describeChanges(
+	base: RootContent[],
+	after: RootContent[],
+	operations: Operation[],
+): Change[] {
+	// A batch that replaced the whole plan changed every block in it, and a
+	// document marked from end to end says nothing at all. `replace_root` has
+	// to stand alone, so this is the whole condition.
+	if (operations.some(operation => operation.op === "replace_root")) return [];
+
+	let carried = new Set(base);
+	let place = new Map(after.map((node, index) => [node, index]));
+
+	let left: { node: RootContent; index: number; moved: boolean }[] = [];
+	for (let operation of operations) {
+		switch (operation.op) {
+			case "delete": {
+				let node = base[operation.index];
+				if (node) left.push({ node, index: operation.index, moved: false });
+				break;
+			}
+			case "detach_question": {
+				let index = base.findIndex(node => questionnaire(node) === operation.id);
+				let node = base[index];
+				if (node) left.push({ node, index, moved: false });
+				break;
+			}
+			case "move": {
+				// `step` treats this as a no-op, so neither end is worth marking.
+				if (operation.to === operation.index) break;
+				let node = base[operation.index];
+				if (node) left.push({ node, index: operation.index, moved: true });
+				break;
+			}
+		}
+	}
+
+	let vacating = new Set(left.map(item => item.node));
+	let changes: Change[] = [];
+
+	for (let [node, index] of place) {
+		if (!carried.has(node)) changes.push({ kind: "added", index, ...excerpt(node) });
+	}
+
+	// Removals that left the same space collapse into one mark: three blocks
+	// deleted in a row is one hole in the prose, not three.
+	let holes = new Map<string, { at: Spot; blocks: Excerpt[] }>();
+
+	for (let item of left) {
+		let gap = gapAt(base, place, vacating, item.index);
+		if (!gap) continue;
+
+		if (item.moved) {
+			let index = place.get(item.node);
+			if (index === undefined) continue;
+			changes.push({ kind: "moved", index, from: gap, ...excerpt(item.node) });
+			continue;
+		}
+
+		let key = `${gap.index}:${gap.side}`;
+		let hole = holes.get(key) ?? { at: gap, blocks: [] };
+		hole.blocks.push(excerpt(item.node));
+		holes.set(key, hole);
+	}
+
+	for (let hole of holes.values()) changes.push({ kind: "removed", ...hole });
+
+	// Document order, so the list of changes reads the way the plan does.
+	return changes.sort((a, b) => at(a) - at(b));
+}
+
+function at(change: Change): number {
+	return change.kind === "removed" ? change.at.index : change.index;
+}
+
+/**
+ * The gap a departed block left, named by a block still beside it.
+ *
+ * Scanned outwards from where it was, forward first, so a hole reads as
+ * sitting above the block that followed it. Only blocks the batch inherited
+ * are candidates — a block the batch wrote is not somewhere content used to
+ * be — and a candidate must not itself have vacated: without that, deleting
+ * one block and moving the next in the same batch would anchor the hole to a
+ * block that has gone elsewhere, and point at the wrong prose.
+ *
+ * Nothing is returned when a batch vacated every block it inherited. The plan
+ * cannot be emptied, so this only happens when everything moved, and a mark
+ * omitted is cheaper than one that lies.
+ */
+function gapAt(
+	base: RootContent[],
+	place: Map<RootContent, number>,
+	vacating: Set<RootContent>,
+	index: number,
+): Spot | undefined {
+	for (let step = index + 1; step < base.length; step++) {
+		let node = base[step]!;
+		if (vacating.has(node)) continue;
+		let found = place.get(node);
+		if (found !== undefined) return { index: found, side: "before" };
+	}
+	for (let step = index - 1; step >= 0; step--) {
+		let node = base[step]!;
+		if (vacating.has(node)) continue;
+		let found = place.get(node);
+		if (found !== undefined) return { index: found, side: "after" };
+	}
+	return undefined;
 }
 
 /** Apply one operation, or describe why it cannot be applied. */
@@ -424,12 +586,21 @@ function decision(node: RootContent): boolean {
 }
 
 function describe(node: RootContent, index: number): Block {
+	return { index, ...excerpt(node), digest: fingerprint(node) };
+}
+
+/**
+ * Enough of a block to recognise it, without hashing it.
+ *
+ * Split from `describe` because what the agent removed has to be shown in a
+ * list after the block itself is gone, and a fingerprint of something that no
+ * longer exists is nothing anyone can use.
+ */
+function excerpt(node: RootContent): Excerpt {
 	let text = content(node);
 	return {
-		index,
 		type: node.type === "mdxJsxFlowElement" ? node.name || "component" : node.type,
 		preview: text.length > PREVIEW ? text.slice(0, PREVIEW) + "…" : text,
-		digest: fingerprint(node),
 	};
 }
 

--- a/apps/server/src/plan/presence.test.ts
+++ b/apps/server/src/plan/presence.test.ts
@@ -1,0 +1,167 @@
+/**
+ * The agent, as a peer with a cursor.
+ *
+ * Every failure here is invisible at the other end: a state Lexical will not
+ * draw, an update a peer discards, or a cursor left standing after the turn
+ * that put it there has finished. So these assert against a second `Awareness`
+ * fed the encoded bytes, which is exactly what a browser does with them —
+ * checking the state we set would only prove we set it.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { applyAwarenessUpdate, Awareness, encodeAwarenessUpdate } from "y-protocols/awareness";
+import * as Y from "yjs";
+
+import * as presence from "./presence";
+
+import type { Attention, Presence } from "./presence";
+
+/** A position of the kind an anchor decodes to. */
+function somewhere(): Y.RelativePosition {
+	let doc = new Y.Doc();
+	return Y.createRelativePositionFromTypeIndex(doc.getText("t"), 0, -1);
+}
+
+function attention(): Attention {
+	let at = somewhere();
+	return {
+		name: "ai",
+		color: "#475569",
+		focusing: true,
+		agent: true,
+		anchorPos: at,
+		focusPos: at,
+		awarenessData: {},
+	};
+}
+
+/** A client receiving what the server sends, and what it makes of it. */
+function peer(subject: Presence) {
+	let remote = new Awareness(new Y.Doc());
+	remote.setLocalState(null);
+	return {
+		apply: (update: Uint8Array) => applyAwarenessUpdate(remote, update, "server"),
+		state: () => remote.getStates().get(subject.awareness.clientID),
+		clock: () => remote.meta.get(subject.awareness.clientID)?.clock,
+		seen: () => remote.meta.get(subject.awareness.clientID)?.lastUpdated,
+	};
+}
+
+describe("the agent's cursor", () => {
+	it("reaches a peer as something Lexical will draw", () => {
+		let subject = presence.create();
+		let client = peer(subject);
+
+		client.apply(presence.attend(subject, attention()));
+
+		// All four are required: Lexical destroys the caret of a state that is
+		// not focusing, and skips a colour the browser cannot parse.
+		expect(client.state()).toMatchObject({
+			name: "ai",
+			color: "#475569",
+			focusing: true,
+			agent: true,
+		});
+		expect(client.state()?.anchorPos).toBeDefined();
+	});
+
+	/** The row of faces is for people, and the agent has no avatar to show. */
+	it("marks itself as not being a member", () => {
+		let subject = presence.create();
+		let client = peer(subject);
+
+		client.apply(presence.attend(subject, attention()));
+
+		expect(client.state()?.agent).toBe(true);
+	});
+
+	it("carries a position that survives the trip as JSON", () => {
+		let subject = presence.create();
+		let client = peer(subject);
+
+		client.apply(presence.attend(subject, attention()));
+
+		// Awareness states are JSON on the wire, so what arrives is a plain
+		// object rather than a RelativePosition. Yjs reads it structurally,
+		// which is the only reason any cursor works at all.
+		expect(client.state()?.anchorPos).toMatchObject({ assoc: -1 });
+	});
+
+	it("moves rather than accumulating when the agent edits again", () => {
+		let subject = presence.create();
+		let client = peer(subject);
+
+		client.apply(presence.attend(subject, attention()));
+		client.apply(presence.attend(subject, attention()));
+
+		expect([...subject.awareness.getStates().keys()]).toHaveLength(1);
+	});
+});
+
+describe("keeping the cursor alive", () => {
+	/**
+	 * The one that fails in silence.
+	 *
+	 * A peer drops a state it has not heard about for thirty seconds, and
+	 * `applyAwarenessUpdate` ignores an update whose clock has not advanced —
+	 * without refreshing its timer either. So a renewal that merely re-encoded
+	 * the same state would be discarded, and the cursor would disappear
+	 * partway through a long turn with nothing anywhere to say why.
+	 */
+	it("advances the clock, so a peer treats the repeat as news", () => {
+		let subject = presence.create();
+		let client = peer(subject);
+
+		client.apply(presence.attend(subject, attention()));
+		let before = client.clock();
+
+		let renewed = presence.renew(subject);
+		expect(renewed).toBeDefined();
+		client.apply(renewed!);
+
+		expect(client.clock()).toBeGreaterThan(before!);
+	});
+
+	it("has nothing to repeat when the agent is not anywhere", () => {
+		let subject = presence.create();
+		expect(presence.renew(subject)).toBeUndefined();
+	});
+});
+
+describe("taking the cursor down", () => {
+	it("clears it at the peer rather than leaving it to time out", () => {
+		let subject = presence.create();
+		let client = peer(subject);
+
+		client.apply(presence.attend(subject, attention()));
+		expect(client.state()).toBeDefined();
+
+		client.apply(presence.release(subject)!);
+
+		expect(client.state()).toBeUndefined();
+	});
+
+	it("says nothing when there was no cursor to take down", () => {
+		let subject = presence.create();
+		expect(presence.release(subject)).toBeUndefined();
+	});
+
+	/**
+	 * The agent has no socket, so nothing it owns can be attributed to one.
+	 * Were it in `owners`, the first member to close a tab would take the
+	 * agent's cursor with them.
+	 */
+	it("is not carried off by a member disconnecting", () => {
+		let subject = presence.create();
+		let socket = {};
+
+		let member = new Awareness(new Y.Doc());
+		member.setLocalState({ name: "kris", color: "#e06c75", focusing: true });
+		presence.track(subject, socket, encodeAwarenessUpdate(member, [member.clientID]));
+		presence.attend(subject, attention());
+
+		presence.drop(subject, socket);
+
+		expect(subject.awareness.getLocalState()).not.toBeNull();
+	});
+});

--- a/apps/server/src/plan/presence.ts
+++ b/apps/server/src/plan/presence.ts
@@ -7,9 +7,15 @@
  * arriving client watches an apparently empty document while two other cursors
  * move through it.
  *
- * This only ever mirrors what it relays. It never originates state, it is not
- * consulted for anything but the join snapshot, and it is discarded with the
- * epoch it describes.
+ * It mirrors what it relays, and originates exactly one state of its own: the
+ * agent's. Everything else here is a reflection of somebody's socket, which is
+ * why a disconnect can clear it; the agent has no socket to disconnect, so its
+ * cursor is put in the mirror's own local slot and taken down deliberately
+ * when the turn ends. Riding in that slot is also what puts it in the join
+ * snapshot, so somebody arriving mid-turn sees where the agent is working.
+ *
+ * Otherwise it is not consulted for anything but that snapshot, and it is
+ * discarded with the epoch it describes.
  */
 
 import {
@@ -38,13 +44,31 @@ export type Presence = {
 	owners: WeakMap<object, Set<number>>;
 };
 
+/**
+ * The agent, as a peer.
+ *
+ * Lexical refuses to draw a cursor without all four of these: a state that is
+ * not `focusing` has its caret destroyed, and a colour it cannot parse paints
+ * nothing. The extra field is what keeps the agent out of the row of faces —
+ * it is not somebody with a GitHub avatar.
+ */
+export type Attention = {
+	name: string;
+	color: string;
+	focusing: true;
+	agent: true;
+	anchorPos: Y.RelativePosition;
+	focusPos: Y.RelativePosition;
+	awarenessData: object;
+};
+
 export function create(): Presence {
 	let doc = new Y.Doc();
 	let awareness = new Awareness(doc);
 	let owners = new WeakMap<object, Set<number>>();
 
-	// The mirror is a bystander. Announcing a state of its own would put a
-	// phantom cursor belonging to the server in everyone's editor.
+	// Empty until the agent edits something. The mirror originates nothing on
+	// anyone else's behalf: every other state here belongs to a socket.
 	awareness.setLocalState(null);
 
 	awareness.on("update", (
@@ -95,6 +119,49 @@ export function drop(presence: Presence, ws: object): Uint8Array | undefined {
 	// Encoded after removal, so each client carries a null state and a bumped
 	// clock — which is what a peer reads as "they left".
 	return encodeAwarenessUpdate(presence.awareness, clients);
+}
+
+/**
+ * Put the agent's cursor somewhere, and say so.
+ *
+ * Returns the update to broadcast. Moving it is the same call again: awareness
+ * has no notion of a cursor moving, only of a state being replaced.
+ */
+export function attend(presence: Presence, at: Attention): Uint8Array {
+	presence.awareness.setLocalState(at);
+	return encodeAwarenessUpdate(presence.awareness, [presence.awareness.clientID]);
+}
+
+/**
+ * Say the agent is still there.
+ *
+ * Peers drop a state they have not heard about for thirty seconds, so a cursor
+ * that outlives that has to be repeated. Repeating is not enough on its own:
+ * `applyAwarenessUpdate` ignores an update whose clock has not moved, and
+ * ignoring it means not refreshing the timer either — so a re-encode of an
+ * unchanged state would be discarded in silence and the cursor would vanish
+ * mid-turn. Setting the state again is what advances the clock.
+ *
+ * Nothing to say when the agent is not anywhere.
+ */
+export function renew(presence: Presence): Uint8Array | undefined {
+	let held = presence.awareness.getLocalState();
+	if (!held) return undefined;
+	return attend(presence, held as Attention);
+}
+
+/**
+ * Take the agent's cursor down.
+ *
+ * A null state with a bumped clock, which is what a peer reads as "they left"
+ * — the same shape `drop` sends for a member who disconnected. Waiting for the
+ * timeout instead would leave the agent apparently mid-edit for half a minute
+ * after it had finished.
+ */
+export function release(presence: Presence): Uint8Array | undefined {
+	if (!presence.awareness.getLocalState()) return undefined;
+	presence.awareness.setLocalState(null);
+	return encodeAwarenessUpdate(presence.awareness, [presence.awareness.clientID]);
 }
 
 /** Discard everything. Presence describes an epoch and does not outlive it. */

--- a/apps/server/src/plan/room.ts
+++ b/apps/server/src/plan/room.ts
@@ -553,6 +553,37 @@ export function anchorAt(target: Document, index: number, hash: string): Anchor 
 	return anchorForKey(target, key, hash);
 }
 
+/**
+ * A position at the end of the block at `index`.
+ *
+ * Where an edit finished rather than where it started, which is the difference
+ * between a caret that says the agent has written this and one that looks like
+ * it is about to. An anchor is deliberately the other way round — it names a
+ * block, and the start is the stable end of one — so this is its own function
+ * rather than a parameter.
+ *
+ * Raw, because a cursor carries positions as they are: only an anchor needs
+ * the base64 and the digest that go with travelling as a durable reference.
+ */
+export function endOf(target: Document, index: number): Y.RelativePosition {
+	let key: string | undefined;
+	target.editor.getEditorState().read(() => {
+		key = addressable()[index]?.getKey();
+	});
+
+	let collab = key ? target.binding.collabNodeMap.get(key) : undefined;
+	let type = collab?.getSharedType();
+	if (!type) throw new Error("block has no collaborative identity");
+
+	// A decorator block — a questionnaire, a decision — is a map rather than a
+	// sequence, so it has no inside for a caret to be at the end of. Nought is
+	// the only position it has. Asked by shape rather than with `instanceof`,
+	// which is the check that breaks when two copies of Yjs are loaded.
+	let end = "length" in type ? type.length : 0;
+
+	return Y.createRelativePositionFromTypeIndex(type, end, -1);
+}
+
 /** The local node an anchor names, if it still names one. */
 export function resolveAnchor(target: Document, anchor: Anchor): string | undefined {
 	if (anchor.epoch !== target.epoch) return undefined;

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -418,10 +418,17 @@ export function changes(
 		};
 
 		let wired: Wire.Change[] = [];
+		// The furthest down the plan this batch reached, of what could be
+		// anchored — where the agent leaves its cursor.
+		let last: number | undefined;
+
 		for (let change of found) {
 			if (change.kind === "removed") {
 				let at = gap(change.at);
-				if (at) wired.push({ kind: "removed", at, blocks: change.blocks });
+				if (at) {
+					wired.push({ kind: "removed", at, blocks: change.blocks });
+					last = change.at.index;
+				}
 				continue;
 			}
 
@@ -429,6 +436,7 @@ export function changes(
 			if (!at) continue;
 			if (change.kind === "added") {
 				wired.push({ kind: "added", at, type: change.type, preview: change.preview });
+				last = change.index;
 				continue;
 			}
 
@@ -437,6 +445,7 @@ export function changes(
 			let from = gap(change.from);
 			if (from) {
 				wired.push({ kind: "moved", at, from, type: change.type, preview: change.preview });
+				last = change.index;
 			}
 		}
 
@@ -448,11 +457,10 @@ export function changes(
 			changes: wired,
 		});
 
-		// From the same anchoring pass, deliberately. Two passes could disagree
-		// about where the edit was, and then the cursor would be pointing at
-		// one block while the marks described another.
-		let last = wired.at(-1)!;
-		attend(plan, server, roomId, last.kind === "removed" ? last.at.at : last.at);
+		// Read off the same pass, deliberately. Working it out separately could
+		// disagree, and then the cursor would point at one block while the
+		// marks described another.
+		if (last !== undefined) attend(plan, server, roomId, last);
 	} catch (err) {
 		console.error("[plan] could not say what the agent changed:", err);
 	}
@@ -509,14 +517,14 @@ function attend(
 	plan: Plan,
 	server: Server<SocketData>,
 	roomId: string,
-	at: Wire.Anchor,
+	block: number,
 ): void {
 	// The last turn may still be counting down to taking the cursor away. It is
 	// about to be somewhere new, so that removal is no longer the truth.
 	clearTimeout(plan.chat.lingering);
 	plan.chat.lingering = undefined;
 
-	let position = Y.decodeRelativePosition(decode(at.position));
+	let position = room.endOf(plan.document, block);
 	let update = presence.attend(plan.presence, {
 		name: MENTION.slice(1),
 		color: AGENT_COLOR,

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -25,6 +25,7 @@ import type { Plan as Wire, Request } from "@chopin/protocol";
 import type { Socket, SocketData } from "../wire";
 import type { Presence } from "./presence";
 import type { Document } from "./room";
+import type * as edit from "./edit";
 import type { Block } from "./edit";
 import type { Sink } from "./snapshot";
 
@@ -373,6 +374,73 @@ export function publish(
 	});
 	room.mark(plan.document);
 	plan.sink.touch();
+}
+
+/**
+ * Relay what the agent just did, so a reader can be shown where.
+ *
+ * Indices become anchors here rather than in the edit engine: only the live
+ * document can say where a block is in the collaborative history, and only
+ * these survive somebody else editing between this frame being sent and the
+ * browser painting it.
+ *
+ * Sent after the update that created the blocks it names, which is what makes
+ * it resolvable at the other end. Guarded whole, and silent on failure: this
+ * is decoration, and a room that dropped an edit over a mark nobody would
+ * have noticed would be a poor trade.
+ */
+export function changes(
+	plan: Plan,
+	server: Server<SocketData>,
+	roomId: string,
+	found: edit.Change[],
+): void {
+	if (found.length === 0) return;
+
+	try {
+		let digests = room.digests(plan.document);
+		let anchor = (index: number): Wire.Anchor | undefined => {
+			let digest = digests[index];
+			return digest === undefined ? undefined : room.anchorAt(plan.document, index, digest);
+		};
+		let gap = (spot: edit.Spot): Wire.Gap | undefined => {
+			let at = anchor(spot.index);
+			return at && { at, side: spot.side };
+		};
+
+		let wired: Wire.Change[] = [];
+		for (let change of found) {
+			if (change.kind === "removed") {
+				let at = gap(change.at);
+				if (at) wired.push({ kind: "removed", at, blocks: change.blocks });
+				continue;
+			}
+
+			let at = anchor(change.index);
+			if (!at) continue;
+			if (change.kind === "added") {
+				wired.push({ kind: "added", at, type: change.type, preview: change.preview });
+				continue;
+			}
+
+			// Both ends or neither: a move shown only where it landed reads as
+			// new prose, and shown only where it left reads as a deletion.
+			let from = gap(change.from);
+			if (from) {
+				wired.push({ kind: "moved", at, from, type: change.type, preview: change.preview });
+			}
+		}
+
+		if (wired.length === 0) return;
+		broadcast(server, roomId, {
+			kind: "plan:changes",
+			ts: 0,
+			epoch: plan.document.epoch,
+			changes: wired,
+		});
+	} catch (err) {
+		console.error("[plan] could not say what the agent changed:", err);
+	}
 }
 
 /** Relay the current relationship snapshot to the whole room. */

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -12,6 +12,8 @@
 
 import * as Y from "yjs";
 
+import { MENTION } from "@chopin/protocol/address";
+
 import * as presence from "./presence";
 import * as room from "./room";
 import * as snapshot from "./snapshot";
@@ -93,6 +95,8 @@ export type Plan = {
 	outlines: Map<number, Block[]>;
 	queue: Queued[];
 	timer: ReturnType<typeof setTimeout> | undefined;
+	/** Repeats the agent's cursor while it has one, so peers do not drop it. */
+	attention: ReturnType<typeof setInterval> | undefined;
 	/** Serialises commits so two batches cannot interleave. */
 	flushing: Promise<void>;
 	meters: WeakMap<Socket, Meter>;
@@ -151,6 +155,7 @@ export async function open(id: string, dir: string, server: Server<SocketData>):
 		revision: stored?.state.revision ?? 0,
 		queue: [],
 		timer: undefined,
+		attention: undefined,
 		flushing: Promise.resolve(),
 		meters: new WeakMap(),
 		sink: snapshot.sink({
@@ -303,7 +308,11 @@ async function commit(plan: Plan): Promise<void> {
 
 		let rebuilt = await room.rebuild(plan.document);
 		plan.document = rebuilt;
-		// Cursors describe positions in a history that no longer exists.
+		// Cursors describe positions in a history that no longer exists. The
+		// agent's is in there too, and the interval repeating it would outlive
+		// the presence it repeats.
+		clearInterval(plan.attention);
+		plan.attention = undefined;
 		presence.destroy(plan.presence);
 		plan.presence = presence.create();
 		// So do anchors and passages, and unlike a cursor nobody re-announces
@@ -438,6 +447,12 @@ export function changes(
 			epoch: plan.document.epoch,
 			changes: wired,
 		});
+
+		// From the same anchoring pass, deliberately. Two passes could disagree
+		// about where the edit was, and then the cursor would be pointing at
+		// one block while the marks described another.
+		let last = wired.at(-1)!;
+		attend(plan, server, roomId, last.kind === "removed" ? last.at.at : last.at);
 	} catch (err) {
 		console.error("[plan] could not say what the agent changed:", err);
 	}
@@ -455,6 +470,98 @@ export function anchors(
 		epoch: plan.document.epoch,
 		widgets: Questions.anchors(plan),
 		threads: Comments.anchors(plan),
+	});
+}
+
+/**
+ * How often to repeat the agent's cursor.
+ *
+ * Comfortably inside the thirty seconds after which a peer drops a state it
+ * has not heard about. Ours rather than the awareness library's, because a
+ * cursor that quietly disappears partway through a long turn is not a failure
+ * anybody would think to attribute to a renewal cadence changing underneath.
+ */
+const RENEW_MS = 10_000;
+
+/**
+ * The colour of the agent's cursor.
+ *
+ * A graphite, deliberately outside the palette `packages/editor/src/cursor.ts`
+ * hands to people: the agent is not one of them, and a cursor that looked like
+ * a colleague's would be read as one. Literal rather than a theme token
+ * because Lexical validates it with `CSS.supports` and writes it inline, so a
+ * `var()` would resolve against the wrong scope or not at all.
+ *
+ * Duplicated across the package boundary rather than shared for one string. If
+ * the palette there ever grows a slate, this is what it must not collide with.
+ */
+const AGENT_COLOR = "#475569";
+
+/**
+ * Put the agent's cursor where it just edited.
+ *
+ * Presence rather than a record: it says the agent is working here now, which
+ * is why it is broadcast rather than held, and why it does not wait to be
+ * seen the way the marks do. Somebody scrolled elsewhere is not shown it at
+ * all — that is what the marks and the chips are for.
+ */
+function attend(
+	plan: Plan,
+	server: Server<SocketData>,
+	roomId: string,
+	at: Wire.Anchor,
+): void {
+	// The last turn may still be counting down to taking the cursor away. It is
+	// about to be somewhere new, so that removal is no longer the truth.
+	clearTimeout(plan.chat.lingering);
+	plan.chat.lingering = undefined;
+
+	let position = Y.decodeRelativePosition(decode(at.position));
+	let update = presence.attend(plan.presence, {
+		name: MENTION.slice(1),
+		color: AGENT_COLOR,
+		focusing: true,
+		agent: true,
+		anchorPos: position,
+		focusPos: position,
+		awarenessData: {},
+	});
+
+	broadcast(server, roomId, {
+		kind: "plan:awareness",
+		ts: 0,
+		epoch: plan.document.epoch,
+		update: encode(update),
+	});
+
+	// Restarted, not stacked: an agent that edits twice in a turn should not
+	// end up with two intervals repeating its cursor.
+	clearInterval(plan.attention);
+	plan.attention = setInterval(() => {
+		let renewed = presence.renew(plan.presence);
+		if (!renewed) return;
+		broadcast(server, roomId, {
+			kind: "plan:awareness",
+			ts: 0,
+			epoch: plan.document.epoch,
+			update: encode(renewed),
+		});
+	}, RENEW_MS);
+}
+
+/** Take the agent's cursor down, and stop repeating it. */
+export function release(plan: Plan, server: Server<SocketData>, roomId: string): void {
+	clearInterval(plan.attention);
+	plan.attention = undefined;
+
+	let update = presence.release(plan.presence);
+	if (!update) return;
+
+	broadcast(server, roomId, {
+		kind: "plan:awareness",
+		ts: 0,
+		epoch: plan.document.epoch,
+		update: encode(update),
 	});
 }
 
@@ -480,6 +587,7 @@ export function departed(plan: Plan, ws: Socket): void {
 /** Write anything outstanding and let go. */
 export async function close(plan: Plan): Promise<void> {
 	if (plan.timer) clearTimeout(plan.timer);
+	clearInterval(plan.attention);
 	await plan.flushing;
 	await plan.sink.flush();
 	await Chat.close(plan.chat);

--- a/packages/editor/src/changes-chip.tsx
+++ b/packages/editor/src/changes-chip.tsx
@@ -1,0 +1,142 @@
+/**
+ * How to reach what the agent changed while you were reading somewhere else.
+ *
+ * A mark is held back until it is on screen, which answers the question of
+ * whether it was worth showing but not the question of how to find it. These
+ * are the other half: one chip per edge, counting only what is still unread in
+ * that direction, and going to the nearest one when clicked — which reveals it
+ * the ordinary way, by putting it in front of the reader.
+ *
+ * The list behind them shows every live change, seen or not. That is the only
+ * place a removal can be read: the hole in the prose can say that something
+ * was here, but the block itself is gone and cannot be asked what it was.
+ */
+
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+
+import type { ChangeStore, Entry, Snapshot } from "./changes";
+
+/** Past this the number stops being informative and starts being noise. */
+const MANY = 9;
+
+export function useChanges(store: ChangeStore): Snapshot {
+	return useSyncExternalStore(store.subscribe, store.snapshot, store.snapshot);
+}
+
+function count(value: number): string {
+	return value > MANY ? `${MANY}+` : String(value);
+}
+
+function label(entry: Entry): string {
+	switch (entry.kind) {
+		case "added":
+			return "Written";
+		case "moved":
+			return "Moved";
+		case "removed":
+			return entry.blocks.length > 1 ? `Removed ${entry.blocks.length} blocks` : "Removed";
+	}
+}
+
+function describe(entry: Entry): string {
+	let first = entry.blocks[0];
+	if (!first) return "";
+	let text = first.preview.trim();
+	// A block with no words of its own — a divider, an image, a component with
+	// nothing written in it — is named by what it is instead.
+	return text || first.type;
+}
+
+function List({ entries }: { entries: Entry[] }) {
+	if (entries.length === 0) {
+		return <p className="plan-changes-empty">Nothing recent.</p>;
+	}
+
+	return (
+		<ul className="plan-changes-list">
+			{entries.map(entry => (
+				<li
+					key={entry.id}
+					className="plan-changes-item"
+					data-kind={entry.kind}
+					// Held back rather than shown yet, which is the difference
+					// between this list and a plain history of the turn.
+					data-unread={entry.seen ? undefined : ""}
+				>
+					<span className="plan-changes-kind">{label(entry)}</span>
+					<span className="plan-changes-text">{describe(entry)}</span>
+				</li>
+			))}
+		</ul>
+	);
+}
+
+function Chip(
+	{ entries, onGo, side, waiting }: {
+		entries: Entry[];
+		onGo: () => void;
+		side: "above" | "below";
+		waiting: number;
+	},
+) {
+	let [open, setOpen] = useState(false);
+	let box = useRef<HTMLDivElement>(null);
+
+	// Closing on an outside click rather than on blur: the list is inside the
+	// same box as the button, so blur fires on the way to clicking it.
+	useEffect(() => {
+		if (!open) return;
+		let close = (event: MouseEvent) => {
+			if (!box.current?.contains(event.target as Node)) setOpen(false);
+		};
+		document.addEventListener("mousedown", close);
+		return () => document.removeEventListener("mousedown", close);
+	}, [open]);
+
+	useEffect(() => {
+		if (waiting === 0) setOpen(false);
+	}, [waiting]);
+
+	if (waiting === 0) return null;
+
+	return (
+		<div ref={box} className="plan-changes" data-side={side}>
+			{open && <List entries={entries} />}
+			<div className="plan-changes-bar">
+				<button
+					type="button"
+					className="plan-changes-go"
+					onClick={onGo}
+					title={`Go to the nearest change ${side}`}
+				>
+					<span aria-hidden="true">{side === "above" ? "↑" : "↓"}</span>
+					{`${count(waiting)} ${waiting === 1 ? "change" : "changes"} ${side}`}
+				</button>
+				<button
+					type="button"
+					className="plan-changes-more"
+					aria-expanded={open}
+					onClick={() => setOpen(value => !value)}
+					title="What the agent changed"
+				>
+					<span aria-hidden="true">{open ? "▾" : "▸"}</span>
+					<span className="sr-only">What the agent changed</span>
+				</button>
+			</div>
+		</div>
+	);
+}
+
+export function PlanChanges({ store }: { store: ChangeStore }) {
+	let { above, below, entries } = useChanges(store);
+
+	let goUp = useCallback(() => store.reveal("above"), [store]);
+	let goDown = useCallback(() => store.reveal("below"), [store]);
+
+	return (
+		<>
+			<Chip entries={entries} onGo={goUp} side="above" waiting={above} />
+			<Chip entries={entries} onGo={goDown} side="below" waiting={below} />
+		</>
+	);
+}

--- a/packages/editor/src/changes-observer.tsx
+++ b/packages/editor/src/changes-observer.tsx
@@ -1,0 +1,34 @@
+/**
+ * Keeps the agent's marks on the right blocks as the document moves.
+ *
+ * Mounted inside the editor, because placing a mark needs to read the document
+ * and Lexical only lends that out to a composer child. Kept apart from the
+ * store itself so nothing that touches React is in the way of testing the
+ * bookkeeping.
+ */
+
+import { useEffect } from "react";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+
+import type { ChangeStore } from "./changes";
+
+export function ChangeObserver({ store }: { store: ChangeStore }) {
+	let [editor] = useLexicalComposerContext();
+
+	useEffect(() => {
+		store.attach(editor);
+		store.refresh();
+
+		// Every keystroke lands here, and almost none of them move a mark. The
+		// store returns immediately when it is holding none, which is what
+		// keeps that from costing anything while nobody is watching an edit.
+		let off = editor.registerUpdateListener(store.refresh);
+
+		return () => {
+			off();
+			store.attach(undefined);
+		};
+	}, [editor, store]);
+
+	return null;
+}

--- a/packages/editor/src/changes.ts
+++ b/packages/editor/src/changes.ts
@@ -6,7 +6,7 @@
  * reached it. Everything is drawn by attribute on a block that already exists,
  * so the marks add no element and take no space — an agent editing below the
  * fold must not shift the sentence somebody is in the middle of typing, and a
- * mark that expires ten seconds later must not shift it back.
+ * mark that expires a few seconds later must not shift it back.
  *
  * A block that has gone cannot carry a mark, so a hole is drawn on the edge of
  * the block still beside it and the side is part of the address. That is also

--- a/packages/editor/src/changes.ts
+++ b/packages/editor/src/changes.ts
@@ -1,0 +1,487 @@
+/**
+ * Showing the reader what the agent just did to the plan.
+ *
+ * The server says what a batch wrote, moved and took out; this puts each of
+ * those somewhere on screen, and holds it back until the reader has actually
+ * reached it. Everything is drawn by attribute on a block that already exists,
+ * so the marks add no element and take no space — an agent editing below the
+ * fold must not shift the sentence somebody is in the middle of typing, and a
+ * mark that expires ten seconds later must not shift it back.
+ *
+ * A block that has gone cannot carry a mark, so a hole is drawn on the edge of
+ * the block still beside it and the side is part of the address. That is also
+ * why a hole can only ever say that something was here: what it was lives in
+ * the list behind the chips, which is the one place a removal can be read
+ * after the fact.
+ *
+ * Nothing is written into the document. These are one reader's marks, arriving
+ * at a different moment for everybody in the room, and putting them in the
+ * document would send them to everyone else and make them undoable.
+ */
+
+import { resolve } from "./anchors";
+import { trail } from "./trail";
+
+import type { Binding } from "@lexical/yjs";
+import type { LexicalEditor } from "lexical";
+import type { Plan } from "@chopin/protocol";
+import type { Trail } from "./trail";
+
+/**
+ * How far into the viewport a block has to come to count as seen.
+ *
+ * An inset on the root rather than a ratio of the element: `threshold` is a
+ * fraction of the observed block, so a code block taller than the window could
+ * never reach one and would stay unread however long it was looked at.
+ */
+const MARGIN = 24;
+
+/** Which of the four marks a placement draws. */
+export type Kind = "added" | "moved" | "removed" | "vacated";
+
+/** One end of a change, resolved to somewhere in this editor. */
+type Placement = {
+	id: string;
+	change: string;
+	kind: Kind;
+	anchor: Plan.Anchor;
+	/** Which edge of the anchored block, for the two that draw a hole. */
+	side?: "before" | "after";
+};
+
+/** A change, as the list behind the chips shows it. */
+export type Entry = {
+	id: string;
+	kind: Plan.Change["kind"];
+	/** What was written, or what was taken out. */
+	blocks: Plan.Excerpt[];
+	/** Whether the reader has been shown it yet. */
+	seen: boolean;
+};
+
+export type Snapshot = {
+	entries: Entry[];
+	/** Unseen marks the reader would have to scroll up to reach. */
+	above: number;
+	/** Unseen marks below the fold. */
+	below: number;
+};
+
+const EMPTY: Snapshot = { entries: [], above: 0, below: 0 };
+
+function attribute(placement: Placement): string {
+	return placement.kind === "added" || placement.kind === "moved"
+		? "data-plan-change"
+		: `data-plan-gap-${placement.side ?? "before"}`;
+}
+
+function value(placement: Placement): string {
+	return placement.kind;
+}
+
+export class ChangeStore {
+	#listeners = new Set<() => void>();
+	#snapshot: Snapshot = EMPTY;
+
+	#editor: LexicalEditor | undefined;
+	#binding: Binding | undefined;
+	#scroller: HTMLElement | undefined;
+
+	#changes = new Map<string, Plan.Change>();
+	#placements = new Map<string, Placement>();
+	#marks: Trail = trail(() => this.refresh());
+	#counter = 0;
+
+	/** Which way out of view each unseen mark is, from the last time it moved. */
+	#side = new Map<string, "above" | "below">();
+
+	#observer: IntersectionObserver | undefined;
+	/** What each observed element currently stands for. */
+	#observed = new Map<Element, Set<string>>();
+	/** Attributes this store put on the document, so it can take them off. */
+	#painted = new Map<HTMLElement, Set<string>>();
+
+	#scrolled = 0;
+	#frame = 0;
+
+	subscribe = (listener: () => void): () => void => {
+		this.#listeners.add(listener);
+		return () => this.#listeners.delete(listener);
+	};
+
+	snapshot = (): Snapshot => this.#snapshot;
+
+	// -- attachment ----------------------------------------------------------
+
+	/** The editor, so a node key can be turned into something on screen. */
+	attach(editor: LexicalEditor | undefined): void {
+		if (this.#editor && this.#editor !== editor) this.clear();
+		this.#editor = editor;
+	}
+
+	/** The Yjs binding, so a relative position can be turned into a node key. */
+	bind(binding: Binding | undefined): void {
+		this.#binding = binding;
+	}
+
+	/**
+	 * The element the plan scrolls in, which is what "in view" is measured
+	 * against. The pane around it is the wrong frame: it does not scroll.
+	 */
+	viewport(element: HTMLElement | undefined): void {
+		if (this.#scroller === element) return;
+		this.#scroller = element;
+		this.#observer?.disconnect();
+		this.#observer = undefined;
+		this.#observed.clear();
+		this.refresh();
+	}
+
+	// -- what the agent did --------------------------------------------------
+
+	/**
+	 * Take on a batch.
+	 *
+	 * A move arrives as one change with two ends, and stays one entry in the
+	 * list: shown as a disappearance and an arrival, a reader would have to
+	 * work out for themselves that they were the same block.
+	 */
+	mark(changes: Plan.Change[]): void {
+		for (let change of changes) {
+			let id = `c${this.#counter++}`;
+			this.#changes.set(id, change);
+
+			let ends: Placement[] = [];
+			if (change.kind === "removed") {
+				ends.push({
+					id: `${id}:at`,
+					change: id,
+					kind: "removed",
+					anchor: change.at.at,
+					side: change.at.side,
+				});
+			} else {
+				ends.push({ id: `${id}:at`, change: id, kind: change.kind, anchor: change.at });
+				if (change.kind === "moved") {
+					ends.push({
+						id: `${id}:from`,
+						change: id,
+						kind: "vacated",
+						anchor: change.from.at,
+						side: change.from.side,
+					});
+				}
+			}
+
+			for (let end of ends) this.#placements.set(end.id, end);
+			this.#marks.add(ends.map(end => end.id));
+		}
+
+		this.refresh();
+	}
+
+	/** Forget everything. The epoch rotated, or the editor went away. */
+	clear(): void {
+		this.#marks.dispose();
+		this.#marks = trail(() => this.refresh());
+		this.#changes.clear();
+		this.#placements.clear();
+		this.#side.clear();
+		this.#unpaint();
+		this.#observer?.disconnect();
+		this.#observer = undefined;
+		this.#observed.clear();
+		this.#publish(EMPTY);
+	}
+
+	dispose(): void {
+		this.clear();
+		this.#marks.dispose();
+		if (this.#frame) cancelAnimationFrame(this.#frame);
+		this.#frame = 0;
+	}
+
+	// -- painting ------------------------------------------------------------
+
+	/**
+	 * Resolve every mark against the document as it is now, and paint.
+	 *
+	 * Re-resolved on every pass rather than once on arrival: a relative
+	 * position survives edits around it, so re-resolving is what keeps a mark
+	 * on the right block while somebody types above it. Elements are looked up
+	 * again for the same reason — Lexical rebuilds a block's element when the
+	 * block changes, and an attribute set on the old one goes with it.
+	 *
+	 * Guarded whole. This runs from a Lexical update listener, and Lexical runs
+	 * those in one loop with no isolation: a throw here would skip the listener
+	 * that syncs the document, and the room would lose edits over a highlight.
+	 */
+	refresh = (): void => {
+		try {
+			this.#resolve();
+		} catch (err) {
+			console.error("[plan] could not mark what the agent changed:", err);
+		}
+	};
+
+	#resolve(): void {
+		let editor = this.#editor;
+		let binding = this.#binding;
+		if (!editor || !binding) return;
+
+		// Called from a Lexical update listener, so this runs on every
+		// keystroke in the plan and almost none of them concern a mark.
+		if (this.#placements.size === 0 && this.#painted.size === 0) return;
+
+		// A mark that expired on its own left its placement behind: the trail
+		// owns the lifetime and has no way to reach in here when a timer runs
+		// out, so what it has forgotten is collected on the next pass.
+		this.#prune();
+
+		let elements = new Map<string, HTMLElement>();
+		let gone: string[] = [];
+
+		for (let placement of this.#placements.values()) {
+			if (!this.#marks.phase(placement.id)) continue;
+
+			let key = resolve(binding, placement.anchor);
+			if (!key) {
+				// The block it named is gone. Told apart from a block that
+				// simply has not been painted yet, below, because that one
+				// resolves to a key and only wants another pass.
+				gone.push(placement.id);
+				continue;
+			}
+
+			let element = editor.getElementByKey(key);
+			if (element) elements.set(placement.id, element);
+		}
+
+		if (gone.length > 0) this.#marks.drop(gone);
+		this.#observe(elements);
+		this.#paint(elements);
+		this.#publish(this.#describe(elements));
+	}
+
+	/** Watch what is on screen, so a mark can wait until it has been read. */
+	#observe(elements: Map<string, HTMLElement>): void {
+		let root = this.#scroller;
+		if (!root || typeof IntersectionObserver === "undefined") {
+			// No way to tell what is in view, so nothing can be held back.
+			// Over-showing beats marks that would never appear at all.
+			this.#marks.saw(elements.keys());
+			return;
+		}
+
+		this.#observer ??= new IntersectionObserver(entries => this.#sighted(entries), {
+			root,
+			rootMargin: `-${MARGIN}px 0px`,
+		});
+
+		let wanted = new Map<Element, Set<string>>();
+		for (let [id, element] of elements) {
+			let ids = wanted.get(element) ?? new Set();
+			ids.add(id);
+			wanted.set(element, ids);
+		}
+
+		for (let element of this.#observed.keys()) {
+			if (!wanted.has(element)) this.#observer.unobserve(element);
+		}
+		for (let element of wanted.keys()) {
+			if (!this.#observed.has(element)) this.#observer.observe(element);
+		}
+		this.#observed = wanted;
+	}
+
+	#sighted(entries: IntersectionObserverEntry[]): void {
+		let seen: string[] = [];
+
+		for (let entry of entries) {
+			let ids = this.#observed.get(entry.target);
+			if (!ids) continue;
+
+			if (entry.isIntersecting) {
+				for (let id of ids) seen.push(id);
+				continue;
+			}
+
+			// Which way it went. An unseen mark cannot change side without
+			// crossing the viewport, and crossing produces an entry, so this
+			// stays true without watching the scroll — except across a jump
+			// that skips the viewport entirely, which `#jumped` picks up.
+			let top = entry.rootBounds?.top ?? 0;
+			let side: "above" | "below" = entry.boundingClientRect.bottom <= top ? "above" : "below";
+			for (let id of ids) this.#side.set(id, side);
+		}
+
+		if (seen.length > 0) this.#marks.saw(seen);
+		this.refresh();
+	}
+
+	/**
+	 * Recheck which way out of view everything is.
+	 *
+	 * Only worth doing after a jump: an element that leaves one edge of the
+	 * viewport and arrives past the other within a single frame is never
+	 * intersecting at either end, so the observer has nothing to report and
+	 * the side it was last seen on is stale.
+	 */
+	onScroll = (): void => {
+		let root = this.#scroller;
+		if (!root) return;
+
+		let moved = Math.abs(root.scrollTop - this.#scrolled);
+		this.#scrolled = root.scrollTop;
+		if (moved <= root.clientHeight) return;
+
+		if (this.#frame) cancelAnimationFrame(this.#frame);
+		this.#frame = requestAnimationFrame(() => {
+			this.#frame = 0;
+			this.#jumped();
+		});
+	};
+
+	#jumped(): void {
+		let root = this.#scroller;
+		if (!root) return;
+
+		let bounds = root.getBoundingClientRect();
+		for (let [element, ids] of this.#observed) {
+			let rect = element.getBoundingClientRect();
+			if (rect.bottom > bounds.top && rect.top < bounds.bottom) continue;
+			let side: "above" | "below" = rect.bottom <= bounds.top ? "above" : "below";
+			for (let id of ids) this.#side.set(id, side);
+		}
+		this.refresh();
+	}
+
+	#paint(elements: Map<string, HTMLElement>): void {
+		let next = new Map<HTMLElement, Set<string>>();
+
+		for (let id of this.#marks.showing()) {
+			let placement = this.#placements.get(id);
+			let element = elements.get(id);
+			if (!placement || !element) continue;
+
+			let names = next.get(element) ?? new Set();
+			names.add(attribute(placement));
+			next.set(element, names);
+			element.setAttribute(attribute(placement), value(placement));
+		}
+
+		for (let [element, names] of this.#painted) {
+			for (let name of names) {
+				if (!next.get(element)?.has(name)) element.removeAttribute(name);
+			}
+		}
+		this.#painted = next;
+	}
+
+	#unpaint(): void {
+		for (let [element, names] of this.#painted) {
+			for (let name of names) element.removeAttribute(name);
+		}
+		this.#painted.clear();
+	}
+
+	// -- what the chips say --------------------------------------------------
+
+	#describe(elements: Map<string, HTMLElement>): Snapshot {
+		let above = 0;
+		let below = 0;
+
+		for (let id of this.#marks.pending()) {
+			// Only what can actually be reached is worth counting. A mark whose
+			// block has not been painted yet is not somewhere to send anyone.
+			if (!elements.has(id)) continue;
+			if (this.#side.get(id) === "above") above++;
+			else below++;
+		}
+
+		// A move has two ends, and reaching either of them is having been shown
+		// the change — so this is worked out per change rather than per end.
+		let shown = new Set<string>();
+		for (let id of this.#marks.showing()) {
+			let placement = this.#placements.get(id);
+			if (placement) shown.add(placement.change);
+		}
+
+		let entries: Entry[] = [];
+		let listed = new Set<string>();
+		for (let id of this.#marks.ids()) {
+			let placement = this.#placements.get(id);
+			if (!placement || listed.has(placement.change)) continue;
+			let change = this.#changes.get(placement.change);
+			if (!change) continue;
+
+			listed.add(placement.change);
+			entries.push({
+				id: placement.change,
+				kind: change.kind,
+				blocks: change.kind === "removed"
+					? change.blocks
+					: [{ type: change.type, preview: change.preview }],
+				seen: shown.has(placement.change),
+			});
+		}
+
+		return { entries, above, below };
+	}
+
+	#publish(snapshot: Snapshot): void {
+		let same = snapshot.above === this.#snapshot.above
+			&& snapshot.below === this.#snapshot.below
+			&& JSON.stringify(snapshot.entries) === JSON.stringify(this.#snapshot.entries);
+		if (same) return;
+
+		this.#snapshot = snapshot;
+		for (let listener of this.#listeners) listener();
+	}
+
+	/** Drop changes no end of which is still being tracked. */
+	#prune(): void {
+		let live = new Set<string>();
+		for (let id of this.#marks.ids()) {
+			let placement = this.#placements.get(id);
+			if (placement) live.add(placement.change);
+		}
+		for (let id of this.#placements.keys()) {
+			if (!this.#marks.phase(id)) this.#placements.delete(id);
+		}
+		for (let id of this.#changes.keys()) {
+			if (!live.has(id)) this.#changes.delete(id);
+		}
+	}
+
+	// -- going to one --------------------------------------------------------
+
+	/** Scroll to the nearest unseen mark in one direction, which reveals it. */
+	reveal(direction: "above" | "below"): void {
+		let root = this.#scroller;
+		if (!root) return;
+
+		let bounds = root.getBoundingClientRect();
+		let best: { element: Element; distance: number } | undefined;
+
+		for (let id of this.#marks.pending()) {
+			if ((this.#side.get(id) ?? "below") !== direction) continue;
+
+			for (let [element, ids] of this.#observed) {
+				if (!ids.has(id)) continue;
+				let rect = element.getBoundingClientRect();
+				let distance = direction === "above"
+					? bounds.top - rect.bottom
+					: rect.top - bounds.bottom;
+				if (!best || distance < best.distance) best = { element, distance };
+			}
+		}
+
+		best?.element.scrollIntoView({
+			block: "center",
+			// A scroll behaviour set in script is out of the stylesheet's
+			// reach, so the reduced-motion preference has to be read here.
+			behavior: matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth",
+		});
+	}
+}

--- a/packages/editor/src/collaboration.tsx
+++ b/packages/editor/src/collaboration.tsx
@@ -223,7 +223,7 @@ function Collaboration(options: CollaborationOptions) {
 		frame.append(container);
 		binding.cursorsContainer = container;
 
-		let flash = labels(binding);
+		let flash = labels(binding, provider);
 		let paint = () => {
 			cursors(binding, provider);
 			flash.sync();

--- a/packages/editor/src/labels.ts
+++ b/packages/editor/src/labels.ts
@@ -11,7 +11,7 @@
  * moved; the painted position is the only thing that changes exactly when a
  * peer does.
  *
- * The agent's label stays up ten times as long. A person's caret is one of
+ * The agent's label stays up five times as long. A person's caret is one of
  * several and its owner is watching it, so a second is enough to say who moved
  * where; the agent's arrives unannounced in a document somebody else is
  * reading, and the whole reason it is drawn at all is to say what put it
@@ -25,7 +25,7 @@ import type { Binding, Provider } from "@lexical/yjs";
 const LINGER = 1000;
 
 /** How long the agent's stays, for the same reason it is louder at all. */
-const AGENT_LINGER = 10_000;
+const AGENT_LINGER = 5_000;
 
 export type Labels = {
 	/** Flashes whoever moved. Call after cursors are painted. */

--- a/packages/editor/src/labels.ts
+++ b/packages/editor/src/labels.ts
@@ -10,12 +10,22 @@
  * from awareness. Awareness churns on a renewal timer whether or not anyone
  * moved; the painted position is the only thing that changes exactly when a
  * peer does.
+ *
+ * The agent's label stays up ten times as long. A person's caret is one of
+ * several and its owner is watching it, so a second is enough to say who moved
+ * where; the agent's arrives unannounced in a document somebody else is
+ * reading, and the whole reason it is drawn at all is to say what put it
+ * there. Naming it for one second and going quiet answers a question nobody
+ * had time to ask.
  */
 
-import type { Binding } from "@lexical/yjs";
+import type { Binding, Provider } from "@lexical/yjs";
 
 /** How long a label stays up after its peer stops moving. */
 const LINGER = 1000;
+
+/** How long the agent's stays, for the same reason it is louder at all. */
+const AGENT_LINGER = 10_000;
 
 export type Labels = {
 	/** Flashes whoever moved. Call after cursors are painted. */
@@ -23,7 +33,21 @@ export type Labels = {
 	dispose: () => void;
 };
 
-export function labels(binding: Binding, linger = LINGER): Labels {
+export function labels(
+	binding: Binding,
+	provider: Provider,
+	linger = LINGER,
+	agentLinger = AGENT_LINGER,
+): Labels {
+	/*
+	 * Read from awareness rather than from the cursor, which only carries a
+	 * name and a colour. Matching on the name would be the obvious shortcut
+	 * and is wrong: handles are GitHub logins, `github.com/ai` is a real
+	 * account, and somebody signing in as that would get the agent's chrome.
+	 */
+	let agent = (client: number): boolean =>
+		provider.awareness.getStates().get(client)?.agent === true;
+
 	let seen = new Map<number, string>();
 	let timers = new Map<number, ReturnType<typeof setTimeout>>();
 
@@ -62,7 +86,7 @@ export function labels(binding: Binding, linger = LINGER): Labels {
 					setTimeout(() => {
 						caret.removeAttribute("data-plan-active");
 						timers.delete(client);
-					}, linger),
+					}, agent(client) ? agentLinger : linger),
 				);
 			}
 

--- a/packages/editor/src/plan-editor.tsx
+++ b/packages/editor/src/plan-editor.tsx
@@ -14,6 +14,8 @@ import "@mdxeditor/editor/style.css";
 import "./styles.css";
 import { plugins as dialectPlugins } from "@chopin/dialect";
 
+import { ChangeStore } from "./changes";
+import { PlanChanges } from "./changes-chip";
 import { collaborationPlugin } from "./collaboration";
 import { PlanPresence } from "./presence";
 import { PlanStatus } from "./status";
@@ -87,20 +89,26 @@ export function PlanEditor(
 	// synchronously during an event, so they keep reading the ref.
 	let [presence, setPresence] = useState<PlanProvider>();
 	let previousWire = useRef(wire);
+	// Nothing outside the editor reads this one, unlike the questionnaires,
+	// so it is owned here rather than being handed down from the room.
+	let [changes] = useState(() => new ChangeStore());
 
 	// A rotated epoch invalidates the whole local document, so the editor is
-	// rebuilt rather than reconciled — that is what "reset" means.
+	// rebuilt rather than reconciled — that is what "reset" means. The marks
+	// describe a history that no longer exists, so they go with it.
 	let onReset = useCallback((reason: Plan.Reset["reason"]) => {
+		changes.clear();
 		setState(prev => ({ ...prev, synced: false, reset: reason }));
 		setGeneration(value => value + 1);
-	}, []);
+	}, [changes]);
 
 	// The store resolves anchors itself, because a Lexical key is per-editor:
 	// the server's key for a block means nothing in this browser.
 	let onBinding = useCallback((value: Binding | undefined) => {
 		questions?.bind(value);
 		threads?.bind(value);
-	}, [questions, threads]);
+		changes.bind(value);
+	}, [questions, threads, changes]);
 
 	let onAnchors = useCallback(
 		(snapshot: { widgets: Plan.WidgetAnchors[]; threads: Plan.ThreadAnchors[] }) => {
@@ -109,6 +117,22 @@ export function PlanEditor(
 		},
 		[questions, threads],
 	);
+
+	let onChanges = useCallback((found: Plan.Change[]) => {
+		changes.mark(found);
+	}, [changes]);
+
+	// The scroll container is what "in view" is measured against, and it only
+	// exists once the editor has rendered.
+	useEffect(() => {
+		changes.viewport(scroller.current ?? undefined);
+		let element = scroller.current;
+		if (!element) return;
+		element.addEventListener("scroll", changes.onScroll, { passive: true });
+		return () => element.removeEventListener("scroll", changes.onScroll);
+	}, [changes, generation, wire]);
+
+	useEffect(() => () => changes.dispose(), [changes]);
 
 	let onProvider = useCallback((value: PlanProvider | undefined) => {
 		provider.current = value;
@@ -176,11 +200,30 @@ export function PlanEditor(
 					 * dialect: keep its serialiser able to write every node, and
 					 * it has no reason to throw.
 					 */
-					collaborationPlugin({ wire, user, onReset, onProvider, onBinding, onAnchors }),
-					widgetsPlugin({ questions, threads }),
+					collaborationPlugin({
+						wire,
+						user,
+						onReset,
+						onProvider,
+						onBinding,
+						onAnchors,
+						onChanges,
+					}),
+					widgetsPlugin({ questions, threads, changes }),
 				]
 				: [],
-		[wire, user, onReset, onProvider, onBinding, onAnchors, questions, threads],
+		[
+			wire,
+			user,
+			onReset,
+			onProvider,
+			onBinding,
+			onAnchors,
+			onChanges,
+			questions,
+			threads,
+			changes,
+		],
 	);
 
 	useEffect(() => {
@@ -234,7 +277,8 @@ export function PlanEditor(
 						/>
 					</div>
 					<PlanPresence provider={presence} />
-					{/* In the document column, so it tracks the prose, not the pane. */}
+					{/* In the document column, so they track the prose, not the pane. */}
+					<PlanChanges store={changes} />
 					<PlanStatus
 						wire={wire}
 						connection={connection}

--- a/packages/editor/src/presence.tsx
+++ b/packages/editor/src/presence.tsx
@@ -27,16 +27,23 @@ function names(people: string[]): string {
 }
 
 /**
- * Peers, excluding this client.
+ * Peers, excluding this client and the agent.
  *
  * Deduplicated by handle: someone with the plan open in two windows is one
  * person, and showing them twice reads as two colleagues.
+ *
+ * The agent has a cursor in here too, and it is not a member. Every face is
+ * built into a github.com avatar URL, and `github.com/ai` is somebody — so
+ * without this the room would show a stranger's photograph, and the usual
+ * fallback to initials would never fire because the image loads perfectly
+ * well. That the agent is working is already said beside the plan.
  */
 function peers(provider: PlanProvider | undefined): string[] {
 	if (!provider) return [];
 	let found = new Set<string>();
 	for (let [client, state] of provider.awareness.getStates()) {
 		if (client === provider.awareness.clientID) continue;
+		if (state?.agent) continue;
 		let name = state?.name;
 		if (typeof name === "string" && name) found.add(name);
 	}

--- a/packages/editor/src/provider.ts
+++ b/packages/editor/src/provider.ts
@@ -54,6 +54,14 @@ export type PlanProviderOptions = {
 	 * copy of the other.
 	 */
 	onAnchors?: (snapshot: { widgets: Plan.WidgetAnchors[]; threads: Plan.ThreadAnchors[] }) => void;
+	/**
+	 * What the agent just did, to be marked in the prose.
+	 *
+	 * Unlike the anchors, this is not part of opening a document: it says what
+	 * changed a moment ago, which is only true for a moment. Somebody arriving
+	 * afterwards is reading the plan, not watching it being written.
+	 */
+	onChanges?: (changes: Plan.Change[]) => void;
 };
 
 /**
@@ -185,6 +193,9 @@ export class PlanProvider implements Provider {
 			this.#wire.on<Plan.Ack>("plan:ack", event => this.#settle(event.id)),
 			this.#wire.on<Plan.Awareness>("plan:awareness", event => this.#presence(event)),
 			this.#wire.on<Plan.Reset>("plan:reset", event => this.#reset(event)),
+			this.#wire.on<Plan.Changes>("plan:changes", event => {
+				if (event.epoch === this.#epoch) this.#options.onChanges?.(event.changes);
+			}),
 			this.#wire.on<Plan.Anchors>("plan:anchors", event => {
 				if (event.epoch === this.#epoch) {
 					this.#anchors({ widgets: event.widgets, threads: event.threads });

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -593,7 +593,7 @@
  * Marks that take no space and add no element.
  *
  * An agent editing below the fold must not shift the sentence somebody is in
- * the middle of typing, and a mark that expires ten seconds later must not
+ * the middle of typing, and a mark that expires a few seconds later must not
  * shift it back. So a block is washed, and a hole is drawn in `box-shadow` on
  * the edge of the block still beside it. A `::before` rule was the obvious way
  * to draw a hole and is the wrong one: it needs the block to become a

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -586,3 +586,220 @@
 	border-radius: 9999px;
 	background: currentColor;
 }
+
+/* What the agent changed ------------------------------------------------- */
+
+/*
+ * Marks drawn entirely in `box-shadow`, which is what keeps them free of the
+ * layout.
+ *
+ * An agent editing below the fold must not shift the sentence somebody is in
+ * the middle of typing, and a mark that expires ten seconds later must not
+ * shift it back — so nothing here may take space, and nothing here may add an
+ * element. A `::before` bar was the obvious way to draw the gutter and is the
+ * wrong one: it needs the block to become a containing block, which re-anchors
+ * any absolutely positioned widget chrome inside it for as long as the mark is
+ * up.
+ *
+ * An outset shadow offset into the gutter with a negative spread leaves a
+ * sliver beside the block, outside it, costing no space and no stacking.
+ */
+.plan .plan-content [data-plan-change] {
+	transition: box-shadow 600ms ease-out, background 600ms ease-out;
+}
+
+/* Written just now: a solid rule beside it, and a wash over it. */
+.plan .plan-content [data-plan-change="added"] {
+	box-shadow: -0.5rem 0 0 -0.375rem var(--color-ring);
+	background: color-mix(in oklch, var(--color-ring) 10%, transparent);
+}
+
+/*
+ * Moved, not written. Deliberately quieter than the wash above: the words are
+ * ones the reader may already have read, and marking them as loudly as new
+ * prose would say something untrue about them.
+ */
+.plan .plan-content [data-plan-change="moved"] {
+	box-shadow: -0.5rem 0 0 -0.4375rem color-mix(in oklch, var(--color-ring) 70%, transparent);
+}
+
+/*
+ * A hole where something was.
+ *
+ * Drawn on the edge of the block still beside it, because what went has no
+ * element to carry a mark. The two sides are separate properties so one block
+ * can hold a removal above it and a vacancy below it at once.
+ */
+.plan .plan-content [data-plan-gap-before],
+.plan .plan-content [data-plan-gap-after] {
+	transition: box-shadow 600ms ease-out;
+}
+
+.plan .plan-content [data-plan-gap-before="removed"] {
+	box-shadow: 0 -0.375rem 0 -0.3125rem var(--color-muted-foreground);
+}
+
+.plan .plan-content [data-plan-gap-after="removed"] {
+	box-shadow: 0 0.375rem 0 -0.3125rem var(--color-muted-foreground);
+}
+
+/*
+ * Where a block left from, as opposed to where one was deleted. Fainter, since
+ * nothing was lost — the content is still in the plan, further up or down.
+ */
+.plan .plan-content [data-plan-gap-before="vacated"] {
+	box-shadow: 0 -0.375rem 0 -0.34375rem
+		color-mix(in oklch, var(--color-muted-foreground) 55%, transparent);
+}
+
+.plan .plan-content [data-plan-gap-after="vacated"] {
+	box-shadow: 0 0.375rem 0 -0.34375rem
+		color-mix(in oklch, var(--color-muted-foreground) 55%, transparent);
+}
+
+/*
+ * A block can be both: written where something else was taken out. The
+ * shadows compose in one property, so the combinations have to be spelled out
+ * rather than left to the cascade, which would keep only the last.
+ */
+.plan .plan-content [data-plan-change="added"][data-plan-gap-before="removed"] {
+	box-shadow:
+		-0.5rem 0 0 -0.375rem var(--color-ring),
+		0 -0.375rem 0 -0.3125rem var(--color-muted-foreground);
+}
+
+.plan .plan-content [data-plan-change="added"][data-plan-gap-after="removed"] {
+	box-shadow:
+		-0.5rem 0 0 -0.375rem var(--color-ring),
+		0 0.375rem 0 -0.3125rem var(--color-muted-foreground);
+}
+
+/*
+ * The agent wrote this block and the reader is pointing at a card that refers
+ * to it.
+ *
+ * Only reachable where there is no Highlight API, since that is the only path
+ * on which a sidecar mark touches the element's own background. The two rules
+ * have equal specificity, so without saying so the later one — this file's —
+ * would simply replace the earlier and the pointer would lose its wash.
+ * Pointing is something the reader just did and the agent's mark is ambient,
+ * so the pointer wins; the gutter bar is in `box-shadow` and survives either
+ * way.
+ */
+.plan .plan-content [data-plan-related][data-plan-change] {
+	background: color-mix(in oklch, var(--color-accent) 20%, transparent);
+}
+
+/* Reaching the ones off screen ------------------------------------------- */
+
+/*
+ * One chip per edge, over the prose rather than in it, and only while
+ * something in that direction is still unread. Opposite the status chip at the
+ * bottom, which is why the lower one sits inline-start of it.
+ */
+.plan-changes {
+	position: absolute;
+	z-index: 3;
+	inset-inline-start: 50%;
+	translate: -50% 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.375rem;
+	max-width: min(24rem, 80%);
+}
+
+.plan-changes[data-side="above"] {
+	inset-block-start: 0.75rem;
+}
+
+.plan-changes[data-side="below"] {
+	inset-block-end: 0.75rem;
+	flex-direction: column-reverse;
+}
+
+.plan-changes-bar {
+	display: flex;
+	align-self: center;
+	align-items: stretch;
+	border: 1px solid var(--color-border);
+	border-radius: 9999px;
+	background: var(--color-background);
+	box-shadow: 0 1px 3px color-mix(in oklch, var(--color-foreground) 12%, transparent);
+	font-size: 0.6875rem;
+	line-height: 1rem;
+	overflow: hidden;
+}
+
+.plan-changes-go,
+.plan-changes-more {
+	display: flex;
+	align-items: center;
+	gap: 0.375rem;
+	padding: 0.25rem 0.625rem;
+	color: var(--color-foreground);
+	cursor: pointer;
+}
+
+.plan-changes-more {
+	padding-inline: 0.375rem;
+	border-inline-start: 1px solid var(--color-border);
+}
+
+.plan-changes-go:hover,
+.plan-changes-more:hover {
+	background: var(--color-accent);
+}
+
+.plan-changes-list,
+.plan-changes-empty {
+	margin: 0;
+	padding: 0.375rem;
+	max-height: 12rem;
+	overflow-y: auto;
+	list-style: none;
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-md);
+	background: var(--color-background);
+	box-shadow: 0 2px 8px color-mix(in oklch, var(--color-foreground) 12%, transparent);
+	font-size: 0.6875rem;
+	line-height: 1rem;
+}
+
+.plan-changes-empty {
+	padding: 0.5rem 0.625rem;
+	color: var(--color-muted-foreground);
+}
+
+.plan-changes-item {
+	display: flex;
+	gap: 0.5rem;
+	padding: 0.25rem 0.5rem;
+	border-radius: var(--radius-sm);
+}
+
+.plan-changes-kind {
+	flex: none;
+	font-weight: 600;
+	color: var(--color-muted-foreground);
+}
+
+/* Still waiting to be reached, as opposed to already shown and counted down. */
+.plan-changes-item[data-unread] {
+	background: color-mix(in oklch, var(--color-ring) 8%, transparent);
+}
+
+.plan-changes-item[data-unread] .plan-changes-kind {
+	color: var(--color-foreground);
+}
+
+.plan-changes-item[data-kind="removed"] .plan-changes-text {
+	color: var(--color-muted-foreground);
+	text-decoration: line-through;
+}
+
+/* One line each: this is an index, not a diff. */
+.plan-changes-text {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -590,57 +590,63 @@
 /* What the agent changed ------------------------------------------------- */
 
 /*
- * Marks drawn entirely in `box-shadow`, which is what keeps them free of the
- * layout.
+ * Marks that take no space and add no element.
  *
  * An agent editing below the fold must not shift the sentence somebody is in
  * the middle of typing, and a mark that expires ten seconds later must not
- * shift it back — so nothing here may take space, and nothing here may add an
- * element. A `::before` bar was the obvious way to draw the gutter and is the
- * wrong one: it needs the block to become a containing block, which re-anchors
- * any absolutely positioned widget chrome inside it for as long as the mark is
- * up.
+ * shift it back. So a block is washed, and a hole is drawn in `box-shadow` on
+ * the edge of the block still beside it. A `::before` rule was the obvious way
+ * to draw a hole and is the wrong one: it needs the block to become a
+ * containing block, which re-anchors any absolutely positioned widget chrome
+ * inside it for as long as the mark is up.
  *
- * An outset shadow offset into the gutter with a negative spread leaves a
- * sliver beside the block, outside it, costing no space and no stacking.
+ * Two colours, and they mean different things. `ring` is prose that was
+ * written; `muted-foreground` is structure that moved or went, where no words
+ * are new. Where the agent is working *now* is not said here at all — that is
+ * its cursor, which comes and goes with the turn rather than waiting to be
+ * read.
  */
 .plan .plan-content [data-plan-change] {
-	transition: box-shadow 600ms ease-out, background 600ms ease-out;
+	transition: background 600ms ease-out;
 }
 
-/* Written just now: a solid rule beside it, and a wash over it. */
+/* Written just now. */
 .plan .plan-content [data-plan-change="added"] {
-	box-shadow: -0.5rem 0 0 -0.375rem var(--color-ring);
 	background: color-mix(in oklch, var(--color-ring) 10%, transparent);
 }
 
 /*
- * Moved, not written. Deliberately quieter than the wash above: the words are
- * ones the reader may already have read, and marking them as loudly as new
- * prose would say something untrue about them.
+ * Moved, not written. In the structural colour rather than a fainter version
+ * of the one above: the words are ones the reader may already have read, and
+ * saying "new, but less so" about them would not be true.
  */
 .plan .plan-content [data-plan-change="moved"] {
-	box-shadow: -0.5rem 0 0 -0.4375rem color-mix(in oklch, var(--color-ring) 70%, transparent);
+	background: color-mix(in oklch, var(--color-muted-foreground) 9%, transparent);
 }
 
 /*
  * A hole where something was.
  *
- * Drawn on the edge of the block still beside it, because what went has no
- * element to carry a mark. The two sides are separate properties so one block
- * can hold a removal above it and a vacancy below it at once.
+ * One block can hold a hole above it and another below — delete the second and
+ * fourth of four blocks and the third carries both — so the two sides cannot
+ * each set `box-shadow`, or the cascade would keep only whichever rule came
+ * last and one hairline would silently never draw. Custom properties do
+ * cascade independently, so each side sets one and they compose here.
  */
 .plan .plan-content [data-plan-gap-before],
 .plan .plan-content [data-plan-gap-after] {
+	box-shadow:
+		var(--plan-gap-above, 0 0 transparent),
+		var(--plan-gap-below, 0 0 transparent);
 	transition: box-shadow 600ms ease-out;
 }
 
 .plan .plan-content [data-plan-gap-before="removed"] {
-	box-shadow: 0 -0.375rem 0 -0.3125rem var(--color-muted-foreground);
+	--plan-gap-above: 0 -0.375rem 0 -0.3125rem var(--color-muted-foreground);
 }
 
 .plan .plan-content [data-plan-gap-after="removed"] {
-	box-shadow: 0 0.375rem 0 -0.3125rem var(--color-muted-foreground);
+	--plan-gap-below: 0 0.375rem 0 -0.3125rem var(--color-muted-foreground);
 }
 
 /*
@@ -648,30 +654,19 @@
  * nothing was lost — the content is still in the plan, further up or down.
  */
 .plan .plan-content [data-plan-gap-before="vacated"] {
-	box-shadow: 0 -0.375rem 0 -0.34375rem
-		color-mix(in oklch, var(--color-muted-foreground) 55%, transparent);
+	--plan-gap-above: 0 -0.375rem 0 -0.34375rem color-mix(
+		in oklch,
+		var(--color-muted-foreground) 55%,
+		transparent
+	);
 }
 
 .plan .plan-content [data-plan-gap-after="vacated"] {
-	box-shadow: 0 0.375rem 0 -0.34375rem
-		color-mix(in oklch, var(--color-muted-foreground) 55%, transparent);
-}
-
-/*
- * A block can be both: written where something else was taken out. The
- * shadows compose in one property, so the combinations have to be spelled out
- * rather than left to the cascade, which would keep only the last.
- */
-.plan .plan-content [data-plan-change="added"][data-plan-gap-before="removed"] {
-	box-shadow:
-		-0.5rem 0 0 -0.375rem var(--color-ring),
-		0 -0.375rem 0 -0.3125rem var(--color-muted-foreground);
-}
-
-.plan .plan-content [data-plan-change="added"][data-plan-gap-after="removed"] {
-	box-shadow:
-		-0.5rem 0 0 -0.375rem var(--color-ring),
-		0 0.375rem 0 -0.3125rem var(--color-muted-foreground);
+	--plan-gap-below: 0 0.375rem 0 -0.34375rem color-mix(
+		in oklch,
+		var(--color-muted-foreground) 55%,
+		transparent
+	);
 }
 
 /*

--- a/packages/editor/src/trail.test.ts
+++ b/packages/editor/src/trail.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Marks wait to be seen, then expire.
+ *
+ * The deferral is the whole feature: the agent writes wherever it likes, and
+ * the reader is only shown a mark once it has reached them. What is tested
+ * here is that bookkeeping and nothing else — resolving an anchor, finding an
+ * element and painting it all need a document, and the test runtime has none.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { trail } from "./trail";
+
+/** Short enough that a test can wait for it without being slow. */
+const LINGER = 20;
+
+function sleep(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe("waiting to be seen", () => {
+	it("holds a mark unseen without a clock running", async () => {
+		let marks = trail(() => {}, LINGER);
+		marks.add(["a"]);
+
+		await sleep(LINGER * 3);
+
+		expect(marks.pending()).toEqual(["a"]);
+		expect(marks.showing()).toEqual([]);
+	});
+
+	it("starts the clock when a mark is seen", () => {
+		let marks = trail(() => {}, LINGER);
+		marks.add(["a", "b"]);
+		marks.saw(["a"]);
+
+		expect(marks.showing()).toEqual(["a"]);
+		expect(marks.pending()).toEqual(["b"]);
+	});
+
+	it("takes a mark down once its time is up", async () => {
+		let marks = trail(() => {}, LINGER);
+		marks.add(["a"]);
+		marks.saw(["a"]);
+
+		await sleep(LINGER * 2);
+
+		expect(marks.ids()).toEqual([]);
+	});
+
+	/** Nobody asked for this transition, so nobody is watching for it either. */
+	it("says when a mark expired on its own", async () => {
+		let told = 0;
+		let marks = trail(() => told++, LINGER);
+		marks.add(["a"]);
+		marks.saw(["a"]);
+
+		await sleep(LINGER * 2);
+
+		expect(told).toBe(1);
+	});
+
+	/**
+	 * The clock is wall time, not attention. A mark that went off screen is
+	 * still on its way out — it cannot go dark and light up again later, which
+	 * would read as a second edit that never happened.
+	 */
+	it("keeps counting after a mark scrolls back out of view", async () => {
+		let marks = trail(() => {}, LINGER);
+		marks.add(["a"]);
+		marks.saw(["a"]);
+		marks.saw([]);
+
+		await sleep(LINGER * 2);
+
+		expect(marks.ids()).toEqual([]);
+	});
+
+	it("does not give a mark more time for being looked at twice", async () => {
+		let marks = trail(() => {}, LINGER);
+		marks.add(["a"]);
+		marks.saw(["a"]);
+
+		await sleep(LINGER * 0.6);
+		marks.saw(["a"]);
+		await sleep(LINGER * 0.6);
+
+		expect(marks.ids()).toEqual([]);
+	});
+});
+
+describe("keeping the set bounded", () => {
+	it("leaves a mark it already holds alone", () => {
+		let marks = trail(() => {}, LINGER);
+		marks.add(["a"]);
+		marks.saw(["a"]);
+		marks.add(["a"]);
+
+		expect(marks.phase("a")).toBe("showing");
+	});
+
+	it("drops the oldest unseen marks past the cap", () => {
+		let marks = trail(() => {}, LINGER);
+		marks.add([...Array(60)].map((_, index) => `m${index}`));
+
+		expect(marks.ids()).toHaveLength(50);
+		expect(marks.phase("m0")).toBeUndefined();
+		expect(marks.phase("m59")).toBe("pending");
+	});
+
+	it("forgets marks that no longer name anywhere", () => {
+		let marks = trail(() => {}, LINGER);
+		marks.add(["a", "b"]);
+		marks.drop(["a"]);
+
+		expect(marks.ids()).toEqual(["b"]);
+	});
+
+	it("stops the clock on everything when disposed", async () => {
+		let told = 0;
+		let marks = trail(() => told++, LINGER);
+		marks.add(["a"]);
+		marks.saw(["a"]);
+		marks.dispose();
+
+		await sleep(LINGER * 2);
+
+		expect(told).toBe(0);
+		expect(marks.ids()).toEqual([]);
+	});
+});

--- a/packages/editor/src/trail.ts
+++ b/packages/editor/src/trail.ts
@@ -1,0 +1,121 @@
+/**
+ * How long the reader has left to notice each thing the agent changed.
+ *
+ * A mark waits until it has been looked at. The agent can write below the fold
+ * while somebody is reading the top of the plan, and a mark that spent its ten
+ * seconds off screen would have told nobody anything — so nothing starts
+ * counting down until it has been in the viewport, and until then it is an
+ * unread marker rather than a flash. Unread markers do not expire on a clock;
+ * that is the whole point of deferring them.
+ *
+ * Once seen the clock runs whether or not the mark is still in view. Two
+ * states and one timer: a mark can never go dark and light up again on a later
+ * scroll, which would read as a second edit that never happened.
+ *
+ * Nothing here knows what a mark looks like, where it is, or that there is a
+ * document. It is the part worth testing and the part that does not need a
+ * browser — the test runtime has neither a DOM nor a controllable clock, which
+ * is also why the duration is an argument rather than a constant.
+ */
+
+/** How long a mark stays up once it has been seen. */
+const LINGER = 10_000;
+
+/**
+ * How many unseen marks to keep.
+ *
+ * Unbounded, a long session in a plan the reader never scrolls through would
+ * accumulate one for every block the agent ever wrote. The oldest go first:
+ * what the agent did a moment ago is worth more than what it did an hour ago.
+ */
+const CAPACITY = 50;
+
+export type Phase = "pending" | "showing";
+
+export type Trail = {
+	/** Take on marks. One already tracked keeps the phase it had. */
+	add: (ids: string[]) => void;
+	/** Report what is in the viewport. Anything newly seen starts its clock. */
+	saw: (ids: Iterable<string>) => void;
+	/** Give up on marks that no longer name anywhere. */
+	drop: (ids: Iterable<string>) => void;
+	phase: (id: string) => Phase | undefined;
+	/** Every live mark, oldest first. */
+	ids: () => string[];
+	pending: () => string[];
+	showing: () => string[];
+	dispose: () => void;
+};
+
+/**
+ * Track a set of marks through being seen and expiring.
+ *
+ * `changed` is called when a mark expires on its own, which is the only
+ * transition nobody asked for and so the only one a caller cannot predict.
+ */
+export function trail(changed: () => void, linger = LINGER): Trail {
+	// Insertion-ordered, which is what makes evicting the oldest a matter of
+	// taking the first key rather than tracking arrival times.
+	let phases = new Map<string, Phase>();
+	let timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+	let stop = (id: string) => {
+		let timer = timers.get(id);
+		if (timer === undefined) return;
+		clearTimeout(timer);
+		timers.delete(id);
+	};
+
+	let forget = (id: string) => {
+		stop(id);
+		phases.delete(id);
+	};
+
+	let of = (phase: Phase) => [...phases].flatMap(([id, held]) => held === phase ? [id] : []);
+
+	return {
+		add(ids) {
+			for (let id of ids) {
+				if (phases.has(id)) continue;
+				phases.set(id, "pending");
+			}
+			while (phases.size > CAPACITY) {
+				let oldest = phases.keys().next().value;
+				if (oldest === undefined) break;
+				forget(oldest);
+			}
+		},
+
+		saw(ids) {
+			for (let id of ids) {
+				// Only the first sighting counts. Scrolling back to something
+				// already showing must not buy it another ten seconds, or a
+				// mark could be kept alive indefinitely by being looked at.
+				if (phases.get(id) !== "pending") continue;
+				phases.set(id, "showing");
+				timers.set(
+					id,
+					setTimeout(() => {
+						forget(id);
+						changed();
+					}, linger),
+				);
+			}
+		},
+
+		drop(ids) {
+			for (let id of ids) forget(id);
+		},
+
+		phase: id => phases.get(id),
+		ids: () => [...phases.keys()],
+		pending: () => of("pending"),
+		showing: () => of("showing"),
+
+		dispose() {
+			for (let timer of timers.values()) clearTimeout(timer);
+			timers.clear();
+			phases.clear();
+		},
+	};
+}

--- a/packages/editor/src/trail.ts
+++ b/packages/editor/src/trail.ts
@@ -2,7 +2,7 @@
  * How long the reader has left to notice each thing the agent changed.
  *
  * A mark waits until it has been looked at. The agent can write below the fold
- * while somebody is reading the top of the plan, and a mark that spent its ten
+ * while somebody is reading the top of the plan, and a mark that spent its few
  * seconds off screen would have told nobody anything — so nothing starts
  * counting down until it has been in the viewport, and until then it is an
  * unread marker rather than a flash. Unread markers do not expire on a clock;
@@ -19,7 +19,7 @@
  */
 
 /** How long a mark stays up once it has been seen. */
-const LINGER = 10_000;
+const LINGER = 5_000;
 
 /**
  * How many unseen marks to keep.
@@ -89,7 +89,7 @@ export function trail(changed: () => void, linger = LINGER): Trail {
 		saw(ids) {
 			for (let id of ids) {
 				// Only the first sighting counts. Scrolling back to something
-				// already showing must not buy it another ten seconds, or a
+				// already showing must not buy it another five seconds, or a
 				// mark could be kept alive indefinitely by being looked at.
 				if (phases.get(id) !== "pending") continue;
 				phases.set(id, "showing");

--- a/packages/editor/src/widgets-plugin.tsx
+++ b/packages/editor/src/widgets-plugin.tsx
@@ -14,11 +14,13 @@
 import { addComposerChild$, realmPlugin } from "@mdxeditor/editor";
 import { Cell } from "@mdxeditor/gurx";
 
+import { ChangeObserver } from "./changes-observer";
 import { QuestionnaireObserver } from "./questionnaires";
 import { ThreadObserver } from "./threads";
 import { Toolbar } from "./toolbar";
 import { CalloutPlugin, PreviewPlugin, TabsPlugin } from "./widgets";
 
+import type { ChangeStore } from "./changes";
 import type { QuestionnaireStore } from "./questionnaires";
 import type { ThreadStore } from "./threads";
 
@@ -27,6 +29,8 @@ export type WidgetsOptions = {
 	questions?: QuestionnaireStore;
 	/** The same arrangement for comments: observed here, rendered in the pane. */
 	threads?: ThreadStore;
+	/** Marks what the agent changed, which needs the document to place them. */
+	changes?: ChangeStore;
 };
 
 /** Live host configuration. Read it; do not capture it. */
@@ -44,6 +48,10 @@ export const widgetsPlugin = realmPlugin<WidgetsOptions>({
 		if (params?.threads) {
 			let store = params.threads;
 			realm.pub(addComposerChild$, () => <ThreadObserver store={store} />);
+		}
+		if (params?.changes) {
+			let store = params.changes;
+			realm.pub(addComposerChild$, () => <ChangeObserver store={store} />);
 		}
 		realm.pub(addComposerChild$, TabsPlugin);
 		realm.pub(addComposerChild$, PreviewPlugin);

--- a/packages/protocol/plan.d.ts
+++ b/packages/protocol/plan.d.ts
@@ -22,6 +22,7 @@ export declare namespace Plan {
 		| (Update & { sender?: string })
 		| (Awareness & { sender?: string })
 		| Anchors
+		| Changes
 		| Reset
 		| Status;
 
@@ -126,6 +127,52 @@ export declare namespace Plan {
 		epoch: string;
 		widgets: WidgetAnchors[];
 		threads: ThreadAnchors[];
+	};
+
+	/**
+	 * A place between blocks, named by the block still beside it.
+	 *
+	 * What the agent took out has no anchor of its own: a relative position
+	 * needs a live collaborative type and the departed block's is gone. So a
+	 * gap is described by a survivor and the side the content was on. That the
+	 * plan can never be emptied is what guarantees a survivor exists.
+	 */
+	export type Gap = {
+		at: Anchor;
+		side: "before" | "after";
+	};
+
+	/** Enough of a block to recognise it in a list. */
+	export type Excerpt = {
+		/** The MDAST node type, or the component name for a dialect block. */
+		type: string;
+		/** Bounded flattened text. */
+		preview: string;
+	};
+
+	/**
+	 * One thing the agent did to the plan, as a reader can find it.
+	 *
+	 * A move is one change rather than a disappearance and an arrival, because
+	 * a reader who is shown those separately has to work out for themselves
+	 * that they are the same block. A rewrite is `added` alone: something is
+	 * still there to look at, and marking a gap as well would put a tombstone
+	 * on the most common edit the agent makes.
+	 */
+	export type Change =
+		| ({ kind: "added"; at: Anchor } & Excerpt)
+		| ({ kind: "moved"; at: Anchor; from: Gap } & Excerpt)
+		| { kind: "removed"; at: Gap; blocks: Excerpt[] };
+
+	/**
+	 * What the agent just did to the plan.
+	 *
+	 * Ephemeral, and deliberately not replayed on open: somebody arriving
+	 * afterwards is reading the plan, not watching it being written.
+	 */
+	export type Changes = KIND<"plan:changes"> & {
+		epoch: string;
+		changes: Change[];
 	};
 
 	/**


### PR DESCRIPTION
Two things the plan could not say: what the agent just did to it, and where
it is working right now. They are different questions with different
lifetimes, and this answers them separately.

## What the agent did

`edit.apply` already knew and threw it away. A batch is reconciled by object
identity, so a block the agent wrote is one the reconciler did not carry
through — free to report, and impossible for the agent to misstate. What
*moved or went* cannot be had that way: a node missing from the result may
have been deleted or replaced, and a node at a new index may have moved or
merely been pushed down by an insert above it. Those come from the
operations, which say exactly.

Three kinds reach the browser as anchors, not indices, because somebody may
type between the frame being sent and it being painted:

| | drawn as |
|---|---|
| written | a wash in the prose colour |
| moved | a wash in the structural colour — the words are not new |
| removed | a hairline on the edge of the block still beside it |

A rewrite is one mark, not a disappearance and an arrival. A move is one
entry with two ends, so a reader is not left to work out that the block
that vanished here is the one that turned up there.

## Marks wait to be seen

The agent writes wherever it likes, including several screens from whoever
is reading, so a mark that spent its few seconds off screen would have told
nobody anything. Nothing counts down until it has been in the viewport,
which makes it an unread marker rather than a flash — and unread markers do
not expire on a clock, so an unseen one waits indefinitely and the set is
bounded by a cap instead. Once seen the clock runs whether or not the mark
is still in view: two states and one timer, so nothing can go dark and light
up again on a later scroll.

Chips at each edge count what is still unread in that direction and go to
the nearest one. The list behind them is the only place a removal can be
read after the fact, because the block itself is gone.

## Where it is working

A cursor, in the language the room already has for a peer — Lexical draws
it, `labels.ts` flashes its name. It rides in the presence mirror's own
local slot: everything else there reflects a socket, which is what lets a
disconnect clear it, and the agent has no socket. That slot is also in the
join snapshot, so somebody arriving mid-turn sees it.

It sits at the end of what the agent wrote. An anchor names a block from its
start, which is the stable end of one to point at; a cursor is where an edit
*finished*, and a caret at the top of a new paragraph looks like something
about to be typed.

The cursor and the marks disagree about time deliberately. The cursor is
presence and goes shortly after the turn; a mark is a record and may sit
unread. Somebody returning after a long turn sees marks and no cursor, which
reads as an inconsistency until you notice they answer different questions.

## Nothing takes space

No mark may add an element or occupy layout: an agent editing below the fold
must not shift the sentence somebody is mid-way through typing, and a mark
expiring must not shift it back. Blocks are washed; holes are drawn in
`box-shadow` on a neighbour's edge.

## Tests

412 pass, up from 375. The new ones cover the parts that fail invisibly:

- the derivation — an insert at the top reports no moves, a rewrite leaves
  no hole, a delete and a move in one batch does not anchor the hole to the
  block that left
- index → anchor → block, mutation-checked: an off-by-one fails it
- `endOf` resolved through Lexical's own resolver, so what is asserted is
  where a browser would draw the caret
- awareness renewal advancing the clock — re-encoding an unchanged state is
  silently discarded, and the cursor would vanish mid-turn
- the mark lifecycle, kept free of the DOM so it can be tested at all

## Worth knowing before merging

**Not yet run in a browser.** Types, lint and tests are green and the logic
is covered, but the visual judgements — the wash percentages, the hairline
geometry, the caret against a heading or list item — have not been looked
at. Expect to want to tune them.

**Two corrections to `agents.md` came out of this.** The highlight registry
is `plan-related`, not `plan-comment*`. And five test files blamed happy-dom
for returning zero measurements; happy-dom is not a dependency and there is
no DOM at all — the conclusion was right for a reason that would have sent
the next person to install it.

**One latent CSS bug fixed on the way.** A block can carry a hole above and
below at once — delete the second and fourth of four blocks — and two rules
setting `box-shadow` at equal specificity meant the cascade kept one and the
other silently never drew. The sides are custom properties now, which
compose.

**Known gaps, by choice.** `replace_root` reports nothing, because a
document marked end to end says nothing. A hole is anchored to a neighbour,
so rewriting that neighbour orphans it. A reconnect discards the trail.
