### PR TITLE
Leave the resolved decisions showing, and remember the choice

### DIFF
--- a/packages/editor/src/decisions.tsx
+++ b/packages/editor/src/decisions.tsx
@@ -7,9 +7,13 @@
  * comment *is* a decision, and would otherwise have to pick a side.
  *
  * Outstanding items come first, in document order, because one of those is
- * blocking somebody. Everything resolved collapses behind a disclosure: it is
- * the record, worth keeping and not worth scrolling past. A dismissed thread is
- * not shown at all; the transcript is where it left its trace.
+ * blocking somebody. Everything resolved follows, showing: it is the record of
+ * what the room settled, and a decision nobody can see is one that gets made a
+ * second time. The disclosure stays because resolved items are kept forever and
+ * a long-lived plan will out-scroll the pane — and which way it is left is
+ * remembered, since collapsing it and finding it open again on the next load
+ * reads as a toggle that does not work. A dismissed thread is not shown at all;
+ * the transcript is where it left its trace.
  *
  * An item also knows where it lives. Hovering a question lights the passage it
  * concerns; hovering a comment lights the phrase it marks. The highlight is
@@ -47,11 +51,30 @@ function undecided(entry: QuestionnaireEntry): boolean {
 	return entry.value.questions.some(question => question.answer === undefined);
 }
 
+/** Where the disclosure is remembered, alongside the pane widths. */
+let HISTORY = "chopin:decisions:resolved";
+
+/**
+ * Whether the resolved list is showing, remembered across reloads.
+ *
+ * Anything other than the one stored string reads as open, so an absent key and
+ * a corrupt one both mean nobody has collapsed this — which is the default.
+ */
+function useHistory() {
+	let [history, setHistory] = useState(() => localStorage.getItem(HISTORY) !== "false");
+
+	useEffect(() => {
+		localStorage.setItem(HISTORY, String(history));
+	}, [history]);
+
+	return [history, setHistory] as const;
+}
+
 export function Decisions({ connected, reveal, store, threads, wire }: DecisionsProps) {
 	let entries = useQuestionnaires(store);
 	let state = useThreads(threads);
 	let content = useRef<HTMLDivElement>(null);
-	let [history, setHistory] = useState(false);
+	let [history, setHistory] = useHistory();
 
 	// Leaving the pane should not leave the prose lit. A highlight belongs to
 	// the pointer that asked for it.
@@ -148,6 +171,7 @@ export function Decisions({ connected, reveal, store, threads, wire }: Decisions
 				{resolved > 0 && (
 					<div className={outstanding > 0 || state.draft ? "mt-3" : ""}>
 						<button
+							aria-expanded={history}
 							className="w-full rounded-md px-1 py-1 text-left text-xs text-muted-foreground hover:text-foreground"
 							onClick={() => setHistory(value => !value)}
 							type="button"


### PR DESCRIPTION
The sidecar kept everything resolved behind a closed disclosure, on the
grounds that it was worth keeping and not worth scrolling past. But it is
the record of what the room settled, and a decision nobody can see is one
that gets made a second time. The pane's own argument for putting questions
and accepted comments in one list is that both are decisions — and it was
then hiding half of them by default.

So the list starts open. The disclosure stays, because resolved threads are
kept forever and a plan worked on for any length of time will out-scroll the
pane; somebody who wants only what is still blocking them should be able to
say so.

Which way it is left is remembered, beside the pane widths. Collapsing it
and finding it open again on the next load reads as a toggle that does not
work. Anything other than the one stored string means open, so an absent key
and a corrupt one both give the default rather than a pane that starts
closed for a reason nobody can find. The hook is duplicated rather than
shared with `usePaneWidth`, which lives in `apps/web` and cannot be reached
from a package.

`aria-expanded` goes on the button while it is being touched — the ▾/▸ was
the only thing saying which way it was, which is nothing at all to a screen
reader. The `reveal` scroll also loses a trap it had not yet sprung: it is a
`querySelector`, and a settled questionnaire behind a closed disclosure has
no element to find, though everything that asks for one today asks for an
unanswered one.

Nothing here is tested. The pane needs a DOM to render into and the test
runtime has none, which is the same reason `card.test.ts` covers only its
timestamp formatter. `bun run types`, `bun run ci` and `bun test` (412) are
clean.

Left alone deliberately: `localStorage` is read without a guard, so it
throws where storage is disabled. `usePaneWidth` has the identical exposure
and would take the whole app down before this could take the sidecar down,
so guarding one and not the other buys nothing.
