### PR TITLE
Take the reader to the prose a decision points at

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -117,6 +117,18 @@ re-serialising the document. The two ends must agree on which blocks the source
 addresses; they need not agree on the offset, so a divergence surfaces as a
 refusal rather than a comment landing on the wrong sentence.
 
+**A decision has one place in the plan, not two.** A question used to carry
+what it was about and what its answer produced as separate anchor sets, on the
+theory that they move independently. Asked to tell them apart, the agent
+anchored the first block of the result and called it the subject — in every
+record it ever wrote — so a resolved card offered two adjacent, identically
+labelled buttons that led to the same block. The subject was also never derived
+when a question was asked and never invalidated when the plan moved, so it sat
+permanently unreviewed: an inert link, and an entry in `anchors_pending` that no
+amount of anchoring could clear. A comment thread still keeps two, because there
+the halves have different authors and different shapes and neither can stand for
+the other.
+
 **The quote is the way back, not the card.** A sidecar card holds a reply box,
 an Accept and a Dismiss, so making the whole of it a link would mean deciding on
 every click whether the reader meant the link or the control they actually hit.
@@ -242,6 +254,15 @@ edits. Opening is driven by the connection now, not by the mount.
 `config.agent`; accepting a comment reached `Chat.instruct` directly and opened
 a session under `AGENT=off`. Anything that can start a turn has to check, and
 the check lives in `instruct` now so the next one cannot miss it.
+
+**A record read back from disk is not checked by anything.** `Anchors.read`
+hands back what `JSON.parse` produced, cast to the current type, so changing the
+shape of anything under `data/<room>/state.json` is somebody's existing room
+breaking rather than a type error here. It does not even break loudly: the carry
+on open is guarded, so a set the new code cannot read is caught, logged once,
+and every decision in the plan quietly loses its place — and because that guard
+is shared, one stale questionnaire takes the comment threads' anchors with it.
+`folded` is where the last such change is absorbed, and where the next one goes.
 
 **An optional callback nobody passes is a button that does nothing.**
 `QuestionView` rendered a real `<button>` labelled "Show in plan", with a

--- a/agents.md
+++ b/agents.md
@@ -117,6 +117,31 @@ re-serialising the document. The two ends must agree on which blocks the source
 addresses; they need not agree on the offset, so a divergence surfaces as a
 refusal rather than a comment landing on the wrong sentence.
 
+**The quote is the way back, not the card.** A sidecar card holds a reply box,
+an Accept and a Dismiss, so making the whole of it a link would mean deciding on
+every click whether the reader meant the link or the control they actually hit.
+The quotation becomes a button when the thread has somewhere to send one and
+stays a blockquote when it does not, which is the rule a question's answer
+already followed. It matters most for an accepted comment: a `<Decision>` draws
+nothing in the prose, so the pane is the whole of where the decision can be seen
+and the quote is the only route to what it produced.
+
+**A hover asks; a click sends.** Both leave the same wash, because they are the
+same fact — this is the prose that card refers to — and the difference is how
+long it is owed. A hover is over when the pointer moves; a click has put the
+reader somewhere they were not looking, so the mark is pinned for five seconds
+after the pointer has gone, or they arrive at a block with nothing to say which
+one it was. Pointing at another card in the meantime borrows the wash and gives
+it back, which is what makes a detour a detour.
+
+**There is one pin, in `marks.ts`, not one per store.** A reader has one
+pointer, so going to a comment has to put out the question they went to before
+it — the same argument that already put the registry there. Whether a walk
+through several places continues is asked of the pin rather than announced by
+it: nothing needs redrawing when it lapses, since the lapse redraws itself, and
+a callback fired on the way to replacing a pin would reach a store in the middle
+of walking and wipe the step it had just taken.
+
 **Hard-fail at boot.** A missing token, an unusable CLI or a `WORKING_DIR` that
 is not there are all detectable in seconds by trying, and discovering them when
 somebody types their first message is worse. `AGENT=off` is the deliberate way
@@ -217,6 +242,16 @@ edits. Opening is driven by the connection now, not by the mount.
 `config.agent`; accepting a comment reached `Chat.instruct` directly and opened
 a session under `AGENT=off`. Anything that can start a turn has to check, and
 the check lives in `instruct` now so the next one cannot miss it.
+
+**An optional callback nobody passes is a button that does nothing.**
+`QuestionView` rendered a real `<button>` labelled "Show in plan", with a
+pointer cursor and a count of how many places it would go to, calling an
+`onRelationSelect` that no caller ever supplied — `QuestionnaireCard` forwarded
+the two hover props beside it and dropped this one. It typechecks, it renders,
+it takes a tab stop, and it is inert. The same wiring in reverse is worth
+watching for: the tabs called `onRelationSelect` too, which read as harmless
+for as long as it was undefined and became the plan scrolling out from under
+somebody the moment it was not.
 
 **Rebasing used to happen only inside `edit_plan`.** So a block a person moved
 kept its anchors broken until the agent next happened to edit, and everything

--- a/apps/server/src/agent/planner.ts
+++ b/apps/server/src/agent/planner.ts
@@ -105,12 +105,13 @@ which blocks changed — read again and retry rather than forcing the edit.
 
 Every successful \`edit_plan\` returns \`anchors_pending\`, and you MUST clear it
 with \`anchor_plan\` before you reply or end the turn, quoting that result's
-revision and block digests. A question's own text maps to \`subject\`; the prose
-its answer caused maps to \`result\`. An accepted comment takes \`thread\` instead,
-and its blocks are the prose your revision produced. Link only blocks that would
-have to change if that decision changed — not the goal, not the architecture,
-not everything written after it. An empty list is a real answer: it records that
-you looked and there is deliberately nothing related.
+revision and block digests. A question takes \`widget\` and \`question\`; an
+accepted comment takes \`thread\`. Either way the blocks are the prose that
+decision lives in — what answering it, or accepting it, caused to be written.
+Link only blocks that would have to change if that decision changed — not the
+goal, not the architecture, not everything written after it. An empty list is a
+real answer: it records that you looked and there is deliberately nothing
+related.
 
 People comment on passages of the plan, and when the room accepts a thread you
 are asked to act on it. An accepted comment is an instruction: revise the prose

--- a/apps/server/src/agent/tools.ts
+++ b/apps/server/src/agent/tools.ts
@@ -256,14 +256,12 @@ export function toolbox(context: Context): Tool[] {
 		},
 		{
 			name: "anchor_plan",
-			description: "Say which passages of the plan each decision concerns and produced. Call it "
-				+ "immediately after every successful `edit_plan`, using that result's revision and "
-				+ "block digests. For a question, give `widget`, `question` and `relation`: its text "
-				+ "maps to `subject`, and the prose its answer caused maps to `result`. For an "
-				+ "accepted comment, give `thread` instead — the blocks are the prose your revision "
-				+ "produced. Link only blocks that would have to change if that decision changed. An "
-				+ "empty list means reviewed and deliberately unrelated, which is a real answer and "
-				+ "clears the review.",
+			description: "Say where in the plan each decision lives. Call it immediately after every "
+				+ "successful `edit_plan`, using that result's revision and block digests. For a "
+				+ "question, give `widget` and `question`; for an accepted comment, give `thread`. "
+				+ "Either way the blocks are the prose that decision produced. Link only blocks that "
+				+ "would have to change if the decision changed. An empty list means reviewed and "
+				+ "deliberately unrelated, which is a real answer and clears the review.",
 			parameters: {
 				type: "object",
 				properties: {
@@ -277,15 +275,12 @@ export function toolbox(context: Context): Tool[] {
 							properties: {
 								widget: {
 									type: "string",
-									description: "The questionnaire id. Give with `question` and `relation`.",
+									description: "The questionnaire id. Give with `question`.",
 								},
 								question: { type: "string", description: "The question id." },
-								relation: { type: "string", enum: ["subject", "result"] },
 								thread: {
 									type: "string",
-									description:
-										"An accepted comment thread's id, instead of widget/question/relation. "
-										+ "The blocks are the prose your revision produced.",
+									description: "An accepted comment thread's id, instead of widget/question.",
 								},
 								blocks: {
 									type: "array",
@@ -318,7 +313,6 @@ export function toolbox(context: Context): Tool[] {
 						anchors: Array<{
 							widget?: string;
 							question?: string;
-							relation?: "subject" | "result";
 							thread?: string;
 							blocks: Array<{ index: number; digest: string }>;
 						}>;
@@ -337,15 +331,9 @@ export function toolbox(context: Context): Tool[] {
 					for (let update of args.anchors) {
 						let failure = update.thread
 							? Comments.relate(context.plan, update.thread, update.blocks)
-							: update.widget && update.question && update.relation
-							? Questions.relate(
-								context.plan,
-								update.widget,
-								update.question,
-								update.relation,
-								update.blocks,
-							)
-							: "give either `thread`, or all of `widget`, `question` and `relation`.";
+							: update.widget && update.question
+							? Questions.relate(context.plan, update.widget, update.question, update.blocks)
+							: "give either `thread`, or both `widget` and `question`.";
 						if (failure) failures.push(failure);
 					}
 

--- a/apps/server/src/questions.anchors.test.ts
+++ b/apps/server/src/questions.anchors.test.ts
@@ -1,0 +1,189 @@
+/**
+ * A questionnaire's decisions, through a real room.
+ *
+ * `anchors.ts` covers the bookkeeping on its own. What needs a document is
+ * everything either side of it: minting an anchor from a block the agent named,
+ * carrying it forward when the plan moves, and — the reason this file exists —
+ * opening a room whose `state.json` was written before a question's two anchor
+ * sets were folded into one.
+ *
+ * That last one cannot be caught anywhere else. Records are restored with a
+ * cast (`plan/service.ts`), so nothing between `JSON.parse` and the first read
+ * checks the shape — and the carry on open is guarded, so getting it wrong does
+ * not fail the open. It is caught, logged once, and every decision in the plan
+ * silently loses its place, comment threads included, since they share the
+ * guard. Which is why the room opening is not what these assert.
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import * as Questions from "./questions/service";
+import * as room from "./plan/room";
+import * as Service from "./plan/service";
+
+import type { Server } from "bun";
+import type { Plan } from "./plan/service";
+import type { SocketData } from "./wire";
+
+const SOURCE = `# Title
+
+The renderer caches tiles for 60 seconds.
+
+The second paragraph.
+`;
+
+let rooms: string[] = [];
+let opens: Plan[] = [];
+
+afterEach(async () => {
+	for (let plan of opens) await Service.close(plan);
+	opens = [];
+	for (let dir of rooms) await rm(dir, { recursive: true, force: true });
+	rooms = [];
+});
+
+async function opened(state?: object) {
+	let dir = await mkdtemp(join(tmpdir(), "chopin-questions-"));
+	rooms.push(dir);
+	await writeFile(join(dir, "plan.mdx"), SOURCE);
+	if (state) await writeFile(join(dir, "state.json"), JSON.stringify(state));
+
+	let server = { publish() {} } as unknown as Server<SocketData>;
+	let plan = await Service.open("test", dir, server);
+	opens.push(plan);
+	return plan;
+}
+
+/** An answered questionnaire, as `state.json` holds one. */
+function stored(anchors?: object) {
+	return {
+		revision: 1,
+		questions: [{
+			id: "w1",
+			status: "answered",
+			resolver: "ana",
+			definition: {
+				questions: [{
+					id: "q1",
+					header: "Cache",
+					question: "How long do we cache?",
+					multiple: false,
+					options: [],
+				}],
+			},
+			answers: { q1: "60 seconds" },
+			...(anchors ? { anchors } : {}),
+		}],
+	};
+}
+
+describe("saying where a decision lives", () => {
+	it("owes a review until the agent has said, and stops when it has", async () => {
+		let plan = await opened(stored());
+
+		expect(Questions.outstanding(plan)).toEqual([
+			{ widget: "w1", question: "q1", reason: "missing" },
+		]);
+
+		let digest = room.digests(plan.document)[1]!;
+		expect(Questions.relate(plan, "w1", "q1", [{ index: 1, digest }])).toBeUndefined();
+
+		expect(Questions.outstanding(plan)).toEqual([]);
+		expect(Questions.anchors(plan)[0]?.questions.q1?.anchors).toHaveLength(1);
+	});
+
+	/** An empty list is a real answer: reviewed, deliberately related to nothing. */
+	it("accepts that a decision produced nothing worth pointing at", async () => {
+		let plan = await opened(stored());
+
+		expect(Questions.relate(plan, "w1", "q1", [])).toBeUndefined();
+		expect(Questions.outstanding(plan)).toEqual([]);
+	});
+
+	it("refuses to anchor against a block that has changed", async () => {
+		let plan = await opened(stored());
+
+		expect(Questions.relate(plan, "w1", "q1", [{ index: 1, digest: "sha256:stale" }]))
+			.toContain("has changed");
+	});
+
+	it("refuses a questionnaire the room does not have", async () => {
+		let plan = await opened(stored());
+
+		expect(Questions.relate(plan, "nope", "q1", [])).toContain("no questionnaire");
+	});
+
+	it("owes the review again once the plan has moved beneath it", async () => {
+		let plan = await opened(stored());
+		let digest = room.digests(plan.document)[1]!;
+		Questions.relate(plan, "w1", "q1", [{ index: 1, digest }]);
+
+		Questions.invalidate(plan, "plan_changed");
+
+		expect(Questions.outstanding(plan)).toEqual([
+			{ widget: "w1", question: "q1", reason: "plan_changed" },
+		]);
+	});
+});
+
+describe("opening a room written before the fold", () => {
+	/** The shape a released build persisted, which no longer typechecks. */
+	function split() {
+		return stored({
+			widget: "w1",
+			questions: {
+				q1: {
+					subject: { anchors: [], pending: true, reason: "missing" },
+					result: { anchors: [], pending: false },
+				},
+			},
+		});
+	}
+
+	/**
+	 * The open is guarded, so a record the fold missed would still produce a
+	 * room — one that had dropped every anchor it held and said so only to the
+	 * console. The complaint is the signal; the room is not.
+	 */
+	it("carries the anchors in rather than giving up on them", async () => {
+		let complaints: unknown[] = [];
+		let complain = console.error;
+		console.error = (...args: unknown[]) => complaints.push(args);
+		try {
+			await opened(split());
+		} finally {
+			console.error = complain;
+		}
+
+		expect(complaints).toEqual([]);
+	});
+
+	it("reads as one placement per question", async () => {
+		let plan = await opened(split());
+		let value = Questions.anchors(plan)[0];
+
+		expect(Object.keys(value?.questions ?? {})).toEqual(["q1"]);
+		expect(value?.questions.q1?.anchors).toEqual([]);
+	});
+
+	/**
+	 * The subject was raised the moment a question existed and cleared by
+	 * nothing, so every old room carries one the agent can never discharge.
+	 */
+	it("stops owing the review that could never be cleared", async () => {
+		let plan = await opened(split());
+
+		expect(Questions.outstanding(plan)).toEqual([]);
+	});
+
+	it("can still be anchored afterwards", async () => {
+		let plan = await opened(split());
+		let digest = room.digests(plan.document)[1]!;
+
+		expect(Questions.relate(plan, "w1", "q1", [{ index: 1, digest }])).toBeUndefined();
+		expect(Questions.anchors(plan)[0]?.questions.q1?.anchors).toHaveLength(1);
+	});
+});

--- a/apps/server/src/questions/anchors.test.ts
+++ b/apps/server/src/questions/anchors.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Where a questionnaire's decisions live, and what the agent owes on them.
+ *
+ * One placement per question. It used to be two — what the question was about
+ * and what its answer produced — and the pair had no test at any layer, which
+ * is part of how it survived long enough for the agent to anchor both halves to
+ * the same block in every record it ever wrote.
+ *
+ * No document here: minting an anchor needs a Yjs room and is covered in
+ * `plan/anchors.test.ts`. What is testable without one is the bookkeeping —
+ * which questions owe a review, when they stop owing it, and whether a record
+ * written before the fold can still be read.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import * as Anchors from "./anchors";
+
+import type { Plan } from "@chopin/protocol";
+import type { Record as Question } from "./service";
+
+function anchor(digest: string): Plan.Anchor {
+	return { epoch: "e1", position: "cG9z", digest: `sha256:${digest}` };
+}
+
+function record(over: Partial<Question> = {}): Question {
+	return {
+		id: "w1",
+		status: "open",
+		definition: {
+			questions: [
+				{ id: "q1", header: "Cache", question: "Where do we cache?", multiple: false, options: [] },
+				{ id: "q2", header: "Store", question: "Which store?", multiple: false, options: [] },
+			],
+		},
+		...over,
+	};
+}
+
+describe("what a question owes the agent", () => {
+	/**
+	 * There is no decision to place until somebody has made one, and a question
+	 * that owed a review from the moment it was asked would owe it forever —
+	 * nothing derives a placement at ask time, so nothing could ever clear it.
+	 */
+	it("owes nothing while nobody has answered", () => {
+		expect(Anchors.pending(record())).toEqual([]);
+	});
+
+	it("owes one review per question once it is answered", () => {
+		expect(Anchors.pending(record({ status: "answered" }))).toEqual([
+			{ widget: "w1", question: "q1", reason: "missing" },
+			{ widget: "w1", question: "q2", reason: "missing" },
+		]);
+	});
+
+	it("stops owing it once the agent has said where the decision lives", () => {
+		let answered = record({ status: "answered" });
+		let value = Anchors.set(Anchors.read(answered), "q1", [anchor("aa")]);
+
+		expect(Anchors.pending({ ...answered, anchors: value })).toEqual([
+			{ widget: "w1", question: "q2", reason: "missing" },
+		]);
+	});
+
+	/** Looking and finding nothing is a review, and has to be able to end one. */
+	it("takes an empty list as a real answer rather than as never having looked", () => {
+		let answered = record({ status: "answered" });
+		let value = Anchors.set(Anchors.read(answered), "q1", []);
+
+		expect(value.questions.q1).toEqual({ anchors: [], pending: false });
+		expect(Anchors.pending({ ...answered, anchors: value })).toHaveLength(1);
+	});
+
+	it("ignores a question the questionnaire does not ask", () => {
+		let value = Anchors.read(record());
+		expect(Anchors.set(value, "nope", [anchor("aa")])).toEqual(value);
+	});
+
+	it("owes the review again when the plan moves beneath it", () => {
+		let answered = record({ status: "answered" });
+		let anchored = {
+			...answered,
+			anchors: Anchors.set(Anchors.read(answered), "q1", [anchor("aa")]),
+		};
+
+		let value = Anchors.invalidate(anchored, "plan_changed");
+
+		expect(value.questions.q1?.pending).toBe(true);
+		// The anchors are kept: they are still the best guess at where it was,
+		// and the review is about whether they are still right.
+		expect(value.questions.q1?.anchors).toHaveLength(1);
+		expect(Anchors.pending({ ...anchored, anchors: value })).toContainEqual({
+			widget: "w1",
+			question: "q1",
+			reason: "plan_changed",
+		});
+	});
+
+	it("does not raise a review on a question nobody has answered", () => {
+		let open = record();
+		let value = Anchors.invalidate(open, "plan_changed");
+
+		expect(Anchors.pending({ ...open, anchors: value })).toEqual([]);
+	});
+});
+
+/**
+ * A room written before the two halves were folded into one.
+ *
+ * `read` hands back what was persisted verbatim, and nothing between
+ * `JSON.parse` and it checks the shape — so without this the first client to
+ * open an existing room reads `undefined.map` and the plan does not load.
+ */
+describe("reading a record written before the fold", () => {
+	function split(subject: Plan.AnchorSet, result: Plan.AnchorSet): Question {
+		return record({
+			status: "answered",
+			// The shape a released build wrote, which no longer typechecks.
+			anchors: {
+				widget: "w1",
+				questions: { q1: { subject, result } },
+			} as unknown as Plan.WidgetAnchors,
+		});
+	}
+
+	it("reads the two halves as the one placement", () => {
+		let value = Anchors.read(split(
+			{ anchors: [anchor("aa")], pending: false },
+			{ anchors: [anchor("aa"), anchor("bb")], pending: false },
+		));
+
+		// The subject was a subset of the result in every record the agent
+		// wrote, so the union is the result and nothing is duplicated.
+		expect(value.questions.q1?.anchors.map(item => item.digest)).toEqual([
+			"sha256:aa",
+			"sha256:bb",
+		]);
+		expect(value.questions.q1?.pending).toBe(false);
+	});
+
+	/** Where it was not a subset, dropping it would lose the only placement there was. */
+	it("keeps a subject the agent anchored and never followed with a result", () => {
+		let value = Anchors.read(split(
+			{ anchors: [anchor("aa")], pending: false },
+			{ anchors: [], pending: true, reason: "missing" },
+		));
+
+		expect(value.questions.q1?.anchors).toHaveLength(1);
+		// Still owed, because the half that was maintained was never reviewed.
+		expect(value.questions.q1?.pending).toBe(true);
+		expect(value.questions.q1?.reason).toBe("missing");
+	});
+
+	it("owes one review per question, not two", () => {
+		let old = split(
+			{ anchors: [], pending: true, reason: "missing" },
+			{ anchors: [], pending: true, reason: "plan_changed" },
+		);
+
+		expect(Anchors.pending(old)).toEqual([
+			{ widget: "w1", question: "q1", reason: "plan_changed" },
+		]);
+	});
+
+	it("leaves a record already written in the new shape alone", () => {
+		let already: Plan.WidgetAnchors = {
+			widget: "w1",
+			questions: { q1: { anchors: [anchor("aa")], pending: false } },
+		};
+
+		expect(Anchors.read(record({ status: "answered", anchors: already }))).toEqual(already);
+	});
+});

--- a/apps/server/src/questions/anchors.ts
+++ b/apps/server/src/questions/anchors.ts
@@ -1,11 +1,17 @@
 /**
- * What each question concerns, and what answering it produced.
+ * Where each of a questionnaire's decisions lives in the plan.
  *
- * Two relationships per question, both pointing at prose: `subject` is what
- * the question is about, `result` is the passage the answer caused to be
- * written. They are separate because they move independently — an answer can
- * be rewritten without the question changing meaning, and the passage a
- * decision produced is rarely the passage that prompted it.
+ * One relationship per question. It used to be two — `subject` for what the
+ * question was about, `result` for what answering it produced — on the theory
+ * that they move independently. They did not: asked to tell them apart, the
+ * agent anchored the first block of the result and called it the subject, in
+ * every record it ever wrote. What a reader wants is the prose the decision
+ * lives in, which is the one thing an accepted comment has always carried.
+ *
+ * The split also cost something. A subject was never derived when a question
+ * was asked and never invalidated when the plan moved, so it sat permanently
+ * unreviewed — which rendered as an inert link and put an entry in the agent's
+ * `anchors_pending` that no amount of anchoring could clear.
  *
  * A relationship is either trustworthy or pending. Pending is not an error: it
  * says the agent has not reviewed this since the plan last changed, which is
@@ -17,12 +23,9 @@ import type { Plan } from "@chopin/protocol";
 import type { Definition } from "@chopin/question";
 import type { Record as Question } from "./service";
 
-export type Relation = "subject" | "result";
-
 export type Pending = {
 	widget: string;
 	question: string;
-	relation: Relation;
 	reason: Plan.AnchorReason;
 };
 
@@ -39,36 +42,81 @@ function ids(definition: Definition): string[] {
  *
  * One that has never been anchored still gets a full set, so a reader is told
  * why nothing highlights rather than having to infer it from an absence. An
- * unanswered question has no result to point at yet, which is not pending —
- * there is nothing outstanding until there is an answer.
+ * unanswered question is not pending: there is no decision to place until
+ * somebody has made one, and owing a review for it would be owing one forever.
  */
 export function read(record: Question): Plan.WidgetAnchors {
-	if (record.anchors) return structuredClone(record.anchors);
+	if (record.anchors) return folded(structuredClone(record.anchors));
 
 	let answered = record.status === "answered";
-	let questions: { [id: string]: Plan.QuestionAnchors } = {};
+	let questions: { [id: string]: Plan.AnchorSet } = {};
 	for (let id of ids(record.definition)) {
-		questions[id] = {
-			subject: empty(true, "missing"),
-			result: empty(answered, answered ? "missing" : undefined),
-		};
+		questions[id] = empty(answered, answered ? "missing" : undefined);
 	}
 	return { widget: record.id, questions };
 }
 
+/** A question as it was persisted before the two halves were folded into one. */
+type Split = { subject?: Plan.AnchorSet; result?: Plan.AnchorSet };
+
 /**
- * Mark every result as needing review.
+ * Bring a record written before the fold forward.
  *
- * Called when the plan changes or an answer does. The passage a decision
- * produced is the thing most likely to have been rewritten, and a link to
- * where it used to be is worse than an admission that nobody has checked.
+ * `read` hands back what was persisted verbatim, and nothing between
+ * `JSON.parse` and here checks it, so a shape change reaches the rebase as a
+ * set with no `anchors` array. That does not crash the room — the carry on open
+ * is guarded — which is worse: it is caught, logged, and every decision in the
+ * plan quietly loses its place. The guard is shared with the comment threads,
+ * so one stale question record takes their anchors down too.
+ *
+ * Both halves are kept. In practice the subject was a subset of the result, so
+ * the union is the result; where it was not, the agent anchored the subject and
+ * never got round to the other, and dropping it would lose the only placement
+ * that question ever had. Review state comes from the result, which is the half
+ * that was actually maintained.
+ */
+function folded(value: Plan.WidgetAnchors): Plan.WidgetAnchors {
+	let questions: { [id: string]: Plan.AnchorSet } = {};
+
+	for (let [id, set] of Object.entries(value.questions)) {
+		let split = set as Plan.AnchorSet & Split;
+		if (Array.isArray(split.anchors)) {
+			questions[id] = set;
+			continue;
+		}
+
+		let result = split.result ?? empty(true, "missing");
+		let seen = new Set<string>();
+		let anchors: Plan.Anchor[] = [];
+		for (let anchor of [...result.anchors, ...(split.subject?.anchors ?? [])]) {
+			if (seen.has(anchor.digest)) continue;
+			seen.add(anchor.digest);
+			anchors.push(anchor);
+		}
+
+		questions[id] = {
+			anchors,
+			pending: result.pending,
+			...(result.reason ? { reason: result.reason } : {}),
+		};
+	}
+
+	return { widget: value.widget, questions };
+}
+
+/**
+ * Mark every placement as needing review.
+ *
+ * Called when the plan changes or an answer does. The prose a decision lives in
+ * is the thing most likely to have been rewritten, and a link to where it used
+ * to be is worse than an admission that nobody has checked.
  */
 export function invalidate(record: Question, reason: Plan.AnchorReason): Plan.WidgetAnchors {
 	let value = read(record);
 	if (record.status !== "answered") return value;
 
-	for (let question of Object.values(value.questions)) {
-		question.result = { ...question.result, pending: true, reason };
+	for (let [id, set] of Object.entries(value.questions)) {
+		value.questions[id] = { ...set, pending: true, reason };
 	}
 	return value;
 }
@@ -78,41 +126,28 @@ export function pending(record: Question): Pending[] {
 	let value = read(record);
 	let out: Pending[] = [];
 
-	for (let [question, anchors] of Object.entries(value.questions)) {
-		for (let relation of ["subject", "result"] as const) {
-			let state = anchors[relation];
-			if (!state.pending) continue;
-			out.push({
-				widget: value.widget,
-				question,
-				relation,
-				reason: state.reason ?? "missing",
-			});
-		}
+	for (let [question, set] of Object.entries(value.questions)) {
+		if (!set.pending) continue;
+		out.push({ widget: value.widget, question, reason: set.reason ?? "missing" });
 	}
 	return out;
 }
 
-/** Replace one relationship, and consider it reviewed. */
+/** Replace where a question's decision lives, and consider it reviewed. */
 export function set(
 	value: Plan.WidgetAnchors,
 	question: string,
-	relation: Relation,
 	anchors: Plan.Anchor[],
 ): Plan.WidgetAnchors {
-	let existing = value.questions[question];
-	if (!existing) return value;
+	if (!value.questions[question]) return value;
 
 	return {
 		...value,
 		questions: {
 			...value.questions,
-			[question]: {
-				...existing,
-				// An empty list is a real answer: reviewed, and deliberately
-				// related to nothing. It is not the same as never having looked.
-				[relation]: { anchors, pending: false },
-			},
+			// An empty list is a real answer: reviewed, and deliberately
+			// related to nothing. It is not the same as never having looked.
+			[question]: { anchors, pending: false },
 		},
 	};
 }

--- a/apps/server/src/questions/service.ts
+++ b/apps/server/src/questions/service.ts
@@ -65,7 +65,7 @@ export type Record = {
 	resolver?: string;
 	/** When it was settled, Unix seconds. Absent on one settled before we recorded it. */
 	at?: number;
-	/** Where in the prose each question and its answer live. */
+	/** Where in the prose each of its decisions lives. */
 	anchors?: Wired.WidgetAnchors;
 };
 
@@ -334,13 +334,10 @@ export function anchors(plan: Plan): Wired.WidgetAnchors[] {
 export function rebase(plan: Plan): void {
 	for (let [id, record] of plan.records) {
 		let value = Anchors.read(record);
-		let questions: { [question: string]: Wired.QuestionAnchors } = {};
+		let questions: { [question: string]: Wired.AnchorSet } = {};
 
-		for (let [question, relations] of Object.entries(value.questions)) {
-			questions[question] = {
-				subject: carry(plan, relations.subject),
-				result: carry(plan, relations.result),
-			};
+		for (let [question, set] of Object.entries(value.questions)) {
+			questions[question] = carry(plan, set);
 		}
 
 		plan.records.set(id, { ...record, anchors: { widget: value.widget, questions } });
@@ -369,12 +366,11 @@ export function outstanding(plan: Plan): Anchors.Pending[] {
 	return [...plan.records.values()].flatMap(record => Anchors.pending(record));
 }
 
-/** Replace one relationship with the blocks the agent reviewed it against. */
+/** Replace where a decision lives with the blocks the agent reviewed it against. */
 export function relate(
 	plan: Plan,
 	widget: string,
 	question: string,
-	relation: Anchors.Relation,
 	blocks: Array<{ index: number; digest: string }>,
 ): string | undefined {
 	let record = plan.records.get(widget);
@@ -396,7 +392,7 @@ export function relate(
 
 	plan.records.set(widget, {
 		...record,
-		anchors: Anchors.set(Anchors.read(record), question, relation, anchors),
+		anchors: Anchors.set(Anchors.read(record), question, anchors),
 	});
 	return undefined;
 }

--- a/packages/editor/src/anchors.test.ts
+++ b/packages/editor/src/anchors.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Resolving where a decision lives against this editor's tree.
+ *
+ * A Lexical key is per-editor, so the server can only say which blocks it means
+ * as Yjs relative positions and every client works out its own keys. That is
+ * the whole of what `relate` does, and it had no test — which is how a two-part
+ * relationship nobody could tell apart survived as long as it did.
+ *
+ * Real Lexical and real Yjs, because the question is whether positions resolve.
+ * What the resolved keys are then used for needs a browser and is not here.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createHeadlessEditor } from "@lexical/headless";
+import { createYjsBinding, syncLexicalUpdateToYjs } from "@lexical/yjs";
+import { $getRoot, $isParagraphNode } from "lexical";
+import * as Y from "yjs";
+
+import { importPlan, registry } from "@chopin/dialect";
+
+import { counts, relate, resolve } from "./anchors";
+
+import type { Binding, Provider } from "@lexical/yjs";
+import type { LexicalEditor, LexicalNode } from "lexical";
+import type { Plan } from "@chopin/protocol";
+
+const REGISTRY = registry();
+
+/** Awareness is never read here, so a no-op provider suffices. */
+const PROVIDER = {
+	awareness: {
+		getLocalState: () => null,
+		getStates: () => new Map(),
+		off() {},
+		on() {},
+		setLocalState() {},
+		setLocalStateField() {},
+	},
+	connect() {},
+	disconnect() {},
+	off() {},
+	on() {},
+} as unknown as Provider;
+
+const SOURCE = `# Title
+
+The renderer caches tiles for 60 seconds.
+
+The second paragraph.
+`;
+
+function room(): { editor: LexicalEditor; binding: Binding } {
+	let editor = createHeadlessEditor({
+		nodes: REGISTRY.nodes,
+		onError(err) {
+			throw err;
+		},
+	});
+
+	let doc = new Y.Doc();
+	let binding = createYjsBinding({ editor, id: "plan", doc, docMap: new Map([["plan", doc]]) });
+
+	// A block has no collaborative identity until the tree has been synced, and
+	// an anchor is that identity — so without this there is nothing to anchor.
+	editor.registerUpdateListener(
+		({ dirtyElements, dirtyLeaves, editorState, normalizedNodes, prevEditorState, tags }) => {
+			if (tags.has("skip-collab")) return;
+			syncLexicalUpdateToYjs(
+				binding,
+				PROVIDER,
+				prevEditorState,
+				editorState,
+				dirtyElements,
+				dirtyLeaves,
+				normalizedNodes,
+				tags,
+			);
+		},
+	);
+
+	importPlan(editor, SOURCE, { registry: REGISTRY });
+	return { editor, binding };
+}
+
+/** The blocks the source addresses, the way both ends count them. */
+function blocks(editor: LexicalEditor): LexicalNode[] {
+	let found: LexicalNode[] = [];
+	editor.getEditorState().read(() => {
+		found = $getRoot().getChildren().filter(
+			node => !($isParagraphNode(node) && node.getChildrenSize() === 0),
+		);
+	});
+	return found;
+}
+
+function encode(value: Uint8Array): string {
+	let binary = "";
+	for (let byte of value) binary += String.fromCharCode(byte);
+	return btoa(binary);
+}
+
+/** An anchor on the block at `index`, minted the way the server mints one. */
+function anchor(editor: LexicalEditor, binding: Binding, index: number): Plan.Anchor {
+	let key = blocks(editor)[index]!.getKey();
+	let type = binding.collabNodeMap.get(key)?.getSharedType();
+	if (!type) throw new Error(`block ${index} has no collaborative identity`);
+
+	return {
+		epoch: "e1",
+		position: encode(Y.encodeRelativePosition(Y.createRelativePositionFromTypeIndex(type, 0, -1))),
+		digest: `sha256:${index}`,
+	};
+}
+
+function widget(questions: { [id: string]: Plan.AnchorSet }): Plan.WidgetAnchors {
+	return { widget: "w1", questions };
+}
+
+describe("where a questionnaire's decisions live", () => {
+	it("resolves each one to the blocks it names in this editor", () => {
+		let { binding, editor } = room();
+
+		let found = relate(binding, [widget({
+			q1: { anchors: [anchor(editor, binding, 1), anchor(editor, binding, 2)], pending: false },
+		})]);
+
+		expect(found).toHaveLength(1);
+		expect(found[0]?.keys).toEqual([
+			blocks(editor)[1]!.getKey(),
+			blocks(editor)[2]!.getKey(),
+		]);
+	});
+
+	/** One entry per question. It used to be two, and they led to the same prose. */
+	it("gives a question one placement, not one per kind of relationship", () => {
+		let { binding, editor } = room();
+
+		let found = relate(binding, [widget({
+			q1: { anchors: [anchor(editor, binding, 1)], pending: false },
+			q2: { anchors: [anchor(editor, binding, 2)], pending: false },
+		})]);
+
+		expect(found.map(item => item.question)).toEqual(["q1", "q2"]);
+	});
+
+	it("drops an anchor whose block this document no longer has", () => {
+		let { binding } = room();
+
+		let found = relate(binding, [widget({
+			q1: {
+				anchors: [{ epoch: "e1", position: "", digest: "sha256:gone", orphaned: true }],
+				pending: false,
+			},
+		})]);
+
+		expect(found[0]?.keys).toEqual([]);
+	});
+
+	/** A position from a history this document does not hold, not a crash. */
+	it("survives an anchor it cannot decode", () => {
+		let { binding } = room();
+
+		expect(() =>
+			relate(binding, [widget({
+				q1: { anchors: [{ epoch: "e0", position: "!!!", digest: "sha256:x" }], pending: false },
+			})])
+		).not.toThrow();
+	});
+
+	it("resolves nothing from an anchor marked orphaned without trying", () => {
+		let { binding } = room();
+		let gone: Plan.Anchor = { epoch: "e1", position: "", digest: "sha256:x", orphaned: true };
+
+		expect(resolve(binding, gone)).toBeUndefined();
+	});
+});
+
+describe("how much prose a card says it points at", () => {
+	it("counts the blocks each decision resolves to", () => {
+		let { binding, editor } = room();
+		let found = relate(binding, [widget({
+			q1: { anchors: [anchor(editor, binding, 1), anchor(editor, binding, 2)], pending: false },
+		})]);
+
+		expect(counts(found, "w1")).toEqual({ q1: 2 });
+	});
+
+	/**
+	 * Pending means nobody has checked since the plan moved. Counting it as
+	 * nowhere is what keeps the text inert rather than offering a jump that
+	 * may land somewhere stale.
+	 */
+	it("counts an unreviewed decision as nowhere, however many blocks it names", () => {
+		let { binding, editor } = room();
+		let found = relate(binding, [widget({
+			q1: { anchors: [anchor(editor, binding, 1)], pending: true, reason: "plan_changed" },
+		})]);
+
+		expect(counts(found, "w1")).toEqual({ q1: 0 });
+	});
+
+	it("reports only the questionnaire that was asked about", () => {
+		let { binding, editor } = room();
+		let found = [
+			...relate(binding, [
+				widget({ q1: { anchors: [anchor(editor, binding, 1)], pending: false } }),
+			]),
+			...relate(binding, [{
+				widget: "w2",
+				questions: { q9: { anchors: [anchor(editor, binding, 2)], pending: false } },
+			}]),
+		];
+
+		expect(counts(found, "w1")).toEqual({ q1: 1 });
+	});
+});

--- a/packages/editor/src/anchors.ts
+++ b/packages/editor/src/anchors.ts
@@ -1,10 +1,10 @@
 /**
  * Where a decision lives in the prose.
  *
- * The server says which blocks each question concerns and each answer
- * produced, as Yjs relative positions. Resolving one gives a Lexical node key,
- * and from there the element on screen — which is what lets hovering a
- * decision light up the passage it belongs to.
+ * The server says which blocks each of a questionnaire's decisions produced,
+ * as Yjs relative positions. Resolving one gives a Lexical node key, and from
+ * there the element on screen — which is what lets hovering a decision light up
+ * the passage it belongs to, and clicking it go there.
  *
  * Resolution has to happen here rather than server-side because a Lexical key
  * is per-editor: the server's key for a block means nothing in this browser.
@@ -16,13 +16,10 @@ import * as Y from "yjs";
 import type { Binding } from "@lexical/yjs";
 import type { Plan } from "@chopin/protocol";
 
-export type Relation = "subject" | "result";
-
-/** A relationship, resolved to the nodes it names in this editor. */
+/** Where one decision lives, resolved to the nodes it names in this editor. */
 export type Related = {
 	widget: string;
 	question: string;
-	relation: Relation;
 	keys: string[];
 	/** True when the agent has yet to review this since the plan changed. */
 	pending: boolean;
@@ -59,34 +56,27 @@ export function relate(binding: Binding, widgets: Plan.WidgetAnchors[]): Related
 	let out: Related[] = [];
 
 	for (let widget of widgets) {
-		for (let [question, relations] of Object.entries(widget.questions)) {
-			for (let relation of ["subject", "result"] as const) {
-				let set = relations[relation];
-				let keys = set.anchors
-					.map(anchor => resolve(binding, anchor))
-					.filter((key): key is string => !!key);
+		for (let [question, set] of Object.entries(widget.questions)) {
+			let keys = set.anchors
+				.map(anchor => resolve(binding, anchor))
+				.filter((key): key is string => !!key);
 
-				out.push({ widget: widget.widget, question, relation, keys, pending: set.pending });
-			}
+			out.push({ widget: widget.widget, question, keys, pending: set.pending });
 		}
 	}
 
 	return out;
 }
 
-/** How much prose a relationship resolves to, for the card that offers it. */
-export function counts(
-	related: Related[],
-	widget: string,
-): { [question: string]: { subject: number; result: number } } {
-	let out: { [question: string]: { subject: number; result: number } } = {};
+/** How much prose each decision resolves to, for the card that offers it. */
+export function counts(related: Related[], widget: string): { [question: string]: number } {
+	let out: { [question: string]: number } = {};
 
 	for (let item of related) {
 		if (item.widget !== widget) continue;
-		out[item.question] ??= { subject: 0, result: 0 };
 		// A pending relationship resolves to nothing on purpose: it is what
 		// makes the text inert rather than offering a jump that may be stale.
-		out[item.question]![item.relation] = item.pending ? 0 : item.keys.length;
+		out[item.question] = item.pending ? 0 : item.keys.length;
 	}
 
 	return out;

--- a/packages/editor/src/comments.tsx
+++ b/packages/editor/src/comments.tsx
@@ -46,13 +46,56 @@ function Note({ note }: { note: Comment.Note }) {
 	);
 }
 
-/** The prose the thread marks, as a quotation the card can be read without. */
-function Quote({ drifted, text }: { drifted?: boolean; text: string }) {
+const QUOTED =
+	"m-0 w-full border-l-2 border-border pl-2 text-left text-xs text-muted-foreground italic";
+
+/**
+ * The prose the thread marks, as a quotation the card can be read without.
+ *
+ * A button when there is somewhere to go, a blockquote when there is not —
+ * which is the rule `QuestionView` already applies to an answer, so both halves
+ * of the sidecar offer the same thing in the same way. A real element carries
+ * the affordance and the keyboard handling rather than a quotation pretending
+ * to be one, and a drifted thread offers no jump it could not honour: the card
+ * still reads, which is the durable part of a comment.
+ *
+ * The quote rather than the card. A card holds a reply box, an Accept and a
+ * Dismiss; making the whole of it a link would mean deciding, on every click,
+ * whether the reader meant the link or the control they actually hit.
+ */
+function Quote(
+	{ count = 0, drifted, onSelect, text }: {
+		count?: number;
+		drifted?: boolean;
+		onSelect?: () => void;
+		text: string;
+	},
+) {
 	return (
 		<div className="flex flex-col gap-1">
-			<blockquote className="m-0 border-l-2 border-border pl-2 text-xs text-muted-foreground italic">
-				{text}
-			</blockquote>
+			{count > 0 && onSelect
+				? (
+					<button
+						// The quote is part of the name, not replaced by it: it is the
+						// only place the marked phrase appears on the card, so a label
+						// saying only where the button goes would take it away from
+						// anybody who cannot see it.
+						aria-label={count > 1
+							? `${text} — show in plan, ${count} places`
+							: `${text} — show in plan`}
+						className={`${QUOTED} cursor-pointer rounded-sm outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/40`}
+						onClick={onSelect}
+						type="button"
+					>
+						{text}
+						{count > 1 && (
+							<span aria-hidden="true" className="ml-1.5 text-[10px] not-italic">
+								{count}
+							</span>
+						)}
+					</button>
+				)
+				: <blockquote className={QUOTED}>{text}</blockquote>}
 			{drifted && (
 				<p className="m-0 text-[10px] text-warning">
 					The text this refers to has changed.
@@ -204,6 +247,8 @@ export type ThreadCardProps = {
 	onTyping: (writing: boolean) => void;
 	onFocus: () => void;
 	onBlur: () => void;
+	/** Take the reader to the prose this points at. */
+	onReveal: () => void;
 };
 
 export function ThreadCard({
@@ -216,6 +261,7 @@ export function ThreadCard({
 	onFocus,
 	onReply,
 	onRetry,
+	onReveal,
 	onTyping,
 	quote,
 	view,
@@ -252,7 +298,7 @@ export function ThreadCard({
 			onMouseEnter={onFocus}
 			onMouseLeave={onBlur}
 		>
-			<Quote drifted={view.drifted} text={quote} />
+			<Quote count={view.places.length} drifted={view.drifted} onSelect={onReveal} text={quote} />
 
 			<ul className="m-0 flex list-none flex-col gap-2 p-0">
 				{thread.notes.map(note => <Note key={note.id} note={note} />)}

--- a/packages/editor/src/decisions.tsx
+++ b/packages/editor/src/decisions.tsx
@@ -16,10 +16,13 @@
  * the transcript is where it left its trace.
  *
  * An item also knows where it lives. Hovering a question lights the passage it
- * concerns; hovering a comment lights the phrase it marks. The highlight is
- * written to the DOM rather than the document — it is one reader's pointer, not
- * a fact about the plan, and putting it in the document would send it to
- * everybody else and make it undoable.
+ * concerns; hovering a comment lights the phrase it marks. Clicking either goes
+ * there — which is the only way to reach the prose an accepted comment
+ * produced, since a `<Decision>` draws nothing in the document and the pane is
+ * the whole of where it can be seen. The highlight is written to the DOM rather
+ * than the document — it is one reader's pointer, not a fact about the plan,
+ * and putting it in the document would send it to everybody else and make it
+ * undoable.
  */
 
 import { useEffect, useRef, useState } from "react";
@@ -77,16 +80,22 @@ export function Decisions({ connected, reveal, store, threads, wire }: Decisions
 	let [history, setHistory] = useHistory();
 
 	// Leaving the pane should not leave the prose lit. A highlight belongs to
-	// the pointer that asked for it.
-	useEffect(() => () => store.clear(), [store]);
+	// the pointer that asked for it, and a pin to the pane that set it.
+	useEffect(() => () => {
+		store.release();
+		threads.release();
+	}, [store, threads]);
 
 	useEffect(() => {
 		if (!reveal) return;
+		let id = CSS.escape(reveal.widget);
+		// Either kind of card. An id addressed at a pane that only knows how to
+		// find one of them fails by scrolling nowhere, which says nothing.
 		let target = content.current?.querySelector<HTMLElement>(
-			`[data-plan-sidecar-questionnaire="${CSS.escape(reveal.widget)}"]`,
+			`[data-plan-sidecar-questionnaire="${id}"], [data-plan-sidecar-thread="${id}"]`,
 		);
 		target?.scrollIntoView({ block: "center", behavior: "smooth" });
-	}, [entries, reveal]);
+	}, [entries, reveal, state.threads]);
 
 	let open = state.threads.filter(view => view.thread.status === "open");
 	let accepted = state.threads.filter(view => view.thread.status === "accepted");
@@ -108,6 +117,7 @@ export function Decisions({ connected, reveal, store, threads, wire }: Decisions
 			onFocus={() => threads.focus(view.thread.id)}
 			onReply={text => threads.reply(view.thread.id, text)}
 			onRetry={() => threads.retry(view.thread.id)}
+			onReveal={() => threads.reveal(view.thread.id)}
 			onTyping={writing => threads.announce(view.thread.id, writing)}
 			quote={view.quote}
 			view={view}
@@ -121,6 +131,7 @@ export function Decisions({ connected, reveal, store, threads, wire }: Decisions
 			key={entry.id}
 			onRelationEnter={(q, relation) => store.highlight(entry.id, q, relation)}
 			onRelationLeave={() => store.clear()}
+			onRelationSelect={(q, relation) => store.reveal(entry.id, q, relation)}
 			relations={store.counts(entry.id)}
 			value={entry.value}
 			wire={wire}

--- a/packages/editor/src/decisions.tsx
+++ b/packages/editor/src/decisions.tsx
@@ -129,10 +129,10 @@ export function Decisions({ connected, reveal, store, threads, wire }: Decisions
 		<QuestionnaireCard
 			connected={connected}
 			key={entry.id}
-			onRelationEnter={(q, relation) => store.highlight(entry.id, q, relation)}
-			onRelationLeave={() => store.clear()}
-			onRelationSelect={(q, relation) => store.reveal(entry.id, q, relation)}
-			relations={store.counts(entry.id)}
+			onQuestionEnter={question => store.highlight(entry.id, question)}
+			onQuestionLeave={() => store.clear()}
+			onQuestionSelect={question => store.reveal(entry.id, question)}
+			places={store.counts(entry.id)}
 			value={entry.value}
 			wire={wire}
 		/>

--- a/packages/editor/src/marks.test.ts
+++ b/packages/editor/src/marks.test.ts
@@ -1,10 +1,14 @@
 /**
- * Two stores, one registry.
+ * Two stores, one registry, one pin.
  *
  * `CSS.highlights` is document-wide and painting sets it wholesale, so the
  * question sidecar and the comment sidecar cannot each own it — the second to
  * repaint would erase the first. What is worth pinning is that they coexist:
  * declaring what one wants marked never drops what the other asked for.
+ *
+ * The pin is the other half. It is what a reader who clicked is left looking
+ * at, so it has to survive the pointer leaving the card and give way while the
+ * pointer is somewhere else.
  *
  * The registration itself is not tested. There is no `CSS.highlights` in the
  * test runtime and no layout to measure, which is the same reason the toolbar's
@@ -13,7 +17,7 @@
 
 import { afterEach, describe, expect, it } from "bun:test";
 
-import { clear, paint, union } from "./marks";
+import { clear, holds, paint, pin, union, unpin } from "./marks";
 
 import type { LexicalEditor } from "lexical";
 import type { Points } from "./passage";
@@ -99,5 +103,88 @@ describe("sharing the registry", () => {
 		} finally {
 			console.error = complain;
 		}
+	});
+});
+
+/** A short one, so a lapse can be watched without waiting five seconds for it. */
+const BRIEF = 5;
+
+function tick(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe("being sent somewhere", () => {
+	it("keeps the mark up after the pointer has left the card", () => {
+		pin(editor, "comments", [points("c")]);
+
+		// The hover that lit it is over by the time the click has landed.
+		paint(editor, "comments", []);
+
+		expect(union()).toEqual([points("c")]);
+	});
+
+	it("lends the mark to whatever the pointer moves to next", () => {
+		pin(editor, "comments", [points("c")]);
+		paint(editor, "questions", [points("q")]);
+
+		// One wash, and it says what is being pointed at rather than both.
+		expect(union()).toEqual([points("q")]);
+	});
+
+	it("gives it back when the pointer moves off again", () => {
+		pin(editor, "comments", [points("c")]);
+		paint(editor, "questions", [points("q")]);
+		paint(editor, "questions", []);
+
+		expect(union()).toEqual([points("c")]);
+	});
+
+	/** One reader, one pointer: two places at once cannot say which was meant. */
+	it("holds one place, whichever half of the sidecar asked", () => {
+		pin(editor, "comments", [points("c")]);
+		pin(editor, "questions", [points("q")]);
+
+		expect(union()).toEqual([points("q")]);
+		expect(holds("comments")).toBe(false);
+		expect(holds("questions")).toBe(true);
+	});
+
+	it("goes out on its own, so it cannot become a standing mark", async () => {
+		pin(editor, "comments", [points("c")], BRIEF);
+		expect(union()).toEqual([points("c")]);
+
+		await tick(BRIEF * 4);
+
+		expect(union()).toEqual([]);
+		expect(holds("comments")).toBe(false);
+	});
+
+	/** Walking to the next place has to keep the pin alive, or it cannot be walked. */
+	it("starts the clock again each time it is asked", async () => {
+		pin(editor, "comments", [points("c1")], BRIEF * 6);
+		await tick(BRIEF * 3);
+		pin(editor, "comments", [points("c2")], BRIEF * 6);
+		await tick(BRIEF * 3);
+
+		expect(union()).toEqual([points("c2")]);
+	});
+
+	it("is only the owner's to drop", () => {
+		pin(editor, "comments", [points("c")]);
+
+		unpin(editor, "questions");
+		expect(union()).toEqual([points("c")]);
+
+		unpin(editor, "comments");
+		expect(union()).toEqual([]);
+	});
+
+	it("goes with everything else when the editor does", () => {
+		pin(editor, "comments", [points("c")]);
+
+		clear();
+
+		expect(union()).toEqual([]);
+		expect(holds("comments")).toBe(false);
 	});
 });

--- a/packages/editor/src/marks.ts
+++ b/packages/editor/src/marks.ts
@@ -24,6 +24,21 @@
  * store. Each declares what it wants marked and the union is painted; neither
  * can erase the other by repainting itself.
  *
+ * Asking to be taken somewhere is a second kind of pointing, and it outlives
+ * the pointer. A reader who clicks a card is sent where they were not looking,
+ * so a mark that went out the moment the mouse left the card would land them
+ * on a block with nothing to say which one it was. That is the pin: the same
+ * wash, held for a few seconds after the pointer has gone.
+ *
+ * There is one pin, not one per store, for the same reason the registry is
+ * shared: a reader has one pointer, so going to a comment has to put out the
+ * question they went to before it.
+ *
+ * A hover outranks the pin rather than joining it. Two washes at once cannot
+ * say which one the reader was sent to, and pointing at a second card is a
+ * question about that card — so it borrows the wash and gives it back, which
+ * is what makes a detour a detour rather than a new destination.
+ *
  * The name cannot collide with Lexical's, which are `lexical-cursor-<id>`.
  *
  * Where the API is missing the prose cannot be washed, so the blocks it covers
@@ -43,18 +58,33 @@ export type Owner = "questions" | "comments";
 
 const NAME = "plan-related";
 
+/**
+ * How long a pin stays up.
+ *
+ * The same five seconds an agent's mark gets, and for the same reason: long
+ * enough to land an eye, short of becoming a standing mark. It only ever runs
+ * down once the pointer has left the card, because a hover outranks the pin —
+ * which is exactly the moment the number has to be right for.
+ */
+const LINGER = 5_000;
+
 /** What each store wants marked, most recently declared. */
 const wanted = new Map<Owner, Points[]>();
+
+/** Where the reader asked to be taken, until it lapses. */
+let pinned: { owner: Owner; places: Points[] } | undefined;
+let lapsing: ReturnType<typeof setTimeout> | undefined;
 
 /**
  * Everything to paint.
  *
  * Pure, and exported for that reason: whether two stores can coexist in one
- * registry is the part of this worth testing, and it is the part that does not
- * need a browser.
+ * registry, and whether a hover can borrow the wash from a pin without losing
+ * it, are the parts of this worth testing and the parts that need no browser.
  */
 export function union(): Points[] {
-	return [...wanted.values()].flat();
+	let hover = [...wanted.values()].flat();
+	return hover.length > 0 ? hover : pinned?.places ?? [];
 }
 
 function available(): boolean {
@@ -80,18 +110,7 @@ export function $rangeOf(editor: LexicalEditor, points: Points): Range | null {
 export function paint(editor: LexicalEditor, owner: Owner, places: Points[]): void {
 	try {
 		wanted.set(owner, places);
-		if (!available()) return fallback(editor);
-
-		let ranges: Range[] = [];
-		editor.getEditorState().read(() => {
-			for (let points of union()) {
-				let range = $rangeOf(editor, points);
-				if (range) ranges.push(range);
-			}
-		});
-
-		if (ranges.length === 0) CSS.highlights.delete(NAME);
-		else CSS.highlights.set(NAME, new Highlight(...ranges));
+		render(editor);
 	} catch (err) {
 		// This is reached from a Lexical update listener, and Lexical runs
 		// those in one unisolated loop — a throw here would skip the listener
@@ -101,11 +120,103 @@ export function paint(editor: LexicalEditor, owner: Owner, places: Points[]): vo
 	}
 }
 
-/** Take every mark down. Called when the editor goes away. */
+/**
+ * Hold a mark on where the reader asked to be taken.
+ *
+ * Replaces whatever was pinned, whoever pinned it, and restarts the clock —
+ * so walking from one place to the next keeps the pin alive for as long as
+ * somebody is walking.
+ *
+ * The places are node keys, taken once and not re-resolved. A block rewritten
+ * inside the five seconds leaves a key that names nothing, and the mark goes
+ * out early — which is what a lapse looks like anyway, and cheaper than a
+ * second subscription to the document for a mark this short-lived. Keys are
+ * never reused, so the failure can only ever be no mark, not a wrong one.
+ *
+ * `linger` is an argument rather than a constant for the reason `trail.ts`
+ * gives: the test runtime has no controllable clock, so the only way to watch
+ * a pin lapse is to ask for a short one.
+ */
+export function pin(
+	editor: LexicalEditor,
+	owner: Owner,
+	places: Points[],
+	linger = LINGER,
+): void {
+	try {
+		if (lapsing !== undefined) clearTimeout(lapsing);
+		pinned = { owner, places };
+		lapsing = setTimeout(() => {
+			lapsing = undefined;
+			pinned = undefined;
+			// Guarded again: this runs on a timer, outside every call the
+			// editor makes, so nothing above it would catch a throw.
+			try {
+				render(editor);
+			} catch (err) {
+				console.error("[plan] could not take a mark down:", err);
+			}
+		}, linger);
+		render(editor);
+	} catch (err) {
+		console.error("[plan] could not mark prose:", err);
+	}
+}
+
+/**
+ * Whether the pin is currently this store's.
+ *
+ * Asked rather than announced. The only thing that depends on a pin having
+ * lapsed is the next click on the card that set it — nothing has to be redrawn,
+ * because the lapse redraws itself — and a callback fired on the way to
+ * replacing a pin would reach a store in the middle of walking and wipe the
+ * step it had just taken.
+ */
+export function holds(owner: Owner): boolean {
+	return pinned?.owner === owner;
+}
+
+/** Drop the pin, if it is the caller's to drop. */
+export function unpin(editor?: LexicalEditor, owner?: Owner): void {
+	if (owner !== undefined && !holds(owner)) return;
+	release();
+	if (editor) {
+		try {
+			render(editor);
+		} catch (err) {
+			console.error("[plan] could not take a mark down:", err);
+		}
+	}
+}
+
+/** Take every mark down, pin included. Called when the editor goes away. */
 export function clear(editor?: LexicalEditor): void {
 	wanted.clear();
+	release();
 	if (available()) CSS.highlights.delete(NAME);
 	if (editor) outline(editor, []);
+}
+
+function release(): void {
+	if (lapsing !== undefined) clearTimeout(lapsing);
+	lapsing = undefined;
+	pinned = undefined;
+}
+
+/** Write the union to the registry. Throws; every caller guards. */
+function render(editor: LexicalEditor): void {
+	if (!available()) return fallback(editor);
+
+	let ranges: Range[] = [];
+	editor.getEditorState().read(() => {
+		for (let points of union()) {
+			let range = $rangeOf(editor, points);
+			if (range) ranges.push(range);
+		}
+	});
+
+	if (ranges.length === 0) CSS.highlights.delete(NAME);
+	else CSS.highlights.set(NAME, new Highlight(...ranges));
 }
 
 /** Blocks currently outlined by the fallback, so they can be un-outlined. */

--- a/packages/editor/src/places.test.ts
+++ b/packages/editor/src/places.test.ts
@@ -20,7 +20,7 @@ import * as Y from "yjs";
 
 import { importPlan, registry } from "@chopin/dialect";
 
-import { clear, union } from "./marks";
+import { clear, union, unpin } from "./marks";
 import { ThreadStore } from "./threads";
 
 import type { Binding, Provider } from "@lexical/yjs";
@@ -176,6 +176,11 @@ function marked(): number {
 	return union().length;
 }
 
+/** Which one, when it matters which. */
+function at(): string | undefined {
+	return union()[0]?.anchorKey;
+}
+
 describe("an accepted thread after the agent has acted", () => {
 	it("points at the prose the decision produced", () => {
 		let { binding, editor } = room();
@@ -326,5 +331,134 @@ describe("an accepted thread after the agent has acted", () => {
 		expect(view.drifted).toBe(true);
 		// Still readable: the conversation is the durable part of a comment.
 		expect(view.thread.notes).toHaveLength(1);
+	});
+});
+
+/**
+ * Asking to be taken to a thread's prose.
+ *
+ * The scroll itself is not here — that needs a viewport, and `scroll.ts` is the
+ * whole of the part that has one. What is testable is everything that decides
+ * where to send somebody, and the mark they find when they arrive.
+ */
+describe("going to what a thread points at", () => {
+	/** Two blocks, which is what a revision that rewrote a section leaves. */
+	function revised(subject: ThreadStore, editor: LexicalEditor, binding: Binding, id: string) {
+		subject.anchors([{
+			thread: id,
+			subject: rewritten(),
+			result: {
+				anchors: [anchor(editor, binding, 1), anchor(editor, binding, 2)],
+				pending: false,
+			},
+		}]);
+	}
+
+	it("marks where it sent the reader, and keeps it there", () => {
+		let { binding, editor } = room();
+		let subject = store(editor, binding);
+		let value = thread();
+
+		subject.sync([value]);
+		revised(subject, editor, binding, value.id);
+
+		subject.reveal(value.id);
+
+		// One place, not both: arriving somewhere has to say which somewhere.
+		expect(marked()).toBe(1);
+		expect(at()).toBe(subject.snapshot().threads[0]!.places[0]!.anchorKey);
+	});
+
+	it("walks to the next place each time it is asked", () => {
+		let { binding, editor } = room();
+		let subject = store(editor, binding);
+		let value = thread();
+
+		subject.sync([value]);
+		revised(subject, editor, binding, value.id);
+		let places = subject.snapshot().threads[0]!.places;
+
+		subject.reveal(value.id);
+		expect(at()).toBe(places[0]!.anchorKey);
+
+		subject.reveal(value.id);
+		expect(at()).toBe(places[1]!.anchorKey);
+
+		// Round, rather than stopping at the end with nothing to say why.
+		subject.reveal(value.id);
+		expect(at()).toBe(places[0]!.anchorKey);
+	});
+
+	/**
+	 * The step belongs to the pin. A reader whose mark has gone has moved on,
+	 * and starting them at the third block a minute later would be a jump with
+	 * nothing on screen to explain it.
+	 */
+	it("starts again once the mark it left has gone", () => {
+		let { binding, editor } = room();
+		let subject = store(editor, binding);
+		let value = thread();
+
+		subject.sync([value]);
+		revised(subject, editor, binding, value.id);
+		let places = subject.snapshot().threads[0]!.places;
+
+		subject.reveal(value.id);
+		subject.reveal(value.id);
+		expect(at()).toBe(places[1]!.anchorKey);
+
+		unpin();
+
+		subject.reveal(value.id);
+		expect(at()).toBe(places[0]!.anchorKey);
+	});
+
+	it("lends the mark to whatever the reader points at next, then takes it back", () => {
+		let { binding, editor } = room();
+		let subject = store(editor, binding);
+		let value = thread();
+
+		subject.sync([value]);
+		revised(subject, editor, binding, value.id);
+		subject.reveal(value.id);
+
+		// Pointing at the card asks about the whole thread, both blocks of it.
+		subject.focus(value.id);
+		expect(marked()).toBe(2);
+
+		// And leaving it goes back to the one block they were sent to.
+		subject.focus(undefined);
+		expect(marked()).toBe(1);
+	});
+
+	it("sends nobody anywhere when the thread has lost its place", () => {
+		let { binding, editor } = room();
+		let subject = store(editor, binding);
+		let value = thread();
+
+		subject.sync([value]);
+		subject.anchors([{
+			thread: value.id,
+			subject: rewritten(),
+			result: { anchors: [], pending: false },
+		}]);
+
+		subject.reveal(value.id);
+
+		expect(marked()).toBe(0);
+	});
+
+	it("leaves nothing marked once the pane is gone", () => {
+		let { binding, editor } = room();
+		let subject = store(editor, binding);
+		let value = thread();
+
+		subject.sync([value]);
+		revised(subject, editor, binding, value.id);
+		subject.reveal(value.id);
+
+		subject.release();
+
+		expect(marked()).toBe(0);
 	});
 });

--- a/packages/editor/src/questionnaires.ts
+++ b/packages/editor/src/questionnaires.ts
@@ -18,8 +18,9 @@ import { useEffect } from "react";
 import { QuestionnaireNode } from "@chopin/dialect";
 
 import { counts, relate } from "./anchors";
-import { paint } from "./marks";
+import { holds, paint, pin, unpin } from "./marks";
 import { $blockPoints } from "./passage";
+import { scrollToKey } from "./scroll";
 
 import type { Binding } from "@lexical/yjs";
 import type { LexicalEditor } from "lexical";
@@ -52,6 +53,11 @@ export class QuestionnaireStore {
 	#binding: Binding | undefined;
 	#editor: LexicalEditor | undefined;
 	#related: Related[] = [];
+	/**
+	 * Which relationship the reader last asked to be taken to, and how far
+	 * along it. Never cleared: whether it is still live is the pin's answer.
+	 */
+	#walk: { widget: string; question: string; relation: Relation; index: number } | undefined;
 
 	subscribe = (listener: () => void): () => void => {
 		this.#listeners.add(listener);
@@ -77,7 +83,9 @@ export class QuestionnaireStore {
 
 	/** The editor, so a node key can be turned into something on screen. */
 	attach(editor: LexicalEditor | undefined): void {
-		if (!editor && this.#editor) this.clear();
+		// Everything, not just the preview: a pin outlives the pointer but it
+		// cannot outlive the document it names.
+		if (!editor && this.#editor) this.release();
 		this.#editor = editor;
 	}
 
@@ -128,10 +136,66 @@ export class QuestionnaireStore {
 		let editor = this.#editor;
 		if (!editor) return;
 
+		let places = this.#places(widget, question, relation);
+		if (!places) return this.clear();
+
+		paint(editor, "questions", places);
+	}
+
+	/**
+	 * Take the reader to the prose a relationship names.
+	 *
+	 * The click behind `Show in plan`, which a question has offered for as long
+	 * as there has been anywhere to send one and which used to do nothing at
+	 * all. A relationship can name several blocks — the button says how many —
+	 * so clicking again walks to the next and round.
+	 */
+	reveal(widget: string, question: string, relation: Relation): void {
+		let editor = this.#editor;
+		if (!editor) return;
+
+		let places = this.#places(widget, question, relation);
+		if (!places || places.length === 0) return;
+
+		let walk = this.#walk;
+		let index = holds("questions")
+				&& walk !== undefined
+				&& walk.widget === widget
+				&& walk.question === question
+				&& walk.relation === relation
+			? (walk.index + 1) % places.length
+			: 0;
+
+		let place = places[index];
+		if (!place) return;
+
+		this.#walk = { widget, question, relation, index };
+		pin(editor, "questions", [place]);
+		scrollToKey(editor, place.anchorKey);
+	}
+
+	/** Stop previewing. Whatever was pinned stays, which is what a pin is for. */
+	clear(): void {
+		if (this.#editor) paint(this.#editor, "questions", []);
+	}
+
+	/** Stop pointing at anything at all. The pane is going away. */
+	release(): void {
+		unpin(this.#editor, "questions");
+		this.clear();
+	}
+
+	/** The blocks a relationship resolves to, or nothing if it names none. */
+	#places(widget: string, question: string, relation: Relation): Points[] | undefined {
+		let editor = this.#editor;
+		if (!editor) return undefined;
+
 		let found = this.#related.find(item =>
 			item.widget === widget && item.question === question && item.relation === relation
 		);
-		if (!found || found.pending) return this.clear();
+		// Pending means nobody has checked this since the plan moved, so it is
+		// not somewhere worth sending a reader.
+		if (!found || found.pending) return undefined;
 
 		let places: Points[] = [];
 		editor.getEditorState().read(() => {
@@ -141,11 +205,7 @@ export class QuestionnaireStore {
 			}
 		});
 
-		paint(editor, "questions", places);
-	}
-
-	clear(): void {
-		if (this.#editor) paint(this.#editor, "questions", []);
+		return places;
 	}
 }
 

--- a/packages/editor/src/questionnaires.ts
+++ b/packages/editor/src/questionnaires.ts
@@ -25,7 +25,7 @@ import { scrollToKey } from "./scroll";
 import type { Binding } from "@lexical/yjs";
 import type { LexicalEditor } from "lexical";
 import type { Plan } from "@chopin/protocol";
-import type { Related, Relation } from "./anchors";
+import type { Related } from "./anchors";
 import type { Points } from "./passage";
 import type { Questionnaire } from "@chopin/dialect";
 
@@ -42,9 +42,6 @@ export function collectQuestionnaires(): QuestionnaireEntry[] {
 	}));
 }
 
-/** What is currently lit up, and why. */
-export type Highlight = { widget: string; question: string; relation: Relation };
-
 export class QuestionnaireStore {
 	#entries: QuestionnaireEntry[] = [];
 	#listeners = new Set<() => void>();
@@ -54,10 +51,10 @@ export class QuestionnaireStore {
 	#editor: LexicalEditor | undefined;
 	#related: Related[] = [];
 	/**
-	 * Which relationship the reader last asked to be taken to, and how far
-	 * along it. Never cleared: whether it is still live is the pin's answer.
+	 * Which decision the reader last asked to be taken to, and how far along
+	 * it. Never cleared: whether it is still live is the pin's answer.
 	 */
-	#walk: { widget: string; question: string; relation: Relation; index: number } | undefined;
+	#walk: { widget: string; question: string; index: number } | undefined;
 
 	subscribe = (listener: () => void): () => void => {
 		this.#listeners.add(listener);
@@ -115,13 +112,13 @@ export class QuestionnaireStore {
 		for (let listener of this.#listeners) listener();
 	}
 
-	/** How much prose each of a questionnaire's questions resolves to. */
-	counts(widget: string): { [question: string]: { subject: number; result: number } } {
+	/** How much prose each of a questionnaire's decisions resolves to. */
+	counts(widget: string): { [question: string]: number } {
 		return counts(this.#related, widget);
 	}
 
 	/**
-	 * Mark the prose a relationship names.
+	 * Mark the prose a decision lives in.
 	 *
 	 * Painted rather than written into the document. A highlight is one
 	 * reader's pointer, not a fact about the plan, and putting it in the
@@ -132,29 +129,29 @@ export class QuestionnaireStore {
 	 * to be an outlined block and a washed range respectively, which made one
 	 * fact — this is the prose that card refers to — read as two.
 	 */
-	highlight(widget: string, question: string, relation: Relation): void {
+	highlight(widget: string, question: string): void {
 		let editor = this.#editor;
 		if (!editor) return;
 
-		let places = this.#places(widget, question, relation);
+		let places = this.#places(widget, question);
 		if (!places) return this.clear();
 
 		paint(editor, "questions", places);
 	}
 
 	/**
-	 * Take the reader to the prose a relationship names.
+	 * Take the reader to the prose a decision lives in.
 	 *
 	 * The click behind `Show in plan`, which a question has offered for as long
 	 * as there has been anywhere to send one and which used to do nothing at
-	 * all. A relationship can name several blocks — the button says how many —
-	 * so clicking again walks to the next and round.
+	 * all. A decision can have produced several blocks — the button says how
+	 * many — so clicking again walks to the next and round.
 	 */
-	reveal(widget: string, question: string, relation: Relation): void {
+	reveal(widget: string, question: string): void {
 		let editor = this.#editor;
 		if (!editor) return;
 
-		let places = this.#places(widget, question, relation);
+		let places = this.#places(widget, question);
 		if (!places || places.length === 0) return;
 
 		let walk = this.#walk;
@@ -162,14 +159,13 @@ export class QuestionnaireStore {
 				&& walk !== undefined
 				&& walk.widget === widget
 				&& walk.question === question
-				&& walk.relation === relation
 			? (walk.index + 1) % places.length
 			: 0;
 
 		let place = places[index];
 		if (!place) return;
 
-		this.#walk = { widget, question, relation, index };
+		this.#walk = { widget, question, index };
 		pin(editor, "questions", [place]);
 		scrollToKey(editor, place.anchorKey);
 	}
@@ -185,14 +181,12 @@ export class QuestionnaireStore {
 		this.clear();
 	}
 
-	/** The blocks a relationship resolves to, or nothing if it names none. */
-	#places(widget: string, question: string, relation: Relation): Points[] | undefined {
+	/** The blocks a decision resolves to, or nothing if it names none. */
+	#places(widget: string, question: string): Points[] | undefined {
 		let editor = this.#editor;
 		if (!editor) return undefined;
 
-		let found = this.#related.find(item =>
-			item.widget === widget && item.question === question && item.relation === relation
-		);
+		let found = this.#related.find(item => item.widget === widget && item.question === question);
 		// Pending means nobody has checked this since the plan moved, so it is
 		// not somewhere worth sending a reader.
 		if (!found || found.pending) return undefined;

--- a/packages/editor/src/scroll.ts
+++ b/packages/editor/src/scroll.ts
@@ -1,0 +1,57 @@
+/**
+ * Going to a block, from a node key.
+ *
+ * The sidecar knows where a card points as Lexical keys, and a key can name a
+ * phrase inside a paragraph as easily as the paragraph itself: a comment
+ * resolves to text nodes, a decision's result resolves to blocks. Both have to
+ * arrive at the same thing on screen, so everything is walked up to the block
+ * it sits in first.
+ *
+ * The scroll container is not asked for. `scrollIntoView` walks the ancestor
+ * chain by itself, and the only ancestor of the prose that scrolls is the
+ * document column — the panes beside it are `overflow-hidden` and the workspace
+ * does not scroll at all. Threading a viewport through two more stores would
+ * buy a reference nothing would read.
+ *
+ * Untested, deliberately. There is no DOM in the test runtime, so this is the
+ * whole of the part that needs a browser, kept apart from the part that decides
+ * where to go — which is in the stores and is tested there.
+ */
+
+import type { LexicalEditor } from "lexical";
+
+/**
+ * The block element a node key sits in.
+ *
+ * Guarded: a headless editor has no elements and says so by throwing rather
+ * than by returning nothing.
+ */
+export function blockElement(editor: LexicalEditor, key: string): HTMLElement | undefined {
+	try {
+		let element = editor.getElementByKey(key);
+		if (!element) return undefined;
+
+		// The root element is `.plan-content`, so its direct children are the
+		// blocks both ends of the wire count.
+		let block = element.closest<HTMLElement>(".plan-content > *");
+		return block ?? element;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Bring the block a key sits in into view, if there is a view to bring it into. */
+export function scrollToKey(editor: LexicalEditor, key: string): void {
+	let element = blockElement(editor, key);
+	if (!element?.scrollIntoView) return;
+
+	element.scrollIntoView({
+		block: "center",
+		// A scroll behaviour set in script is out of the stylesheet's reach, so
+		// the reduced-motion preference has to be read here.
+		behavior: typeof matchMedia === "function"
+				&& matchMedia("(prefers-reduced-motion: reduce)").matches
+			? "auto"
+			: "smooth",
+	});
+}

--- a/packages/editor/src/threads.ts
+++ b/packages/editor/src/threads.ts
@@ -17,8 +17,9 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import { useEffect } from "react";
 
 import { resolve } from "./anchors";
-import { clear as unpaint, paint } from "./marks";
+import { clear as unpaint, holds, paint, pin, unpin } from "./marks";
 import { $blockPoints, $recover, locate } from "./passage";
+import { blockElement, scrollToKey } from "./scroll";
 
 import type { Binding } from "@lexical/yjs";
 import type { LexicalEditor } from "lexical";
@@ -76,6 +77,13 @@ export class ThreadStore {
 	#draft: Draft | undefined;
 	#focused: string | undefined;
 	#error: string | undefined;
+	/**
+	 * Which card the reader last asked to be taken to, and how far along it.
+	 *
+	 * Never cleared. Whether it is still live is the pin's answer, not this
+	 * one's, and a second copy of that rule is a second thing to get wrong.
+	 */
+	#walk: { thread: string; index: number } | undefined;
 
 	#binding: Binding | undefined;
 	#editor: LexicalEditor | undefined;
@@ -262,6 +270,43 @@ export class ThreadStore {
 	}
 
 	/**
+	 * Take the reader to the prose a thread points at.
+	 *
+	 * A decision can have produced several blocks, so clicking again walks to
+	 * the next one and round. The step is part of the pin rather than a fact
+	 * about the card: a pin that has lapsed means the reader has moved on, and
+	 * starting a minute later at the third place would be a jump with nothing
+	 * on screen to explain it.
+	 *
+	 * Marked as well as scrolled. Arriving is not the same as being shown
+	 * which block was meant, and the hover that lit it is over by the time the
+	 * click has landed.
+	 */
+	reveal(id: string): void {
+		let editor = this.#editor;
+		let places = this.#state.threads.find(view => view.thread.id === id)?.places ?? [];
+		if (!editor || places.length === 0) return;
+
+		let walk = this.#walk;
+		let index = holds("comments") && walk !== undefined && walk.thread === id
+			? (walk.index + 1) % places.length
+			: 0;
+
+		let place = places[index];
+		if (!place) return;
+
+		this.#walk = { thread: id, index };
+		pin(editor, "comments", [place]);
+		scrollToKey(editor, place.anchorKey);
+	}
+
+	/** Stop pointing at anything. The pane is going away. */
+	release(): void {
+		unpin(this.#editor, "comments");
+		this.focus(undefined);
+	}
+
+	/**
 	 * Re-resolve and repaint.
 	 *
 	 * Called on every editor update as well as on new data, because a passage
@@ -424,13 +469,12 @@ export class ThreadStore {
  */
 function order(editor: LexicalEditor, key: string): number | undefined {
 	try {
-		let element = editor.getElementByKey(key);
-		if (!element) return undefined;
+		let block = blockElement(editor, key);
+		if (!block) return undefined;
 
 		let root = editor.getRootElement();
 		if (!root) return undefined;
 
-		let block = element.closest(".plan-content > *") ?? element;
 		let index = [...root.children].indexOf(block);
 		return index === -1 ? undefined : index;
 	} catch {

--- a/packages/editor/src/widgets/questionnaire.tsx
+++ b/packages/editor/src/widgets/questionnaire.tsx
@@ -51,14 +51,23 @@ export type QuestionnaireCardProps = {
 	relations?: { [question: string]: { subject: number; result: number } };
 	onRelationEnter?: (question: string, relation: Relation) => void;
 	onRelationLeave?: (question: string, relation: Relation) => void;
+	/** Take the reader to that prose. Without it the shared view's jump is inert. */
+	onRelationSelect?: (question: string, relation: Relation) => void;
 };
 
 export function QuestionnaireCard(
-	{ connected = false, onRelationEnter, onRelationLeave, relations, value, wire }:
-		QuestionnaireCardProps,
+	{
+		connected = false,
+		onRelationEnter,
+		onRelationLeave,
+		onRelationSelect,
+		relations,
+		value,
+		wire,
+	}: QuestionnaireCardProps,
 ) {
 	let resolved = answers(value);
-	let pointing = { relations, onRelationEnter, onRelationLeave };
+	let pointing = { relations, onRelationEnter, onRelationLeave, onRelationSelect };
 
 	return resolved
 		? <Decided resolved={resolved} value={value} {...pointing} />
@@ -69,6 +78,7 @@ type Pointing = {
 	relations?: { [question: string]: { subject: number; result: number } };
 	onRelationEnter?: (question: string, relation: Relation) => void;
 	onRelationLeave?: (question: string, relation: Relation) => void;
+	onRelationSelect?: (question: string, relation: Relation) => void;
 };
 
 function Undecided(

--- a/packages/editor/src/widgets/questionnaire.tsx
+++ b/packages/editor/src/widgets/questionnaire.tsx
@@ -41,33 +41,31 @@ function definition(value: Questionnaire) {
 	};
 }
 
-export type Relation = "subject" | "result";
-
 export type QuestionnaireCardProps = {
 	value: Questionnaire;
 	wire?: Transport;
 	connected?: boolean;
-	/** How much prose each question and answer resolves to. */
-	relations?: { [question: string]: { subject: number; result: number } };
-	onRelationEnter?: (question: string, relation: Relation) => void;
-	onRelationLeave?: (question: string, relation: Relation) => void;
+	/** How much prose each decision lives in. */
+	places?: { [question: string]: number };
+	onQuestionEnter?: (question: string) => void;
+	onQuestionLeave?: (question: string) => void;
 	/** Take the reader to that prose. Without it the shared view's jump is inert. */
-	onRelationSelect?: (question: string, relation: Relation) => void;
+	onQuestionSelect?: (question: string) => void;
 };
 
 export function QuestionnaireCard(
 	{
 		connected = false,
-		onRelationEnter,
-		onRelationLeave,
-		onRelationSelect,
-		relations,
+		onQuestionEnter,
+		onQuestionLeave,
+		onQuestionSelect,
+		places,
 		value,
 		wire,
 	}: QuestionnaireCardProps,
 ) {
 	let resolved = answers(value);
-	let pointing = { relations, onRelationEnter, onRelationLeave, onRelationSelect };
+	let pointing = { places, onQuestionEnter, onQuestionLeave, onQuestionSelect };
 
 	return resolved
 		? <Decided resolved={resolved} value={value} {...pointing} />
@@ -75,10 +73,10 @@ export function QuestionnaireCard(
 }
 
 type Pointing = {
-	relations?: { [question: string]: { subject: number; result: number } };
-	onRelationEnter?: (question: string, relation: Relation) => void;
-	onRelationLeave?: (question: string, relation: Relation) => void;
-	onRelationSelect?: (question: string, relation: Relation) => void;
+	places?: { [question: string]: number };
+	onQuestionEnter?: (question: string) => void;
+	onQuestionLeave?: (question: string) => void;
+	onQuestionSelect?: (question: string) => void;
 };
 
 function Undecided(

--- a/packages/protocol/plan.d.ts
+++ b/packages/protocol/plan.d.ts
@@ -29,9 +29,8 @@ export declare namespace Plan {
 	/**
 	 * A decision's place in the prose.
 	 *
-	 * A questionnaire asks about something and produces something, and both are
-	 * passages of the plan rather than the questionnaire itself. Anchoring them
-	 * is what lets a reader move between a decision and the text it concerns.
+	 * A decision is settled in the sidecar and lives in the plan, and those are
+	 * two different places. Anchoring is what lets a reader move between them.
 	 *
 	 * The position is a Yjs relative position, so it survives edits above it.
 	 * The digest is the block's full canonical hash, which is how a position
@@ -53,8 +52,6 @@ export declare namespace Plan {
 	export type AnchorReason =
 		/** Never anchored. */
 		| "missing"
-		/** The answer changed, so what it produced may have too. */
-		| "answer_changed"
 		/** The plan changed beneath it. */
 		| "plan_changed"
 		/** The block it named is gone, or is no longer unique. */
@@ -67,12 +64,19 @@ export declare namespace Plan {
 		reason?: AnchorReason;
 	};
 
-	/** What one question concerns, and what answering it produced. */
-	export type QuestionAnchors = { subject: AnchorSet; result: AnchorSet };
-
+	/**
+	 * Where each of a questionnaire's decisions lives in the plan.
+	 *
+	 * One set per question, not two. A question used to carry what it was about
+	 * and what its answer produced separately, on the theory that the two move
+	 * independently — and the agent, asked to tell them apart, anchored the
+	 * first block of the second and called it the first. What a reader wants is
+	 * the prose the decision lives in, which is what an accepted comment has
+	 * always carried.
+	 */
 	export type WidgetAnchors = {
 		widget: string;
-		questions: { [question: string]: QuestionAnchors };
+		questions: { [question: string]: AnchorSet };
 	};
 
 	/**
@@ -110,11 +114,13 @@ export declare namespace Plan {
 	/**
 	 * What an accepted comment thread marks, and what accepting it produced.
 	 *
-	 * The two halves have different authors, which is why they have different
-	 * shapes. `subject` is the passage a person selected, and the server keeps
-	 * it moving with the plan. `result` is the prose the agent's revision
-	 * produced, and only the agent can say what that is — so it is an ordinary
-	 * anchor set, reviewed and pending exactly like a question's.
+	 * A thread keeps two, where a question keeps one, because these two have
+	 * different authors and so different shapes. `subject` is the passage a
+	 * person selected, and the server keeps it moving with the plan. `result`
+	 * is the prose the agent's revision produced, and only the agent can say
+	 * what that is — so it is an ordinary anchor set, reviewed and pending
+	 * exactly like a question's. Neither can stand for the other: a thread's
+	 * subject is usually the prose it asked to have rewritten.
 	 */
 	export type ThreadAnchors = {
 		thread: string;

--- a/packages/question/src/react/question-view.tsx
+++ b/packages/question/src/react/question-view.tsx
@@ -37,18 +37,18 @@ export type QuestionViewProps = {
 	/** Shown instead of controls once the questionnaire has resolved. */
 	answers?: Answer[];
 	resolver?: string;
-	onRelationEnter?: (question: string, relation: "subject" | "result") => void;
-	onRelationLeave?: (question: string, relation: "subject" | "result") => void;
-	/** Follows a relation to the prose it refers to. */
-	onRelationSelect?: (question: string, relation: "subject" | "result") => void;
+	onQuestionEnter?: (question: string) => void;
+	onQuestionLeave?: (question: string) => void;
+	/** Goes to the prose the decision lives in. */
+	onQuestionSelect?: (question: string) => void;
 	/**
-	 * How many passages each relation points at, by question.
+	 * How many passages each decision lives in, by question.
 	 *
-	 * Absent where nothing links the two — the chat card, or a plan relation
-	 * still waiting to be anchored. Without a destination the text stays inert
-	 * prose rather than advertising a jump that would do nothing.
+	 * Absent where nothing links the two — the chat card, or a decision still
+	 * waiting to be anchored. Without a destination the text stays inert prose
+	 * rather than advertising a jump that would do nothing.
 	 */
-	relations?: Record<string, { subject: number; result: number }>;
+	places?: Record<string, number>;
 	collaborators?: Collaborator[];
 	/** Validation or synchronisation problem, announced to assistive tech. */
 	error?: string;
@@ -172,47 +172,58 @@ function Custom(
 }
 
 const LINK =
-	"block w-full cursor-pointer rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
+	"flex w-full cursor-pointer items-start justify-between gap-2 rounded-sm text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
 
 /**
- * Text that may refer to somewhere else.
+ * Something that may refer to somewhere else.
  *
  * Rendered as a button only when there is somewhere to go, so a real element
- * carries the affordance and the keyboard handling rather than a paragraph
- * pretending to be one. Unlinked text stays a paragraph, takes no tab stop,
- * and offers no focus ring it could never show.
+ * carries the affordance and the keyboard handling rather than text pretending
+ * to be one. Unlinked, it takes no tab stop and offers no focus ring it could
+ * never show.
+ *
+ * Wraps whatever it is given rather than being a paragraph itself, because on a
+ * resolved card what points into the plan is the question *and* its answer
+ * together. Those used to be two adjacent, identically-labelled buttons — one
+ * for what the question was about, one for what the answer produced — which the
+ * agent anchored to overlapping prose, so the two led to the same block.
+ *
+ * `label` is the plain-text reading of the children. It is composed into the
+ * accessible name rather than replacing it: the decision is what the button is
+ * for, and a name saying only where it goes would take it away from anybody who
+ * cannot see it.
  */
 function Related(
-	{ id, relation, count, className, children, onEnter, onLeave, onSelect }: {
+	{ id, count, label, className, children, onEnter, onLeave, onSelect }: {
 		id: string | undefined;
-		relation: "subject" | "result";
 		count: number;
+		label: string;
 		className: string;
 		children: ReactNode;
-		onEnter?: QuestionViewProps["onRelationEnter"];
-		onLeave?: QuestionViewProps["onRelationLeave"];
-		onSelect?: QuestionViewProps["onRelationSelect"];
+		onEnter?: QuestionViewProps["onQuestionEnter"];
+		onLeave?: QuestionViewProps["onQuestionLeave"];
+		onSelect?: QuestionViewProps["onQuestionSelect"];
 	},
 ) {
-	if (!id || count === 0) return <p className={`m-0 text-sm ${className}`}>{children}</p>;
+	if (!id || count === 0) return <div className={className}>{children}</div>;
 
 	return (
 		<button
 			type="button"
 			data-ace-question-id={id}
-			data-ace-relation={relation}
-			aria-label={count > 1 ? `Show in plan, ${count} places` : "Show in plan"}
-			onClick={() => onSelect?.(id, relation)}
-			onMouseEnter={() => onEnter?.(id, relation)}
-			onMouseLeave={event =>
-				event.currentTarget !== document.activeElement && onLeave?.(id, relation)}
-			onFocus={() => onEnter?.(id, relation)}
-			onBlur={event => !event.currentTarget.matches(":hover") && onLeave?.(id, relation)}
-			className={`m-0 text-sm ${className} ${LINK}`}
+			aria-label={count > 1
+				? `${label} — show in plan, ${count} places`
+				: `${label} — show in plan`}
+			onClick={() => onSelect?.(id)}
+			onMouseEnter={() => onEnter?.(id)}
+			onMouseLeave={event => event.currentTarget !== document.activeElement && onLeave?.(id)}
+			onFocus={() => onEnter?.(id)}
+			onBlur={event => !event.currentTarget.matches(":hover") && onLeave?.(id)}
+			className={`${className} ${LINK}`}
 		>
-			{children}
+			<span className="min-w-0 flex-1">{children}</span>
 			{count > 1 && (
-				<span aria-hidden="true" className="ml-1.5 text-xs text-muted-foreground">
+				<span aria-hidden="true" className="shrink-0 text-xs text-muted-foreground">
 					{count}
 				</span>
 			)}
@@ -225,50 +236,43 @@ function Resolved(
 		answers,
 		definition,
 		resolver,
-		relations,
-		onRelationEnter,
-		onRelationLeave,
-		onRelationSelect,
+		places,
+		onQuestionEnter,
+		onQuestionLeave,
+		onQuestionSelect,
 	}: {
 		answers: Answer[];
 		definition: Definition;
 		resolver?: string;
-		relations?: QuestionViewProps["relations"];
-		onRelationEnter?: QuestionViewProps["onRelationEnter"];
-		onRelationLeave?: QuestionViewProps["onRelationLeave"];
-		onRelationSelect?: QuestionViewProps["onRelationSelect"];
+		places?: QuestionViewProps["places"];
+		onQuestionEnter?: QuestionViewProps["onQuestionEnter"];
+		onQuestionLeave?: QuestionViewProps["onQuestionLeave"];
+		onQuestionSelect?: QuestionViewProps["onQuestionSelect"];
 	},
 ) {
 	return (
 		<div className="space-y-2 px-3 py-2.5">
 			{answers.map((answer, index) => {
 				let id = definition.questions[index]?.id;
-				let linked = id ? relations?.[id] : undefined;
+				let chosen = answer.custom ?? (answer.choices ?? []).join(", ");
 				return (
-					<div key={id ?? index} data-ace-question-id={id}>
-						<Related
-							id={id}
-							relation="subject"
-							count={linked?.subject ?? 0}
-							className="text-muted-foreground"
-							onEnter={onRelationEnter}
-							onLeave={onRelationLeave}
-							onSelect={onRelationSelect}
-						>
-							{answer.question}
-						</Related>
-						<Related
-							id={id}
-							relation="result"
-							count={linked?.result ?? 0}
-							className="font-medium text-foreground"
-							onEnter={onRelationEnter}
-							onLeave={onRelationLeave}
-							onSelect={onRelationSelect}
-						>
-							{answer.custom ?? (answer.choices ?? []).join(", ")}
-						</Related>
-					</div>
+					<Related
+						key={id ?? index}
+						id={id}
+						count={(id ? places?.[id] : undefined) ?? 0}
+						label={`${answer.question} — ${chosen}`}
+						className=""
+						onEnter={onQuestionEnter}
+						onLeave={onQuestionLeave}
+						onSelect={onQuestionSelect}
+					>
+						{
+							/* The question and what was chosen are one decision, so they are
+						    one target: two stacked buttons led to the same prose. */
+						}
+						<p className="m-0 text-sm text-muted-foreground">{answer.question}</p>
+						<p className="m-0 text-sm font-medium text-foreground">{chosen}</p>
+					</Related>
 				);
 			})}
 			{resolver && <p className="m-0 text-xs text-muted-foreground">Answered by @{resolver}</p>}
@@ -304,10 +308,10 @@ export function QuestionView(props: QuestionViewProps) {
 		collaborators = [],
 		error,
 		aside,
-		relations,
-		onRelationEnter,
-		onRelationLeave,
-		onRelationSelect,
+		places,
+		onQuestionEnter,
+		onQuestionLeave,
+		onQuestionSelect,
 	} = props;
 
 	let base = useId();
@@ -364,10 +368,10 @@ export function QuestionView(props: QuestionViewProps) {
 					answers={answers}
 					definition={definition}
 					resolver={resolver}
-					relations={relations}
-					onRelationEnter={onRelationEnter}
-					onRelationLeave={onRelationLeave}
-					onRelationSelect={onRelationSelect}
+					places={places}
+					onQuestionEnter={onQuestionEnter}
+					onQuestionLeave={onQuestionLeave}
+					onQuestionSelect={onQuestionSelect}
 				/>
 			</div>
 		);
@@ -394,7 +398,6 @@ export function QuestionView(props: QuestionViewProps) {
 							<button
 								key={question.id}
 								data-ace-question-id={question.id}
-								data-ace-relation="subject"
 								id={`${base}-tab-${question.id}`}
 								type="button"
 								role="tab"
@@ -407,17 +410,16 @@ export function QuestionView(props: QuestionViewProps) {
 								// intentional for as long as nothing was listening — wired
 								// up, it scrolls the plan out from under a reader who was
 								// stepping through the tabs to read them. Hovering a tab
-								// already lights what its question is about, and the panel
+								// already lights where its decision lives, and the panel
 								// below carries the control that says "show in plan".
 								onClick={() => setActive(question.id)}
-								onMouseEnter={() => onRelationEnter?.(question.id, "subject")}
+								onMouseEnter={() => onQuestionEnter?.(question.id)}
 								onMouseLeave={event =>
 									event.currentTarget !== document.activeElement
-									&& onRelationLeave?.(question.id, "subject")}
-								onFocus={() => onRelationEnter?.(question.id, "subject")}
+									&& onQuestionLeave?.(question.id)}
+								onFocus={() => onQuestionEnter?.(question.id)}
 								onBlur={event =>
-									!event.currentTarget.matches(":hover")
-									&& onRelationLeave?.(question.id, "subject")}
+									!event.currentTarget.matches(":hover") && onQuestionLeave?.(question.id)}
 								onKeyDown={event => move(event, index)}
 								className={`shrink-0 rounded-t-md px-2.5 py-1 text-xs font-medium transition-colors ${
 									question.id === active
@@ -442,19 +444,18 @@ export function QuestionView(props: QuestionViewProps) {
 			{current && (
 				<section
 					data-ace-question-id={current.id}
-					data-ace-relation="subject"
 					id={`${base}-panel`}
 					role={multiple ? "tabpanel" : undefined}
 					className="px-3 py-2.5"
-					onMouseEnter={() => onRelationEnter?.(current.id, "subject")}
+					onMouseEnter={() => onQuestionEnter?.(current.id)}
 					onMouseLeave={event =>
 						!event.currentTarget.contains(document.activeElement)
-						&& onRelationLeave?.(current.id, "subject")}
-					onFocusCapture={() => onRelationEnter?.(current.id, "subject")}
+						&& onQuestionLeave?.(current.id)}
+					onFocusCapture={() => onQuestionEnter?.(current.id)}
 					onBlurCapture={event =>
 						!event.currentTarget.contains(event.relatedTarget)
 						&& !event.currentTarget.matches(":hover")
-						&& onRelationLeave?.(current.id, "subject")}
+						&& onQuestionLeave?.(current.id)}
 				>
 					<header className="flex items-baseline justify-between gap-2">
 						<h4 className="m-0 text-sm font-semibold text-foreground">{current.header}</h4>
@@ -464,12 +465,12 @@ export function QuestionView(props: QuestionViewProps) {
 					{/* Never the whole panel: below this is a form. */}
 					<Related
 						id={current.id}
-						relation="subject"
-						count={relations?.[current.id]?.subject ?? 0}
-						className="mt-1 mb-2 text-muted-foreground"
-						onSelect={onRelationSelect}
+						count={places?.[current.id] ?? 0}
+						label={current.question}
+						className="mt-1 mb-2"
+						onSelect={onQuestionSelect}
 					>
-						{current.question}
+						<p className="m-0 text-sm text-muted-foreground">{current.question}</p>
 					</Related>
 
 					<Choices

--- a/packages/question/src/react/question-view.tsx
+++ b/packages/question/src/react/question-view.tsx
@@ -402,12 +402,14 @@ export function QuestionView(props: QuestionViewProps) {
 								aria-controls={`${base}-panel`}
 								aria-label={done ? `${question.header}, answered` : question.header}
 								tabIndex={question.id === active ? 0 : -1}
-								onClick={() => {
-									setActive(question.id);
-									// Switching question also shows what it is about; clicking
-									// the tab you are already on walks that question's passages.
-									onRelationSelect?.(question.id, "subject");
-								}}
+								// Switching question, and only that. A tab used to ask to be
+								// taken to the question's prose as well, which read as
+								// intentional for as long as nothing was listening — wired
+								// up, it scrolls the plan out from under a reader who was
+								// stepping through the tabs to read them. Hovering a tab
+								// already lights what its question is about, and the panel
+								// below carries the control that says "show in plan".
+								onClick={() => setActive(question.id)}
 								onMouseEnter={() => onRelationEnter?.(question.id, "subject")}
 								onMouseLeave={event =>
 									event.currentTarget !== document.activeElement

--- a/readme.md
+++ b/readme.md
@@ -55,11 +55,11 @@ WORKING_DIR=../some-project bun run dev
 3. Ask it something it cannot know: `@ai ask us whether to support Y`. The
    question appears in the decisions pane on the right, both windows can edit
    the answer together, and either can submit it.
-4. Hover the answer once it is decided — the prose it produced lights up.
+4. Hover the decision once it is settled — the prose it produced lights up.
    Click it and the plan goes there, and stays marked for a few seconds after
-   the pointer has gone. Comment on a passage and the accepted thread works the
-   same way: its quote is the way back to what it produced, which is the only
-   way to find it.
+   the pointer has gone; click again to walk through the rest of what it wrote.
+   Comment on a passage and the accepted thread works the same way: its quote is
+   the way back to what it produced, which is the only way to find it.
 
 ## Configuration
 

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,10 @@ WORKING_DIR=../some-project bun run dev
    question appears in the decisions pane on the right, both windows can edit
    the answer together, and either can submit it.
 4. Hover the answer once it is decided — the prose it produced lights up.
+   Click it and the plan goes there, and stays marked for a few seconds after
+   the pointer has gone. Comment on a passage and the accepted thread works the
+   same way: its quote is the way back to what it produced, which is the only
+   way to find it.
 
 ## Configuration
 


### PR DESCRIPTION
Two changes, one story: clicking a decision in the sidecar had nowhere to take
you, and the decision itself had two places to be taken to.

---

# 1. Take the reader to the prose a decision points at

Clicking a sidecar card did nothing.

Everything needed to go somewhere was already resolved and already correct — a
thread's `places`, a question's relations, both as Lexical node keys — and the
only thing consuming any of it was the hover wash. A question even rendered a
real `<button>` labelled "Show in plan", with a pointer cursor and a count of
how many places it would reach, calling an `onRelationSelect` that no caller
ever supplied. It typechecked, it rendered, it took a tab stop, and it was
inert.

## The affordance is the quote

A button when the card has somewhere to send one, a blockquote when it has not
— the rule `QuestionView` already applied to an answer, so both halves of the
sidecar now offer the same thing in the same way. It matters most for an
accepted comment: a `<Decision>` draws nothing in the prose, so the pane is the
whole of where the decision can be seen and the quote is the only route to what
it produced.

Not the whole card. A card holds a reply box, an Accept and a Dismiss, and
making the whole of it a link would mean deciding on every click whether the
reader meant the link or the control they actually hit.

## A hover asks; a click sends

Both leave the same wash, because they are the same fact — this is the prose
that card refers to — and the difference is how long it is owed. A hover is over
when the pointer moves; a click has put the reader somewhere they were not
looking, so the mark is pinned for five seconds after the pointer has gone, or
they arrive at a block with nothing to say which one it was.

There is one pin, in `marks.ts`, not one per store. A reader has one pointer, so
going to a comment has to put out the question they went to before it — the same
argument that already put the registry there. Pointing at another card in the
meantime borrows the wash and gives it back.

## Clicking again walks

A decision can have produced several blocks, and the button already said how
many. The step belongs to the pin rather than to the card: a lapsed pin means
the reader has moved on, so the walk starts over rather than jumping to the
third block a minute later with nothing on screen to explain it.

Whether a walk continues is asked of the pin rather than announced by it.
Nothing needs redrawing when it lapses, since the lapse redraws itself, and a
callback fired on the way to replacing a pin would reach a store in the middle
of walking and wipe the step it had just taken.

## Also

- The question tabs called `onRelationSelect` too. Harmless for as long as it
  was `undefined`; wired up, it becomes the plan scrolling out from under
  somebody stepping through them to read. A tab switches tabs now.
- `Decisions`' own `reveal` effect only ever matched
  `data-plan-sidecar-questionnaire`. `data-plan-sidecar-thread` had no reader at
  all. It matches either kind of card now.
- The new button's accessible name includes the quote rather than replacing it.

---

# 2. Give a decision one place in the plan, not two

A question carried what it was about and what its answer produced as separate
anchor sets, on the theory that they move independently. The agent, asked to
tell them apart, anchored the first block of the result and called it the
subject — in every record it has ever written:

```
q1  subject 72e814   result 72e814, 5b5cb2, d8f0c6
q2  subject 0fe395   result 0fe395, 5b5cb2
q3  subject 72e814   result 72e814, d8f0c6
```

So a resolved card offered two adjacent, full-width, identically labelled
"Show in plan" buttons that led to the same block — which is what made the
first change land badly.

## The split cost more than the duplicate

A subject was never derived when a question was asked and never invalidated when
the plan moved, so it sat permanently unreviewed: `counts()` reported nowhere,
which rendered it inert, and `anchors_pending` carried an entry per question
that no amount of anchoring could clear and that every `edit_plan` served back
to the agent. It was untested at every layer, and `answer_changed` — the one
reason that would have justified separate lifecycles — was never emitted.

## One `AnchorSet` per question

`anchor_plan` takes `{widget, question, blocks}` beside the `{thread, blocks}`
it already took, which is the shape a comment thread has always used. A thread
keeps its two, because there the halves have different authors and different
shapes and neither can stand for the other — a thread's subject is usually the
prose it asked to have rewritten.

On a resolved card the question and what was chosen are one button, since they
are one decision. An unanswered question owes nothing, rather than owing a
review from the moment it exists.

## The fold is not optional

Records written before this are read through `folded`, which keeps both halves.
Without it the rebase on open meets a set with no `anchors` array — and that
does **not** fail the open. It is caught and logged, so every decision in the
plan silently loses its place, and because that guard is shared, one stale
questionnaire takes the comment threads' anchors down with it.

Verified against a real room carrying the old shape: three questions, one
placement each, nothing owed, where the agent previously owed three reviews it
could never discharge.

---

## Testing

454 tests, up from 426. `bun run types`, `bun run ci` and `bun run build` clean.

The anchor path had **zero** coverage at any layer before this — `anchors.ts`,
`Questions.relate/rebase/outstanding/invalidate` and `editor/anchors` were all
untested, and `plan/anchors.test.ts` despite its name covers only the `Anchor`
primitive. Three new files:

- `packages/editor/src/marks.test.ts` (extended) — a pin survives the pointer
  leaving; a hover borrows the wash and gives it back; one pin whichever half of
  the sidecar asked; the clock restarts on each ask so a walk can be walked.
- `packages/editor/src/places.test.ts` (extended) — reveal marks one place, not
  all of them; clicking walks and wraps; the walk restarts once the mark has
  gone.
- `apps/server/src/questions/anchors.test.ts` — the bookkeeping, and reading a
  record written before the fold.
- `apps/server/src/questions.anchors.test.ts` — the same through `Service.open`,
  asserting the open logs no complaint, since with the guard in place the
  complaint is the only signal there is.
- `packages/editor/src/anchors.test.ts` — resolution against a real editor.

Both migration tests were confirmed to fail with the fold removed.

`scroll.ts` has no test on purpose: there is no DOM in the test runtime, so it
is kept as the whole of the part that needs a browser.

## Not verified here

The `anchor_plan` schema and the system prompt both changed, and `AGENT=off`
cannot prove the model calls the tool with the new shape. `additionalProperties`
is `false`, so a model still sending `relation` out of habit would have the call
rejected. Needs one real agent turn against a token before merge.
