### PR TITLE
Give a table rails to reshape it by

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -7,7 +7,7 @@ people running it; this is for people editing it.
 
 ```bash
 bun run dev        # supervisor: Vite + server on one origin, Ctrl-C stops both
-bun test           # 230 tests, no agent spawned
+bun test           # 500 tests, no agent spawned
 bun run types      # every package
 bun run ci         # dprint check && oxlint
 bun run build      # production client
@@ -21,11 +21,11 @@ agent, which is what the tests use.
 
 ```
 packages/dialect     4.5k   the MDX dialect and its Lexical schema
-packages/editor      6.6k   the browser editor, cursors, the sidecar, agent marks
+packages/editor      9.5k   the browser editor, cursors, the sidecar, agent marks
 packages/question    1.8k   questionnaires: definition, shared answer, derivation
 packages/protocol    0.9k   the wire, as types, plus the addressing rule
-apps/server          9.5k   rooms, documents, questions, comments, the agent
-apps/web             1.4k   the three panes
+apps/server         11.4k   rooms, documents, questions, comments, the agent
+apps/web             1.5k   the three panes
 scripts/dev.ts              the development supervisor
 ```
 
@@ -138,6 +138,37 @@ already followed. It matters most for an accepted comment: a `<Decision>` draws
 nothing in the prose, so the pane is the whole of where the decision can be seen
 and the quote is the only route to what it produced.
 
+**A table's header row is furniture, not a row.** GFM has exactly one header
+and it is always the first, so nothing in the document marks it as one — being
+first is the whole of what makes it the header, and the column alignment hangs
+off its cells. A drag that moved it would therefore not reorder the table so
+much as change what it claims: two rows would swap meaning at the next save and
+the alignment would follow whichever stopped being the header. So the header
+cannot be dragged, cannot be dropped onto, cannot be removed, and nothing can
+be inserted above it. Its bar is still drawn, because a rail with a gap where
+a row plainly is reads as a bug. The last _body_ row can go, though —
+`| a |\n| - |\n` is well formed and round-trips, and refusing it would mean the
+only way to empty a table is to delete it.
+
+**The rails are measured, because a `<table>` cannot contain a `<div>`.** Every
+other widget in the editor puts its chrome in a `data-plan-chrome` slot the
+node reserves and Lexical is told to leave alone. A table has nowhere to put
+one: the browser hoists a stray div straight back out. So the choice was
+between subclassing `TableNode` and measuring cell rectangles, and measuring is
+what the selection bubble already does. The grips are one lane and the buttons
+another, with nothing overlapping — a cross in the middle of a grip is exactly
+where a drag is most naturally begun, and it swallowed the gesture it was drawn
+beside. Intermittently, too, since whether it had become live yet depended on a
+re-render landing between the pointer arriving and the button going down.
+
+**A limit is enforced where the button is, not where the document is.** A table
+past `MAX_TABLE_ROWS` or `MAX_TABLE_COLUMNS` applies locally, syncs cleanly and
+is then refused by the server — which cannot undo a Yjs transaction, so it
+rebuilds the room under a fresh epoch and everyone in it loses their undo and
+their cursors. `table/shape.ts` is asked before anything is created, so the
+cost of reaching a hundred rows is a grey button rather than everybody's
+session. The same argument as `toolbar/url.ts`, one order of magnitude worse.
+
 **A hover asks; a click sends.** Both leave the same wash, because they are the
 same fact — this is the prose that card refers to — and the difference is how
 long it is owed. A hover is over when the pointer moves; a click has put the
@@ -240,6 +271,36 @@ failed tool chips; without that a boundary the agent keeps hitting is invisible.
 **Tailwind v4 translate utilities emit the `translate` property**, not
 `transform`. They compose rather than override, so an element positioned by
 script must not also carry them.
+
+**A library that paints through the theme paints nothing when the theme is
+silent.** `@lexical/table` marks a selected cell by adding
+`theme.tableCellSelected` and does nothing else — no inline style, no fallback
+— and MDXEditor's `lexicalTheme` names no table class of any kind. So dragging
+across cells produced a live `TableSelection` that was completely invisible,
+and the next keystroke replaced everything it covered. The entries are in
+`plan-editor.tsx` beside the `collaboration` block, which is there for the
+identical reason.
+
+**`$moveTableRow` and `$moveTableColumn` return silently on a table with merged
+cells**, which is why `shape.ts` carries `simple` and the grips go inert rather
+than becoming drags that do nothing. A plan cannot contain a merged cell — GFM
+cannot write one, and the export visitor ignores spans — but a paste can still
+introduce one, so `registerTableCellUnmergeTransform` is registered to take
+them back out.
+
+**A rail that lets pointer events through has a hole wherever it has no
+control.** `pointerleave` fires the moment the pointer crosses one, so the
+first version blinked the rails out from under a hand moving along them,
+whenever it passed the header's bar. The rail takes events across the whole of
+itself now and accepts that it covers 28px of gutter for as long as its table
+is the one being pointed at.
+
+**A seam is on the edge, so what is drawn on one straddles it.** The rail
+clips, to hide a grip belonging to a column scrolled out of the table's own
+scroller — and that clip cut the first and last insert buttons in half, which
+are the two most likely to be wanted. The rail carries half a seam of slack at
+each end for this, and measures its origin from its own edge rather than the
+table's so the two cannot disagree.
 
 **A transport comes up on its own schedule; whatever mounted against it does
 not.** The provider opened the document once, when the editor mounted, so a

--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,7 @@
         "@lexical/react": "catalog:mdx",
         "@lexical/rich-text": "catalog:mdx",
         "@lexical/selection": "catalog:mdx",
+        "@lexical/table": "catalog:mdx",
         "@lexical/yjs": "catalog:mdx",
         "@mdxeditor/editor": "catalog:mdx",
         "@mdxeditor/gurx": "catalog:mdx",

--- a/packages/dialect/src/dialect.test.ts
+++ b/packages/dialect/src/dialect.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
+import * as limits from "./limits";
 import { parse } from "./parse";
 import { serialize } from "./serialize";
 import { validate } from "./validate";
@@ -269,6 +270,14 @@ describe("limits", () => {
 		let header = `| ${Array.from({ length: 25 }, (_, i) => `c${i}`).join(" | ")} |`;
 		let divider = `| ${Array.from({ length: 25 }, () => "-").join(" | ")} |`;
 		expect(codes(`${header}\n${divider}`)).toContain("table-too-wide");
+	});
+
+	it("rejects tables beyond the row limit", () => {
+		// The counterpart to the width limit, and the one the editor's rails
+		// hold themselves to: a plan that reaches either is refused by the
+		// server, which cannot undo the update and so rotates the room's epoch.
+		let rows = Array.from({ length: limits.MAX_TABLE_ROWS + 1 }, () => "| x |").join("\n");
+		expect(codes(`| c |\n| - |\n${rows}`)).toContain("table-too-tall");
 	});
 
 	it("rejects excessive nesting", () => {

--- a/packages/dialect/src/index.ts
+++ b/packages/dialect/src/index.ts
@@ -75,6 +75,15 @@ export type { Option, Question, Questionnaire } from "./nodes/questionnaire";
 export { $createDecisionNode, $isDecisionNode, DecisionNode } from "./nodes/decision";
 export type { Decision, Note } from "./nodes/decision";
 
+/*
+ * A `createState` handle is an identity, not a description: state written under
+ * one is invisible to another built from the same arguments. The UI that edits
+ * column alignment has to use this exact one, so it is exported rather than
+ * redeclared.
+ */
+export { alignState } from "./nodes/table";
+export type { Align } from "./nodes/table";
+
 export { render, setRenderer } from "./nodes/render";
 export type { Renderer } from "./nodes/render";
 

--- a/packages/dialect/src/nodes/table.ts
+++ b/packages/dialect/src/nodes/table.ts
@@ -27,7 +27,8 @@ import type { LexicalExportVisitor, MdastImportVisitor } from "@mdxeditor/editor
 import type { ElementNode } from "lexical";
 import type * as Mdast from "mdast";
 
-type Align = Mdast.AlignType;
+/** How a column's text is aligned; `null` is the default the source omits. */
+export type Align = Mdast.AlignType;
 
 const ALIGNMENTS = new Set(["left", "center", "right"]);
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -22,6 +22,7 @@
 		"@lexical/react": "catalog:mdx",
 		"@lexical/rich-text": "catalog:mdx",
 		"@lexical/selection": "catalog:mdx",
+		"@lexical/table": "catalog:mdx",
 		"@lexical/yjs": "catalog:mdx",
 		"@mdxeditor/editor": "catalog:mdx",
 		"@mdxeditor/gurx": "catalog:mdx",

--- a/packages/editor/src/plan-editor.tsx
+++ b/packages/editor/src/plan-editor.tsx
@@ -34,6 +34,12 @@ import type { Connection, Transport } from "./transport";
  * Lexical paints remote cursors with inline styles unless the theme names a
  * class for them, and inline styles cannot be restyled from a stylesheet. The
  * classes are how the cursors become ours rather than the library's.
+ *
+ * The table entries are the same arrangement one step worse: `@lexical/table`
+ * paints a selected cell by adding `theme.tableCellSelected` and nothing else,
+ * so a theme that does not name one — MDXEditor's does not name any table class
+ * at all — draws a cell selection that is completely invisible. Dragging across
+ * cells then appears to do nothing while a `TableSelection` is very much live.
  */
 const THEME = {
 	...lexicalTheme,
@@ -43,6 +49,8 @@ const THEME = {
 		selection: "plan-cursor-selection",
 		selectionBg: "plan-cursor-selection-bg",
 	},
+	tableCellSelected: "plan-cell-selected",
+	tableSelection: "plan-table-selecting",
 };
 
 // Decorator nodes render through whatever the UI registered, so this has to

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -366,6 +366,230 @@
 	margin-block: 0;
 }
 
+/*
+ * A selected range of cells.
+ *
+ * `@lexical/table` marks one by adding the class the theme names under
+ * `tableCellSelected` and does nothing else at all — no inline style, no
+ * fallback. MDXEditor's theme names no table class of any kind, so before
+ * `plan-editor.tsx` added these the selection was live and completely
+ * invisible: dragging across cells appeared to do nothing while a
+ * `TableSelection` was very much in effect, and the next keystroke replaced
+ * everything it covered.
+ */
+.plan .plan-content .plan-cell-selected {
+	background: color-mix(in oklch, var(--color-ring) 22%, transparent);
+}
+
+/* Set on the table while a cell range is being dragged out, so the browser's
+   own text selection does not paint underneath ours. */
+.plan .plan-content .plan-table-selecting,
+.plan .plan-content .disable-selection {
+	user-select: none;
+}
+
+/* Table rails ------------------------------------------------------------ */
+
+/*
+ * The grips a table is reshaped from.
+ *
+ * Positioned by script from measured cell rectangles, because a `<table>`
+ * cannot contain a `<div>` and there is nowhere inside the node to put them.
+ * So: `position: fixed`, and no Tailwind translate utility anywhere near them
+ * — v4 emits the `translate` property, which composes with a transform rather
+ * than replacing it.
+ */
+/*
+ * The rail takes pointer events across the whole of itself, holes included.
+ *
+ * It is tempting to pass the gaps through so the prose behind stays clickable,
+ * and that is what this did first. But `pointerleave` fires the instant the
+ * pointer crosses anything untargetable, so every hole was somewhere the rails
+ * blinked out from under a hand on its way across them. A rail exists only
+ * while its table is being pointed at, and it is 28 pixels of a 32-pixel
+ * gutter; the prose it covers for that moment is not worth the flicker.
+ */
+.plan-rail {
+	position: fixed;
+	z-index: 40;
+	overflow: hidden;
+}
+
+.plan-rail > * {
+	position: absolute;
+	padding: 0;
+	border: 0;
+	background: transparent;
+}
+
+.plan-grip {
+	border-radius: var(--radius-sm);
+	background: var(--color-muted);
+	transition: background-color 120ms ease;
+}
+
+.plan-grip:hover,
+.plan-grip:focus-visible {
+	background: color-mix(in oklch, var(--color-ring) 45%, transparent);
+}
+
+.plan-grip:focus-visible {
+	outline: 2px solid var(--color-ring);
+	outline-offset: 1px;
+}
+
+[data-plan-rail="column"] .plan-grip {
+	cursor: grab;
+}
+
+[data-plan-rail="row"] .plan-grip {
+	cursor: grab;
+}
+
+.plan-grip.is-held {
+	cursor: grabbing;
+	background: var(--color-ring);
+}
+
+/* The header row's bar. Drawn so the rail has no gap where the row plainly is,
+   but not a control: the header cannot move and cannot be removed. */
+.plan-grip.is-fixed {
+	background: color-mix(in oklch, var(--color-border) 60%, transparent);
+	cursor: default;
+}
+
+/*
+ * Remove and insert, in the lane beyond the grips.
+ *
+ * Nothing here overlaps a grip, so a drag can begin anywhere along one. Hiding
+ * is `opacity` rather than `display`, so a button keeps its size and its place
+ * in the tab order while it is out of sight — and `pointer-events` with it, so
+ * an invisible cross cannot be clicked by accident.
+ */
+.plan-grip-remove,
+.plan-insert,
+.plan-align {
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 120ms ease;
+	border-radius: var(--radius-sm);
+	background: var(--color-popover);
+	box-shadow: 0 0 0 1px var(--color-border);
+	color: var(--color-muted-foreground);
+}
+
+.plan-grip-remove[data-plan-shown],
+.plan-align[data-plan-shown],
+.plan-grip-remove:focus-visible,
+.plan-align:focus-visible,
+.plan-rail:hover .plan-insert,
+.plan-insert:focus-visible {
+	opacity: 1;
+	pointer-events: auto;
+}
+
+.plan-grip-remove:hover,
+.plan-insert:hover,
+.plan-align:hover {
+	color: var(--color-foreground);
+	box-shadow: 0 0 0 1px var(--color-ring);
+}
+
+.plan-grip-remove:focus-visible,
+.plan-insert:focus-visible,
+.plan-align:focus-visible {
+	outline: 2px solid var(--color-ring);
+	outline-offset: 1px;
+}
+
+/* Drawn rather than lettered: at fifteen pixels a glyph is a smudge, and these
+   have to read at a glance in the margin of a paragraph. */
+.plan-grip-remove::before,
+.plan-grip-remove::after,
+.plan-insert::before,
+.plan-insert::after {
+	content: "";
+	position: absolute;
+	inset: 50% 25%;
+	border-top: 1.5px solid currentcolor;
+	translate: 0 -50%;
+}
+
+.plan-grip-remove::before {
+	rotate: 45deg;
+}
+
+.plan-grip-remove::after {
+	rotate: -45deg;
+}
+
+.plan-insert::after {
+	rotate: 90deg;
+}
+
+/*
+ * The alignment button reads as what it does: two lines, the lower one short
+ * and sitting where the text will. A column with no alignment of its own shows
+ * the same figure at half strength rather than a fourth icon, because "no
+ * alignment" and "left" render identically in the table and a control claiming
+ * otherwise would be lying about the source.
+ */
+.plan-align::before,
+.plan-align::after {
+	content: "";
+	position: absolute;
+	left: 3px;
+	right: 3px;
+	border-top: 1.5px solid currentcolor;
+}
+
+.plan-align::before {
+	top: 5px;
+}
+
+.plan-align::after {
+	top: 9px;
+}
+
+.plan-align[data-plan-align="default"] {
+	opacity: 0;
+}
+
+.plan-align[data-plan-align="default"][data-plan-shown],
+.plan-align[data-plan-align="default"]:focus-visible {
+	opacity: 0.55;
+}
+
+.plan-align[data-plan-align="default"]::after,
+.plan-align[data-plan-align="left"]::after {
+	right: 7px;
+}
+
+.plan-align[data-plan-align="center"]::after {
+	left: 5px;
+	right: 5px;
+}
+
+.plan-align[data-plan-align="right"]::after {
+	left: 7px;
+}
+
+/* Where the drag will land. A hairline, because it is a position rather than a
+   region: anything wider reads as the width of what is being moved. */
+.plan-drop {
+	background: var(--color-ring);
+	border-radius: 1px;
+	pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.plan-grip,
+	.plan-grip-remove,
+	.plan-insert {
+		transition: none;
+	}
+}
+
 /* Remote cursors --------------------------------------------------------- */
 
 /*

--- a/packages/editor/src/table/geometry.test.ts
+++ b/packages/editor/src/table/geometry.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "bun:test";
+
+import { destination, gripBox, rowDestination, seamAt, seamBox, seams } from "./geometry";
+
+import type { Track } from "./geometry";
+
+/** Four tracks of unequal width, as measured cells actually are. */
+const TRACKS: Track[] = [
+	{ start: 0, end: 40 },
+	{ start: 40, end: 140 },
+	{ start: 140, end: 180 },
+	{ start: 180, end: 380 },
+];
+
+describe("seams", () => {
+	it("gives one more line than there are tracks", () => {
+		expect(seams(TRACKS)).toEqual([0, 40, 140, 180, 380]);
+	});
+
+	it("has nothing to offer for a table with no tracks", () => {
+		expect(seams([])).toEqual([]);
+	});
+});
+
+describe("finding the seam a pointer means", () => {
+	it("takes the nearest line rather than the track under the pointer", () => {
+		expect(seamAt(TRACKS, 45)).toBe(1);
+		expect(seamAt(TRACKS, 135)).toBe(2);
+	});
+
+	it("answers for a pointer past either end, so an overshoot still lands", () => {
+		expect(seamAt(TRACKS, -500)).toBe(0);
+		expect(seamAt(TRACKS, 9000)).toBe(4);
+	});
+});
+
+describe("turning a seam into a destination index", () => {
+	/*
+	 * The library evaluates the destination after lifting the moved track out,
+	 * so every seam past the origin means an index one lower. Getting this
+	 * wrong lands the track one place from where it was dropped and nothing
+	 * anywhere reports it.
+	 */
+	it("shifts down for a seam after the track's own position", () => {
+		expect(destination(0, 3, 4)).toBe(2);
+		expect(destination(0, 4, 4)).toBe(3);
+	});
+
+	it("does not shift for a seam before it", () => {
+		expect(destination(3, 0, 4)).toBe(0);
+		expect(destination(3, 2, 4)).toBe(2);
+	});
+
+	it("refuses both seams bounding where the track already is", () => {
+		expect(destination(2, 2, 4)).toBeUndefined();
+		expect(destination(2, 3, 4)).toBeUndefined();
+	});
+
+	it("refuses a seam off the end of the table", () => {
+		expect(destination(0, 5, 4)).toBeUndefined();
+		expect(destination(0, -1, 4)).toBeUndefined();
+	});
+
+	it("moves a track to the very front", () => {
+		expect(destination(2, 0, 4)).toBe(0);
+	});
+});
+
+describe("dropping a row", () => {
+	it("clamps a drag above the header to the seam below it", () => {
+		// The pointer ran off the top of a short table; that is still a request
+		// for "as high as it goes", not a failed drag.
+		expect(rowDestination(3, 0, 4)).toBe(1);
+	});
+
+	it("still refuses a drop that would not move the row", () => {
+		expect(rowDestination(1, 0, 4)).toBeUndefined();
+		expect(rowDestination(1, 1, 4)).toBeUndefined();
+		expect(rowDestination(1, 2, 4)).toBeUndefined();
+	});
+
+	it("otherwise behaves as any other track", () => {
+		expect(rowDestination(1, 4, 4)).toBe(3);
+	});
+});
+
+describe("laying a rail out", () => {
+	it("gives a column grip the width of its column and the depth of the rail", () => {
+		// The rail starts where the table does, so a track measured at x=140
+		// in the page sits 140 along a rail whose origin is 0.
+		expect(gripBox("column", { start: 140, end: 180 }, 0, 16))
+			.toEqual({ left: 140, top: 0, width: 40, height: 16 });
+	});
+
+	it("turns the same track through a right angle for a row", () => {
+		expect(gripBox("row", { start: 140, end: 180 }, 0, 16))
+			.toEqual({ left: 0, top: 140, width: 16, height: 40 });
+	});
+
+	it("subtracts the rail's own origin, so a scrolled table still lines up", () => {
+		expect(gripBox("column", { start: 340, end: 380 }, 300, 16))
+			.toEqual({ left: 40, top: 0, width: 40, height: 16 });
+	});
+
+	it("straddles a seam rather than starting at it", () => {
+		// A seam is a line with no width; what is aimed at has to cover both
+		// sides of it or it can only be hit from one.
+		expect(seamBox("column", 140, 0, 16, 12))
+			.toEqual({ left: 134, top: 0, width: 12, height: 16 });
+		expect(seamBox("row", 140, 0, 16, 12))
+			.toEqual({ left: 0, top: 134, width: 16, height: 12 });
+	});
+});

--- a/packages/editor/src/table/geometry.ts
+++ b/packages/editor/src/table/geometry.ts
@@ -1,0 +1,152 @@
+/**
+ * Where a drag lands.
+ *
+ * Two coordinate systems meet here and they do not agree, which is the whole
+ * reason this is its own module. A drop is expressed as a *seam* — the line
+ * between two tracks, so `n` tracks have `n + 1` of them — because that is what
+ * a person aims at and what the insertion line is drawn on. `$moveTableRow` and
+ * `$moveTableColumn` instead take a destination *index*, evaluated after the
+ * moved track has already been lifted out, so every seam past the one it came
+ * from means an index one lower.
+ *
+ * Off by one here is invisible: nothing throws, the table stays well-formed,
+ * and the column simply arrives one place from where it was dropped. Hence a
+ * module of plain numbers with no DOM in it.
+ */
+
+import { HEADER } from "./shape";
+
+/**
+ * Where a track sits along the axis being dragged, in viewport pixels.
+ *
+ * Measured rather than derived: cells size themselves from their contents, so
+ * there is no stride to multiply by.
+ */
+export type Track = { start: number; end: number };
+
+/**
+ * Which way a rail runs.
+ *
+ * The two rails are one piece of geometry seen twice, with the axes swapped:
+ * a column grip is as wide as its column and as tall as the rail, a row grip
+ * the other way about. Writing it once and turning it means the two cannot
+ * drift apart, which they would, because only one of them is ever the one
+ * being looked at while it is worked on.
+ */
+export type Axis = "column" | "row";
+
+/** The `n + 1` lines a track can be dropped onto. */
+export function seams(list: Track[]): number[] {
+	if (list.length === 0) return [];
+	return [list[0]!.start, ...list.map(track => track.end)];
+}
+
+/**
+ * The seam a pointer is nearest.
+ *
+ * Nearest rather than "inside track `n`, so seam `n` or `n + 1`": a pointer
+ * beyond either end of the table still has an answer this way, and a drag that
+ * overshoots the last column should land after it rather than nowhere.
+ */
+export function seamAt(list: Track[], position: number): number {
+	let lines = seams(list);
+	if (lines.length === 0) return 0;
+
+	let best = 0;
+	let closest = Infinity;
+	for (let index = 0; index < lines.length; index++) {
+		let distance = Math.abs(lines[index]! - position);
+		// Strictly closer, so a pointer exactly between two seams takes the
+		// earlier one rather than depending on which way the loop runs.
+		if (distance < closest) {
+			closest = distance;
+			best = index;
+		}
+	}
+	return best;
+}
+
+/**
+ * The destination index a seam means, for a track lifted from `from`.
+ *
+ * Returns undefined when the drop would not move anything — the seam on either
+ * side of where the track already is puts it back where it started. Saying so
+ * is what lets the caller leave the document alone rather than commit a
+ * no-op edit that still costs everyone in the room a sync.
+ */
+export function destination(from: number, seam: number, count: number): number | undefined {
+	if (seam < 0 || seam > count) return undefined;
+	// Both seams bounding the track's current position are where it already is.
+	if (seam === from || seam === from + 1) return undefined;
+	return seam > from ? seam - 1 : seam;
+}
+
+/**
+ * The seam a drop lands on, once the header is accounted for.
+ *
+ * A row cannot go above the header, so the seam at the very top of the table is
+ * not a target and a drag that reaches for it is clamped to the one below.
+ * Clamped rather than refused: a pointer that has run off the top of a short
+ * table is still asking for "as high as it goes", and dropping nothing because
+ * it went two pixels too far reads as the drag having failed.
+ *
+ * The clamp is applied here rather than inside `destination` so the insertion
+ * line can be drawn on the seam the drop will actually use. Deciding it twice
+ * is how the line ends up promising one thing and the drop doing another.
+ */
+export function dropSeam(axis: Axis, seam: number): number {
+	return axis === "row" ? Math.max(seam, HEADER + 1) : seam;
+}
+
+/** {@link destination}, for a row, through {@link dropSeam}. */
+export function rowDestination(from: number, seam: number, count: number): number | undefined {
+	return destination(from, dropSeam("row", seam), count);
+}
+
+/** A rectangle relative to the rail it is drawn in. */
+export type Box = { left: number; top: number; width: number; height: number };
+
+/**
+ * A grip covering one track.
+ *
+ * `origin` is where the rail starts along the axis, in the same viewport
+ * coordinates the tracks were measured in — subtracting it is what turns a
+ * measurement of the page into a position inside the rail. `lane` is the
+ * offset across the rail, which is what keeps the grips and the buttons in
+ * separate lanes: a button sharing a lane with the grip it belongs to sits
+ * exactly where a drag would naturally be started from, and swallows it.
+ */
+export function gripBox(
+	axis: Axis,
+	track: Track,
+	origin: number,
+	thickness: number,
+	lane = 0,
+): Box {
+	let extent = Math.max(track.end - track.start, 0);
+	let offset = track.start - origin;
+	return axis === "column"
+		? { left: offset, top: lane, width: extent, height: thickness }
+		: { left: lane, top: offset, width: thickness, height: extent };
+}
+
+/**
+ * A target centred on a seam.
+ *
+ * Centred rather than starting at it, because a seam is a line with no width
+ * and the thing a person aims at straddles it. `size` is the whole extent, so
+ * half of it falls on each side of the two tracks the seam divides.
+ */
+export function seamBox(
+	axis: Axis,
+	position: number,
+	origin: number,
+	thickness: number,
+	size: number,
+	lane = 0,
+): Box {
+	let offset = position - origin - size / 2;
+	return axis === "column"
+		? { left: offset, top: lane, width: size, height: thickness }
+		: { left: lane, top: offset, width: thickness, height: size };
+}

--- a/packages/editor/src/table/ops.test.ts
+++ b/packages/editor/src/table/ops.test.ts
@@ -1,0 +1,261 @@
+/**
+ * The rail's edits, judged by the MDX they produce.
+ *
+ * Asserting on canonical source rather than on the node tree is deliberate:
+ * the source is what is saved, what the agent reads and what the next session
+ * parses, so a change that leaves a plausible tree behind but writes the wrong
+ * table is exactly the failure worth catching. It also covers the two things
+ * the tree would not show — that the header row stays the header, and that a
+ * column's alignment travels with it.
+ *
+ * It is a module identity check as well, in the way `interop.test.ts` is one
+ * for the dialect. These operations reach for `@lexical/table` while the
+ * document they act on was built by `@chopin/dialect`'s visitors, so a second
+ * copy of the package would make every `$isTableNode` here return false and
+ * every case below would go quiet rather than fail loudly. The catalog is what
+ * prevents it; this is what would notice.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createHeadlessEditor } from "@lexical/headless";
+import { exportPlan, importPlan, limits, registry } from "@chopin/dialect";
+import { $getRoot } from "lexical";
+import { $isTableNode } from "@lexical/table";
+
+import {
+	$addColumn,
+	$addRow,
+	$describe,
+	$moveColumn,
+	$moveRow,
+	$removeColumn,
+	$removeRow,
+	$setAlign,
+} from "./ops";
+
+import type { LexicalEditor, NodeKey } from "lexical";
+
+const REGISTRY = registry();
+
+const TABLE = "| Name | Count |\n| :--- | ----: |\n| API  |     1 |\n| Web  |     2 |\n";
+
+function open(source: string): { editor: LexicalEditor; key: NodeKey } {
+	let editor = createHeadlessEditor({
+		nodes: REGISTRY.nodes,
+		onError(err) {
+			throw err;
+		},
+	});
+	importPlan(editor, source, { registry: REGISTRY });
+
+	let key = "";
+	editor.getEditorState().read(() => {
+		let table = $getRoot().getChildren().find($isTableNode);
+		key = table?.getKey() ?? "";
+	});
+	if (!key) throw new Error("no table in the source");
+
+	return { editor, key };
+}
+
+/**
+ * Run one operation and commit it.
+ *
+ * `discrete` because a headless editor has no DOM to reconcile against and so
+ * defers an ordinary update past the read that follows it. The browser wants
+ * the default, which is why the operations take the update rather than opening
+ * one of their own.
+ */
+function apply(editor: LexicalEditor, op: () => void): void {
+	editor.update(op, { discrete: true });
+}
+
+function source(editor: LexicalEditor): string {
+	return exportPlan(editor, { registry: REGISTRY });
+}
+
+/** A table of the given size, so the limits can be reached without ceremony. */
+function grid(rows: number, columns: number): string {
+	let cells = (fill: string) => `| ${Array.from({ length: columns }, () => fill).join(" | ")} |`;
+	return [
+		cells("h"),
+		cells("-"),
+		...Array.from({ length: rows - 1 }, () => cells("x")),
+	].join("\n") + "\n";
+}
+
+describe("adding a row", () => {
+	it("inserts below the row a seam sits under", () => {
+		let { editor, key } = open(TABLE);
+		apply(editor, () => $addRow(key, 2));
+		expect(source(editor)).toBe(
+			"| Name | Count |\n| :--- | ----: |\n| API  |     1 |\n|      |       |\n| Web  |     2 |\n",
+		);
+	});
+
+	it("appends at the end of the table", () => {
+		let { editor, key } = open(TABLE);
+		apply(editor, () => $addRow(key, 3));
+		expect(source(editor)).toBe(
+			"| Name | Count |\n| :--- | ----: |\n| API  |     1 |\n| Web  |     2 |\n|      |       |\n",
+		);
+	});
+
+	it("cannot be pushed above the header, which would rename the columns", () => {
+		let { editor, key } = open(TABLE);
+		apply(editor, () => $addRow(key, 0));
+		// Clamped to just below the header, not inserted above it.
+		expect(source(editor)).toBe(
+			"| Name | Count |\n| :--- | ----: |\n|      |       |\n| API  |     1 |\n| Web  |     2 |\n",
+		);
+	});
+
+	it("does not add the row that would break the dialect's limit", () => {
+		let { editor, key } = open(grid(limits.MAX_TABLE_ROWS, 2));
+		apply(editor, () => $addRow(key, limits.MAX_TABLE_ROWS));
+		expect(shapeOf(editor, key).rows).toBe(limits.MAX_TABLE_ROWS);
+	});
+});
+
+describe("adding a column", () => {
+	it("inserts before the first column when the seam is at the start", () => {
+		let { editor, key } = open(TABLE);
+		apply(editor, () => $addColumn(key, 0));
+		expect(source(editor)).toBe(
+			"|   | Name | Count |\n| - | :--- | ----: |\n|   | API  |     1 |\n|   | Web  |     2 |\n",
+		);
+	});
+
+	it("appends at the end of the table", () => {
+		let { editor, key } = open(TABLE);
+		apply(editor, () => $addColumn(key, 2));
+		expect(source(editor)).toBe(
+			"| Name | Count |   |\n| :--- | ----: | - |\n| API  |     1 |   |\n| Web  |     2 |   |\n",
+		);
+	});
+
+	it("gives the new column a header cell and no alignment of its own", () => {
+		let { editor, key } = open(TABLE);
+		apply(editor, () => $addColumn(key, 2));
+		// The two existing columns keep theirs; the new one is unaligned.
+		expect(shapeOf(editor, key).align).toEqual(["left", "right", null]);
+	});
+
+	it("does not add the column that would break the dialect's limit", () => {
+		let { editor, key } = open(grid(2, limits.MAX_TABLE_COLUMNS));
+		apply(editor, () => $addColumn(key, limits.MAX_TABLE_COLUMNS));
+		expect(shapeOf(editor, key).columns).toBe(limits.MAX_TABLE_COLUMNS);
+	});
+});
+
+describe("removing", () => {
+	it("removes a body row", () => {
+		let { editor, key } = open(TABLE);
+		apply(editor, () => $removeRow(key, 1));
+		expect(source(editor)).toBe("| Name | Count |\n| :--- | ----: |\n| Web  |     2 |\n");
+	});
+
+	it("leaves a table with only its header when the last body row goes", () => {
+		let { editor, key } = open("| Name |\n| ---- |\n| API  |\n");
+		apply(editor, () => $removeRow(key, 1));
+		expect(source(editor)).toBe("| Name |\n| ---- |\n");
+	});
+
+	it("refuses to remove the header row", () => {
+		let { editor, key } = open(TABLE);
+		apply(editor, () => $removeRow(key, 0));
+		expect(source(editor)).toBe(TABLE);
+	});
+
+	it("removes a column and the alignment that belonged to it", () => {
+		let { editor, key } = open(TABLE);
+		apply(editor, () => $removeColumn(key, 0));
+		expect(source(editor)).toBe("| Count |\n| ----: |\n|     1 |\n|     2 |\n");
+	});
+
+	it("refuses to remove the last column, which has no GFM form", () => {
+		let { editor, key } = open("| Name |\n| ---- |\n| API  |\n");
+		apply(editor, () => $removeColumn(key, 0));
+		expect(source(editor)).toBe("| Name |\n| ---- |\n| API  |\n");
+	});
+});
+
+describe("reordering", () => {
+	it("moves a body row down", () => {
+		let { editor, key } = open(TABLE);
+		apply(editor, () => $moveRow(key, 1, 2));
+		expect(source(editor)).toBe(
+			"| Name | Count |\n| :--- | ----: |\n| Web  |     2 |\n| API  |     1 |\n",
+		);
+	});
+
+	it("refuses to move the header row, or anything above it", () => {
+		let { editor, key } = open(TABLE);
+		apply(editor, () => $moveRow(key, 0, 2));
+		apply(editor, () => $moveRow(key, 2, 0));
+		expect(source(editor)).toBe(TABLE);
+	});
+
+	it("moves a column and carries its alignment with it", () => {
+		let { editor, key } = open(TABLE);
+		apply(editor, () => $moveColumn(key, 0, 1));
+		// `Name` was left-aligned and `Count` right; both stay that way after
+		// the swap, because the alignment lives on the header cell that moved.
+		expect(source(editor)).toBe(
+			"| Count | Name |\n| ----: | :--- |\n|     1 | API  |\n|     2 | Web  |\n",
+		);
+	});
+});
+
+describe("alignment", () => {
+	it("realigns a column through its header cell", () => {
+		let { editor, key } = open(TABLE);
+		apply(editor, () => $setAlign(key, 1, "center"));
+		expect(source(editor)).toBe(
+			"| Name | Count |\n| :--- | :---: |\n| API  |   1   |\n| Web  |   2   |\n",
+		);
+	});
+
+	it("clears an alignment back to the default the source omits", () => {
+		let { editor, key } = open(TABLE);
+		apply(editor, () => $setAlign(key, 0, null));
+		expect(source(editor)).toBe(
+			"| Name | Count |\n| ---- | ----: |\n| API  |     1 |\n| Web  |     2 |\n",
+		);
+	});
+});
+
+describe("a table that is no longer there", () => {
+	it("is edited by nobody", () => {
+		// Between the render that drew a grip and the click that used it, the
+		// agent may have rewritten the block out from under it.
+		let { editor, key } = open(TABLE);
+		editor.update(() => {
+			$getRoot().clear();
+		}, { discrete: true });
+
+		expect(() => apply(editor, () => $addRow(key, 1))).not.toThrow();
+		expect(() => apply(editor, () => $removeColumn(key, 0))).not.toThrow();
+		expect(() => apply(editor, () => $moveRow(key, 1, 2))).not.toThrow();
+		expect(() => apply(editor, () => $setAlign(key, 0, "center"))).not.toThrow();
+
+		// And nothing was conjured back into existence to be edited.
+		expect(editor.getEditorState().read(() => $getRoot().getChildren().some($isTableNode)))
+			.toBe(false);
+	});
+});
+
+function shapeOf(editor: LexicalEditor, key: NodeKey) {
+	let out = { rows: 0, columns: 0, align: [] as unknown[] };
+	editor.getEditorState().read(() => {
+		let table = $getRoot().getChildren().find($isTableNode);
+		if (!table || table.getKey() !== key) return;
+		let described = $describe(table);
+		out = {
+			rows: described.shape.rows,
+			columns: described.shape.columns,
+			align: described.align,
+		};
+	});
+	return out;
+}

--- a/packages/editor/src/table/ops.ts
+++ b/packages/editor/src/table/ops.ts
@@ -1,0 +1,185 @@
+/**
+ * The edits a rail can make.
+ *
+ * All `$`-prefixed and all callable only inside an `editor.update()`, so the
+ * caller decides when the update commits — the browser wants the default and a
+ * headless editor has to be told `discrete`, which is the same split `convert.ts`
+ * draws between `$importPlan` and `importPlan`.
+ *
+ * Every one of these takes a node key and resolves it here rather than a node
+ * captured when the control rendered: a Lexical node is a snapshot, and between
+ * the render that drew a grip and the click that used it the document may have
+ * been rewritten by somebody else or by the agent.
+ *
+ * They are also all refusals first. `shape.ts` says what is permitted and this
+ * asks it before touching anything, so a control that should have been disabled
+ * still cannot produce a document the server will reject.
+ */
+
+import {
+	$deleteTableColumn,
+	$insertTableColumnAtNode,
+	$insertTableRowAtNode,
+	$isSimpleTable,
+	$isTableCellNode,
+	$isTableNode,
+	$isTableRowNode,
+	$moveTableColumn,
+	$moveTableRow,
+	$removeTableRowAtIndex,
+} from "@lexical/table";
+import { $getNodeByKey, $getState, $setState } from "lexical";
+import { alignState } from "@chopin/dialect";
+
+import {
+	canAddColumn,
+	canAddRow,
+	canMoveColumn,
+	canMoveRow,
+	canRemoveColumn,
+	canRemoveRow,
+	HEADER,
+} from "./shape";
+
+import type { Align } from "@chopin/dialect";
+import type { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
+import type { NodeKey } from "lexical";
+import type { Shape } from "./shape";
+
+/** A table read out of the document, with everything a rail needs to draw itself. */
+export type Table = {
+	key: NodeKey;
+	shape: Shape;
+	/** Row keys in document order, the header first. */
+	rows: NodeKey[];
+	/** Cell keys by row, then column. */
+	cells: NodeKey[][];
+	/** Per column, from the header cells. */
+	align: Align[];
+};
+
+function $rowsOf(table: TableNode): TableRowNode[] {
+	return table.getChildren().filter($isTableRowNode);
+}
+
+function $cellsOf(row: TableRowNode): TableCellNode[] {
+	return row.getChildren().filter($isTableCellNode);
+}
+
+/** The table a key names, or nothing if it is gone or no longer one. */
+function $table(key: NodeKey): TableNode | undefined {
+	let node = $getNodeByKey(key);
+	return $isTableNode(node) ? node : undefined;
+}
+
+/** Everything about one table, as data. */
+export function $describe(table: TableNode): Table {
+	let rows = $rowsOf(table);
+	let cells = rows.map($cellsOf);
+	let header = cells[HEADER] ?? [];
+
+	return {
+		key: table.getKey(),
+		shape: {
+			rows: rows.length,
+			// From the header, so a ragged row cannot make the rail wider than
+			// the columns the table actually has.
+			columns: header.length,
+			simple: $isSimpleTable(table),
+		},
+		rows: rows.map(row => row.getKey()),
+		cells: cells.map(row => row.map(cell => cell.getKey())),
+		align: header.map(cell => $getState(cell, alignState)),
+	};
+}
+
+/**
+ * The cell an insertion hangs off, and which side of it to insert on.
+ *
+ * `@lexical/table` inserts relative to a cell rather than at an index, because
+ * an index is ambiguous once cells can span. Turning one into the other is the
+ * only awkward part: a seam is a position *between* tracks, so it is expressed
+ * as the track before it, and only the seam at the very start has none.
+ */
+function locate(count: number, at: number): { index: number; after: boolean } {
+	return at <= 0 ? { index: 0, after: false } : { index: Math.min(at, count) - 1, after: true };
+}
+
+/** Insert a row at a seam, counting the header as row zero. */
+export function $addRow(key: NodeKey, at: number): void {
+	let table = $table(key);
+	if (!table) return;
+
+	let described = $describe(table);
+	if (!canAddRow(described.shape)) return;
+
+	// Never above the header: a new row inserted before it would become the
+	// header at the next save, taking the column alignment with it.
+	let { after, index } = locate(described.shape.rows, Math.max(at, HEADER + 1));
+	let cell = $getNodeByKey(described.cells[index]?.[0] ?? "");
+	if ($isTableCellNode(cell)) $insertTableRowAtNode(cell, after);
+}
+
+/** Insert a column at a seam. */
+export function $addColumn(key: NodeKey, at: number): void {
+	let table = $table(key);
+	if (!table) return;
+
+	let described = $describe(table);
+	if (!canAddColumn(described.shape)) return;
+
+	let { after, index } = locate(described.shape.columns, at);
+	let cell = $getNodeByKey(described.cells[HEADER]?.[index] ?? "");
+	// `shouldSetSelection: false`. Adding a column is a change to the shape of
+	// the table, not a request to go and edit the new cells, and the caret is
+	// very likely in one of the old ones with a half-typed word in it. Moving
+	// it there would lose the word and the place at once.
+	if ($isTableCellNode(cell)) $insertTableColumnAtNode(cell, after, false);
+}
+
+export function $removeRow(key: NodeKey, index: number): void {
+	let table = $table(key);
+	if (!table) return;
+	if (!canRemoveRow($describe(table).shape, index)) return;
+	$removeTableRowAtIndex(table, index);
+}
+
+export function $removeColumn(key: NodeKey, index: number): void {
+	let table = $table(key);
+	if (!table) return;
+	if (!canRemoveColumn($describe(table).shape, index)) return;
+	// Deprecated upstream only because it cannot cope with merged cells, which
+	// is a shape the dialect has no way to write and the unmerge transform
+	// keeps out of the document.
+	$deleteTableColumn(table, index);
+}
+
+export function $moveRow(key: NodeKey, from: number, to: number): void {
+	let table = $table(key);
+	if (!table) return;
+	if (!canMoveRow($describe(table).shape, from, to)) return;
+	$moveTableRow(table, from, to);
+}
+
+export function $moveColumn(key: NodeKey, from: number, to: number): void {
+	let table = $table(key);
+	if (!table) return;
+	if (!canMoveColumn($describe(table).shape, from, to)) return;
+	$moveTableColumn(table, from, to);
+}
+
+/**
+ * Realign a column.
+ *
+ * The alignment is written to the header cell because that is the only place
+ * GFM has to put it — the `| :--- |` row describes the column, not any one
+ * value in it. Two people realigning different columns therefore write to
+ * different nodes and do not conflict.
+ */
+export function $setAlign(key: NodeKey, column: number, align: Align): void {
+	let table = $table(key);
+	if (!table) return;
+
+	let cell = $getNodeByKey($describe(table).cells[HEADER]?.[column] ?? "");
+	if ($isTableCellNode(cell)) $setState(cell, alignState, align);
+}

--- a/packages/editor/src/table/rails.tsx
+++ b/packages/editor/src/table/rails.tsx
@@ -1,0 +1,685 @@
+/**
+ * The rails a table is reshaped from.
+ *
+ * A grip per column above the table and per row beside it: the handle a drag
+ * starts from, the button a row or column is removed by, and — between two of
+ * them — where a new one is inserted.
+ *
+ * They are drawn as a fixed overlay measured from cell rectangles rather than
+ * as chrome inside the node, because a `<table>` cannot contain a `<div>`. The
+ * `data-plan-chrome` slot that callouts and tabs portal into is not available
+ * at any price here: the browser hoists a stray div straight back out of a
+ * table, so the choice is between measuring and subclassing `TableNode`. This
+ * is the technique the selection bubble already uses.
+ *
+ * Only one table has rails at a time — whichever the pointer is over, or the
+ * caret is in. Rails on every table at once would be a page of grey furniture
+ * around prose that is mostly not tables.
+ *
+ * There is no test for this file, on purpose: it is rectangles and pointers all
+ * the way down and the test runtime has no DOM. What can be decided without one
+ * — which seam a drop means, what a rail's boxes are, what the table permits —
+ * lives in `geometry.ts` and `shape.ts`, which are tested.
+ */
+
+import { Fragment, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+	$findTableNode,
+	$isTableNode,
+	registerTableCellUnmergeTransform,
+	registerTablePlugin,
+	registerTableSelectionObserver,
+} from "@lexical/table";
+import { readOnly$ } from "@mdxeditor/editor";
+import { useCellValue } from "@mdxeditor/gurx";
+import { $getRoot, $getSelection, $isElementNode, $isRangeSelection, mergeRegister } from "lexical";
+
+import { destination, dropSeam, gripBox, seamAt, seamBox, seams } from "./geometry";
+import {
+	$addColumn,
+	$addRow,
+	$describe,
+	$moveColumn,
+	$moveRow,
+	$removeColumn,
+	$removeRow,
+	$setAlign,
+} from "./ops";
+import { canAddColumn, canAddRow, canRemoveColumn, canRemoveRow, HEADER } from "./shape";
+
+import type { Align } from "@chopin/dialect";
+import type { ElementNode, LexicalEditor, NodeKey } from "lexical";
+import type { Axis, Track } from "./geometry";
+import type { Table } from "./ops";
+
+/*
+ * A rail is two lanes: grips against the table, buttons beyond them.
+ *
+ * They are separate because they were not, once. A cross in the middle of a
+ * grip is where a drag is most naturally begun, so it swallowed the gesture it
+ * was drawn beside — and only sometimes, since whether it had become live yet
+ * depended on a re-render landing between the pointer arriving and the button
+ * going down. Nothing in the two lanes overlaps now, so neither can take the
+ * other's pointer.
+ */
+const GRIP = 14;
+const TOOL = 14;
+const DEPTH = GRIP + TOOL;
+
+/** How much of a seam can be aimed at. */
+const SEAM = 16;
+
+/** One button in the tool lane, and how far each of a pair sits from centre. */
+const BUTTON = 15;
+const PAIR = 8;
+
+/**
+ * What the alignment button steps through.
+ *
+ * `null` first because it is what a column starts as and what the source omits;
+ * stepping off the end returns to it, so the control can always be put back.
+ */
+const ALIGNMENTS: Align[] = [null, "left", "center", "right"];
+
+const ALIGN_LABEL: Record<string, string> = {
+	null: "default",
+	left: "left",
+	center: "centre",
+	right: "right",
+};
+
+function nextAlign(current: Align): Align {
+	let index = ALIGNMENTS.indexOf(current ?? null);
+	return ALIGNMENTS[(index + 1) % ALIGNMENTS.length] ?? null;
+}
+
+/** Where a measured table is on the screen, and where its tracks are. */
+type Metrics = {
+	/**
+	 * The table these were taken from.
+	 *
+	 * Carried so a render that has already switched tables can tell that the
+	 * measurements have not caught up, and draw nothing for the one frame
+	 * before the layout effect runs. Without it the rails appear at the last
+	 * table's coordinates first, which reads as them jumping into place.
+	 */
+	key: NodeKey;
+	left: number;
+	top: number;
+	width: number;
+	height: number;
+	columns: Track[];
+	rows: Track[];
+};
+
+/** A drag in progress. */
+type Drag = { axis: Axis; from: number; seam: number };
+
+/** Read every table out of the document. */
+function collect(editor: LexicalEditor): Table[] {
+	let out: Table[] = [];
+	editor.getEditorState().read(() => {
+		let walk = (node: ElementNode) => {
+			for (let child of node.getChildren()) {
+				// A table cannot nest inside a table in this dialect, but a
+				// callout or a tab panel can hold one, so the walk cannot stop
+				// at the top level.
+				if ($isTableNode(child)) out.push($describe(child));
+				else if ($isElementNode(child)) walk(child);
+			}
+		};
+		walk($getRoot());
+	});
+	return out;
+}
+
+/**
+ * Measure one table.
+ *
+ * Cells are found by key rather than by `querySelector`, so nothing here
+ * depends on the DOM `@lexical/table` happens to build — whether rows sit
+ * under a `tbody`, whether a `colgroup` comes first.
+ *
+ * Returns nothing when the table is not rendered, which is the case for one
+ * inside a tab panel that is not the open tab.
+ */
+function measure(editor: LexicalEditor, table: Table): Metrics | undefined {
+	let element = editor.getElementByKey(table.key);
+	if (!element) return undefined;
+
+	let frame = element.getBoundingClientRect();
+	if (frame.width === 0 && frame.height === 0) return undefined;
+
+	let box = (key: NodeKey | undefined) =>
+		key ? editor.getElementByKey(key)?.getBoundingClientRect() : undefined;
+
+	// Columns from the header row, rows from the first column: one pass along
+	// each edge rather than over the whole grid.
+	let columns: Track[] = [];
+	for (let key of table.cells[HEADER] ?? []) {
+		let rect = box(key);
+		if (!rect) return undefined;
+		columns.push({ start: rect.left, end: rect.right });
+	}
+
+	let rows: Track[] = [];
+	for (let row of table.cells) {
+		let rect = box(row[0]);
+		if (!rect) return undefined;
+		rows.push({ start: rect.top, end: rect.bottom });
+	}
+
+	return {
+		key: table.key,
+		left: frame.left,
+		top: frame.top,
+		width: frame.width,
+		height: frame.height,
+		columns,
+		rows,
+	};
+}
+
+/**
+ * Project each column's alignment onto its cells.
+ *
+ * The alignment is recorded on the header cell, because the `| :--- |` row is
+ * the only place GFM has to put it, but it describes the whole column — and CSS
+ * cannot cascade from one cell to the others beneath it. So it is written to
+ * the elements rather than the document: the same arrangement as a tab panel's
+ * visibility, for the same reason, which is that how a column is drawn should
+ * not be an edit.
+ *
+ * Re-applied on every update, because Lexical rebuilds a block's element when
+ * the block changes and a style set on the old one goes with it.
+ */
+function paint(editor: LexicalEditor, tables: Table[]): void {
+	for (let table of tables) {
+		for (let row of table.cells) {
+			for (let column = 0; column < row.length; column++) {
+				let element = editor.getElementByKey(row[column]!);
+				if (!element) continue;
+				// Empty rather than "start", so clearing an alignment hands the
+				// column back to the stylesheet instead of pinning it to a
+				// value that would then win against any later change there.
+				element.style.textAlign = table.align[column] ?? "";
+			}
+		}
+	}
+}
+
+export function TableRails() {
+	let [editor] = useLexicalComposerContext();
+	let disabled = useCellValue(readOnly$);
+
+	let [tables, setTables] = useState<Table[]>([]);
+	let [active, setActive] = useState<NodeKey>();
+	let [metrics, setMetrics] = useState<Metrics>();
+	let [drag, setDrag] = useState<Drag>();
+
+	/*
+	 * Everything `@lexical/table` assumes is installed, and was not.
+	 *
+	 * Without `registerTablePlugin` a table has no keyboard navigation and none
+	 * of the transforms that keep it rectangular. Without the unmerge transform
+	 * a table pasted from HTML keeps its spans, which the dialect has no way to
+	 * write — the export visitor ignores them, so the cells silently
+	 * redistribute themselves at the next save.
+	 */
+	useEffect(
+		() =>
+			mergeRegister(
+				registerTablePlugin(editor),
+				registerTableSelectionObserver(editor),
+				registerTableCellUnmergeTransform(editor),
+			),
+		[editor],
+	);
+
+	let table = tables.find(item => item.key === active);
+
+	let remeasure = useCallback(() => {
+		setMetrics(table ? measure(editor, table) : undefined);
+	}, [editor, table]);
+
+	// A ref so `schedule` can stay stable across renders while still calling
+	// the current measurement, which changes whenever the active table does.
+	let latest = useRef(remeasure);
+	latest.current = remeasure;
+
+	let pending = useRef(0);
+	let schedule = useCallback(() => {
+		cancelAnimationFrame(pending.current);
+		pending.current = requestAnimationFrame(() => latest.current());
+	}, []);
+
+	useEffect(() => () => cancelAnimationFrame(pending.current), []);
+
+	/*
+	 * Read the document, and only say so when it has actually changed shape.
+	 *
+	 * Every keystroke fires an update, and `collect` allocates as it walks — so
+	 * publishing unconditionally would re-render the rails and re-measure the
+	 * table once per character typed anywhere in the plan. The measurement
+	 * still has to happen on every update, because typing into a cell widens
+	 * its column, but that is a rectangle read behind a frame rather than a
+	 * pass over the whole tree.
+	 */
+	let last = useRef("");
+	useEffect(() => {
+		let refresh = () => {
+			// An update listener that throws takes every listener after it with
+			// it, including the one that syncs to Yjs. Losing the rails is the
+			// cheapest outcome available and the only acceptable one.
+			try {
+				let next = collect(editor);
+				let json = JSON.stringify(next);
+				if (json !== last.current) {
+					last.current = json;
+					setTables(next);
+					paint(editor, next);
+				}
+				schedule();
+			} catch (err) {
+				console.error("[plan] table rails could not read the document", err);
+			}
+		};
+		refresh();
+		return editor.registerUpdateListener(refresh);
+	}, [editor, schedule]);
+
+	/*
+	 * Repaint the alignment after any render that could have replaced an
+	 * element. Lexical rebuilds a block's element when the block changes, and
+	 * an inline style set on the old one goes with it — so this cannot be left
+	 * to the update above, which deliberately says nothing when the shape has
+	 * not moved.
+	 */
+	useEffect(() => {
+		try {
+			paint(editor, tables);
+		} catch (err) {
+			console.error("[plan] column alignment could not be painted", err);
+		}
+	}, [editor, tables]);
+
+	// Synchronously on a change of table, so switching between two never draws
+	// one frame of rails at the other's coordinates.
+	useLayoutEffect(() => {
+		remeasure();
+	}, [remeasure, tables]);
+
+	/*
+	 * Re-measure whenever anything could have moved the table.
+	 *
+	 * Rectangles go stale for more reasons than the document changing: the pane
+	 * resizes, the document scrolls, and the table scrolls inside itself, which
+	 * is a scroll the document never hears about. Scroll is taken on the
+	 * capture phase rather than from any one element, because which element
+	 * scrolls is not fixed.
+	 */
+	useEffect(() => {
+		if (!table) return;
+
+		window.addEventListener("scroll", schedule, { capture: true, passive: true });
+		window.addEventListener("resize", schedule, { passive: true });
+
+		let element = editor.getElementByKey(table.key);
+		let observer = new ResizeObserver(schedule);
+		if (element) observer.observe(element);
+
+		return () => {
+			window.removeEventListener("scroll", schedule, { capture: true });
+			window.removeEventListener("resize", schedule);
+			observer.disconnect();
+		};
+	}, [editor, table, schedule]);
+
+	/*
+	 * Which table the rails belong to.
+	 *
+	 * Pointer rather than caret alone, so a table can be reshaped without first
+	 * clicking into it — and caret as well, so it can be reshaped with no
+	 * pointer at all.
+	 */
+	let dragging = useRef(false);
+	dragging.current = drag !== undefined;
+	let leaving = useRef(0);
+
+	let hover = useCallback((key: NodeKey | undefined) => {
+		cancelAnimationFrame(leaving.current);
+		if (key) return setActive(key);
+		// A drag holds the pointer captured well outside the rail it started
+		// from, so a leave during one is not a leave.
+		if (dragging.current) return;
+		/*
+		 * Otherwise deferred by a frame: moving from the last cell onto a grip
+		 * leaves the table before it reaches the rail, and clearing at once
+		 * would take the rails out from under a pointer on its way to them.
+		 * The rail's own handler cancels this before it runs.
+		 */
+		leaving.current = requestAnimationFrame(() => setActive(undefined));
+	}, []);
+
+	useEffect(() => {
+		let root = editor.getRootElement();
+		if (!root) return;
+
+		let over = (event: PointerEvent) => {
+			let target = event.target;
+			if (!(target instanceof Node)) return;
+			hover(tables.find(item => editor.getElementByKey(item.key)?.contains(target))?.key);
+		};
+		let out = () => hover(undefined);
+
+		root.addEventListener("pointerover", over);
+		root.addEventListener("pointerleave", out);
+		return () => {
+			root.removeEventListener("pointerover", over);
+			root.removeEventListener("pointerleave", out);
+		};
+	}, [editor, tables, hover]);
+
+	/*
+	 * The caret, so a table can be reshaped with no pointer at all.
+	 *
+	 * Only when it moves into a *different* table, not on every update that
+	 * happens to leave it in one. Otherwise typing in a table would keep
+	 * re-asserting it against a pointer resting somewhere else, and the rails
+	 * would flick between the two as long as somebody kept writing.
+	 */
+	let caret = useRef<NodeKey | undefined>(undefined);
+	useEffect(() => {
+		return editor.registerUpdateListener(() => {
+			editor.getEditorState().read(() => {
+				let selection = $getSelection();
+				let found = $isRangeSelection(selection)
+					? $findTableNode(selection.anchor.getNode())?.getKey()
+					: undefined;
+				if (found === caret.current) return;
+				caret.current = found;
+				if (found) setActive(found);
+			});
+		});
+	}, [editor]);
+
+	let act = useCallback((op: () => void) => editor.update(op), [editor]);
+
+	// Metrics lag the active table by a frame; drawing against the previous
+	// table's rectangles would put the rails somewhere they do not belong.
+	if (disabled || !table || !metrics || metrics.key !== table.key) return null;
+
+	return (
+		<>
+			<Rail
+				axis="column"
+				drag={drag}
+				metrics={metrics}
+				onAct={act}
+				onDrag={setDrag}
+				onHover={hover}
+				table={table}
+				tracks={metrics.columns}
+			/>
+			<Rail
+				axis="row"
+				drag={drag}
+				metrics={metrics}
+				onAct={act}
+				onDrag={setDrag}
+				onHover={hover}
+				table={table}
+				tracks={metrics.rows}
+			/>
+		</>
+	);
+}
+
+type RailProps = {
+	axis: Axis;
+	drag: Drag | undefined;
+	metrics: Metrics;
+	onAct: (op: () => void) => void;
+	onDrag: (drag: Drag | undefined) => void;
+	onHover: (key: NodeKey | undefined) => void;
+	table: Table;
+	tracks: Track[];
+};
+
+function Rail({ axis, drag, metrics, onAct, onDrag, onHover, table, tracks }: RailProps) {
+	let column = axis === "column";
+	let key = table.key;
+	let count = tracks.length;
+	let lines = seams(tracks);
+	// `Axis` is already the word for it.
+	let noun = axis;
+
+	/*
+	 * The track the pointer is on, which is the only one showing a remove
+	 * button.
+	 *
+	 * A cross against every row at once is a rail asking to be misread, and the
+	 * one that matters is always the one being pointed at. Every button is
+	 * rendered regardless, so they all keep their place in the tab order; this
+	 * only decides which of them is drawn.
+	 */
+	let [under, setUnder] = useState<number>();
+
+	/*
+	 * Where the rail sits, in viewport coordinates.
+	 *
+	 * `overflow: hidden` so a column scrolled out of the table's own scroller
+	 * takes its grip with it rather than leaving one floating past the edge.
+	 * The grips lie against the table and the buttons in a lane beyond them, so
+	 * the rail is as deep as the two together.
+	 *
+	 * Half a seam of slack at each end, because the first and last seams sit
+	 * exactly on the table's edges and what is drawn on a seam straddles it:
+	 * without the slack the clip that keeps a scrolled-away grip hidden cuts
+	 * the outermost insert buttons in half, which are the two most likely to
+	 * be wanted.
+	 */
+	let pad = SEAM / 2;
+	let frame = column
+		? {
+			left: metrics.left - pad,
+			top: metrics.top - DEPTH,
+			width: metrics.width + pad * 2,
+			height: DEPTH,
+		}
+		: {
+			left: metrics.left - DEPTH,
+			top: metrics.top - pad,
+			width: DEPTH,
+			height: metrics.height + pad * 2,
+		};
+
+	// Measured against the rail's own edge, slack included, so the two agree.
+	let origin = column ? frame.left : frame.top;
+
+	let mine = drag?.axis === axis ? drag : undefined;
+	let at = mine ? dropSeam(axis, mine.seam) : undefined;
+	let target = mine && at !== undefined ? destination(mine.from, at, count) : undefined;
+
+	let move = (from: number, to: number) =>
+		onAct(() => (column ? $moveColumn(key, from, to) : $moveRow(key, from, to)));
+	let insert = (seam: number) => onAct(() => (column ? $addColumn(key, seam) : $addRow(key, seam)));
+	let remove = (index: number) =>
+		onAct(() => (column ? $removeColumn(key, index) : $removeRow(key, index)));
+
+	let addable = column ? canAddColumn(table.shape) : canAddRow(table.shape);
+	let removable = (index: number) =>
+		column ? canRemoveColumn(table.shape, index) : canRemoveRow(table.shape, index);
+	// Every column may be taken hold of; the header row may not.
+	let holdable = (index: number) => table.shape.simple && (column || index > HEADER);
+
+	return (
+		<div
+			className="plan-rail"
+			data-plan-rail={axis}
+			// Placement is measured, so it is a style rather than a class.
+			style={frame}
+			onPointerOver={() => onHover(key)}
+			onPointerLeave={() => {
+				onHover(undefined);
+				setUnder(undefined);
+			}}
+		>
+			{tracks.map((track, index) => {
+				// `TOOL` is the lane offset: the grips are the lane against the
+				// table, the buttons the one beyond it.
+				let box = gripBox(axis, track, origin, GRIP, TOOL);
+				if (!holdable(index)) {
+					// The header still gets a bar, so the rail does not have a
+					// gap in it where the row everybody can see plainly is.
+					return <div key={index} className="plan-grip is-fixed" style={box} />;
+				}
+				return (
+					<button
+						key={index}
+						type="button"
+						aria-label={`Move ${noun} ${index + 1}`}
+						className={`plan-grip ${mine?.from === index ? "is-held" : ""}`}
+						style={box}
+						title={`Drag to move this ${noun}`}
+						onPointerEnter={() => setUnder(index)}
+						onFocus={() => setUnder(index)}
+						onPointerDown={event => {
+							// Pointer capture rather than window listeners: the
+							// pointer leaves the grip on any real drag, and
+							// capture is what keeps the events coming without a
+							// document-level subscription to tear down.
+							event.currentTarget.setPointerCapture(event.pointerId);
+							onDrag({ axis, from: index, seam: index });
+						}}
+						onPointerMove={event => {
+							if (!event.currentTarget.hasPointerCapture(event.pointerId)) return;
+							onDrag({
+								axis,
+								from: index,
+								seam: seamAt(tracks, column ? event.clientX : event.clientY),
+							});
+						}}
+						onPointerUp={event => {
+							event.currentTarget.releasePointerCapture(event.pointerId);
+							/*
+							 * Recomputed from the event rather than read off
+							 * the render that drew this handler. The last
+							 * pointermove and this can fall in the same frame,
+							 * and a drop that used a destination one move out
+							 * of date would land a column beside where it was
+							 * released with nothing anywhere to say why.
+							 */
+							let seam = dropSeam(
+								axis,
+								seamAt(tracks, column ? event.clientX : event.clientY),
+							);
+							let to = destination(index, seam, count);
+							if (to !== undefined) move(index, to);
+							onDrag(undefined);
+						}}
+						onPointerCancel={() => onDrag(undefined)}
+						onKeyDown={event => {
+							// The whole gesture from the keyboard too: a
+							// reorder that is only ever a drag is a reorder
+							// some people cannot perform at all.
+							if (!event.metaKey && !event.ctrlKey) return;
+							let back = event.key === (column ? "ArrowLeft" : "ArrowUp");
+							let forward = event.key === (column ? "ArrowRight" : "ArrowDown");
+							if (!back && !forward) return;
+							event.preventDefault();
+							move(index, index + (back ? -1 : 1));
+						}}
+					/>
+				);
+			})}
+
+			{
+				/*
+				 * Removal is a sibling of the grip rather than a child of it: a
+				 * button cannot contain a button, and demoting the cross to a
+				 * span would cost it its place in the tab order for the sake of
+				 * the nesting. It sits in the far lane, over the middle of the
+				 * track it removes.
+				 */
+			}
+			{tracks.map((track, index) => {
+				let middle = (track.start + track.end) / 2;
+				// A column carries two buttons, so they sit either side of the
+				// track's middle rather than both on it; a row has only the one.
+				let place = (offset: number) =>
+					seamBox(axis, middle + (column ? offset : 0), origin, TOOL, BUTTON);
+				let shown = under === index ? "" : undefined;
+
+				return (
+					<Fragment key={`tools-${index}`}>
+						{column
+							? (
+								<button
+									type="button"
+									aria-label={`Align ${noun} ${index + 1}, currently ${
+										ALIGN_LABEL[String(table.align[index] ?? null)]
+									}`}
+									className="plan-align"
+									data-plan-align={table.align[index] ?? "default"}
+									data-plan-shown={shown}
+									style={place(-PAIR)}
+									title="Change this column's alignment"
+									onFocus={() => setUnder(index)}
+									onPointerEnter={() => setUnder(index)}
+									onClick={() =>
+										onAct(() => $setAlign(key, index, nextAlign(table.align[index] ?? null)))}
+								/>
+							)
+							: null}
+						{removable(index)
+							? (
+								<button
+									type="button"
+									aria-label={`Remove ${noun} ${index + 1}`}
+									className="plan-grip-remove"
+									data-plan-shown={shown}
+									style={place(PAIR)}
+									title={`Remove this ${noun}`}
+									onFocus={() => setUnder(index)}
+									onPointerEnter={() => setUnder(index)}
+									onClick={() => remove(index)}
+								/>
+							)
+							: null}
+					</Fragment>
+				);
+			})}
+
+			{addable
+				&& lines.map((line, seam) => {
+					// Nothing may be inserted above the header row.
+					if (!column && seam <= HEADER) return null;
+					return (
+						<button
+							key={`insert-${seam}`}
+							type="button"
+							aria-label={seam === 0
+								? `Insert ${noun} before the first`
+								: `Insert ${noun} after ${noun} ${seam}`}
+							className="plan-insert"
+							style={seamBox(axis, line, origin, TOOL, SEAM)}
+							title={`Insert a ${noun} here`}
+							onClick={() => insert(seam)}
+						/>
+					);
+				})}
+
+			{target !== undefined && at !== undefined
+				? (
+					<div
+						aria-hidden="true"
+						className="plan-drop"
+						style={seamBox(axis, lines[at] ?? 0, origin, GRIP, 2, TOOL)}
+					/>
+				)
+				: null}
+		</div>
+	);
+}

--- a/packages/editor/src/table/shape.test.ts
+++ b/packages/editor/src/table/shape.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import { limits } from "@chopin/dialect";
+
+import {
+	canAddColumn,
+	canAddRow,
+	canMoveColumn,
+	canMoveRow,
+	canRemoveColumn,
+	canRemoveRow,
+} from "./shape";
+
+import type { Shape } from "./shape";
+
+function shape(rows: number, columns: number, simple = true): Shape {
+	return { rows, columns, simple };
+}
+
+describe("growing a table", () => {
+	it("allows a row until the dialect's limit is reached", () => {
+		expect(canAddRow(shape(limits.MAX_TABLE_ROWS - 1, 3))).toBe(true);
+		expect(canAddRow(shape(limits.MAX_TABLE_ROWS, 3))).toBe(false);
+	});
+
+	it("allows a column until the dialect's limit is reached", () => {
+		expect(canAddColumn(shape(3, limits.MAX_TABLE_COLUMNS - 1))).toBe(true);
+		expect(canAddColumn(shape(3, limits.MAX_TABLE_COLUMNS))).toBe(false);
+	});
+});
+
+describe("shrinking a table", () => {
+	it("refuses to remove the header row", () => {
+		expect(canRemoveRow(shape(4, 3), 0)).toBe(false);
+		expect(canRemoveRow(shape(4, 3), 1)).toBe(true);
+	});
+
+	it("removes the last body row, leaving a table with only a header", () => {
+		// `| a |\n| - |\n` is well formed and round-trips, so emptying a table
+		// must not require deleting it.
+		expect(canRemoveRow(shape(2, 3), 1)).toBe(true);
+	});
+
+	it("refuses to remove the last column", () => {
+		expect(canRemoveColumn(shape(3, 2), 0)).toBe(true);
+		expect(canRemoveColumn(shape(3, 1), 0)).toBe(false);
+	});
+});
+
+describe("reordering", () => {
+	it("moves a body row", () => {
+		expect(canMoveRow(shape(4, 2), 1, 3)).toBe(true);
+	});
+
+	it("will not move the header row, or move anything above it", () => {
+		expect(canMoveRow(shape(4, 2), 0, 2)).toBe(false);
+		expect(canMoveRow(shape(4, 2), 2, 0)).toBe(false);
+	});
+
+	it("moves any column, header included, because alignment travels with it", () => {
+		expect(canMoveColumn(shape(4, 3), 0, 2)).toBe(true);
+		expect(canMoveColumn(shape(4, 3), 2, 0)).toBe(true);
+	});
+
+	it("does not reorder a table with merged cells", () => {
+		// `$moveTableRow` and `$moveTableColumn` return silently on one of
+		// these, so a grip that offered the drag would do nothing at all.
+		expect(canMoveRow(shape(4, 3, false), 1, 2)).toBe(false);
+		expect(canMoveColumn(shape(4, 3, false), 0, 2)).toBe(false);
+	});
+
+	it("treats a drop where the track already is as no move", () => {
+		expect(canMoveRow(shape(4, 2), 2, 2)).toBe(false);
+		expect(canMoveColumn(shape(4, 3), 1, 1)).toBe(false);
+	});
+});

--- a/packages/editor/src/table/shape.ts
+++ b/packages/editor/src/table/shape.ts
@@ -1,0 +1,94 @@
+/**
+ * What a table is allowed to become.
+ *
+ * Every predicate here is asked *before* the document is touched, because the
+ * alternative is worse than a disabled button. An edit past the dialect's
+ * limits applies locally, syncs cleanly, and is then refused by the server —
+ * which cannot undo a Yjs transaction, so it rebuilds the room under a fresh
+ * epoch and everybody in it loses their undo history and their cursors. A
+ * control that goes grey at a hundred rows costs one person one row.
+ *
+ * Kept free of Lexical so the rules can be tested as arithmetic, which is what
+ * they are.
+ */
+
+import { limits } from "@chopin/dialect";
+
+/** A table's dimensions, as everything here needs them. */
+export type Shape = {
+	/** Every row, the header included. */
+	rows: number;
+	columns: number;
+	/**
+	 * False when any cell spans more than one row or column.
+	 *
+	 * GFM has no way to write a merged cell, so the dialect cannot represent
+	 * one and a plan should never contain one. It can still arrive by paste,
+	 * and `$moveTableRow` and `$moveTableColumn` both return silently rather
+	 * than reorder such a table — so this is carried through to the grips,
+	 * which go inert instead of becoming drags that do nothing.
+	 */
+	simple: boolean;
+};
+
+/**
+ * The header row.
+ *
+ * A GFM table has exactly one and it is always the first, so its index is a
+ * constant rather than a search. Naming it is worth more than the zero it
+ * stands for: most of the rules below are about it.
+ */
+export const HEADER = 0;
+
+export function canAddRow({ rows }: Shape): boolean {
+	return rows < limits.MAX_TABLE_ROWS;
+}
+
+export function canAddColumn({ columns }: Shape): boolean {
+	return columns < limits.MAX_TABLE_COLUMNS;
+}
+
+/**
+ * The header cannot be removed, but the last body row can.
+ *
+ * `| a |\n| - |\n` is a well-formed table with no body, it round-trips, and it
+ * is what somebody clearing a table out is left holding before they refill it.
+ * Refusing that would mean the only way to empty a table is to delete it.
+ */
+export function canRemoveRow(shape: Shape, index: number): boolean {
+	return index > HEADER && index < shape.rows;
+}
+
+/** Unlike a row, the last column cannot go: a table with no columns has no GFM form. */
+export function canRemoveColumn({ columns }: Shape, index: number): boolean {
+	return columns > 1 && index >= 0 && index < columns;
+}
+
+/**
+ * The header row does not move, in either direction.
+ *
+ * Nothing in the document marks a row as the header — being first is the whole
+ * of what makes it one, and the column alignment hangs off its cells. So a drag
+ * that moved it, or moved another row above it, would not reorder the table so
+ * much as change what it claims: two rows would silently swap meaning at the
+ * next save, and the alignment would go with the one that stopped being the
+ * header. There is no gesture that could mean that, so there is none.
+ */
+export function canMoveRow(shape: Shape, from: number, to: number): boolean {
+	if (!shape.simple) return false;
+	if (from === to) return false;
+	return from > HEADER && to > HEADER && from < shape.rows && to < shape.rows;
+}
+
+/**
+ * A column moves whole, header cell included.
+ *
+ * Which is why this has no equivalent of the rule above: the alignment lives on
+ * the header cell of the column it describes, so moving the column moves it too
+ * and the table means afterwards exactly what it meant before.
+ */
+export function canMoveColumn(shape: Shape, from: number, to: number): boolean {
+	if (!shape.simple) return false;
+	if (from === to) return false;
+	return from >= 0 && to >= 0 && from < shape.columns && to < shape.columns;
+}

--- a/packages/editor/src/toolbar/slash.tsx
+++ b/packages/editor/src/toolbar/slash.tsx
@@ -31,6 +31,7 @@ import {
 	ulid,
 } from "@chopin/dialect";
 
+import { $createTableNodeWithDimensions } from "@lexical/table";
 import { $createParagraphNode, $createTextNode, $insertNodes } from "lexical";
 
 import { askForUrl } from "./url";
@@ -110,6 +111,24 @@ const COMMANDS: SlashCommand[] = [
 				let callout = $createCalloutNode();
 				callout.setId(ulid());
 				return callout;
+			}),
+	},
+	{
+		id: "table",
+		label: "Table",
+		group: "Layout",
+		keywords: ["table", "grid", "row", "column", "spreadsheet"],
+		run: editor =>
+			editor.update(() => {
+				/*
+				 * Row headers only.
+				 *
+				 * `includeHeaders: true` would mark the first cell of every row
+				 * as a header too, which renders as a bold shaded column — and
+				 * GFM has no way to write one, so the table would claim
+				 * something on screen that the saved source does not say.
+				 */
+				$insertNodes([$createTableNodeWithDimensions(3, 3, { rows: true, columns: false })]);
 			}),
 	},
 	{

--- a/packages/editor/src/widgets-plugin.tsx
+++ b/packages/editor/src/widgets-plugin.tsx
@@ -16,6 +16,7 @@ import { Cell } from "@mdxeditor/gurx";
 
 import { ChangeObserver } from "./changes-observer";
 import { QuestionnaireObserver } from "./questionnaires";
+import { TableRails } from "./table/rails";
 import { ThreadObserver } from "./threads";
 import { Toolbar } from "./toolbar";
 import { CalloutPlugin, PreviewPlugin, TabsPlugin } from "./widgets";
@@ -56,6 +57,9 @@ export const widgetsPlugin = realmPlugin<WidgetsOptions>({
 		realm.pub(addComposerChild$, TabsPlugin);
 		realm.pub(addComposerChild$, PreviewPlugin);
 		realm.pub(addComposerChild$, CalloutPlugin);
+		// Also where `@lexical/table`'s own plugins are registered, which the
+		// editor otherwise runs without.
+		realm.pub(addComposerChild$, TableRails);
 		realm.pub(addComposerChild$, Toolbar);
 	},
 	update(realm, params) {


### PR DESCRIPTION
Tables were schema and text-in-cells only: no way to add a row, remove a
column, reorder anything, or make one in the first place. `packages/editor`
had no table code at all — not even the plugins `@lexical/table` assumes are
registered.

## What this adds

Hovering a table, or putting the caret in one, raises a rail on each axis: a
grip per column above it and per row beside it. Drag a grip to reorder, press
the cross to remove, press the plus between two grips to insert there. A
column's grip also carries an alignment button, cycling default → left →
centre → right. Everything has a keyboard equivalent — `Ctrl/Cmd+Arrow` on a
focused grip moves it — because a reorder that is only a drag is a reorder
some people cannot perform at all.

`/table` joins the slash menu, and column alignment is finally drawn: it has
round-tripped through MDX all along while the stylesheet hard-coded
`text-align: start` over the top of it.

Also registered, because the editor was running without them:
`registerTablePlugin` (cell navigation, the integrity transforms),
`registerTableSelectionObserver` (cell-range selection), and
`registerTableCellUnmergeTransform`, which keeps a table pasted from HTML to a
shape GFM can actually write — the export visitor ignores spans, so a merged
cell silently redistributed itself at the next save.

## Three things worth reviewing

**The header row does not take part.** It cannot be dragged, dropped onto,
removed, or inserted above. Nothing in the document marks a row as the header:
being first is the whole of what makes it one, and the column alignment hangs
off its cells. A drag that moved it would not reorder the table so much as
change what it claims — two rows would swap meaning at the next save. The last
*body* row can go, though; `| a |` over `| - |` is well formed and round-trips.

**Limits are checked where the button is, not where the document is.** A table
past `MAX_TABLE_ROWS` or `MAX_TABLE_COLUMNS` applies locally, syncs cleanly and
is then refused by the server — which cannot undo a Yjs transaction, so it
rebuilds the room under a fresh epoch and everyone in it loses their undo and
their cursors. `table/shape.ts` is asked before anything is created. Same
argument as `toolbar/url.ts`, one order of magnitude worse.

**The rails are a measured overlay, not chrome in the node.** A `<table>`
cannot contain a `<div>` — the browser hoists a stray one straight back out —
so the `data-plan-chrome` slot that callouts and tabs portal into is not
available at any price. The choice was between subclassing `TableNode` and
reading cell rectangles; reading rectangles is what the selection bubble
already does.

## Two silent failures found on the way

`@lexical/table` paints a selected cell by adding `theme.tableCellSelected` and
does nothing else — no inline style, no fallback — and MDXEditor's
`lexicalTheme` names no table class of any kind. Cell selection was therefore
live and completely invisible, and the next keystroke replaced everything it
covered. The theme entries are in `plan-editor.tsx` beside the `collaboration`
block, which exists for the identical reason.

`$moveTableRow` and `$moveTableColumn` return silently on a table with merged
cells, which is why `shape.ts` carries `simple` and the grips go inert rather
than becoming drags that do nothing.

Both are written down in `agents.md`, along with two mistakes made and fixed
here: a remove button placed in the middle of a grip swallowed the drag it was
drawn beside — intermittently, depending on whether a re-render landed between
the pointer arriving and the button going down — and a rail that passed pointer
events through its gaps blinked out from under a hand moving across it.

## Layout

```
table/shape.ts       what a table permits; the limits live here
table/geometry.ts    seam ↔ index arithmetic and the rail's boxes
table/ops.ts         the Lexical mutations, each guarded by shape.ts
table/rails.tsx      the overlay: measuring, pointers, registration
```

The first three are pure and tested; `rails.tsx` is rectangles and pointers and
the test runtime has no DOM, so it is untested on purpose — the `trail.ts` and
`changes.ts` split.

## Verification

`bun test` (500), `bun run types` and `bun run ci` are green on each of the
three commits independently, and `bun run build` is clean with one copy of
`@lexical/table` in the bundle — two would make every `$isTableNode` return
false in silence, which `table/ops.test.ts` would catch the way
`interop.test.ts` does for the dialect.

Driven in Chrome against a real room as well: insert, remove, drag, keyboard
move and alignment all confirmed against the canonical MDX written to disk. A
column dragged to the end produced `| B | C | A |` with every row following; a
right-align wrote `---:`; a row dragged above the header clamped to just below
it rather than going nowhere.

`agents.md` also had its line counts and test count corrected — they were
already stale before this branch.
