### PR TITLE
Test the frontend with a browser, and run it on every push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+# Two jobs rather than one, because they fail for unrelated reasons and one of
+# them is slow. `checks` answers in about a minute; `browser` has to build the
+# client before it can serve it, and a formatting mistake should not wait
+# behind a Vite build to be reported.
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# A second push supersedes the first. Nothing here is worth finishing for a
+# commit that is no longer the head of the branch.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Matches the version this is developed against. Bun's lockfile format and
+  # its workspace catalogs are both young enough that "latest" is a variable.
+  BUN_VERSION: 1.3.2
+
+jobs:
+  checks:
+    name: format, lint, types, tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      # Refuses rather than resolving: a lockfile that does not describe
+      # package.json is a difference between what was reviewed and what ran.
+      - run: bun install --frozen-lockfile
+
+      # dprint fetches its plugins as wasm from GitHub releases on first use.
+      # Cached on the config that names them, since that is exactly what
+      # decides which ones are wanted.
+      - uses: actions/cache@v6
+        with:
+          path: ~/.cache/dprint
+          key: dprint-${{ runner.os }}-${{ hashFiles('dprint.json') }}
+
+      - run: bun run ci
+
+      - run: bun run types
+
+      # 500 tests, no browser, no agent. `AGENT=off` is set by the tests that
+      # spawn a server; nothing here needs a token.
+      - run: bun test
+
+  browser:
+    name: e2e
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - run: bun install --frozen-lockfile
+
+      # Keyed on the Playwright version and nothing else. Keying on the
+      # lockfile would discard a 180MB browser every time an unrelated
+      # dependency moved.
+      - name: Resolve the Playwright version
+        id: playwright
+        run: |
+          version=$(bun --print 'require("./package.json").devDependencies["@playwright/test"]')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
+      # Run unconditionally, cache hit or not: the browser is cached but the
+      # shared libraries it links against are installed by apt and are not.
+      # With the binary already present this only does the second half.
+      - run: bun node_modules/@playwright/test/cli.js install --with-deps chromium
+
+      # Builds the client, then runs it. The build is deliberately here rather
+      # than inside the Playwright config: web servers start before any global
+      # setup, so a build racing them would leave the suite on the previous
+      # bundle — green, about code nobody changed.
+      - run: bun run e2e
+
+      # Only on failure, and only the parts worth reading. `test-results`
+      # carries the traces; the report is the thing that indexes them.
+      - if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: |
+            e2e/playwright-report
+            e2e/test-results
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@ logs
 # Room state: plans, sidecars and transcripts are local scratch.
 data/
 
+# The same, for rooms the e2e suite makes up, plus what it reports on them.
+e2e/.scratch/
+e2e/test-results/
+e2e/playwright-report/
+e2e/blob-report/
+
 # Editors
 .vscode/*
 !.vscode/extensions.json

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ e2e/blob-report/
 .claude/settings.local.json
 .opencode/*
 
+# Page snapshots the Playwright MCP writes where it is started.
+.playwright-mcp/
+
 # Generated
 **/dist/**
 *.tsbuildinfo

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,7 +1,10 @@
 {
 	"ignorePatterns": [
 		"**/dist/**",
-		"data/**"
+		"data/**",
+		"e2e/.scratch/**",
+		"e2e/test-results/**",
+		"e2e/playwright-report/**"
 	],
 	"categories": {
 		"correctness": "error",

--- a/agents.md
+++ b/agents.md
@@ -15,6 +15,12 @@ bun run build      # production client
 bun run start      # serve the built client
 ```
 
+`.github/workflows/ci.yml` runs all four checks on every push and pull request,
+in two jobs: `bun run ci`, `bun run types` and `bun test` together, and the
+browser suite on its own because it has to build the client first and should
+not make a formatting mistake wait behind Vite. A failed browser run uploads
+its report and traces.
+
 `bun run dev` needs `GITHUB_TOKEN`. `AGENT=off` runs everything except the
 agent, which is what both suites use.
 

--- a/agents.md
+++ b/agents.md
@@ -7,15 +7,34 @@ people running it; this is for people editing it.
 
 ```bash
 bun run dev        # supervisor: Vite + server on one origin, Ctrl-C stops both
-bun test           # 500 tests, no agent spawned
-bun run types      # every package
+bun test           # 500 tests, no browser, no agent spawned
+bun run e2e        # 40 tests, Chromium, builds the client first
+bun run types      # every package, and e2e
 bun run ci         # dprint check && oxlint
 bun run build      # production client
 bun run start      # serve the built client
 ```
 
 `bun run dev` needs `GITHUB_TOKEN`. `AGENT=off` runs everything except the
-agent, which is what the tests use.
+agent, which is what both suites use.
+
+`bun run e2e` needs a browser once: `bun run e2e:browsers`. It builds the
+client, then starts two servers of its own — 8788, and 8789 with the injection
+flags on — so having `bun run dev` open at the same time costs nothing.
+
+To iterate against a server you are already running, skipping the build and the
+supervision, give it the three things the suite assumes and name it:
+
+```bash
+PORT=8790 AGENT=off DATA_DIR="$PWD/e2e/.scratch/8790" \
+  DEV_QUESTIONS=1 DEV_COMMENTS=1 bun apps/server/src/main.ts
+E2E_BASE_URL=http://127.0.0.1:8790 bun node_modules/@playwright/test/cli.js \
+  test --config e2e/playwright.config.ts
+```
+
+The `DATA_DIR` is not decoration: tests that need prose before anybody opens
+the room write it themselves, and they derive where from the port in the base
+URL. Point it elsewhere and they seed a directory the server never reads.
 
 ## Shape
 
@@ -26,6 +45,7 @@ packages/question    1.8k   questionnaires: definition, shared answer, derivatio
 packages/protocol    0.9k   the wire, as types, plus the addressing rule
 apps/server         11.4k   rooms, documents, questions, comments, the agent
 apps/web             1.5k   the three panes
+e2e                  1.0k   the browser suite, and the servers it runs against
 scripts/dev.ts              the development supervisor
 ```
 
@@ -379,6 +399,48 @@ and gives each its own process group so the whole tree can be taken down.
 different address families, which is why the dev server binds `127.0.0.1`
 explicitly rather than `localhost`.
 
+**Bun's runner claims `.spec.` as well as `.test.`.** A Playwright file under
+either name is collected by `bun test`, which then fails on an import it cannot
+satisfy — so the browser suite is `*.e2e.ts` and the Playwright config matches
+that instead of its own default. Naming one `.spec.ts` breaks the unit run, in
+a file the unit run has no business reading.
+
+**Playwright's web servers start before its `globalSetup`.** So a setup that
+checks for the built client is unreachable when there isn't one: the server
+answers 404 for the `dist` it cannot find, Playwright polls for a minute and
+reports a timeout against a URL, and the check that would have explained it
+never runs. The guard is at the top of `playwright.config.ts` instead, which is
+evaluated before anything is started.
+
+**The client is built by `bun run e2e`, not from inside the config.** A build
+racing servers that are already answering would leave the suite testing the
+_previous_ bundle — green, about code nobody changed. `dist` lingers, so
+`playwright test` invoked directly serves whatever was last built; the guard
+only refuses when there is nothing there at all.
+
+**A `globalTeardown` runs while the web servers are still up.** So the obvious
+place to remove the suite's rooms is one where the snapshot debounce writes
+some of them back: the last test's room is saved 500ms after the wipe, and the
+tree ends up mostly empty and never quite. `setup.ts` clears it on the way in
+instead, which is exact — a server writes nothing until a room is opened — and
+leaves a failed run's plan beside the trace that failed on it.
+
+**`context.setOffline` leaves an established socket alone.** It governs what
+may be opened, and by the time there is a connection worth dropping the opening
+has happened — so the editor stays unlocked and a test written the obvious way
+asserts nothing. `page.routeWebSocket` proxies it, and can therefore close it.
+
+**An accessible name matches as a substring.** "Remove row 4" contains "Move
+row 4", so `getByRole("button", { name: "Move row 4" })` resolves to the grip
+_and_ the button that deletes the row, and refuses to act on either. It reads
+as a flaky selector and is a strict-mode violation every time.
+
+**A mark on the prose is not in the DOM.** The related-passage wash is painted
+through `CSS.highlights`, which takes no space and adds no element — that is
+the whole point of it — so it can only be read with `CSS.highlights.get`.
+`data-plan-related` is the fallback for a browser without the registry, and
+asserting on it in Chromium is asserting on the path that never runs.
+
 ## Conventions
 
 Tabs, `let` over `const`, double quotes, no semicolon-free style — `dprint fmt`
@@ -393,12 +455,20 @@ Tests describe behaviour rather than implementation, and their names read as
 sentences about what the system does. Prefer a test that fails when the
 behaviour regresses over one that fails when the code is rearranged.
 
-A few places have no test on purpose. **There is no DOM in the test runtime** —
-no happy-dom, no preload, `document` is undefined — so anything that reaches
-for an element, a rectangle or an observer cannot be covered at all. The answer
-is not to add one but to keep the part worth testing separable from the part
-that needs a browser: `trail.ts` is the whole of the mark lifecycle with no
-document in it, and `changes.ts` is the adapter that has one and is not tested.
+**There is no DOM in the `bun test` runtime** — no happy-dom, no preload,
+`document` is undefined — so anything that reaches for an element, a rectangle
+or an observer cannot be covered there at all. The answer is not to add one but
+to keep the part worth testing separable from the part that needs a browser:
+`trail.ts` is the whole of the mark lifecycle with no document in it, and
+`changes.ts` is the adapter that has one.
+
+The adapters are what `e2e` is for, and only those. A behaviour that can be
+asserted without a browser belongs in `bun test`, which runs in eighteen
+seconds and does not depend on a rectangle being where it was last week —
+measured rails, a pointer drag, a caret painted for somebody else, a wash in
+`CSS.highlights`. Selectors come from roles, labels and the `data-plan-*`
+attributes the product already carries; nothing here has added a `data-testid`,
+and a test that wants one is usually a test asking for the wrong thing.
 
 ## Diagnostics
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "chopin",
       "devDependencies": {
+        "@playwright/test": "1.62.1",
+        "@types/bun": "catalog:bun",
         "@typescript/native-preview": "7.0.0-dev.20260304.1",
         "dprint": "0.50.2",
         "oxlint": "1.51.0",
@@ -579,6 +581,8 @@
     "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.51.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-q3cEoKH6kwjz/WRyHwSf0nlD2F5Qw536kCXvmlSu+kaShzgrA0ojmh45CA81qL+7udfCaZL2SdKCZlLiGBVFlg=="],
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.51.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Q14+fOGb9T28nWF/0EUsYqERiRA7cl1oy4TJrGmLaqhm+aO2cV+JttboHI3CbdeMCAyDI1+NoSlrM7Melhp/cw=="],
+
+    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
 
     "@preact/signals-core": ["@preact/signals-core@1.14.4", "", {}, "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA=="],
 
@@ -1270,6 +1274,10 @@
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
+
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
+
     "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
 
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
@@ -1449,6 +1457,8 @@
     "micromark-extension-math/katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 

--- a/dprint.json
+++ b/dprint.json
@@ -18,7 +18,10 @@
 		"**/node_modules",
 		"**/*-lock.json",
 		"**/*.lock",
-		"data/**"
+		"data/**",
+		"e2e/.scratch/**",
+		"e2e/test-results/**",
+		"e2e/playwright-report/**"
 	],
 
 	"plugins": [

--- a/e2e/collab.e2e.ts
+++ b/e2e/collab.e2e.ts
@@ -1,0 +1,75 @@
+/**
+ * Two people in one room.
+ *
+ * `apps/web/src/collab.test.ts` already runs two providers against a real
+ * server over real sockets, and it cannot see any of this: with no document to
+ * paint into, convergence is asserted on the Yjs tree rather than on the
+ * prose, and presence and carets are not asserted at all. What only exists
+ * once there is a browser is what this file is for.
+ *
+ * Two pages in one context are two people because identity is per tab —
+ * sessionStorage, deliberately, so that two windows on one machine can be two
+ * participants.
+ */
+
+import { content, expect, test } from "./room";
+
+test("an edit by one appears for the other", async ({ join }) => {
+	let ana = await join("ana");
+	let bo = await join("bo");
+
+	await content(ana).click();
+	await ana.keyboard.type("Storage goes on disk as MDX.");
+
+	await expect(content(bo)).toContainText("Storage goes on disk as MDX.");
+
+	// Both ways: the second client is a peer, not a viewer.
+	await content(bo).click();
+	await bo.keyboard.press("End");
+	await bo.keyboard.type(" Readable and diffable.");
+
+	await expect(content(ana)).toContainText("Readable and diffable.");
+});
+
+test("the header names who else is here", async ({ join }) => {
+	let ana = await join("ana");
+	let bo = await join("bo");
+
+	await expect(ana.locator("header").first()).toContainText("with @bo");
+	await expect(bo.locator("header").first()).toContainText("with @ana");
+
+	await bo.close();
+
+	// A roster that keeps naming somebody who closed the tab is worse than no
+	// roster, because it is what you check before assuming you are alone.
+	await expect(ana.locator("header").first()).not.toContainText("with @bo");
+});
+
+test("a peer's caret is drawn, and named", async ({ join }) => {
+	let ana = await join("ana");
+	let bo = await join("bo");
+
+	await content(ana).click();
+	await ana.keyboard.type("Somewhere to put a caret.");
+	await expect(content(bo)).toContainText("Somewhere to put a caret.");
+
+	await content(bo).click();
+	await bo.keyboard.press("End");
+
+	// A person's caret is one of several and its owner is watching it, so the
+	// name is what tells everyone else whose it is.
+	await expect(ana.locator(".plan-cursor")).toHaveCount(1);
+	await expect(ana.locator(".plan-cursor-name")).toHaveText("bo");
+});
+
+test("nobody sees their own caret twice", async ({ join }) => {
+	let ana = await join("ana");
+
+	await content(ana).click();
+	await ana.keyboard.type("Alone in here.");
+
+	// Awareness reflects every socket including your own, so a mirror that
+	// fails to exclude the local client paints a second caret exactly where
+	// the real one is — invisible until somebody selects a word.
+	await expect(ana.locator(".plan-cursor")).toHaveCount(0);
+});

--- a/e2e/editing.e2e.ts
+++ b/e2e/editing.e2e.ts
@@ -1,0 +1,90 @@
+/**
+ * A keystroke, all the way to the file and back.
+ *
+ * Every layer between the two is covered somewhere in `bun test` — the dialect
+ * round-trips, the room validates, the snapshot writes — and none of those
+ * tests can press a key. What is only testable here is that the chain is
+ * connected: an editor whose update listener throws keeps accepting edits and
+ * sends none of them, which looks exactly like a working editor until you
+ * reload.
+ */
+
+import { content, expect, ready, test, written } from "./room";
+
+import type { WebSocketRoute } from "@playwright/test";
+
+test("typing reaches disk as canonical MDX", async ({ join, room }) => {
+	let page = await join("ana");
+
+	await content(page).click();
+	await page.keyboard.type("Ship the thing by Friday.");
+
+	await written(page, room, /Ship the thing by Friday\./);
+});
+
+test("a reload shows what was typed", async ({ join, room }) => {
+	let page = await join("ana");
+
+	await content(page).click();
+	await page.keyboard.type("Ship the thing by Friday.");
+	await written(page, room, /Ship the thing by Friday\./);
+
+	await page.reload();
+	await ready(page);
+
+	await expect(content(page)).toContainText("Ship the thing by Friday.");
+});
+
+test("a markdown shortcut becomes the block it names", async ({ join, room }) => {
+	let page = await join("ana");
+
+	await content(page).click();
+	await page.keyboard.type("# What we are building\n");
+	await page.keyboard.type("A planning surface two people can share.");
+
+	await expect(content(page).getByRole("heading", { level: 1 })).toHaveText(
+		"What we are building",
+	);
+
+	// The heading has to survive as a heading, not as a paragraph that happens
+	// to start with a hash — that is the difference between a document the
+	// agent can edit structurally and one it can only append to.
+	await written(page, room, /^# What we are building$/m);
+	await written(page, room, /^A planning surface two people can share\.$/m);
+});
+
+test("losing the connection locks the plan, and getting it back unlocks it", async ({ join, page }) => {
+	/*
+	 * Routed rather than `context.setOffline`, which leaves an established
+	 * socket alone — it governs what may be opened, and by the time there is
+	 * anything to disconnect the opening has happened. Proxying the socket is
+	 * the only way to be the thing that drops it.
+	 */
+	let sockets: WebSocketRoute[] = [];
+	await page.routeWebSocket("**/ws?**", route => {
+		route.connectToServer();
+		sockets.push(route);
+	});
+
+	await join("ana");
+
+	await content(page).click();
+	await page.keyboard.type("Before the wire went.");
+
+	await sockets.at(-1)!.close();
+
+	// Read-only is the point: an editor that keeps taking keystrokes it cannot
+	// send is worse than one that stops, because the typing looks like it
+	// worked right up until the reload that loses it.
+	await expect(content(page)).toHaveAttribute("contenteditable", "false");
+	await expect(page.locator(".plan-status")).toContainText("Reconnecting");
+	await expect(page.locator(".plan-status")).toHaveAttribute("data-level", "notice");
+
+	// The client retries on its own; nothing here reconnects it. Opening is
+	// driven by the connection rather than by the mount, and a socket that
+	// comes back without re-opening the document would leave the editor
+	// unlocked over a plan quietly short of everyone else's edits.
+	await ready(page);
+	expect(sockets.length).toBeGreaterThan(1);
+	await expect(content(page)).toContainText("Before the wire went.");
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,110 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { defineConfig, devices } from "@playwright/test";
+
+import { FIXTURES, HOST, PLAIN, ROOT, scratch } from "./servers";
+
+/**
+ * An already-running server to use instead of starting one, e.g. `bun run dev`
+ * on 8787. Skips the build and the supervision, which is what makes iterating
+ * on a single test bearable; the sidecar suite needs `DEV_QUESTIONS` and
+ * `DEV_COMMENTS` set on whatever is listening there.
+ */
+let external = process.env.E2E_BASE_URL;
+
+/*
+ * Refuse a client that is not there, here rather than in a global setup.
+ *
+ * The web servers are started *before* `globalSetup` runs, so a check there is
+ * too late to be read: the server answers 404 for a `dist` it cannot find,
+ * Playwright polls it for a minute and then reports a timeout against a URL,
+ * and the setup that would have explained why never runs at all.
+ *
+ * Nothing here builds it either. A build racing servers already answering
+ * would put the suite on the previous bundle — green, about code nobody
+ * changed — so `bun run e2e` builds first and this only insists on the result.
+ */
+if (!external && !existsSync(join(ROOT, "apps/web/dist/index.html"))) {
+	throw new Error(
+		"chopin: no built client to test. Run `bun run e2e`, which builds first,"
+			+ " or `bun run build` before invoking Playwright directly.",
+	);
+}
+
+function server(port: number, extra: Record<string, string>) {
+	return {
+		/*
+		 * Spawned directly rather than through `bun run start`, for the reason
+		 * `scripts/dev.ts` gives: the wrapper does not exit when the thing it
+		 * started dies, so Playwright would end up supervising nothing.
+		 */
+		command: "bun apps/server/src/main.ts",
+		cwd: ROOT,
+		url: `http://${HOST}:${port}/`,
+		env: {
+			PORT: String(port),
+			SERVER_HOST: HOST,
+			// No token, no CLI probe, no turns.
+			AGENT: "off",
+			DATA_DIR: scratch(port),
+			// Named even when off, so an exported flag in somebody's shell
+			// cannot quietly put a questionnaire in every room.
+			DEV_QUESTIONS: "",
+			DEV_COMMENTS: "",
+			...extra,
+		},
+		reuseExistingServer: !process.env.CI,
+		gracefulShutdown: { signal: "SIGTERM" as const, timeout: 2_000 },
+	};
+}
+
+export default defineConfig({
+	testDir: ".",
+
+	/*
+	 * Bun's test runner claims `*.test.*` and `*.spec.*`. A Playwright file
+	 * under either name would be collected by `bun test` and fail there, so
+	 * these are named for the runner that can actually run them.
+	 */
+	testMatch: "**/*.e2e.ts",
+
+	outputDir: "test-results",
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	reporter: process.env.CI
+		? [["github"], ["html", { open: "never", outputFolder: "playwright-report" }]]
+		: [["list"]],
+
+	expect: {
+		// A websocket round trip, a 5ms edit batch and a 500ms save debounce
+		// all sit under some of these assertions.
+		timeout: 10_000,
+	},
+
+	use: {
+		trace: process.env.CI ? "on-first-retry" : "retain-on-failure",
+	},
+
+	// Clears the previous run's rooms. On the way in, because a teardown runs
+	// while the servers are still up and their debounced saves land after it.
+	globalSetup: "./setup.ts",
+
+	projects: [
+		{
+			name: "chromium",
+			testIgnore: "**/sidecar.e2e.ts",
+			use: { ...devices["Desktop Chrome"], baseURL: external ?? `http://${HOST}:${PLAIN}` },
+		},
+		{
+			name: "fixtures",
+			testMatch: "**/sidecar.e2e.ts",
+			use: { ...devices["Desktop Chrome"], baseURL: external ?? `http://${HOST}:${FIXTURES}` },
+		},
+	],
+
+	webServer: external
+		? undefined
+		: [server(PLAIN, {}), server(FIXTURES, { DEV_QUESTIONS: "1", DEV_COMMENTS: "1" })],
+});

--- a/e2e/room.ts
+++ b/e2e/room.ts
@@ -1,0 +1,123 @@
+/**
+ * A room of one's own, per test.
+ *
+ * A room exists because somebody opened its URL, so isolation costs a name
+ * rather than a fixture that has to create and destroy anything. That is what
+ * makes the suite safe to run fully parallel against one server: two tests can
+ * only collide if they choose the same name, and they do not.
+ *
+ * Signing in is a query parameter. `adopt()` writes `?as=` into sessionStorage
+ * before React renders, so a handle in the URL means the form never appears —
+ * there is no login to script, and two pages in one context are two people
+ * because sessionStorage is per tab.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import * as Path from "node:path";
+
+import { expect, test as base } from "@playwright/test";
+
+import { scratch } from "./servers";
+
+import type { Page } from "@playwright/test";
+
+/** Server-side rule: `/^[a-z0-9][a-z0-9-]{0,63}$/`. */
+function name(): string {
+	return `t-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function port(url: string): number {
+	return Number(new URL(url).port);
+}
+
+type Fixtures = {
+	/** The room this test has to itself. */
+	room: string;
+	/** Open the room as somebody. The first call uses the default page. */
+	join: (handle: string) => Promise<Page>;
+	/** Write the room's plan before anyone opens it. */
+	seed: (source: string) => Promise<void>;
+};
+
+export const test = base.extend<Fixtures>({
+	// Playwright reads a fixture's dependencies out of its destructuring
+	// pattern, and refuses a first argument that is not one. A fixture that
+	// depends on nothing therefore has to destructure nothing, which is the
+	// empty pattern the linter is otherwise right about.
+	// eslint-disable-next-line no-empty-pattern
+	room: async ({}, use) => {
+		await use(name());
+	},
+
+	join: async ({ context, page, room }, use) => {
+		let first = true;
+		await use(async handle => {
+			let target = first ? page : await context.newPage();
+			first = false;
+			await target.goto(`/r/${room}?as=${handle}`);
+			await ready(target);
+			return target;
+		});
+	},
+
+	seed: async ({ baseURL, room }, use) => {
+		await use(async source => {
+			let dir = Path.join(scratch(port(baseURL!)), room);
+			await mkdir(dir, { recursive: true });
+			await writeFile(Path.join(dir, "plan.mdx"), source);
+		});
+	},
+});
+
+export { expect };
+
+/**
+ * The editable surface.
+ *
+ * Not `.plan-content`: MDXEditor gives the placeholder the same class as the
+ * surface it sits behind, so that selector matches two elements and only one
+ * of them can be typed into. The role and the label are on the real one in
+ * both states, read-only included, which is what makes them the address for a
+ * thing whose whole point is that it is sometimes locked.
+ */
+export function content(page: Page) {
+	return page.getByRole("textbox", { name: "editable markdown" });
+}
+
+/**
+ * Wait until the plan can be typed into.
+ *
+ * `readOnly` is `offline || busy || !synced`, so an editable surface is the one
+ * honest answer to "is this room open yet" — it covers the socket, the
+ * document arriving, and no agent holding the turn, and it is the same fact
+ * the person in front of it is waiting for.
+ */
+export async function ready(page: Page): Promise<void> {
+	await expect(content(page)).toHaveAttribute("contenteditable", "true", { timeout: 20_000 });
+}
+
+/** The status pane, which keeps its label in the DOM even when it draws nothing. */
+export function status(page: Page) {
+	return page.locator(".plan-status");
+}
+
+/** Where the server writes this room. */
+export function source(page: Page, room: string): string {
+	return Path.join(scratch(port(page.url())), room, "plan.mdx");
+}
+
+/**
+ * Wait for canonical MDX on disk.
+ *
+ * The status pane says "Saved" whenever nothing is pending, including before
+ * anything has been typed, so watching it cannot distinguish "written" from
+ * "not yet started". The file can. This is also the assertion worth making:
+ * saved is supposed to mean the source reached disk, not that the server
+ * acknowledged an edit.
+ */
+export async function written(page: Page, room: string, text: string | RegExp): Promise<void> {
+	let file = source(page, room);
+	await expect
+		.poll(async () => await readFile(file, "utf8").catch(() => ""), { timeout: 15_000 })
+		.toMatch(text);
+}

--- a/e2e/servers.ts
+++ b/e2e/servers.ts
@@ -1,0 +1,42 @@
+/**
+ * Where the servers under test live.
+ *
+ * Shared by the config, which starts them, and by the tests, which have to
+ * find a room's plan on disk. Both must agree on the data directory, and the
+ * config is re-evaluated in every worker process — so the path is derived from
+ * the port rather than generated. A timestamp here would give each worker a
+ * different answer and the seeding tests would write somewhere nobody reads.
+ */
+
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const HOST = "127.0.0.1";
+
+/**
+ * Clear of 8787, which `bun run dev` binds, and of the 8898–8971 band the unit
+ * suites spawn servers on. Somebody with the app already running is the normal
+ * case, not a conflict worth resolving.
+ */
+export const PLAIN = 8788;
+
+/**
+ * A second server, because `DEV_QUESTIONS` and `DEV_COMMENTS` are read from the
+ * environment on every room open. One server would put a questionnaire and a
+ * comment thread into every other suite's room.
+ */
+export const FIXTURES = 8789;
+
+/** The repository root, from this file rather than from the current directory. */
+export const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+/**
+ * A server's `DATA_DIR`.
+ *
+ * Under `e2e/` rather than the system temporary directory so that a failed run
+ * leaves the room's plan beside the trace that failed on it. Cleared by the
+ * next run rather than by this one, for the reason `setup.ts` gives.
+ */
+export function scratch(port: number): string {
+	return join(ROOT, "e2e", ".scratch", String(port));
+}

--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -1,0 +1,27 @@
+/**
+ * Take the previous run's rooms off disk, on the way in.
+ *
+ * Not on the way out, which is where this obviously belongs and where it does
+ * not work: `globalTeardown` runs before the web servers are stopped, and the
+ * snapshot sink writes on a 500ms idle timer, so a room touched by the last
+ * test is saved *after* the wipe. The result was a teardown that removed most
+ * of the tree and left a handful of directories behind — reliably enough to
+ * look deliberate and never quite empty.
+ *
+ * Here it is exact. Global setup runs after the servers have started but
+ * before any test, and a server writes nothing until a room is opened, so at
+ * this moment the directory holds only what an earlier run left.
+ *
+ * It also means a failed run's plan survives beside the trace that failed on
+ * it, which is the reason the scratch directory is under `e2e/` rather than in
+ * the system temporary directory.
+ */
+
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+
+import { ROOT } from "./servers";
+
+export default async function setup(): Promise<void> {
+	await rm(join(ROOT, "e2e", ".scratch"), { recursive: true, force: true });
+}

--- a/e2e/sidecar.e2e.ts
+++ b/e2e/sidecar.e2e.ts
@@ -1,0 +1,198 @@
+/**
+ * Questionnaires and comment threads, without an agent.
+ *
+ * `DEV_QUESTIONS` and `DEV_COMMENTS` exist so that the whole question and
+ * passage path can be exercised by a room opening rather than by a model
+ * deciding to ask something. They are read from the environment on every room
+ * open, so this file runs against a second server — one with them on would put
+ * a question and a thread into every other suite's room.
+ *
+ * A comment needs prose to mark, and a new room seeds from nothing, so every
+ * test here writes the plan before anybody opens it.
+ */
+
+import { content, expect, test } from "./room";
+
+/** Long enough to be marked: the injector wants twenty characters. */
+const PROSE = "Room state lives on disk as MDX beside the transcript.\n";
+
+/** What the injector will quote: the first forty-eight characters. */
+const QUOTED = "Room state lives on disk as MDX beside the trans";
+
+function questionnaire(page: import("@playwright/test").Page) {
+	return page.locator("article[data-plan-sidecar-questionnaire]");
+}
+
+function thread(page: import("@playwright/test").Page) {
+	return page.locator("article[data-plan-sidecar-thread]");
+}
+
+test("a question the room was asked is waiting in the sidecar", async ({ join, seed }) => {
+	await seed(PROSE);
+	let page = await join("ana");
+
+	let card = questionnaire(page);
+	await expect(card).toHaveCount(1);
+	await expect(card.getByRole("heading", { name: "Storage" })).toBeVisible();
+	await expect(card).toContainText("Where should room state live?");
+
+	// Single choice is a radio and multiple choice a checkbox, because the
+	// control is the only thing that says which it is before you try.
+	await expect(card.getByRole("radio", { name: /On disk as MDX/ })).toBeVisible();
+	await expect(card.getByRole("radio", { name: /In SQLite/ })).toBeVisible();
+});
+
+test("answering both questions resolves the card and writes the decision", async ({ join, seed }) => {
+	await seed(PROSE);
+	let page = await join("ana");
+	let card = questionnaire(page);
+
+	await card.getByRole("radio", { name: /On disk as MDX/ }).check();
+
+	// The footer belongs to the questionnaire, not to a question, so it only
+	// appears on the last tab — there is no submitting half of one.
+	await expect(card.getByRole("button", { name: "Submit" })).toHaveCount(0);
+
+	await card.getByRole("tab", { name: "Scope" }).click();
+	await card.getByRole("checkbox", { name: /Anchors/ }).check();
+	await card.getByRole("checkbox", { name: /Export/ }).check();
+
+	await card.getByRole("button", { name: "Submit" }).click();
+
+	// The record owns the answer and the plan shows it. Both have to happen
+	// before anyone is told it is final, so a resolved card is also a promise
+	// about the document.
+	await expect(card).toContainText("On disk as MDX");
+	await expect(card).toContainText("Anchors, Export");
+	await expect(card).toContainText("Answered by @ana");
+	await expect(card.getByRole("button", { name: "Submit" })).toHaveCount(0);
+});
+
+test("an unanswered question refuses to submit and says which", async ({ join, seed }) => {
+	await seed(PROSE);
+	let page = await join("ana");
+	let card = questionnaire(page);
+
+	await card.getByRole("tab", { name: "Scope" }).click();
+	await card.getByRole("checkbox", { name: /Anchors/ }).check();
+	await card.getByRole("button", { name: "Submit" }).click();
+
+	// Not a disabled button: a control that is grey for a reason it will not
+	// give is worse than one that answers when pressed.
+	await expect(card.getByRole("alert")).toHaveText(
+		"Every question needs an answer before submitting.",
+	);
+	await expect(card).not.toContainText("Answered by");
+});
+
+test("cancelling asks first", async ({ join, seed }) => {
+	await seed(PROSE);
+	let page = await join("ana");
+	let card = questionnaire(page);
+
+	await card.getByRole("tab", { name: "Scope" }).click();
+	await card.getByRole("button", { name: "Cancel" }).click();
+
+	await expect(card).toContainText("Cancel without answering?");
+	await card.getByRole("button", { name: "Keep it" }).click();
+
+	await expect(card.getByRole("button", { name: "Submit" })).toBeVisible();
+});
+
+test("a marked passage arrives as a thread quoting the prose", async ({ join, seed }) => {
+	await seed(PROSE);
+	let page = await join("ana");
+
+	let card = thread(page);
+	await expect(card).toHaveCount(1);
+	await expect(card).toContainText("@dev");
+	await expect(card).toContainText(`Is this still right? — "${QUOTED}"`);
+	await expect(card.getByPlaceholder("Reply…")).toBeVisible();
+});
+
+test("the quote becomes a way back into the prose once it is anchored", async ({ join, seed }) => {
+	await seed(PROSE);
+	let page = await join("ana");
+	let card = thread(page);
+
+	// A blockquote until there is somewhere to send a click, a button after —
+	// the same rule an answer already followed, and the reason the whole card
+	// is not the link.
+	let quote = card.getByRole("button", { name: /— show in plan/ });
+	await expect(quote).toBeVisible();
+
+	await quote.click();
+
+	/*
+	 * Read out of the highlight registry, not off an element. The wash takes no
+	 * space and adds nothing to the tree — an agent editing below the fold must
+	 * not shift the sentence somebody is typing in, and neither must a mark
+	 * appearing beside it. `data-plan-related` is only the fallback for a
+	 * browser without `CSS.highlights`, which Chromium is not.
+	 */
+	await expect.poll(() => washed(page)).toBeGreaterThan(0);
+
+	// Clicking pins it, so it survives the pointer leaving; a reader sent
+	// somewhere they were not looking needs it still there when they arrive.
+	await content(page).hover();
+	await expect.poll(() => washed(page)).toBeGreaterThan(0);
+});
+
+/** How many ranges the shared highlight registry is painting for us. */
+function washed(page: import("@playwright/test").Page): Promise<number> {
+	// Document-wide and shared with Lexical's remote cursors, which are named
+	// `lexical-cursor-*`. A collision would silently unpaint somebody else's.
+	return page.evaluate(() => CSS.highlights.get("plan-related")?.size ?? 0);
+}
+
+test("a reply joins the thread", async ({ join, seed }) => {
+	await seed(PROSE);
+	let page = await join("ana");
+	let card = thread(page);
+
+	await card.getByPlaceholder("Reply…").fill("Still right, but say why.");
+	await card.getByRole("button", { name: "Reply" }).click();
+
+	await expect(card).toContainText("Still right, but say why.");
+	await expect(card).toContainText("@ana");
+});
+
+test("accepting asks twice, and says so in the transcript", async ({ join, seed }) => {
+	await seed(PROSE);
+	let page = await join("ana");
+	let card = thread(page);
+
+	// One click relabels, the second commits. Accepting starts an agent turn
+	// and freezes the thread, which is not something to do on a mis-click.
+	await card.getByRole("button", { name: "Accept" }).click();
+	await expect(card.getByRole("button", { name: "Sure?" })).toBeVisible();
+	await card.getByRole("button", { name: "Sure?" }).click();
+
+	// An agent that begins editing for no visible reason is worse than a noisy
+	// log, so the accept writes itself into the transcript first.
+	await expect(page.getByText(/accepted a comment on/)).toBeVisible();
+
+	// A gate on a message is not a gate on a button: accepting reaches
+	// `Chat.instruct` directly, and under AGENT=off it has to say so rather
+	// than open a session.
+	await expect(
+		page.getByText("The agent is not running, so the plan has not been revised."),
+	).toBeVisible();
+
+	// Frozen: the thread is what the room settled, so there is nothing left to
+	// accept or reply to.
+	await expect(card.getByRole("button", { name: "Accept" })).toHaveCount(0);
+	await expect(card.getByPlaceholder("Reply…")).toHaveCount(0);
+	await expect(card).toContainText("Accepted by @ana");
+});
+
+test("a dismissed thread leaves the sidecar", async ({ join, seed }) => {
+	await seed(PROSE);
+	let page = await join("ana");
+	let card = thread(page);
+
+	await card.getByRole("button", { name: "Dismiss" }).click();
+	await card.getByRole("button", { name: "Sure?" }).click();
+
+	await expect(thread(page)).toHaveCount(0);
+});

--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -1,0 +1,68 @@
+/**
+ * The harness proving itself.
+ *
+ * Everything else in this directory assumes a handle in the URL opens a named
+ * room and leaves an editable plan on screen. If that is not true the rest of
+ * the suite fails in six different ways with six different explanations, so it
+ * is worth one file that fails in one.
+ */
+
+import { content, expect, ready, test } from "./room";
+
+test("a handle in the URL joins without the form", async ({ join, room }) => {
+	let page = await join("ana");
+
+	await expect(page.getByRole("heading", { name: "GitHub handle" })).toHaveCount(0);
+	await expect(page.getByLabel("GitHub handle")).toHaveCount(0);
+	await expect(page.locator("header").first()).toContainText(`/r/${room}`);
+	await expect(page.locator("header").first()).toContainText("@ana");
+});
+
+test("the address bar keeps the handle and loses the key", async ({ page, room }) => {
+	await page.goto(`/r/${room}?as=ana&key=hunter2`);
+	await ready(page);
+
+	// The handle is not a secret and seeing it helps when two windows are open.
+	// The key is, and these sessions get screen shared.
+	expect(page.url()).toContain("as=ana");
+	expect(page.url()).not.toContain("hunter2");
+});
+
+test("a visitor with no handle is asked for one", async ({ page }) => {
+	await page.goto("/");
+
+	await expect(page.getByLabel("GitHub handle")).toBeVisible();
+	await expect(page.getByRole("button", { name: "Join" })).toBeDisabled();
+
+	await page.getByLabel("GitHub handle").fill("ana");
+	await expect(page.getByRole("button", { name: "Join" })).toBeEnabled();
+	await page.getByRole("button", { name: "Join" }).click();
+
+	await ready(page);
+});
+
+test("a path with no room becomes the default room", async ({ page }) => {
+	await page.goto("/?as=ana");
+	await ready(page);
+
+	// Rewritten rather than offered as a choice, and rewritten in place: a
+	// reload has to land on the same room, not on the chooser again.
+	await expect(page).toHaveURL(/\/r\/main(\?|$)/);
+});
+
+test("the three panes are all present", async ({ join }) => {
+	let page = await join("ana");
+
+	await expect(page.getByText("Planner", { exact: true })).toBeVisible();
+	await expect(content(page)).toBeVisible();
+	await expect(page.locator(".plan-decisions")).toBeVisible();
+});
+
+test("an empty room settles rather than loading forever", async ({ join }) => {
+	let page = await join("ana");
+
+	// "Saved" is the resting state and it draws nothing, so the assertion is
+	// on the label the status pane keeps for a screen reader either way.
+	await expect(page.locator(".plan-status")).toContainText("Saved");
+	await expect(page.locator(".plan-status")).toHaveAttribute("data-level", "hidden");
+});

--- a/e2e/table.e2e.ts
+++ b/e2e/table.e2e.ts
@@ -1,0 +1,226 @@
+/**
+ * The rails, which cannot be tested any other way.
+ *
+ * `geometry.ts`, `ops.ts` and `shape.ts` are covered by `bun test` because
+ * they were deliberately kept free of the document. What is left here is the
+ * part that measures cell rectangles and turns a pointer into a reorder, and
+ * measurement needs layout: happy-dom returns zero for every rectangle, which
+ * makes a rail drawn in the right place and one drawn on top of itself
+ * indistinguishable.
+ *
+ * The rails are also where the header row's furniture-not-a-row rule is
+ * actually visible. A header that could be dragged would not reorder the table
+ * so much as change what it claims, and the only place that rule exists is in
+ * which elements get rendered.
+ */
+
+import { content, expect, test } from "./room";
+
+import type { Locator, Page } from "@playwright/test";
+
+/** Header plus three body rows, each nameable. */
+const TABLE = [
+	"| Item  | Note |",
+	"| ----- | ---- |",
+	"| one   | a    |",
+	"| two   | b    |",
+	"| three | c    |",
+	"",
+].join("\n");
+
+/** Raise the rails the way a reader does, and hand back the row one. */
+async function rails(page: Page): Promise<Locator> {
+	await content(page).locator("td").first().hover();
+	let rail = page.locator('[data-plan-rail="row"]');
+	await expect(rail).toBeVisible();
+	return rail;
+}
+
+/**
+ * The first cell of every body row, in document order.
+ *
+ * No `tbody` in the selector: Lexical builds the table by appending rows to the
+ * element itself, and the section browsers insert while parsing HTML is not
+ * inserted for a tree that was constructed. A header cell is a `th`, so `td`
+ * alone is already "body row".
+ */
+function items(page: Page): Locator {
+	return content(page).locator("tr > td:first-child");
+}
+
+/**
+ * A grip, addressed exactly.
+ *
+ * "Remove row 4" contains "Move row 4", and an accessible name matches as a
+ * substring unless it is told not to — so the obvious locator resolves to the
+ * grip *and* the remove button beside it, and refuses to act on either.
+ */
+function grip(rail: Locator, axis: "row" | "column", index: number): Locator {
+	return rail.getByRole("button", { name: `Move ${axis} ${index}`, exact: true });
+}
+
+test("hovering a table raises rails on both axes", async ({ join, seed }) => {
+	await seed(TABLE);
+	let page = await join("ana");
+
+	await expect(page.locator(".plan-rail")).toHaveCount(0);
+
+	await content(page).locator("td").first().hover();
+
+	await expect(page.locator('[data-plan-rail="row"]')).toBeVisible();
+	await expect(page.locator('[data-plan-rail="column"]')).toBeVisible();
+});
+
+test("the header row is drawn a bar, not a grip", async ({ join, seed }) => {
+	await seed(TABLE);
+	let page = await join("ana");
+	let rail = await rails(page);
+
+	// A bar and not a gap: a rail with a hole where a row plainly is reads as
+	// a bug, so the header is drawn and simply cannot be taken hold of.
+	await expect(rail.locator(".plan-grip.is-fixed")).toHaveCount(1);
+	await expect(rail.getByRole("button", { name: "Move row 1" })).toHaveCount(0);
+	await expect(rail.getByRole("button", { name: "Remove row 1" })).toHaveCount(0);
+
+	// Nor can anything be put above it. The first seam a row can use is the
+	// one below the header.
+	await expect(rail.getByRole("button", { name: "Insert row before the first" })).toHaveCount(0);
+	await expect(rail.getByRole("button", { name: "Insert row after row 1" })).toBeAttached();
+
+	// Every body row can be moved.
+	await expect(rail.getByRole("button", { name: /^Move row / })).toHaveCount(3);
+});
+
+test("a grip moves its row from the keyboard", async ({ join, seed }) => {
+	await seed(TABLE);
+	let page = await join("ana");
+	let rail = await rails(page);
+
+	await expect(items(page)).toHaveText(["one", "two", "three"]);
+
+	// A reorder that is only ever a drag is a reorder some people cannot
+	// perform at all.
+	await grip(rail, "row", 2).focus();
+	await page.keyboard.press("Meta+ArrowDown");
+
+	await expect(items(page)).toHaveText(["two", "one", "three"]);
+});
+
+test("a grip drags its row, and says where it will land", async ({ join, seed }) => {
+	await seed(TABLE);
+	let page = await join("ana");
+	let rail = await rails(page);
+
+	let held = grip(rail, "row", 2);
+	let from = (await held.boundingBox())!;
+	let table = (await content(page).locator("table").boundingBox())!;
+
+	await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+	await page.mouse.down();
+	await expect(held).toHaveClass(/is-held/);
+
+	// Past the bottom of the table: the nearest seam is then the last one, so
+	// the destination cannot depend on where a row's midpoint happens to fall.
+	await page.mouse.move(from.x + from.width / 2, table.y + table.height + 8);
+
+	// Drawn on the seam the drop will use, because deciding it twice is how
+	// the line ends up promising one thing and the drop doing another.
+	await expect(page.locator(".plan-drop")).toBeVisible();
+
+	await page.mouse.up();
+
+	await expect(items(page)).toHaveText(["two", "three", "one"]);
+	await expect(page.locator(".plan-drop")).toHaveCount(0);
+});
+
+test("a drag that ends where it started writes nothing", async ({ join, seed }) => {
+	await seed(TABLE);
+	let page = await join("ana");
+	let rail = await rails(page);
+
+	let box = (await grip(rail, "row", 2).boundingBox())!;
+
+	await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+	await page.mouse.down();
+
+	// Either seam bounding the row is where it already is, so there is nothing
+	// to indicate and nothing to commit — a no-op edit still costs everyone in
+	// the room a sync.
+	await expect(page.locator(".plan-drop")).toHaveCount(0);
+
+	await page.mouse.up();
+	await expect(items(page)).toHaveText(["one", "two", "three"]);
+});
+
+test("a row can be removed once its grip is pointed at", async ({ join, seed }) => {
+	await seed(TABLE);
+	let page = await join("ana");
+	let rail = await rails(page);
+
+	// The remove button has no pointer events until the track it belongs to is
+	// the one under the pointer, so the grip has to be hovered first. Clicking
+	// it cold waits for actionability until the test times out.
+	await grip(rail, "row", 4).hover();
+	await expect(rail.getByRole("button", { name: "Remove row 4" })).toHaveAttribute(
+		"data-plan-shown",
+		"",
+	);
+	await rail.getByRole("button", { name: "Remove row 4" }).click();
+
+	await expect(items(page)).toHaveText(["one", "two"]);
+});
+
+test("the last body row can go, and the table survives it", async ({ join, seed }) => {
+	// `| a |\n| - |\n` is well formed and round-trips, so refusing this would
+	// make deleting the table the only way to empty it.
+	await seed("| Item |\n| ---- |\n| one  |\n");
+	let page = await join("ana");
+	let rail = await rails(page);
+
+	await grip(rail, "row", 2).hover();
+	await rail.getByRole("button", { name: "Remove row 2" }).click();
+
+	await expect(content(page).locator("table")).toHaveCount(1);
+	await expect(content(page).locator("th")).toHaveCount(1);
+	await expect(items(page)).toHaveCount(0);
+});
+
+test("a column's alignment cycles, and the last column cannot be removed", async ({ join, seed }) => {
+	await seed("| Item |\n| ---- |\n| one  |\n");
+	let page = await join("ana");
+
+	await content(page).locator("td").first().hover();
+	let rail = page.locator('[data-plan-rail="column"]');
+	await expect(rail).toBeVisible();
+
+	await grip(rail, "column", 1).hover();
+	let align = rail.getByRole("button", { name: /^Align column 1/ });
+	await expect(align).toHaveAttribute("data-plan-align", "default");
+
+	await align.click();
+	await expect(align).toHaveAttribute("data-plan-align", "left");
+
+	// The alignment hangs off the header's cells, which is the other half of
+	// why the header is not a row.
+	await expect(rail.getByRole("button", { name: "Remove column 1" })).toHaveCount(0);
+});
+
+test("a table at its row limit offers nowhere to add another", async ({ join, seed }) => {
+	// The limit counts the header, so this is exactly at it. Asked here rather
+	// than at the server, because a table the server refuses costs everybody
+	// in the room their undo and their cursors under a fresh epoch.
+	let rows = Array.from({ length: 99 }, (_, index) => `| r${index} | x |`);
+	await seed(["| Item | Note |", "| ---- | ---- |", ...rows, ""].join("\n"));
+
+	let page = await join("ana");
+	let rail = await rails(page);
+
+	// Gone rather than disabled: the seam it would have inserted at does not
+	// exist, so there is nothing for a greyed button to be about.
+	await expect(rail.getByRole("button", { name: /^Insert row / })).toHaveCount(0);
+
+	// The column rail is unaffected — the limits are per axis.
+	await expect(
+		page.locator('[data-plan-rail="column"]').getByRole("button", { name: /^Insert column / }),
+	).not.toHaveCount(0);
+});

--- a/e2e/toolbar.e2e.ts
+++ b/e2e/toolbar.e2e.ts
@@ -1,0 +1,155 @@
+/**
+ * The two things that appear because of where the caret is.
+ *
+ * Both are placed by measurement against a live rectangle, so neither can be
+ * covered by `bun test` — `bubble.test.ts` and `slash.test.ts` cover the
+ * decisions those measurements feed, and stop at the point where a browser is
+ * required. Everything here is on the other side of that line.
+ */
+
+import { content, expect, test, written } from "./room";
+
+let MENU = { name: "Insert block" };
+let BUBBLE = { name: "Text formatting" };
+
+test("a slash at the start of a word offers blocks to insert", async ({ join }) => {
+	let page = await join("ana");
+
+	await content(page).click();
+	await page.keyboard.type("/");
+
+	let menu = page.getByRole("listbox", MENU);
+	await expect(menu).toBeVisible();
+	await expect(menu.getByRole("option", { name: "Table" })).toBeVisible();
+	await expect(menu.getByRole("option", { name: "Callout" })).toBeVisible();
+
+	// Substring over label and keywords, so a query narrows rather than
+	// resetting: "tab" keeps Table because "table" contains it.
+	await page.keyboard.type("call");
+	await expect(menu.getByRole("option")).toHaveCount(1);
+	await expect(menu.getByRole("option")).toHaveText("Callout");
+});
+
+test("a slash inside a word is just a slash", async ({ join }) => {
+	let page = await join("ana");
+
+	await content(page).click();
+	await page.keyboard.type("and/or");
+
+	// The menu opening on every path separator would make prose containing one
+	// unwritable, which is most prose about software.
+	await expect(page.getByRole("listbox", MENU)).toHaveCount(0);
+});
+
+test("escape closes the menu and leaves what was typed", async ({ join }) => {
+	let page = await join("ana");
+
+	await content(page).click();
+	await page.keyboard.type("/tab");
+	await expect(page.getByRole("listbox", MENU)).toBeVisible();
+
+	await page.keyboard.press("Escape");
+
+	await expect(page.getByRole("listbox", MENU)).toHaveCount(0);
+	await expect(content(page)).toContainText("/tab");
+});
+
+test("choosing a table inserts one, with a header", async ({ join }) => {
+	let page = await join("ana");
+
+	await content(page).click();
+	await page.keyboard.type("/table");
+	await page.getByRole("listbox", MENU).getByRole("option", { name: "Table" }).click();
+
+	await expect(content(page).locator("table")).toHaveCount(1);
+	await expect(content(page).locator("th")).toHaveCount(3);
+	await expect(content(page).locator("tr")).toHaveCount(3);
+
+	// The query that summoned it has to go: leaving "/table" above the table
+	// is the menu writing its own invocation into the document.
+	await expect(content(page)).not.toContainText("/table");
+});
+
+test("a selection raises exactly one toolbar", async ({ join }) => {
+	let page = await join("ana");
+
+	await content(page).click();
+	await page.keyboard.type("Pick a storage format.");
+	await page.keyboard.press("Shift+Home");
+
+	// Two toolbars is the ported defect: one from the plugin list and one from
+	// the surface, stacked, so the top one takes every click and the other is
+	// only visible as a shadow slightly out of register.
+	await expect(page.getByRole("toolbar", BUBBLE)).toHaveCount(1);
+});
+
+test("a mark from the toolbar reaches the file", async ({ join, room }) => {
+	let page = await join("ana");
+
+	await content(page).click();
+	await page.keyboard.type("Pick a storage format.");
+	await page.keyboard.press("Shift+Home");
+
+	let bubble = page.getByRole("toolbar", BUBBLE);
+	await expect(bubble.getByRole("button", { name: "Bold" })).toHaveAttribute(
+		"aria-pressed",
+		"false",
+	);
+	await bubble.getByRole("button", { name: "Bold" }).click();
+	await expect(bubble.getByRole("button", { name: "Bold" })).toHaveAttribute(
+		"aria-pressed",
+		"true",
+	);
+
+	await written(page, room, /^\*\*Pick a storage format\.\*\*$/m);
+});
+
+test("the block type menu converts the block it names", async ({ join, room }) => {
+	let page = await join("ana");
+
+	await content(page).click();
+	await page.keyboard.type("What we are building");
+	await page.keyboard.press("Shift+Home");
+
+	let bubble = page.getByRole("toolbar", BUBBLE);
+	await bubble.getByRole("button", { name: "Block type: Text" }).click();
+
+	// The submenu replaces the toolbar's contents rather than opening beside
+	// it, so there is never a second popup to decide between.
+	await expect(bubble.getByRole("button", { name: "Bold" })).toHaveCount(0);
+	await bubble.getByRole("button", { name: "Heading 2" }).click();
+
+	await expect(content(page).getByRole("heading", { level: 2 })).toHaveText(
+		"What we are building",
+	);
+	await written(page, room, /^## What we are building$/m);
+});
+
+test("the link prompt refuses a scheme the dialect will not carry", async ({ join, room }) => {
+	let page = await join("ana");
+
+	await content(page).click();
+	await page.keyboard.type("Read the docs.");
+	await page.keyboard.press("Shift+Home");
+
+	let said: string[] = [];
+	page.on("dialog", async dialog => {
+		said.push(dialog.message());
+		await (dialog.type() === "prompt"
+			? dialog.accept("javascript:alert(1)")
+			: dialog.dismiss());
+	});
+
+	await page.getByRole("toolbar", BUBBLE).getByRole("button", { name: "Add link" }).click();
+
+	/*
+	 * Refused where the button is, not where the document is. A URL the
+	 * dialect rejects applies locally, syncs, and is then refused by the
+	 * server — which cannot undo a Yjs transaction, so it rebuilds the room
+	 * under a fresh epoch and everybody in it loses their cursors.
+	 */
+	await expect.poll(() => said).toContain("Only https:, mailto:, relative paths are allowed here.");
+	await expect(content(page).locator("a")).toHaveCount(0);
+
+	await written(page, room, /^Read the docs\.$/m);
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"extends": [
+		"../tsconfig.json"
+	],
+	"include": [
+		"."
+	],
+	"compilerOptions": {
+		"target": "esnext",
+		"lib": ["esnext", "dom", "dom.iterable"],
+		"types": ["bun"],
+
+		"noUnusedLocals": true,
+		"noUnusedParameters": true
+	}
+}

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://opencode.ai/config.json",
+
+	"mcp": {
+		"playwright": {
+			"type": "local",
+			"command": [
+				"bunx",
+				"@playwright/mcp@0.0.78",
+				"--browser",
+				"chrome",
+				"--isolated"
+			],
+			"enabled": true
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -8,9 +8,14 @@
 		"start": "bun run --filter '@chopin/server' start",
 		"ci": "dprint check && oxlint",
 		"fix": "dprint fmt && oxlint --fix",
-		"types": "bun --filter '*' types"
+		"types": "bun --filter '*' types && tsgo --noEmit --skipLibCheck -p e2e",
+		"e2e": "bun run build && bun node_modules/@playwright/test/cli.js test --config e2e/playwright.config.ts",
+		"e2e:ui": "bun run build && bun node_modules/@playwright/test/cli.js test --config e2e/playwright.config.ts --ui",
+		"e2e:browsers": "bun node_modules/@playwright/test/cli.js install chromium"
 	},
 	"devDependencies": {
+		"@playwright/test": "1.62.1",
+		"@types/bun": "catalog:bun",
 		"@typescript/native-preview": "7.0.0-dev.20260304.1",
 		"dprint": "0.50.2",
 		"oxlint": "1.51.0"

--- a/readme.md
+++ b/readme.md
@@ -126,14 +126,20 @@ Three things are worth knowing if you intend to change it:
 ## Development
 
 ```bash
-bun test          # 230 tests
-bun run types     # every package
+bun test          # 500 tests, no browser
+bun run e2e       # 40 tests in Chromium, against the built client
+bun run types     # every package, and e2e
 bun run ci        # dprint + oxlint
 bun run build     # production client
 bun run start     # serve the built client
 ```
 
-Tests never spawn an agent; they set `AGENT=off`.
+Neither suite spawns an agent; both set `AGENT=off`.
+
+The browser suite needs Chromium once — `bun run e2e:browsers` — and builds the
+client each run, so it is the slower of the two by some distance. It starts its
+own servers on 8788 and 8789 and gives every test a room of its own, so it does
+not mind you having `bun run dev` open at the same time.
 
 If you are going to change the code, `agents.md` is the companion to this
 file: how a room works, which decisions were deliberate, and the several


### PR DESCRIPTION
Six adapters in this codebase could not be tested and could not have been: measured table rails, a pointer drag, a caret painted for somebody else, a wash in `CSS.highlights`. `bun test` has no DOM and should not grow one — happy-dom returns zero for every rectangle, so a rail drawn in the right place and one drawn on top of itself pass the same assertion.

Three commits: the suite, the MCP server that drives the same browser by hand, and CI.

## The suite

40 tests in Chromium against the built client, 10 seconds, fully parallel.

| File | Covers |
| --- | --- |
| `smoke` | `?as=` joins without the form, key stripped from the URL, `/` → `/r/main`, three panes, an empty room settles |
| `editing` | keystroke to `plan.mdx`, reload, `# ` becomes a heading, a dropped socket locks the plan and reconnecting unlocks it |
| `collab` | convergence both ways, the roster, a named peer caret, no self-caret |
| `table` | rails on both axes, header-is-furniture, keyboard move, a real pointer drag with drop indicator, remove, alignment cycle, row limit |
| `toolbar` | slash menu opens/filters/escapes, `and/or` does not trigger it, exactly one bubble, bold and heading reach the file, `javascript:` refused |
| `sidecar` | questionnaire answer/refuse/cancel, thread quote as a link, reply, two-click accept, dismiss |

A room exists because somebody opened its URL, so isolation costs a name rather than a fixture. Two servers, started by the suite: 8788, and 8789 with `DEV_QUESTIONS`/`DEV_COMMENTS` on — those are read on every room open, so one server would put a questionnaire in every other suite's room.

`bun test` is untouched: still 500 pass in 18s, and it never sees these files.

## Things that had to be found the hard way

Each of these is now an entry in `agents.md`, because each looked like working code.

- **Bun's runner claims `.spec.` as well as `.test.`** — the conventional Playwright name enrols every one of these in the unit run, which cannot import them. Hence `*.e2e.ts`.
- **Playwright's web servers start before `globalSetup`.** A dist check there is unreachable: verified by deleting `dist` and getting 60s of polling and a timeout naming a URL. The guard is top-level in the config now, and fails instantly with a sentence.
- **`globalTeardown` runs while the servers are still up.** The snapshot sink debounces 500ms, so it wrote rooms back *after* the wipe — the tree ended up mostly empty and never quite. Cleanup moved to the way in, which is exact, and leaves a failed run's plan beside the trace that failed on it.
- **`context.setOffline` leaves an established socket alone.** The offline test asserted nothing until it became `page.routeWebSocket`.
- **`"Remove row 4"` contains `"Move row 4"`.** Accessible names match as substrings, so the obvious grip locator is a strict-mode violation every time.
- **`data-plan-related` never runs in Chromium.** The wash is `CSS.highlights`; asserting on the attribute asserts on the fallback path.

## MCP

`@playwright/mcp` pinned by version, run through `bunx`, so nothing enters `bun.lock`. Every release of it depends on a prerelease `playwright`, and a devDependency would put an alpha and a second `playwright-core` in the lockfile of a project that ships neither. `--browser chrome` avoids a redundant 180MB download.

Probed over stdio before committing: 24 tools, navigates, and it drove the questionnaire end to end — answered both tabs, submitted, and both halves of the two-phase resolution landed (`state.json` says `answered`, `plan.mdx` carries `<Answer value="Anchors, Export" />`).

## CI

Two jobs on `ubuntu-latest`, push to `main` and every PR, superseded runs cancelled.

- `checks` — `bun run ci`, `bun run types`, `bun test`
- `browser` — `playwright install --with-deps chromium`, `bun run e2e`

Separate because they fail for unrelated reasons and only one is slow; a missing blank line should not wait behind Vite. Caches keyed on what decides their contents: dprint on the config naming its wasm plugins, Playwright on its own version rather than the lockfile. Failures upload the report and traces.

## Verification

Replayed in a clean `/tmp` checkout from `git ls-files` — no `node_modules`, no build:

```
bun install --frozen-lockfile   1.78s, 1028 packages
bun run ci                      0
bun run types                   0
bun test                        0    500 pass
playwright install --with-deps  0
CI=true bun run e2e             0    40 passed
```

The first commit was then checked out into its own worktree and put through all five again, so the series is green at every point, not just at the tip. Confirmed the linux-x64 binaries for `tsgo`, `dprint` and `oxlint` are all in the lockfile.

## Worth pushing back on

- **Ubuntu only.** This is developed on macOS and nothing verifies that path in CI. A matrix is a two-line change.
- **`bun run ci` still means `dprint check && oxlint`**, not "what CI runs". I left the name alone rather than redefine a script you may use as a pre-commit check; the workflow lists the four commands explicitly.
- **`@types/bun` moved to the root** because the catalog copies are nested per workspace and `e2e` is not one. Making it a workspace purely to be typechecked seemed the heavier answer.