### PR TITLE
Let the planner reach for a diagram or a formula

### DIFF
--- a/apps/server/src/agent/planner.ts
+++ b/apps/server/src/agent/planner.ts
@@ -191,9 +191,22 @@ is parsed and rendered — so there are no imports, no exports, no \`{}\`
 expressions, and no raw HTML. Anything outside this list is rejected.
 
 Markdown: headings, paragraphs, lists, tables, blockquotes, thematic breaks,
-code fences, math, footnotes, links (\`https:\` and \`mailto:\` only, plus
-repository-relative paths), and images. Use a \`${MERMAID_LANGUAGE}\` fence for
-diagrams. Images are referenced by absolute \`https:\` URL.
+code fences, footnotes, links (\`https:\` and \`mailto:\` only, plus
+repository-relative paths), and images. Images are referenced by absolute
+\`https:\` URL.
+
+Diagrams and formulas both render, and both are worth reaching for. A
+\`${MERMAID_LANGUAGE}\` fence draws a diagram — use one wherever the plan
+describes a flow, a sequence or a state machine, where the shape carries what
+a paragraph can only approximate. Set a formula wherever the plan turns
+quantitative — a cost model, a bound, a threshold — rather than spelling the
+arithmetic out in prose: \`$…$\` inline, and \`$$\` on its own lines around a
+displayed one.
+
+Those delimiters and no others. \`\\(…\\)\` and \`\\[…\\]\` are not math here:
+they parse as ordinary prose, nothing rejects them, and the backslashes are
+eaten on the way out — so \`\\(r = n/t\\)\` is saved as \`(r = n/t)\` and reads
+like prose somebody meant to write.
 
 Components:
 


### PR DESCRIPTION
Both already worked end to end. `math` and `inlineMath` are in the dialect's node allowlist with a `MathNode` behind them and KaTeX rendering in front, a `mermaid` fence renders to SVG, and the slash menu offers a human either one in a keystroke. The agent — which writes most of the plan — was given the bare word "math" inside a list of node names, with no delimiters anywhere.

## Why it needed saying

Guessing the wrong delimiters produces no error of any kind:

| written | validates | parses as | saved as |
| --- | --- | --- | --- |
| `$r = n / t$` | yes | `inlineMath` | `$r = n / t$` |
| `$$\nt = n / r\n$$` | yes | `math` | unchanged |
| `\(r = n / t\)` | yes | `text` | `(r = n / t)` |
| `\[t = n / r\]` | yes | `text` | `\[t = n / r]` |

`\(…\)` is the more common LaTeX convention and so the likelier guess. It is not rejected — it parses as ordinary prose, and markdown eats the backslashes on the way out, so it lands in the plan as `(r = n/t)` and reads like a sentence somebody meant to write. Nothing anywhere would surface it. `\[…\]` survives half-escaped, which is no better for being different.

The other half is framing. That paragraph is the allowlist, so naming a construct in it says only that it will not be refused. Callout and Tabs each get a clause on when they earn their place; a diagram and a formula had none, under a standing instruction that prose is the default. The new paragraph sits before the components, so that damper still reads as being about components.

## The escaping

The counter-example is written `\\(…\\)` in the source. A template literal turns `\(` into `(`, so the obvious spelling would have shipped an instruction about parentheses — silently, in a prompt that nothing tests. Verified by printing `planner.prompt` and reading the rendered output rather than the source, which is the only check that means anything here.

## Checks

`bun run ci`, `bun run types` and `bun test` (500 pass) are clean. Nothing in this change is behaviour and there is no `planner.test.ts` to extend, so no test was added.

## Left undone

The markdown half of that section is still hand-written prose restating `NODES`, `LINK_PROTOCOLS` and `IMAGE_PROTOCOLS`, with nothing tying it to them. This does not widen the gap, but it does leave that as the only part of the dialect description able to drift without anything noticing — and the first draft of this very change asserted that `\(…\)` lands as literal backslashes, which is false. Running it through `parse` and `serialize` is what caught it.
