### PR TITLE
Add two-stop shadow scale tokens

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -40,7 +40,7 @@ function SignIn({ onDone }: { onDone: (handle: string) => void }) {
 				<label className="text-sm font-medium" htmlFor="handle">GitHub handle</label>
 				<input
 					autoFocus
-					className="rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:border-ring"
+					className="rounded-md border border-input bg-background px-3 py-2 text-sm focus-visible:border-ring"
 					id="handle"
 					onChange={event => setValue(event.target.value.trim())}
 					placeholder="octocat"

--- a/apps/web/src/theme.css
+++ b/apps/web/src/theme.css
@@ -65,6 +65,29 @@
 	/* Code and formula surfaces, which want to read as insets rather than cards. */
 	--color-code: oklch(0.972 0.003 285);
 
+	/*
+	 * Two stops from `sm` up: a tight contact shadow where the surface meets the
+	 * page, a wide ambient fall-off around it. One stop has to choose, and either
+	 * choice reads as a blurred border. Mixed from `foreground` rather than black,
+	 * which would grey toward a different hue than the rest of the page.
+	 *
+	 * `initial` first, here and in the scales below: `@theme` merges with
+	 * Tailwind's rather than replacing it, so a rung we do not declare keeps
+	 * resolving to a value from a different design system. Reaching for one
+	 * should draw nothing, not something plausible.
+	 */
+	--shadow-*: initial;
+	--shadow-xs: 0 1px 2px -1px color-mix(in oklch, var(--color-foreground) 8%, transparent);
+	--shadow-sm:
+		0 1px 2px -1px color-mix(in oklch, var(--color-foreground) 8%, transparent),
+		0 2px 4px -1px color-mix(in oklch, var(--color-foreground) 5%, transparent);
+	--shadow-md:
+		0 2px 4px -2px color-mix(in oklch, var(--color-foreground) 8%, transparent),
+		0 6px 12px -2px color-mix(in oklch, var(--color-foreground) 7%, transparent);
+	--shadow-lg:
+		0 4px 8px -4px color-mix(in oklch, var(--color-foreground) 10%, transparent),
+		0 16px 28px -6px color-mix(in oklch, var(--color-foreground) 8%, transparent);
+
 	/* Inter is loaded in `main.tsx`; the editor reads this token rather than repeating the stack. */
 	--font-sans: "Inter Variable", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
 	--font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;

--- a/dprint.json
+++ b/dprint.json
@@ -28,7 +28,7 @@
 		"https://github.com/dprint/dprint-plugin-typescript/releases/download/0.95.13/plugin.wasm",
 		"https://github.com/dprint/dprint-plugin-json/releases/download/0.21.0/plugin.wasm",
 		"https://github.com/dprint/dprint-plugin-markdown/releases/download/0.20.0/plugin.wasm",
-		"https://github.com/g-plane/malva/releases/download/v0.15.1/plugin.wasm",
+		"https://github.com/g-plane/malva/releases/download/v0.16.0/plugin.wasm",
 		"https://github.com/g-plane/markup_fmt/releases/download/v0.23.4/plugin.wasm"
 	]
 }

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -839,7 +839,7 @@
 	border: 1px solid var(--color-border);
 	border-radius: 9999px;
 	background: var(--color-background);
-	box-shadow: 0 1px 2px color-mix(in oklch, var(--color-foreground) 8%, transparent);
+	box-shadow: var(--shadow-xs);
 }
 
 .plan-status-dot {
@@ -982,7 +982,7 @@
 	border: 1px solid var(--color-border);
 	border-radius: 9999px;
 	background: var(--color-background);
-	box-shadow: 0 1px 3px color-mix(in oklch, var(--color-foreground) 12%, transparent);
+	box-shadow: var(--shadow-sm);
 	font-size: 0.6875rem;
 	line-height: 1rem;
 	overflow: hidden;
@@ -1018,7 +1018,7 @@
 	border: 1px solid var(--color-border);
 	border-radius: var(--radius-md);
 	background: var(--color-background);
-	box-shadow: 0 2px 8px color-mix(in oklch, var(--color-foreground) 12%, transparent);
+	box-shadow: var(--shadow-md);
 	font-size: 0.6875rem;
 	line-height: 1rem;
 }


### PR DESCRIPTION
Four `--shadow-*` tokens, replacing three `box-shadow` values written by hand at three call sites — 8% at 2px, 12% at 3px, 12% at 8px, which is three answers to a question nobody meant to ask twice.

Two stops from `sm` up: a tight contact shadow where the surface meets the page, and a wide ambient fall-off around it. One stop has to choose between them, and either choice reads as a blurred border.

Mixed from `foreground` rather than black, since the page is warm-neutral and a black shadow greys toward a different hue than the borders it runs into.

Declared under Tailwind's `--shadow-*` namespace, so the two `shadow-md` utility sites in the toolbar and the slash menu pick the scale up without being touched.

`--shadow-*: initial` comes first. `@theme` merges with Tailwind's theme rather than replacing it, so a rung we do not declare goes on resolving to a different design system's — `shadow-xl` hardcodes `#0000001a`, pure black, with no reference to the theme at all. Deleting the namespace first means reaching for a rung we do not own draws nothing rather than something plausible. That syntax needs malva 0.16 to parse, hence the dprint plugin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Stack

Merge bottom-up. Each PR targets the one below it, so every diff reads in isolation; GitHub retargets the child automatically as each parent merges.

1. #9 &nbsp;— Emit all theme tokens, fix callout colours, load Inter &nbsp;←&nbsp; `main`
2. #10 — Add two-stop shadow scale tokens
3. #11 — Add radius tokens and replace bare rounded classes
4. #12 — Add type scale tokens, replace arbitrary font sizes
5. #13 — Add easing and duration tokens, set transition defaults
6. #15 — Add one focus-visible outline rule for all controls
7. #16 — Scale buttons down on press
8. #17 — Add tabular-nums to figures and balance plan headings
9. #18 — Shorten empty states and composer status copy
10. #19 — Add entrance animation for newly arrived items

Plan: `docs/superpowers/plans/2026-08-04-design-token-foundation.md`

