### PR TITLE
Add radius tokens and replace bare rounded classes

### DIFF
--- a/apps/web/src/chat/chat.tsx
+++ b/apps/web/src/chat/chat.tsx
@@ -151,7 +151,7 @@ export function Chat({ connected, handle, onReveal, waiting, wire }: ChatProps) 
 				)}
 				{busy && (
 					<button
-						className="ml-auto rounded border border-border px-2 py-0.5 text-xs hover:bg-muted"
+						className="ml-auto rounded-sm border border-border px-2 py-0.5 text-xs hover:bg-muted"
 						onClick={() => wire?.send("chat:abort")}
 						type="button"
 					>

--- a/apps/web/src/chat/transcript.tsx
+++ b/apps/web/src/chat/transcript.tsx
@@ -30,7 +30,7 @@ function Activity({ activity }: { activity: Chat.Activity }) {
 	let detail = activity.args || activity.result;
 
 	return (
-		<div className="rounded border border-border bg-muted/40">
+		<div className="rounded-sm border border-border bg-muted/40">
 			<button
 				className={`flex w-full items-center gap-2 px-2 py-1 text-left text-xs ${
 					TOOL_TONE[activity.status]

--- a/apps/web/src/theme.css
+++ b/apps/web/src/theme.css
@@ -66,6 +66,15 @@
 	--color-code: oklch(0.972 0.003 285);
 
 	/*
+	 * Tailwind's own values, declared here so the scale has one owner: a change
+	 * lands in one place, and a misspelt rung is caught rather than waved through.
+	 */
+	--radius-*: initial;
+	--radius-sm: 0.25rem; /* 4px — buttons, grips, toolbar cells */
+	--radius-md: 0.375rem; /* 6px — cards, inputs, callouts, code blocks */
+	--radius-lg: 0.5rem; /* 8px — popovers and panels */
+
+	/*
 	 * Two stops from `sm` up: a tight contact shadow where the surface meets the
 	 * page, a wide ambient fall-off around it. One stop has to choose, and either
 	 * choice reads as a blurred border. Mixed from `foreground` rather than black,

--- a/packages/editor/src/toolbar/bubble.tsx
+++ b/packages/editor/src/toolbar/bubble.tsx
@@ -310,7 +310,7 @@ export function SelectionBubble(
 						aria-current={item.id === block}
 						title={item.label}
 						onClick={() => convert(item.id)}
-						className={`size-7 rounded text-xs font-semibold transition-colors ${
+						className={`size-7 rounded-sm text-xs font-semibold transition-colors ${
 							item.id === block
 								? "bg-muted text-foreground"
 								: "text-muted-foreground hover:bg-muted hover:text-foreground"
@@ -327,7 +327,7 @@ export function SelectionBubble(
 							aria-expanded={false}
 							title={`${describe(block).label} — change block type`}
 							onClick={() => setChoosing(true)}
-							className="size-7 rounded text-xs font-semibold text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+							className="size-7 rounded-sm text-xs font-semibold text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 						>
 							{describe(block).glyph}
 						</button>
@@ -342,7 +342,7 @@ export function SelectionBubble(
 								aria-pressed={active.has(mark.format)}
 								title={`${mark.label} (${mark.shortcut})`}
 								onClick={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, mark.format)}
-								className={`size-7 rounded text-xs font-semibold transition-colors ${
+								className={`size-7 rounded-sm text-xs font-semibold transition-colors ${
 									active.has(mark.format)
 										? "bg-muted text-foreground"
 										: "text-muted-foreground hover:bg-muted hover:text-foreground"
@@ -364,7 +364,7 @@ export function SelectionBubble(
 								if (url === undefined) return;
 								editor.dispatchCommand(TOGGLE_LINK_COMMAND, url);
 							}}
-							className="size-7 rounded text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+							className="size-7 rounded-sm text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 						>
 							🔗
 						</button>
@@ -383,7 +383,7 @@ export function SelectionBubble(
 									 * moment you started typing would be no use.
 									 */
 									onClick={onComment}
-									className="size-7 rounded text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+									className="size-7 rounded-sm text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 								>
 									💬
 								</button>

--- a/packages/editor/src/toolbar/slash.tsx
+++ b/packages/editor/src/toolbar/slash.tsx
@@ -407,7 +407,7 @@ export function SlashMenu({ disabled }: SlashMenuProps) {
 								aria-selected={position === index}
 								onMouseEnter={() => setIndex(position)}
 								onClick={() => choose(command)}
-								className={`flex w-full items-center justify-between rounded px-2 py-1.5 text-left text-sm transition-colors ${
+								className={`flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-left text-sm transition-colors ${
 									position === index
 										? "bg-muted text-foreground"
 										: "text-muted-foreground hover:bg-muted"

--- a/packages/editor/src/widgets/callout.tsx
+++ b/packages/editor/src/widgets/callout.tsx
@@ -78,7 +78,7 @@ function Heading(
 				value={callout.type}
 				disabled={disabled}
 				onChange={event => setType(event.currentTarget.value as CalloutType)}
-				className="rounded border border-transparent bg-transparent text-xs font-semibold tracking-wide text-muted-foreground uppercase hover:border-border focus-visible:border-ring"
+				className="rounded-sm border border-transparent bg-transparent text-xs font-semibold tracking-wide text-muted-foreground uppercase hover:border-border focus-visible:border-ring"
 			>
 				{CALLOUT_TYPES.map(type => <option key={type} value={type}>{LABELS[type]}</option>)}
 			</select>
@@ -90,7 +90,7 @@ function Heading(
 				maxLength={100}
 				disabled={disabled}
 				onChange={event => setTitle(event.currentTarget.value)}
-				className="min-w-0 flex-1 rounded border border-transparent bg-transparent text-sm font-medium text-foreground outline-none placeholder:text-muted-foreground/60 hover:border-border focus-visible:border-ring"
+				className="min-w-0 flex-1 rounded-sm border border-transparent bg-transparent text-sm font-medium text-foreground outline-none placeholder:text-muted-foreground/60 hover:border-border focus-visible:border-ring"
 			/>
 		</div>
 	);

--- a/packages/editor/src/widgets/render-blocks.tsx
+++ b/packages/editor/src/widgets/render-blocks.tsx
@@ -157,7 +157,7 @@ function Language(
 			value={block.language}
 			disabled={disabled}
 			onChange={event => set(event.currentTarget.value)}
-			className="cursor-pointer rounded border border-transparent bg-transparent text-xs text-muted-foreground hover:border-border focus-visible:border-ring"
+			className="cursor-pointer rounded-sm border border-transparent bg-transparent text-xs text-muted-foreground hover:border-border focus-visible:border-ring"
 		>
 			<option value="">Plain text</option>
 			{!listed && block.language && <option value={block.language}>{block.language}</option>}
@@ -178,7 +178,7 @@ function Toggle({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => v
 			// change arrives asynchronously, after the collapse, and reads
 			// as the reader arrowing in — reopening what they just closed.
 			onMouseDown={event => event.preventDefault()}
-			className="cursor-pointer rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+			className="cursor-pointer rounded-sm px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
 		>
 			{collapsed ? "Show source" : "Hide source"}
 		</button>

--- a/scripts/check-tokens.ts
+++ b/scripts/check-tokens.ts
@@ -14,8 +14,8 @@ import { dirname, join, relative } from "node:path";
 const ROOT = dirname(import.meta.dir);
 const ROOTS = ["apps", "packages"];
 
-/** Tailwind's own theme and bookkeeping, so absent from our stylesheets by design. */
-const EXTERNAL = ["--radius-", "--tw-"];
+/** Tailwind's internal bookkeeping, so absent from our stylesheets by design. */
+const EXTERNAL = ["--tw-"];
 
 /** Sources only: a built `dist` carries third-party CSS we neither wrote nor can fix. */
 function stylesheets(dir: string, found: string[] = []): string[] {


### PR DESCRIPTION
The theme inherited Tailwind's radius scale silently, so `--radius-md` meant one thing in the editor's stylesheet and whatever the framework last shipped everywhere else. Declaring the three rungs we use gives the scale one owner: a change lands in one place, and `check-tokens` can see a misspelt rung now that `--radius-` has left its `EXTERNAL` bypass list.

The values are Tailwind's own, so nothing moves. `sm` and `md` are what the editor stylesheet already read; `lg` is the one utility site. `xs` and `xl` are not declared, because nothing uses them.

`--radius-*: initial` first: `@theme` merges with Tailwind's theme rather than replacing it, so a rung we do not declare goes on resolving to a value we never chose — and its untouched `2xl` was `1rem`, the same as an `xl` we might later pick. Reaching for a rung we do not own should draw nothing.

The bare `rounded` utility is spelled `rounded-sm` at ten call sites. Both resolve to `0.25rem`, so this is a rename rather than a change — `rounded` is the v3 name and does not appear in the scale this file now owns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

### Stack

Merge bottom-up. Each PR targets the one below it, so every diff reads in isolation; GitHub retargets the child automatically as each parent merges.

1. #9 &nbsp;— Emit all theme tokens, fix callout colours, load Inter &nbsp;←&nbsp; `main`
2. #10 — Add two-stop shadow scale tokens
3. #11 — Add radius tokens and replace bare rounded classes
4. #12 — Add type scale tokens, replace arbitrary font sizes
5. #13 — Add easing and duration tokens, set transition defaults
6. #15 — Add one focus-visible outline rule for all controls
7. #16 — Scale buttons down on press
8. #17 — Add tabular-nums to figures and balance plan headings
9. #18 — Shorten empty states and composer status copy
10. #19 — Add entrance animation for newly arrived items

Plan: `docs/superpowers/plans/2026-08-04-design-token-foundation.md`

