### PR TITLE
Add type scale tokens, replace arbitrary font sizes

### DIFF
--- a/apps/web/src/chat/chat.tsx
+++ b/apps/web/src/chat/chat.tsx
@@ -41,7 +41,7 @@ function Queued(
 
 	return (
 		<div className="flex shrink-0 flex-col gap-1 border-t border-border px-3 py-2">
-			<span className="text-[0.625rem] font-semibold tracking-wide text-muted-foreground uppercase">
+			<span className="text-2xs font-semibold tracking-wide text-muted-foreground uppercase">
 				Queued
 			</span>
 			{waiting.map(item => (
@@ -199,7 +199,7 @@ export function Chat({ connected, handle, onReveal, waiting, wire }: ChatProps) 
 					value={text}
 				/>
 
-				<div className="flex items-baseline gap-2 px-1 text-[0.625rem]">
+				<div className="flex items-baseline gap-2 px-1 text-2xs">
 					{asking
 						? (
 							<span className="text-primary">

--- a/apps/web/src/chat/transcript.tsx
+++ b/apps/web/src/chat/transcript.tsx
@@ -52,12 +52,12 @@ function Activity({ activity }: { activity: Chat.Activity }) {
 			{open && detail && (
 				<div className="border-t border-border px-2 py-1.5">
 					{activity.args && (
-						<pre className="m-0 overflow-x-auto font-mono text-[0.6875rem] whitespace-pre-wrap text-muted-foreground">
+						<pre className="m-0 overflow-x-auto font-mono text-2xs whitespace-pre-wrap text-muted-foreground">
 {activity.args}
 						</pre>
 					)}
 					{activity.result && (
-						<pre className="m-0 mt-1 overflow-x-auto font-mono text-[0.6875rem] whitespace-pre-wrap text-muted-foreground">
+						<pre className="m-0 mt-1 overflow-x-auto font-mono text-2xs whitespace-pre-wrap text-muted-foreground">
 {activity.result}
 						</pre>
 					)}
@@ -81,7 +81,7 @@ function Entry({ entry }: { entry: Chat.Entry }) {
 			<div className="mt-0.5 shrink-0">
 				{agent
 					? (
-						<span className="grid size-5 place-items-center rounded-full bg-primary text-[0.5rem] font-semibold text-primary-foreground">
+						<span className="grid size-5 place-items-center rounded-full bg-primary text-2xs font-semibold text-primary-foreground">
 							AI
 						</span>
 					)
@@ -93,7 +93,7 @@ function Entry({ entry }: { entry: Chat.Entry }) {
 					<span className="text-xs font-semibold">
 						{author.kind === "member" ? `@${author.handle}` : "Planner"}
 					</span>
-					<span className="text-[0.625rem] text-muted-foreground">{when(entry.ts)}</span>
+					<span className="text-2xs text-muted-foreground">{when(entry.ts)}</span>
 				</div>
 
 				{entry.text && (

--- a/apps/web/src/theme.css
+++ b/apps/web/src/theme.css
@@ -66,6 +66,28 @@
 	--color-code: oklch(0.972 0.003 285);
 
 	/*
+	 * Wide steps from `base` up, where a heading needs to outrank its body by
+	 * more than weight; narrow below, where the sizes are already near the floor
+	 * of legibility. Line heights are declared beside each size because
+	 * Tailwind's defaults are computed against Tailwind's sizes.
+	 */
+	--text-*: initial;
+	--text-2xs: 0.6875rem; /* 11px — timestamps, counts, gutter chips */
+	--text-2xs--line-height: 1rem;
+	--text-xs: 0.75rem; /* 12px — secondary chrome */
+	--text-xs--line-height: 1rem;
+	--text-sm: 0.8125rem; /* 13px — rail body */
+	--text-sm--line-height: 1.25rem;
+	--text-base: 0.9375rem; /* 15px — the document */
+	--text-base--line-height: 1.5rem;
+	--text-lg: 1.125rem; /* 18px — h3 */
+	--text-lg--line-height: 1.5rem;
+	--text-xl: 1.375rem; /* 22px — h2 */
+	--text-xl--line-height: 1.75rem;
+	--text-2xl: 1.75rem; /* 28px — h1 */
+	--text-2xl--line-height: 2.125rem;
+
+	/*
 	 * Tailwind's own values, declared here so the scale has one owner: a change
 	 * lands in one place, and a misspelt rung is caught rather than waved through.
 	 */

--- a/packages/editor/src/card.tsx
+++ b/packages/editor/src/card.tsx
@@ -98,7 +98,7 @@ export function Provenance({ at, by, verb }: ProvenanceProps) {
 	let stamp = at === undefined ? "" : when(at);
 
 	return (
-		<span className="text-[10px] text-muted-foreground">
+		<span className="text-2xs text-muted-foreground">
 			{verb} by @{by}
 			{stamp && ` · ${stamp}`}
 		</span>

--- a/packages/editor/src/comments.tsx
+++ b/packages/editor/src/comments.tsx
@@ -39,7 +39,7 @@ function Note({ note }: { note: Comment.Note }) {
 		<li className="flex flex-col gap-0.5">
 			<div className="flex items-baseline gap-2">
 				<Who handle={note.handle} />
-				<span className="text-[10px] text-muted-foreground">{when(note.ts)}</span>
+				<span className="text-2xs text-muted-foreground">{when(note.ts)}</span>
 			</div>
 			<p className="m-0 text-sm whitespace-pre-wrap text-foreground">{note.text}</p>
 		</li>
@@ -89,7 +89,7 @@ function Quote(
 					>
 						{text}
 						{count > 1 && (
-							<span aria-hidden="true" className="ml-1.5 text-[10px] not-italic">
+							<span aria-hidden="true" className="ml-1.5 text-2xs not-italic">
 								{count}
 							</span>
 						)}
@@ -97,7 +97,7 @@ function Quote(
 				)
 				: <blockquote className={QUOTED}>{text}</blockquote>}
 			{drifted && (
-				<p className="m-0 text-[10px] text-warning">
+				<p className="m-0 text-2xs text-warning">
 					The text this refers to has changed.
 				</p>
 			)}
@@ -279,7 +279,7 @@ export function ThreadCard({
 					<Provenance at={thread.at} by={thread.resolver} verb="Accepted" />
 					{!applied && (
 						<>
-							<span className="ml-auto text-[10px] text-warning">Not yet applied</span>
+							<span className="ml-auto text-2xs text-warning">Not yet applied</span>
 							<button
 								className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
 								disabled={busy}
@@ -305,7 +305,7 @@ export function ThreadCard({
 			</ul>
 
 			{writing && writing.length > 0 && (
-				<p className="m-0 text-[10px] text-muted-foreground">
+				<p className="m-0 text-2xs text-muted-foreground">
 					{writing.join(", ")} {writing.length === 1 ? "is" : "are"} writing…
 				</p>
 			)}
@@ -322,7 +322,7 @@ export function ThreadCard({
 					<div className="flex items-center gap-2 border-t border-border pt-2">
 						<Confirm busy={busy} label="Accept" onConfirm={onAccept} tone="primary" />
 						<Confirm busy={busy} label="Dismiss" onConfirm={onDismiss} tone="quiet" />
-						<span className="ml-auto text-[10px] text-muted-foreground">
+						<span className="ml-auto text-2xs text-muted-foreground">
 							Accepting asks the agent to revise the plan
 						</span>
 					</div>

--- a/packages/editor/src/presence.tsx
+++ b/packages/editor/src/presence.tsx
@@ -77,7 +77,7 @@ function Face({ handle }: { handle: string }) {
 	if (failed) {
 		return (
 			<span
-				className="grid size-5 place-items-center rounded-full text-[0.5rem] font-semibold text-white uppercase"
+				className="grid size-5 place-items-center rounded-full text-2xs font-semibold text-white uppercase"
 				style={{ background: color(handle) }}
 				title={handle}
 			>
@@ -108,7 +108,7 @@ export function PlanPresence({ provider }: { provider: PlanProvider | undefined 
 		<div aria-label={`Also here: ${label}`} className="plan-presence" title={label}>
 			{people.slice(0, CAP).map(handle => <Face handle={handle} key={handle} />)}
 			{people.length > CAP && (
-				<span className="grid size-5 place-items-center rounded-full bg-muted text-[0.5rem] font-semibold text-muted-foreground ring-2 ring-background">
+				<span className="grid size-5 place-items-center rounded-full bg-muted text-2xs font-semibold text-muted-foreground ring-2 ring-background">
 					+{people.length - CAP}
 				</span>
 			)}

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -16,6 +16,14 @@
 	 * the top of the range a reader can track back from without losing the row.
 	 */
 	--plan-measure: 40rem;
+	/*
+	 * Resolved out here because MDXEditor declares `--text-base`, `--text-sm`
+	 * and `--text-xs` on its own root, which sits between `:root` and the
+	 * document — so reading the theme token inside the editor gets its 1rem
+	 * rather than ours. `.plan` is outside that root, so this catches the
+	 * theme's value on the way past.
+	 */
+	--plan-body: var(--text-base);
 }
 
 /* Decisions pane -------------------------------------------------------- */
@@ -193,7 +201,8 @@
 	padding: 1.5rem var(--plan-gutter) 60vh;
 	margin-inline: auto;
 	max-width: calc(var(--plan-measure) + var(--plan-gutter) * 2);
-	font-size: 0.9375rem;
+	font-size: var(--plan-body);
+	/* Prose wants looser leading than the UI rhythm the token pairs with. */
 	line-height: 1.6;
 	color: var(--color-foreground);
 }
@@ -221,16 +230,19 @@
 }
 
 .plan-content h1 {
-	font-size: 1.5rem;
+	font-size: var(--text-2xl);
+	line-height: var(--text-2xl--line-height);
 }
 .plan-content h2 {
-	font-size: 1.25rem;
+	font-size: var(--text-xl);
+	line-height: var(--text-xl--line-height);
 }
 .plan-content h3 {
-	font-size: 1.0625rem;
+	font-size: var(--text-lg);
+	line-height: var(--text-lg--line-height);
 }
 .plan-content :is(h4, h5, h6) {
-	font-size: 1rem;
+	font-size: var(--plan-body);
 }
 
 .plan-content p {
@@ -825,8 +837,8 @@
 	gap: 0.375rem;
 	max-width: min(22rem, 60%);
 	pointer-events: none;
-	font-size: 0.6875rem;
-	line-height: 1rem;
+	font-size: var(--text-2xs);
+	line-height: var(--text-2xs--line-height);
 }
 
 /*
@@ -983,8 +995,8 @@
 	border-radius: 9999px;
 	background: var(--color-background);
 	box-shadow: var(--shadow-sm);
-	font-size: 0.6875rem;
-	line-height: 1rem;
+	font-size: var(--text-2xs);
+	line-height: var(--text-2xs--line-height);
 	overflow: hidden;
 }
 
@@ -1019,8 +1031,8 @@
 	border-radius: var(--radius-md);
 	background: var(--color-background);
 	box-shadow: var(--shadow-md);
-	font-size: 0.6875rem;
-	line-height: 1rem;
+	font-size: var(--text-2xs);
+	line-height: var(--text-2xs--line-height);
 }
 
 .plan-changes-empty {

--- a/packages/editor/src/toolbar/slash.tsx
+++ b/packages/editor/src/toolbar/slash.tsx
@@ -394,7 +394,7 @@ export function SlashMenu({ disabled }: SlashMenuProps) {
 		>
 			{grouped.map(([group, commands]) => (
 				<div key={group}>
-					<div className="px-2 py-1 text-[0.625rem] font-semibold tracking-wide text-muted-foreground uppercase">
+					<div className="px-2 py-1 text-2xs font-semibold tracking-wide text-muted-foreground uppercase">
 						{group}
 					</div>
 					{commands.map(command => {

--- a/packages/question/src/react/question-view.tsx
+++ b/packages/question/src/react/question-view.tsx
@@ -64,7 +64,7 @@ function Badges({ people }: { people: Collaborator[] }) {
 				<span
 					key={person.client}
 					title={`@${person.handle} is editing`}
-					className="max-w-28 truncate rounded-full bg-muted px-1.5 py-0.5 text-[0.625rem] font-medium text-muted-foreground"
+					className="max-w-28 truncate rounded-full bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground"
 				>
 					@{person.handle}
 				</span>
@@ -429,7 +429,7 @@ export function QuestionView(props: QuestionViewProps) {
 							>
 								<span aria-hidden="true">{done ? "✓" : index + 1}</span> {question.header}
 								{people.length > 0 && (
-									<span className="ml-1 text-[0.625rem] text-muted-foreground">
+									<span className="ml-1 text-2xs text-muted-foreground">
 										{people.length}
 									</span>
 								)}


### PR DESCRIPTION
Seven `--text-*` rungs with line heights declared beside them, replacing eighteen arbitrary font sizes across eight files.

Wide steps from `base` up, where a heading needs to outrank its body by more than weight; narrow below, where the sizes are already near the floor of legibility. Line heights are declared per rung because Tailwind's defaults are computed against Tailwind's sizes, so overriding a size alone would pair new type with the old rhythm.

`--text-*: initial` first, so a rung we do not declare stops resolving to Tailwind's — ours stops at `2xl`/28px and its untouched `3xl` is 30px, two pixels apart, in a change about steps being far enough apart to read as steps.

### The document reads `--plan-body`, not `--text-base`

MDXEditor declares `--text-base: 1rem` on its own root, which sits between `:root` and the prose, so reading the theme token inside the editor returns its value and not ours — the body would have gone to 16px while the scale said 15. `.plan` is outside that root, so it catches the theme's value on the way past and passes it down under a name nothing else claims. Measured in a browser: 16px before, 15px after.

**Worth eyeballing before merge:** three badge labels move from 8px to 11px — the AI avatar in the transcript, presence initials, and the `+N` overflow chip — all inside 20px circles. `+12` in a busy room is the tight one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Stack

Merge bottom-up. Each PR targets the one below it, so every diff reads in isolation; GitHub retargets the child automatically as each parent merges.

1. #9 &nbsp;— Emit all theme tokens, fix callout colours, load Inter &nbsp;←&nbsp; `main`
2. #10 — Add two-stop shadow scale tokens
3. #11 — Add radius tokens and replace bare rounded classes
4. #12 — Add type scale tokens, replace arbitrary font sizes
5. #13 — Add easing and duration tokens, set transition defaults
6. #15 — Add one focus-visible outline rule for all controls
7. #16 — Scale buttons down on press
8. #17 — Add tabular-nums to figures and balance plan headings
9. #18 — Shorten empty states and composer status copy
10. #19 — Add entrance animation for newly arrived items

Plan: `docs/superpowers/plans/2026-08-04-design-token-foundation.md`

