### PR TITLE
Add easing and duration tokens, set transition defaults

### DIFF
--- a/apps/web/src/theme.css
+++ b/apps/web/src/theme.css
@@ -119,6 +119,22 @@
 		0 4px 8px -4px color-mix(in oklch, var(--color-foreground) 10%, transparent),
 		0 16px 28px -6px color-mix(in oklch, var(--color-foreground) 8%, transparent);
 
+	/*
+	 * Leaves immediately and settles slowly, so a change reads as a response to
+	 * whatever caused it. Durations are named for the job: `fast` is feedback
+	 * under the pointer, `linger` is the agent's change marks fading unwatched.
+	 */
+	--ease-*: initial;
+	--ease-out: cubic-bezier(0.2, 0, 0, 1);
+
+	--duration-fast: 120ms;
+	--duration-base: 200ms;
+	--duration-linger: 600ms;
+
+	/* Retunes all fifteen `transition-*` utilities, none of which names a curve. */
+	--default-transition-duration: var(--duration-fast);
+	--default-transition-timing-function: var(--ease-out);
+
 	/* Inter is loaded in `main.tsx`; the editor reads this token rather than repeating the stack. */
 	--font-sans: "Inter Variable", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
 	--font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -439,7 +439,7 @@
 .plan-grip {
 	border-radius: var(--radius-sm);
 	background: var(--color-muted);
-	transition: background-color 120ms ease;
+	transition: background-color var(--duration-fast) var(--ease-out);
 }
 
 .plan-grip:hover,
@@ -485,7 +485,7 @@
 .plan-align {
 	opacity: 0;
 	pointer-events: none;
-	transition: opacity 120ms ease;
+	transition: opacity var(--duration-fast) var(--ease-out);
 	border-radius: var(--radius-sm);
 	background: var(--color-popover);
 	box-shadow: 0 0 0 1px var(--color-border);
@@ -641,7 +641,7 @@
 	white-space: nowrap;
 	pointer-events: none;
 	opacity: 0;
-	transition: opacity 200ms ease;
+	transition: opacity var(--duration-base) var(--ease-out);
 }
 
 /* Raised while its peer is moving, then left to fade. */
@@ -882,7 +882,7 @@
  * read.
  */
 .plan .plan-content [data-plan-change] {
-	transition: background 600ms ease-out;
+	transition: background var(--duration-linger) var(--ease-out);
 }
 
 /* Written just now. */
@@ -913,7 +913,7 @@
 	box-shadow:
 		var(--plan-gap-above, 0 0 transparent),
 		var(--plan-gap-below, 0 0 transparent);
-	transition: box-shadow 600ms ease-out;
+	transition: box-shadow var(--duration-linger) var(--ease-out);
 }
 
 .plan .plan-content [data-plan-gap-before="removed"] {


### PR DESCRIPTION
One easing curve and three durations, with Tailwind's transition defaults pointed at them.

Every transition in the project ran on `ease` or `ease-out` — the browser default, and the least characterful curve available. `ease` eases both ways: it spends its opening accelerating before it settles, which blunts the start of a change that ought to feel like a reply. The new curve leaves immediately and settles slowly.

Durations are named for their job rather than numbered. The agent's change marks keep their 600ms as `linger`, which is the one duration here that is not feedback — a fade nobody is waiting on.

Setting `--default-transition-duration` and `--default-transition-timing-function` to the same tokens means the fifteen `transition-*` utilities already written pick the curve up without being edited, and a utility and a hand-written rule beside it now resolve to the same 120ms and the same cubic-bezier.

`--ease-*: initial` first, so `ease-in` stops resolving to Tailwind's curve. One curve is the point; a second one nobody chose is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Stack

Merge bottom-up. Each PR targets the one below it, so every diff reads in isolation; GitHub retargets the child automatically as each parent merges.

1. #9 &nbsp;— Emit all theme tokens, fix callout colours, load Inter &nbsp;←&nbsp; `main`
2. #10 — Add two-stop shadow scale tokens
3. #11 — Add radius tokens and replace bare rounded classes
4. #12 — Add type scale tokens, replace arbitrary font sizes
5. #13 — Add easing and duration tokens, set transition defaults
6. #15 — Add one focus-visible outline rule for all controls
7. #16 — Scale buttons down on press
8. #17 — Add tabular-nums to figures and balance plan headings
9. #18 — Shorten empty states and composer status copy
10. #19 — Add entrance animation for newly arrived items

Plan: `docs/superpowers/plans/2026-08-04-design-token-foundation.md`

