### PR TITLE
Scale buttons down on press

### DIFF
--- a/apps/web/src/chat/chat.tsx
+++ b/apps/web/src/chat/chat.tsx
@@ -163,6 +163,7 @@ export function Chat({ connected, handle, onReveal, waiting, wire }: ChatProps) 
 			{!!waiting && waiting > 0 && (
 				<button
 					className="flex shrink-0 items-center gap-2 border-b border-border bg-muted/60 px-3 py-2 text-left text-xs hover:bg-muted"
+					data-press="wide"
 					onClick={() => onReveal?.("")}
 					type="button"
 				>

--- a/apps/web/src/chat/transcript.tsx
+++ b/apps/web/src/chat/transcript.tsx
@@ -35,6 +35,7 @@ function Activity({ activity }: { activity: Chat.Activity }) {
 				className={`flex w-full items-center gap-2 px-2 py-1 text-left text-xs ${
 					TOOL_TONE[activity.status]
 				}`}
+				data-press="wide"
 				disabled={!detail}
 				onClick={() => setOpen(value => !value)}
 				type="button"

--- a/apps/web/src/theme.css
+++ b/apps/web/src/theme.css
@@ -167,3 +167,28 @@ body {
 	outline: 2px solid var(--color-ring);
 	outline-offset: 1px;
 }
+
+/*
+ * What a press feels like. Zero specificity so a `transition` utility on the
+ * element wins instead — Tailwind's covers `scale` along with the colours.
+ * Disabled controls are excluded: a press that animates and then does nothing
+ * says the opposite of what disabled is trying to say.
+ */
+:where(button, [role="button"]) {
+	transition: scale var(--duration-fast) var(--ease-out);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	:where(button, [role="button"]):not(:disabled):active {
+		scale: 0.96;
+	}
+
+	/*
+	 * A proportion, so a row needs a smaller one: 4% of a full-width row is
+	 * several pixels at each edge and reads as jumping, where 4% of a 28px
+	 * toolbar cell is the one pixel that is wanted.
+	 */
+	:where(button, [role="button"])[data-press="wide"]:not(:disabled):active {
+		scale: 0.99;
+	}
+}

--- a/apps/web/src/workspace.tsx
+++ b/apps/web/src/workspace.tsx
@@ -35,7 +35,7 @@ function Handle({ onResize, side }: { onResize: (delta: number) => void; side: S
 	return (
 		<div
 			aria-hidden="true"
-			className="relative z-10 w-px shrink-0 cursor-col-resize bg-border transition-colors before:absolute before:inset-y-0 before:-inset-x-1 before:content-[''] hover:bg-ring"
+			className="relative z-10 w-px shrink-0 cursor-col-resize bg-border transition before:absolute before:inset-y-0 before:-inset-x-1 before:content-[''] hover:bg-ring"
 			onPointerDown={event => {
 				origin.current = event.clientX;
 				event.currentTarget.setPointerCapture(event.pointerId);

--- a/packages/editor/src/comments.tsx
+++ b/packages/editor/src/comments.tsx
@@ -84,6 +84,7 @@ function Quote(
 							? `${text} — show in plan, ${count} places`
 							: `${text} — show in plan`}
 						className={`${QUOTED} cursor-pointer rounded-sm hover:text-foreground`}
+						data-press="wide"
 						onClick={onSelect}
 						type="button"
 					>

--- a/packages/editor/src/decisions.tsx
+++ b/packages/editor/src/decisions.tsx
@@ -184,6 +184,7 @@ export function Decisions({ connected, reveal, store, threads, wire }: Decisions
 						<button
 							aria-expanded={history}
 							className="w-full rounded-md px-1 py-1 text-left text-xs text-muted-foreground hover:text-foreground"
+							data-press="wide"
 							onClick={() => setHistory(value => !value)}
 							type="button"
 						>

--- a/packages/editor/src/toolbar/bubble.tsx
+++ b/packages/editor/src/toolbar/bubble.tsx
@@ -310,7 +310,7 @@ export function SelectionBubble(
 						aria-current={item.id === block}
 						title={item.label}
 						onClick={() => convert(item.id)}
-						className={`size-7 rounded-sm text-xs font-semibold transition-colors ${
+						className={`size-7 rounded-sm text-xs font-semibold transition ${
 							item.id === block
 								? "bg-muted text-foreground"
 								: "text-muted-foreground hover:bg-muted hover:text-foreground"
@@ -327,7 +327,7 @@ export function SelectionBubble(
 							aria-expanded={false}
 							title={`${describe(block).label} — change block type`}
 							onClick={() => setChoosing(true)}
-							className="size-7 rounded-sm text-xs font-semibold text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+							className="size-7 rounded-sm text-xs font-semibold text-muted-foreground transition hover:bg-muted hover:text-foreground"
 						>
 							{describe(block).glyph}
 						</button>
@@ -342,7 +342,7 @@ export function SelectionBubble(
 								aria-pressed={active.has(mark.format)}
 								title={`${mark.label} (${mark.shortcut})`}
 								onClick={() => editor.dispatchCommand(FORMAT_TEXT_COMMAND, mark.format)}
-								className={`size-7 rounded-sm text-xs font-semibold transition-colors ${
+								className={`size-7 rounded-sm text-xs font-semibold transition ${
 									active.has(mark.format)
 										? "bg-muted text-foreground"
 										: "text-muted-foreground hover:bg-muted hover:text-foreground"
@@ -364,7 +364,7 @@ export function SelectionBubble(
 								if (url === undefined) return;
 								editor.dispatchCommand(TOGGLE_LINK_COMMAND, url);
 							}}
-							className="size-7 rounded-sm text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+							className="size-7 rounded-sm text-xs text-muted-foreground transition hover:bg-muted hover:text-foreground"
 						>
 							🔗
 						</button>
@@ -383,7 +383,7 @@ export function SelectionBubble(
 									 * moment you started typing would be no use.
 									 */
 									onClick={onComment}
-									className="size-7 rounded-sm text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+									className="size-7 rounded-sm text-xs text-muted-foreground transition hover:bg-muted hover:text-foreground"
 								>
 									💬
 								</button>

--- a/packages/editor/src/toolbar/slash.tsx
+++ b/packages/editor/src/toolbar/slash.tsx
@@ -405,9 +405,10 @@ export function SlashMenu({ disabled }: SlashMenuProps) {
 								type="button"
 								role="option"
 								aria-selected={position === index}
+								data-press="wide"
 								onMouseEnter={() => setIndex(position)}
 								onClick={() => choose(command)}
-								className={`flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-left text-sm transition-colors ${
+								className={`flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-left text-sm transition ${
 									position === index
 										? "bg-muted text-foreground"
 										: "text-muted-foreground hover:bg-muted"

--- a/packages/editor/src/widgets/render-blocks.tsx
+++ b/packages/editor/src/widgets/render-blocks.tsx
@@ -178,7 +178,7 @@ function Toggle({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => v
 			// change arrives asynchronously, after the collapse, and reads
 			// as the reader arrowing in — reopening what they just closed.
 			onMouseDown={event => event.preventDefault()}
-			className="cursor-pointer rounded-sm px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+			className="cursor-pointer rounded-sm px-1.5 py-0.5 text-xs text-muted-foreground transition hover:bg-muted hover:text-foreground"
 		>
 			{collapsed ? "Show source" : "Hide source"}
 		</button>

--- a/packages/editor/src/widgets/tabs.tsx
+++ b/packages/editor/src/widgets/tabs.tsx
@@ -83,7 +83,7 @@ function Strip(
 						else return;
 						event.preventDefault();
 					}}
-					className={`shrink-0 rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+					className={`shrink-0 rounded-md px-2.5 py-1 text-xs font-medium transition ${
 						tab.key === active
 							? "bg-muted text-foreground"
 							: "text-muted-foreground hover:text-foreground"

--- a/packages/question/src/react/question-view.tsx
+++ b/packages/question/src/react/question-view.tsx
@@ -165,7 +165,7 @@ function Custom(
 				placeholder="Type another answer"
 				onFocus={() => onChange?.({ mode: "custom" })}
 				onChange={event => onChange?.({ mode: "custom", custom: event.currentTarget.value })}
-				className="mt-1.5 min-h-16 w-full resize-y rounded-md border border-input bg-input/20 px-2.5 py-2 text-sm text-foreground transition-colors placeholder:text-muted-foreground/60 focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-60"
+				className="mt-1.5 min-h-16 w-full resize-y rounded-md border border-input bg-input/20 px-2.5 py-2 text-sm text-foreground transition placeholder:text-muted-foreground/60 focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-60"
 			/>
 		</div>
 	);
@@ -210,6 +210,7 @@ function Related(
 		<button
 			type="button"
 			data-ace-question-id={id}
+			data-press="wide"
 			aria-label={count > 1
 				? `${label} — show in plan, ${count} places`
 				: `${label} — show in plan`}
@@ -420,7 +421,7 @@ export function QuestionView(props: QuestionViewProps) {
 								onBlur={event =>
 									!event.currentTarget.matches(":hover") && onQuestionLeave?.(question.id)}
 								onKeyDown={event => move(event, index)}
-								className={`shrink-0 rounded-t-md px-2.5 py-1 text-xs font-medium transition-colors ${
+								className={`shrink-0 rounded-t-md px-2.5 py-1 text-xs font-medium transition ${
 									question.id === active
 										? "bg-muted text-foreground"
 										: "text-muted-foreground hover:text-foreground"
@@ -507,7 +508,7 @@ export function QuestionView(props: QuestionViewProps) {
 								type="button"
 								onClick={() => setConfirming(false)}
 								disabled={submitting}
-								className="rounded-md px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+								className="rounded-md px-2.5 py-1 text-xs text-muted-foreground transition hover:text-foreground disabled:opacity-50"
 							>
 								Keep it
 							</button>
@@ -515,7 +516,7 @@ export function QuestionView(props: QuestionViewProps) {
 								type="button"
 								onClick={onCancel}
 								disabled={disabled || submitting}
-								className="rounded-md px-2.5 py-1 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10 disabled:opacity-50"
+								className="rounded-md px-2.5 py-1 text-xs font-medium text-destructive transition hover:bg-destructive/10 disabled:opacity-50"
 							>
 								{submitting ? "Cancelling…" : "Yes, cancel"}
 							</button>
@@ -526,7 +527,7 @@ export function QuestionView(props: QuestionViewProps) {
 							type="button"
 							onClick={() => setConfirming(true)}
 							disabled={disabled || submitting}
-							className="rounded-md px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+							className="rounded-md px-2.5 py-1 text-xs text-muted-foreground transition hover:text-foreground disabled:opacity-50"
 						>
 							Cancel
 						</button>


### PR DESCRIPTION
Nothing in the app acknowledged a click. Every control had a hover state and then went straight from hovered to done, so the one moment the user is certain they did something passed without being drawn at all.

Two scales rather than one. Four percent of a full-width row is several pixels at each edge and reads as the row jumping; the same four percent on a 28-pixel toolbar cell is one pixel, which is exactly right. Scale is a proportion, so only the width tells us which case we are in, and `data-press="wide"` marks it — on all six row-shaped controls: two reveal buttons, the history toggle, a slash-menu command, a quoted passage, and a decision pointing into the plan.

The transition sits at zero specificity so any `transition` utility on the element wins instead. That meant moving fourteen sites off `transition-colors`, which covers the colours and pointedly not `scale`, onto the bare `transition` utility that covers both. Buttons carrying no transition of their own fall back to the theme's rather than snapping.

Disabled controls are excluded: a press that animates and then does nothing says the opposite of what disabled is trying to say. The whole of it sits behind `prefers-reduced-motion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Stack

Merge bottom-up. Each PR targets the one below it, so every diff reads in isolation; GitHub retargets the child automatically as each parent merges.

1. #9 &nbsp;— Emit all theme tokens, fix callout colours, load Inter &nbsp;←&nbsp; `main`
2. #10 — Add two-stop shadow scale tokens
3. #11 — Add radius tokens and replace bare rounded classes
4. #12 — Add type scale tokens, replace arbitrary font sizes
5. #13 — Add easing and duration tokens, set transition defaults
6. #15 — Add one focus-visible outline rule for all controls
7. #16 — Scale buttons down on press
8. #17 — Add tabular-nums to figures and balance plan headings
9. #18 — Shorten empty states and composer status copy
10. #19 — Add entrance animation for newly arrived items

Plan: `docs/superpowers/plans/2026-08-04-design-token-foundation.md`

