### PR TITLE
Add tabular-nums to figures and balance plan headings

### DIFF
--- a/apps/web/src/chat/transcript.tsx
+++ b/apps/web/src/chat/transcript.tsx
@@ -47,7 +47,10 @@ function Activity({ activity }: { activity: Chat.Activity }) {
 					{activity.status === "failed" ? "×" : activity.status === "running" ? "•" : "✓"}
 				</span>
 				<span className="font-mono">{activity.name}</span>
-				{activity.took !== undefined && <span className="ml-auto">{activity.took}ms</span>}
+				{/* Tabular: this counts up as the tool runs, and the column is read down. */}
+				{activity.took !== undefined && (
+					<span className="ml-auto tabular-nums">{activity.took}ms</span>
+				)}
 			</button>
 
 			{open && detail && (
@@ -94,7 +97,7 @@ function Entry({ entry }: { entry: Chat.Entry }) {
 					<span className="text-xs font-semibold">
 						{author.kind === "member" ? `@${author.handle}` : "Planner"}
 					</span>
-					<span className="text-2xs text-muted-foreground">{when(entry.ts)}</span>
+					<span className="text-2xs text-muted-foreground tabular-nums">{when(entry.ts)}</span>
 				</div>
 
 				{entry.text && (

--- a/packages/editor/src/card.tsx
+++ b/packages/editor/src/card.tsx
@@ -98,7 +98,7 @@ export function Provenance({ at, by, verb }: ProvenanceProps) {
 	let stamp = at === undefined ? "" : when(at);
 
 	return (
-		<span className="text-2xs text-muted-foreground">
+		<span className="text-2xs text-muted-foreground tabular-nums">
 			{verb} by @{by}
 			{stamp && ` · ${stamp}`}
 		</span>

--- a/packages/editor/src/comments.tsx
+++ b/packages/editor/src/comments.tsx
@@ -39,7 +39,7 @@ function Note({ note }: { note: Comment.Note }) {
 		<li className="flex flex-col gap-0.5">
 			<div className="flex items-baseline gap-2">
 				<Who handle={note.handle} />
-				<span className="text-2xs text-muted-foreground">{when(note.ts)}</span>
+				<span className="text-2xs text-muted-foreground tabular-nums">{when(note.ts)}</span>
 			</div>
 			<p className="m-0 text-sm whitespace-pre-wrap text-foreground">{note.text}</p>
 		</li>
@@ -90,7 +90,7 @@ function Quote(
 					>
 						{text}
 						{count > 1 && (
-							<span aria-hidden="true" className="ml-1.5 text-2xs not-italic">
+							<span aria-hidden="true" className="ml-1.5 text-2xs not-italic tabular-nums">
 								{count}
 							</span>
 						)}

--- a/packages/editor/src/decisions.tsx
+++ b/packages/editor/src/decisions.tsx
@@ -144,7 +144,9 @@ export function Decisions({ connected, reveal, store, threads, wire }: Decisions
 				<span className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
 					Decisions
 				</span>
-				{outstanding > 0 && <span className="text-xs text-muted-foreground">{outstanding}</span>}
+				{outstanding > 0 && (
+					<span className="text-xs text-muted-foreground tabular-nums">{outstanding}</span>
+				)}
 			</header>
 
 			<div className="min-h-0 flex-1 overflow-auto p-3" ref={content}>
@@ -188,7 +190,7 @@ export function Decisions({ connected, reveal, store, threads, wire }: Decisions
 							onClick={() => setHistory(value => !value)}
 							type="button"
 						>
-							{history ? "▾" : "▸"} {resolved} resolved
+							{history ? "▾" : "▸"} <span className="tabular-nums">{resolved}</span> resolved
 						</button>
 						{history && (
 							<div className="mt-2 flex flex-col gap-3">

--- a/packages/editor/src/presence.tsx
+++ b/packages/editor/src/presence.tsx
@@ -108,7 +108,7 @@ export function PlanPresence({ provider }: { provider: PlanProvider | undefined 
 		<div aria-label={`Also here: ${label}`} className="plan-presence" title={label}>
 			{people.slice(0, CAP).map(handle => <Face handle={handle} key={handle} />)}
 			{people.length > CAP && (
-				<span className="grid size-5 place-items-center rounded-full bg-muted text-2xs font-semibold text-muted-foreground ring-2 ring-background">
+				<span className="grid size-5 place-items-center rounded-full bg-muted text-2xs font-semibold text-muted-foreground tabular-nums ring-2 ring-background">
 					+{people.length - CAP}
 				</span>
 			)}

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -223,6 +223,8 @@
 	line-height: 1.3;
 	margin-block: 1.5em 0.5em;
 	color: var(--color-foreground);
+	/* Short enough to weigh every break at once, and an 8/1 split reads as a mistake. */
+	text-wrap: balance;
 }
 
 .plan-content :is(h1, h2, h3, h4, h5, h6):first-child {

--- a/packages/question/src/react/question-view.tsx
+++ b/packages/question/src/react/question-view.tsx
@@ -223,7 +223,7 @@ function Related(
 		>
 			<span className="min-w-0 flex-1">{children}</span>
 			{count > 1 && (
-				<span aria-hidden="true" className="shrink-0 text-xs text-muted-foreground">
+				<span aria-hidden="true" className="shrink-0 text-xs text-muted-foreground tabular-nums">
 					{count}
 				</span>
 			)}
@@ -429,7 +429,7 @@ export function QuestionView(props: QuestionViewProps) {
 							>
 								<span aria-hidden="true">{done ? "✓" : index + 1}</span> {question.header}
 								{people.length > 0 && (
-									<span className="ml-1 text-2xs text-muted-foreground">
+									<span className="ml-1 text-2xs text-muted-foreground tabular-nums">
 										{people.length}
 									</span>
 								)}


### PR DESCRIPTION
Ten places in the app set a figure somebody reads as a column or watches change: tool durations counting up, places-in-plan badges, the outstanding and resolved counts, the overflow chip on the presence row, and the timestamps down the transcript, a comment thread and a provenance line.

Proportional digits are different widths, so 2ms and 72ms put their figures in different places and a column of them twitches as each lands. Tabular numerals cost nothing here; none of these are prose.

Headings get `text-wrap: balance`, so a two-line heading does not break 8/1 and read as a mistake. They are short enough for the browser to weigh every break at once.

Paragraphs are left alone. `text-wrap: pretty` would guard the last line against stranding a word, but the prose is inside a contenteditable and the browser re-evaluates those lines on input — a reflow risk taken for a small typographic gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

### Stack

Merge bottom-up. Each PR targets the one below it, so every diff reads in isolation; GitHub retargets the child automatically as each parent merges.

1. #9 &nbsp;— Emit all theme tokens, fix callout colours, load Inter &nbsp;←&nbsp; `main`
2. #10 — Add two-stop shadow scale tokens
3. #11 — Add radius tokens and replace bare rounded classes
4. #12 — Add type scale tokens, replace arbitrary font sizes
5. #13 — Add easing and duration tokens, set transition defaults
6. #15 — Add one focus-visible outline rule for all controls
7. #16 — Scale buttons down on press
8. #17 — Add tabular-nums to figures and balance plan headings
9. #18 — Shorten empty states and composer status copy
10. #19 — Add entrance animation for newly arrived items

Plan: `docs/superpowers/plans/2026-08-04-design-token-foundation.md`

