### PR TITLE
Shorten empty states and composer status copy

### DIFF
--- a/apps/web/src/chat/chat.tsx
+++ b/apps/web/src/chat/chat.tsx
@@ -194,7 +194,7 @@ export function Chat({ connected, handle, onReveal, waiting, wire }: ChatProps) 
 						event.preventDefault();
 						submit();
 					}}
-					placeholder={`Talk to the room, or mention ${MENTION} to ask the planner…`}
+					placeholder={`Talk to the room, or mention ${MENTION} to ask the planner to read the repo or draft a plan…`}
 					ref={input}
 					rows={3}
 					value={text}
@@ -204,12 +204,12 @@ export function Chat({ connected, handle, onReveal, waiting, wire }: ChatProps) 
 					{asking
 						? (
 							<span className="text-primary">
-								→ planner{busy && ", after the current turn"}
+								→ planner{busy && ", after this turn"}
 							</span>
 						)
 						: (
 							<span className="text-muted-foreground">
-								room only — the planner will see it on its next turn
+								room only — the planner reads it next turn
 							</span>
 						)}
 					<button

--- a/apps/web/src/chat/transcript.tsx
+++ b/apps/web/src/chat/transcript.tsx
@@ -138,11 +138,6 @@ export function Transcript({ entries }: { entries: Chat.Entry[] }) {
 			}}
 			ref={scroller}
 		>
-			{entries.length === 0 && (
-				<p className="m-0 text-xs text-muted-foreground">
-					Ask the planner to draft something, or to read the repository first.
-				</p>
-			)}
 			{entries.map(entry => <Entry entry={entry} key={entry.id} />)}
 			<div ref={bottom} />
 		</div>

--- a/packages/editor/src/decisions.tsx
+++ b/packages/editor/src/decisions.tsx
@@ -170,8 +170,7 @@ export function Decisions({ connected, reveal, store, threads, wire }: Decisions
 				{outstanding === 0 && resolved === 0 && !state.draft
 					? (
 						<p className="m-0 text-xs text-muted-foreground">
-							Select any of the plan to comment on it. Questions the agent asks appear here too, and
-							both stay as a record of what was decided.
+							Select a passage to comment on it.
 						</p>
 					)
 					: (


### PR DESCRIPTION
The transcript's empty state suggested asking the planner to draft something or to read the repository — a cold start hint, sitting two inches above the box you would type it into. The hint is worth keeping and the second surface is not, so it moves into the composer's placeholder, which is attached to the thing it describes and disappears the moment you begin.

The decisions pane opened with three clauses: select prose to comment on it, questions appear here too, both stay as a record. Only the first is undiscoverable by looking. The other two describe what the reader watches happen the first time it happens, so they are gone.

The composer's own status line stays. It is what stops somebody typing into what looks like a prompt and meeting silence, and both halves carry weight — where the message is going, and that it is not lost. Shortened rather than cut, and left in the lower case its sibling beside it uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Stack

Merge bottom-up. Each PR targets the one below it, so every diff reads in isolation; GitHub retargets the child automatically as each parent merges.

1. #9 &nbsp;— Emit all theme tokens, fix callout colours, load Inter &nbsp;←&nbsp; `main`
2. #10 — Add two-stop shadow scale tokens
3. #11 — Add radius tokens and replace bare rounded classes
4. #12 — Add type scale tokens, replace arbitrary font sizes
5. #13 — Add easing and duration tokens, set transition defaults
6. #15 — Add one focus-visible outline rule for all controls
7. #16 — Scale buttons down on press
8. #17 — Add tabular-nums to figures and balance plan headings
9. #18 — Shorten empty states and composer status copy
10. #19 — Add entrance animation for newly arrived items

Plan: `docs/superpowers/plans/2026-08-04-design-token-foundation.md`

