### PR TITLE
Animate newly received messages and status indicators

### DIFF
--- a/apps/web/src/chat/chat.tsx
+++ b/apps/web/src/chat/chat.tsx
@@ -45,7 +45,7 @@ function Queued(
 				Queued
 			</span>
 			{waiting.map(item => (
-				<div className="flex items-baseline gap-2 text-sm" key={item.id}>
+				<div className="animate-enter flex items-baseline gap-2 text-sm" key={item.id}>
 					<span className="text-text-tertiary">@{item.handle}</span>
 					<span className="min-w-0 flex-1 truncate">{item.text}</span>
 					{item.handle === handle && (
@@ -66,6 +66,7 @@ function Queued(
 
 export function Chat({ connected, handle, onReveal, waiting, wire }: ChatProps) {
 	let [entries, setEntries] = useState<Wire.Entry[]>([]);
+	let [arrived, setArrived] = useState<ReadonlySet<string>>(new Set());
 	let [queue, setQueue] = useState<Wire.Waiting[]>([]);
 	let [busy, setBusy] = useState(false);
 	let [turn, setTurn] = useState<string>();
@@ -74,16 +75,26 @@ export function Chat({ connected, handle, onReveal, waiting, wire }: ChatProps) 
 
 	useEffect(() => {
 		if (!wire) return;
+		// History seeds `seen`; only later message frames are arrivals.
+		let loaded = false;
+		let seen = new Set<string>();
 
 		// Streaming arrives as deltas against an entry already in the list, so
 		// the reducer here has to be additive rather than replacing.
 		let off = [
 			wire.on<Wire.History>("chat:history", frame => {
+				loaded = true;
+				seen = new Set(frame.entries.map(entry => entry.id));
 				setEntries(frame.entries);
+				setArrived(new Set());
 				setQueue(frame.queued);
 				setBusy(frame.busy);
 			}),
 			wire.on<Wire.Message>("chat:message", frame => {
+				if (loaded && !seen.has(frame.entry.id)) {
+					setArrived(current => new Set(current).add(frame.entry.id));
+				}
+				seen.add(frame.entry.id);
 				setEntries(current => {
 					let index = current.findIndex(entry => entry.id === frame.entry.id);
 					if (index < 0) return [...current, frame.entry];
@@ -162,7 +173,7 @@ export function Chat({ connected, handle, onReveal, waiting, wire }: ChatProps) 
 
 			{!!waiting && waiting > 0 && (
 				<button
-					className="flex shrink-0 items-center gap-2 bg-warning-wash px-3 py-2 text-left text-sm hover:bg-selected hairline-b"
+					className="animate-enter flex shrink-0 items-center gap-2 bg-warning-wash px-3 py-2 text-left text-sm hover:bg-selected hairline-b"
 					data-press="wide"
 					onClick={() => onReveal?.("")}
 					type="button"
@@ -175,7 +186,7 @@ export function Chat({ connected, handle, onReveal, waiting, wire }: ChatProps) 
 				</button>
 			)}
 
-			<Transcript entries={entries} />
+			<Transcript arrived={arrived} entries={entries} />
 
 			<Queued
 				handle={handle}

--- a/apps/web/src/chat/transcript.tsx
+++ b/apps/web/src/chat/transcript.tsx
@@ -71,9 +71,15 @@ function Activity({ activity }: { activity: Chat.Activity }) {
 	);
 }
 
-function Entry({ entry }: { entry: Chat.Entry }) {
+function Entry({ arrived, entry }: { arrived: boolean; entry: Chat.Entry }) {
 	if (entry.author.kind === "system") {
-		return <p className="m-0 px-1 text-sm text-text-secondary italic">{entry.text}</p>;
+		return (
+			<p
+				className={`m-0 px-1 text-sm text-text-secondary italic ${arrived ? "animate-enter" : ""}`}
+			>
+				{entry.text}
+			</p>
+		);
 	}
 
 	// Narrowed once, so the union does not have to be re-tested at each use.
@@ -81,7 +87,7 @@ function Entry({ entry }: { entry: Chat.Entry }) {
 	let agent = author.kind === "agent";
 
 	return (
-		<div className="flex gap-2">
+		<div className={`flex gap-2 ${arrived ? "animate-enter" : ""}`}>
 			<div className="mt-0.5 shrink-0">
 				{agent
 					? (
@@ -117,7 +123,9 @@ function Entry({ entry }: { entry: Chat.Entry }) {
 	);
 }
 
-export function Transcript({ entries }: { entries: Chat.Entry[] }) {
+export function Transcript(
+	{ arrived, entries }: { arrived: ReadonlySet<string>; entries: Chat.Entry[] },
+) {
 	let bottom = useRef<HTMLDivElement>(null);
 	let scroller = useRef<HTMLDivElement>(null);
 	let pinned = useRef(true);
@@ -143,7 +151,7 @@ export function Transcript({ entries }: { entries: Chat.Entry[] }) {
 					Ask the planner to draft something, or to read the repository first.
 				</p>
 			)}
-			{entries.map(entry => <Entry entry={entry} key={entry.id} />)}
+			{entries.map(entry => <Entry arrived={arrived.has(entry.id)} entry={entry} key={entry.id} />)}
 			<div ref={bottom} />
 		</div>
 	);

--- a/apps/web/src/theme.css
+++ b/apps/web/src/theme.css
@@ -251,6 +251,23 @@ body {
 	outline-offset: 1px;
 }
 
+@keyframes item-enter {
+	from {
+		opacity: 0;
+		translate: 0 0.25rem;
+	}
+}
+
+@utility animate-enter {
+	animation: item-enter var(--duration-base) var(--ease-out) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.animate-enter {
+		animation: none;
+	}
+}
+
 /*
  * What a press feels like. Zero specificity so a `transition` utility on the
  * element wins instead — Tailwind's covers `scale` along with the colours.

--- a/packages/editor/src/changes-chip.tsx
+++ b/packages/editor/src/changes-chip.tsx
@@ -53,7 +53,7 @@ function List({ entries }: { entries: Entry[] }) {
 	}
 
 	return (
-		<ul className="plan-changes-list">
+		<ul className="plan-changes-list animate-enter">
 			{entries.map(entry => (
 				<li
 					key={entry.id}
@@ -102,7 +102,7 @@ function Chip(
 	return (
 		<div ref={box} className="plan-changes" data-side={side}>
 			{open && <List entries={entries} />}
-			<div className="plan-changes-bar">
+			<div className="plan-changes-bar animate-enter">
 				<button
 					type="button"
 					className="plan-changes-go"

--- a/packages/editor/src/status.tsx
+++ b/packages/editor/src/status.tsx
@@ -127,7 +127,7 @@ export function PlanStatus(props: PlanStatusProps) {
 
 	return (
 		<div
-			className="plan-status"
+			className={`plan-status ${level === "notice" ? "animate-enter" : ""}`}
 			data-level={level}
 			// Durability changes are informational; announcing them politely
 			// keeps them out of the way of what the user is typing. The text is


### PR DESCRIPTION
## Summary

- Give newly received chat entries a subtle fade-and-rise entrance without animating loaded history or restarting during streaming.
- Apply the same entrance treatment to queued messages, waiting-question notices, plan status notices, and change indicators.
- Disable entrance motion when `prefers-reduced-motion` is enabled.

## Validation

- `bun run ci`
- `bun run types`
- `bun test` — 565 passed
- `bun run e2e` — 52 passed
