### PR TITLE
Let users hide side panes without shrinking the document below 400px

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -11,10 +11,11 @@ import {
 import { Chat } from "./chat/chat";
 import * as Identity from "./identity";
 import { Wire } from "./wire";
-import { Workspace } from "./workspace";
+import { paneId, usePaneOpen, Workspace } from "./workspace";
 
 import type { Session } from "@chopin/protocol";
 import type { Status } from "./wire";
+import type { Pane } from "./workspace";
 
 /**
  * Claim a handle.
@@ -69,10 +70,47 @@ const TONE: Record<Status, string> = {
 	closed: "text-text-tertiary",
 };
 
+function PaneToggle(
+	{ onToggle, open, pane }: { onToggle: () => void; open: boolean; pane: Pane },
+) {
+	let label = pane === "chat" ? "conversation" : "decisions";
+	let divider = pane === "chat" ? "M8 3.5v13" : "M12 3.5v13";
+
+	return (
+		<button
+			aria-controls={paneId(pane)}
+			aria-expanded={open}
+			aria-label={`${open ? "Hide" : "Show"} ${label} pane`}
+			className="inline-flex size-7 shrink-0 items-center justify-center rounded-sm text-text-tertiary hover:bg-hover hover:text-text-primary"
+			onClick={onToggle}
+			type="button"
+		>
+			<svg aria-hidden="true" fill="none" height="18" viewBox="0 0 20 20" width="18">
+				<rect height="13" rx="2" stroke="currentColor" width="15" x="2.5" y="3.5" />
+				<path d={divider} stroke="currentColor" />
+			</svg>
+		</button>
+	);
+}
+
 function Header(
-	{ handle, members, reason, room, status }: {
+	{
+		chatOpen,
+		decisionsOpen,
+		handle,
+		members,
+		onToggleChat,
+		onToggleDecisions,
+		reason,
+		room,
+		status,
+	}: {
+		chatOpen: boolean;
+		decisionsOpen: boolean;
 		handle: string;
 		members: Session.Member[];
+		onToggleChat: () => void;
+		onToggleDecisions: () => void;
 		reason?: string;
 		room: string;
 		status: Status;
@@ -84,6 +122,7 @@ function Header(
 
 	return (
 		<header className="hairline-b flex h-12 shrink-0 items-center gap-3 px-4">
+			<PaneToggle onToggle={onToggleChat} open={chatOpen} pane="chat" />
 			<span className="text-sm font-semibold">chopin</span>
 			<span className="text-sm text-text-tertiary">/r/{room}</span>
 			<span className={`text-sm ${TONE[status]}`}>
@@ -93,6 +132,7 @@ function Header(
 				@{handle}
 				{others.length > 0 && ` · with ${others.map(member => `@${member.handle}`).join(", ")}`}
 			</span>
+			<PaneToggle onToggle={onToggleDecisions} open={decisionsOpen} pane="decisions" />
 		</header>
 	);
 }
@@ -104,6 +144,8 @@ function Room({ handle }: { handle: string }) {
 	let [members, setMembers] = useState<Session.Member[]>([]);
 	let room = Identity.room();
 	let user = useMemo(() => cursor(handle), [handle]);
+	let [chatOpen, setChatOpen] = usePaneOpen("chat");
+	let [decisionsOpen, setDecisionsOpen] = usePaneOpen("decisions");
 	// Written from inside the editor, read by the decisions pane beside it.
 	let [questions] = useState(() => new QuestionnaireStore());
 	let [threads] = useState(() => new ThreadStore());
@@ -149,15 +191,21 @@ function Room({ handle }: { handle: string }) {
 					wire={wire}
 				/>
 			}
+			chatOpen={chatOpen}
 			header={
 				<Header
+					chatOpen={chatOpen}
+					decisionsOpen={decisionsOpen}
 					handle={handle}
 					members={members}
+					onToggleChat={() => setChatOpen(value => !value)}
+					onToggleDecisions={() => setDecisionsOpen(value => !value)}
 					reason={reason}
 					room={room}
 					status={status}
 				/>
 			}
+			decisionsOpen={decisionsOpen}
 			decisions={
 				<Decisions
 					connected={status === "connected"}

--- a/apps/web/src/workspace.tsx
+++ b/apps/web/src/workspace.tsx
@@ -89,14 +89,35 @@ function usePaneWidth(key: string, initial: number) {
 	return [width, resize] as const;
 }
 
+export type Pane = "chat" | "decisions";
+
+export function paneId(pane: Pane): string {
+	return `pane-${pane}`;
+}
+
+export function usePaneOpen(pane: Pane) {
+	let key = `chopin:pane:${pane}:open`;
+	let [open, setOpen] = useState(() => localStorage.getItem(key) !== "false");
+
+	useEffect(() => {
+		localStorage.setItem(key, String(open));
+	}, [key, open]);
+
+	return [open, setOpen] as const;
+}
+
 export type WorkspaceProps = {
 	header: ReactNode;
 	chat?: ReactNode;
+	chatOpen?: boolean;
 	plan: ReactNode;
 	decisions?: ReactNode;
+	decisionsOpen?: boolean;
 };
 
-export function Workspace({ chat, decisions, header, plan }: WorkspaceProps) {
+export function Workspace(
+	{ chat, chatOpen = true, decisions, decisionsOpen = true, header, plan }: WorkspaceProps,
+) {
 	let [chatWidth, resizeChat] = usePaneWidth("chopin:pane:chat", 340);
 	let [decisionsWidth, resizeDecisions] = usePaneWidth("chopin:pane:decisions", 320);
 
@@ -105,13 +126,19 @@ export function Workspace({ chat, decisions, header, plan }: WorkspaceProps) {
 			{header}
 
 			<div className="flex min-h-0 flex-1 pt-4">
+				{/* `hidden` preserves pane state and subscriptions while removing it from layout. */}
 				{chat && (
-					<aside className="min-w-0 shrink-0 overflow-hidden" style={{ width: chatWidth }}>
+					<aside
+						className="min-w-0 overflow-hidden"
+						hidden={!chatOpen}
+						id={paneId("chat")}
+						style={{ width: chatWidth }}
+					>
 						{chat}
 					</aside>
 				)}
 
-				<main className="relative min-w-0 flex-1 px-1">
+				<main className="relative min-w-[400px] flex-1 px-1">
 					{/* Decoration extends below the viewport without moving the editor contents. */}
 					<div
 						aria-hidden="true"
@@ -119,7 +146,7 @@ export function Workspace({ chat, decisions, header, plan }: WorkspaceProps) {
 					/>
 
 					{/* Lexical consumes Tab, so both handles must precede the editor. */}
-					{chat && (
+					{chat && chatOpen && (
 						<Handle
 							label="Resize the conversation"
 							onResize={resizeChat}
@@ -127,7 +154,7 @@ export function Workspace({ chat, decisions, header, plan }: WorkspaceProps) {
 							width={chatWidth}
 						/>
 					)}
-					{decisions && (
+					{decisions && decisionsOpen && (
 						<Handle
 							label="Resize the decisions"
 							onResize={resizeDecisions}
@@ -140,7 +167,12 @@ export function Workspace({ chat, decisions, header, plan }: WorkspaceProps) {
 				</main>
 
 				{decisions && (
-					<aside className="min-w-0 shrink-0 overflow-hidden" style={{ width: decisionsWidth }}>
+					<aside
+						className="min-w-0 overflow-hidden"
+						hidden={!decisionsOpen}
+						id={paneId("decisions")}
+						style={{ width: decisionsWidth }}
+					>
 						{decisions}
 					</aside>
 				)}

--- a/e2e/shell.e2e.ts
+++ b/e2e/shell.e2e.ts
@@ -1,6 +1,6 @@
-/** Browser coverage for the shell's resize handles. */
+/** Browser coverage for the shell's layout and controls. */
 
-import { expect, test } from "./room";
+import { expect, ready, test } from "./room";
 
 import type { Locator, Page } from "@playwright/test";
 
@@ -18,6 +18,11 @@ function box(target: Locator) {
 function drawn(handle: Locator): Promise<string> {
 	return handle.evaluate(element => getComputedStyle(element, "::after").opacity);
 }
+
+const PANES = [
+	{ label: "conversation", name: "Resize the conversation", region: "pane-chat" },
+	{ label: "decisions", name: "Resize the decisions", region: "pane-decisions" },
+] as const;
 
 test("a drag the browser takes away still puts the bar down", async ({ join, page }) => {
 	await join("ana");
@@ -81,4 +86,48 @@ test("both rail handles are keyboard reachable and resize their rail", async ({ 
 		expect({ rail: name, moved: after - before }).toEqual({ rail: name, moved: grew });
 		await expect(handle).toHaveAttribute("aria-valuenow", String(after));
 	}
+});
+
+test("side panes remember whether they are open and how wide they were", async ({ join, page }) => {
+	await page.setViewportSize({ width: 1600, height: 800 });
+	await join("ana");
+
+	for (let pane of PANES) {
+		await page.getByRole("separator", { name: pane.name }).press("End");
+		let toggle = page.getByRole("button", { name: `Hide ${pane.label} pane` });
+		await expect(toggle).toHaveAttribute("aria-controls", pane.region);
+		await expect(toggle).toHaveAttribute("aria-expanded", "true");
+		await toggle.click();
+		await expect(page.locator(`#${pane.region}`)).toBeHidden();
+	}
+	await expect(page.getByRole("separator")).toHaveCount(0);
+
+	await page.reload();
+	await ready(page);
+
+	for (let pane of PANES) {
+		let toggle = page.getByRole("button", { name: `Show ${pane.label} pane` });
+		await expect(toggle).toHaveAttribute("aria-expanded", "false");
+		await toggle.click();
+		await expect(page.locator(`#${pane.region}`)).toBeVisible();
+		await expect.poll(async () => (await box(page.locator(`#${pane.region}`))).width).toBe(520);
+	}
+});
+
+test("the document keeps 400 pixels before the panes take the deficit", async ({ join, page }) => {
+	await page.setViewportSize({ width: 760, height: 800 });
+	await join("ana");
+
+	expect((await box(page.locator("main"))).width).toBe(400);
+	expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(760);
+});
+
+test("chat keeps its draft while hidden", async ({ join }) => {
+	let page = await join("ana");
+	let draft = page.locator("#pane-chat textarea");
+
+	await draft.fill("unfinished thought");
+	await page.getByRole("button", { name: "Hide conversation pane" }).click();
+	await page.getByRole("button", { name: "Show conversation pane" }).click();
+	await expect(draft).toHaveValue("unfinished thought");
 });


### PR DESCRIPTION
## Summary

- Adds header controls to hide or restore the conversation and decisions panes.
- Persists each pane’s open state and preferred width.
- Gives the document a 400px floor, shrinking side panes first while keeping the shared-ground shell and its resize handles intact.
- Keeps hidden panes mounted so Chat drafts, wire subscriptions, and messages received while hidden survive collapse. Native `hidden` removes their controls from layout and keyboard navigation.

## Validation

- `bun run ci`
- `bun run types`
- `bun test` — 565 pass
- `bun run e2e` — 55 pass