### PR TITLE
Simplify comment and question cards

### DIFF
--- a/packages/editor/src/card.tsx
+++ b/packages/editor/src/card.tsx
@@ -8,9 +8,9 @@
  * convention is how that happens, so the chrome lives here instead and neither
  * card draws its own.
  *
- * The header names the kind, always, so a mixed list can be scanned by what
- * things are. The footer's verb carries the status, because "accepted by" and
- * "answered by" already say it and a separate label would say it twice.
+ * The body distinguishes comments from questions visually; the card keeps its
+ * kind as an accessible name. Settled provenance sits above the body, leaving
+ * the footer for actions that still apply.
  *
  * Controls stay in each body rather than being hoisted into the footer:
  * `QuestionView` owns its submit and cancel and cannot give them up, so moving
@@ -21,13 +21,17 @@
 import type { ComponentProps, ReactNode } from "react";
 
 export type SidecarCardProps = {
-	/** What this is: a comment, a question. Not what has happened to it. */
+	/** The card kind, retained as its programmatic name. */
 	label: string;
-	/** Provenance once it is settled; nothing while it is still open. */
+	/** An action and the reason it remains available. */
 	footer?: ReactNode;
 	children: ReactNode;
 	/** True while the reader is pointing at it, which also marks its prose. */
 	focused?: boolean;
+	/** True once the comment or question can no longer be acted on. */
+	settled?: boolean;
+	/** Who settled the card and when. */
+	status?: ReactNode;
 	/**
 	 * False when the body already insets itself.
 	 *
@@ -39,27 +43,26 @@ export type SidecarCardProps = {
 };
 
 export function SidecarCard(
-	{ children, focused, footer, label, padded = true, ...rest }:
+	{ children, focused, footer, label, padded = true, settled, status, ...rest }:
 		& SidecarCardProps
 		& Omit<ComponentProps<"article">, "children">,
 ) {
+	let surface = settled ? "bg-inset" : "bg-page shadow-resting";
+
 	return (
 		<article
-			className={`flex flex-col overflow-hidden rounded-lg bg-page ring-hairline shadow-resting ${
+			aria-label={label}
+			className={`flex flex-col overflow-hidden rounded-lg ring-hairline ${surface} ${
 				focused ? "bg-selected" : ""
 			}`}
 			{...rest}
 		>
-			<header className="flex items-center gap-2 bg-inset px-3 py-2 hairline-b">
-				<span className="text-sm font-semibold tracking-wide text-text-tertiary uppercase">
-					{label}
-				</span>
-			</header>
+			{status && <div className="flex justify-end px-3 pt-2.5 empty:hidden">{status}</div>}
 
 			<div className={`flex flex-col gap-2 ${padded ? "px-3 py-2.5" : ""}`}>{children}</div>
 
 			{footer && (
-				<footer className="flex items-center gap-2 px-3 py-2 hairline-t">
+				<footer className="flex items-center gap-2 px-3 py-2">
 					{footer}
 				</footer>
 			)}

--- a/packages/editor/src/comments.tsx
+++ b/packages/editor/src/comments.tsx
@@ -46,8 +46,7 @@ function Note({ note }: { note: Comment.Note }) {
 	);
 }
 
-const QUOTED =
-	"m-0 w-full border-l-2 border-edge pl-2 text-left text-sm text-text-secondary italic";
+const QUOTED = "m-0 w-full text-left text-sm text-text-secondary italic";
 
 /**
  * The prose the thread marks, as a quotation the card can be read without.
@@ -196,11 +195,13 @@ function Composer({
 /** A button that asks again before doing something that cannot be undone. */
 function Confirm({
 	busy,
+	consequence,
 	label,
 	onConfirm,
 	tone,
 }: {
 	busy?: boolean;
+	consequence?: string;
 	label: string;
 	onConfirm: () => void;
 	tone: "primary" | "quiet";
@@ -218,18 +219,26 @@ function Confirm({
 		: "text-text-tertiary hover:text-text-primary";
 
 	return (
-		<button
-			className={`rounded-md px-2 py-1 text-sm font-medium disabled:opacity-50 ${style}`}
-			disabled={busy}
-			onClick={() => {
-				if (!asked) return setAsked(true);
-				setAsked(false);
-				onConfirm();
-			}}
-			type="button"
-		>
-			{asked ? "Sure?" : label}
-		</button>
+		<>
+			<button
+				className={`rounded-md px-2 py-1 text-sm font-medium disabled:opacity-50 ${style}`}
+				disabled={busy}
+				onClick={() => {
+					if (!asked) return setAsked(true);
+					setAsked(false);
+					onConfirm();
+				}}
+				type="button"
+			>
+				{asked ? "Sure?" : label}
+			</button>
+			{consequence && (
+				// Keep the live region mounted so later text changes are announced.
+				<span aria-live="polite" className="order-last ml-auto text-sm text-text-secondary">
+					{asked && consequence}
+				</span>
+			)}
+		</>
 	);
 }
 
@@ -275,22 +284,17 @@ export function ThreadCard({
 		<SidecarCard
 			data-plan-sidecar-thread={thread.id}
 			focused={focused}
-			footer={open ? undefined : (
+			footer={!open && !applied && (
 				<>
-					<Provenance at={thread.at} by={thread.resolver} verb="Accepted" />
-					{!applied && (
-						<>
-							<span className="ml-auto text-sm text-warning-ink">Not yet applied</span>
-							<button
-								className="rounded-md px-2 py-1 text-sm text-text-tertiary hover:text-text-primary"
-								disabled={busy}
-								onClick={onRetry}
-								type="button"
-							>
-								Ask again
-							</button>
-						</>
-					)}
+					<span className="text-sm text-warning-ink">Not yet applied</span>
+					<button
+						className="rounded-md px-2 py-1 text-sm text-text-tertiary hover:text-text-primary"
+						disabled={busy}
+						onClick={onRetry}
+						type="button"
+					>
+						Ask again
+					</button>
 				</>
 			)}
 			label="Comment"
@@ -298,6 +302,8 @@ export function ThreadCard({
 			onFocus={onFocus}
 			onMouseEnter={onFocus}
 			onMouseLeave={onBlur}
+			settled={!open}
+			status={!open && <Provenance at={thread.at} by={thread.resolver} verb="Accepted" />}
 		>
 			<Quote count={view.places.length} drifted={view.drifted} onSelect={onReveal} text={quote} />
 
@@ -320,12 +326,15 @@ export function ThreadCard({
 						onTyping={onTyping}
 						placeholder="Reply…"
 					/>
-					<div className="flex items-center gap-2 pt-2 hairline-t">
-						<Confirm busy={busy} label="Accept" onConfirm={onAccept} tone="primary" />
+					<div className="flex items-center gap-2 pt-2">
+						<Confirm
+							busy={busy}
+							consequence="Accepting asks the agent to revise the plan"
+							label="Accept"
+							onConfirm={onAccept}
+							tone="primary"
+						/>
 						<Confirm busy={busy} label="Dismiss" onConfirm={onDismiss} tone="quiet" />
-						<span className="ml-auto text-sm text-text-secondary">
-							Accepting asks the agent to revise the plan
-						</span>
 					</div>
 				</>
 			)}

--- a/packages/editor/src/widgets/questionnaire.tsx
+++ b/packages/editor/src/widgets/questionnaire.tsx
@@ -120,11 +120,11 @@ function Decided(
 	return (
 		<SidecarCard
 			data-plan-sidecar-questionnaire={value.id}
-			// Read off the node, so a late joiner sees it too and it survives a
-			// restart. Absent on one settled before the plan recorded any.
-			footer={<Provenance at={value.at} by={value.by} verb="Answered" />}
 			label="Question"
 			padded={false}
+			settled
+			// Read provenance from the durable node so late joiners see it.
+			status={<Provenance at={value.at} by={value.by} verb="Answered" />}
 		>
 			<QuestionView
 				answers={resolved}


### PR DESCRIPTION
## Summary

- Remove visible card-kind headers while preserving accessible article names.
- Distinguish open and settled cards with the current surface, hairline, and elevation system; move settled provenance to the top.
- Remove redundant internal rules and show the Accept consequence only while confirmation is active.

This is rebuilt directly on the latest `main` and contains no inherited design-stack changes.

## Validation

- `bun run ci`
- `bun run types`
- `bun test` — 565 passed
- `bun run e2e` — production build and 52 Chromium tests passed