### PR TITLE
Print the app's address once both halves are up

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -30,6 +30,11 @@ const GRACE_MS = 2_000;
 
 const WEB = "http://127.0.0.1:5173";
 
+/** Defaults kept in step with `apps/server/src/config.ts`. */
+const APP = `http://${process.env.SERVER_HOST || "127.0.0.1"}:${process.env.PORT || 8787}`;
+
+const READY_MS = 30_000;
+
 type Child = { name: string; proc: Subprocess };
 
 let children: Child[] = [];
@@ -88,6 +93,32 @@ async function stop(code: number): Promise<void> {
 }
 
 /**
+ * Print where the app is, once it answers.
+ *
+ * Vite prints its own address, which does not work — the server is the only
+ * origin. Waiting for a reply puts this line below Vite's banner, and the
+ * server 502s until Vite is up, so a reply means both halves are ready.
+ */
+async function announce(): Promise<void> {
+	let deadline = Date.now() + READY_MS;
+
+	while (Date.now() < deadline) {
+		if (stopping) return;
+
+		try {
+			let response = await fetch(APP, { redirect: "manual" });
+			await response.body?.cancel();
+			if (response.ok) {
+				console.log(`\n[dev] chopin is at ${APP}\n`);
+				return;
+			}
+		} catch {}
+
+		await Bun.sleep(250);
+	}
+}
+
+/**
  * Settle relative paths here, where the current directory is still yours.
  *
  * Each child is started in its own package directory, so `WORKING_DIR=../thing`
@@ -120,6 +151,8 @@ children = [
 for (let name of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
 	process.on(name, () => void stop(0));
 }
+
+void announce();
 
 // A supervisor that outlived its children would leave the terminal looking
 // busy with nothing behind it.


### PR DESCRIPTION
## What

`bun dev` now prints where the app actually is, after probing for it:

```
  VITE v7.3.1  ready in 256 ms

  ➜  Local:   http://127.0.0.1:5173/

[dev] chopin is at http://127.0.0.1:8787

chopin  ·  http://127.0.0.1:8787  ·  client: vite (…)  ·  agent: claude-sonnet-4.6  ·  …
```

## Why

Vite announces its own port on the way up, and that address does not work. The server is the only origin — it owns `/ws` and forwards everything else — so the client derives its socket URL from `location` and dials whatever origin served the page.

Load `:5173` and you get a page that renders perfectly and a socket that goes nowhere:

```
WebSocket connection to 'ws://localhost:5173/ws?room=main&as=…' failed:
  WebSocket opening handshake timed out    @ src/wire.ts:59
```

The header sits at `connecting` and the editor says *"Reconnecting — Editing resumes once connected."* forever. It reads as a broken app rather than a wrong URL. The readme has always documented `:8787`, but the only clickable thing in the terminal was the address that doesn't work.

## How

`announce()` polls the server origin, then prints once. Probing rather than printing immediately buys two things:

- the line lands **beneath** Vite's banner instead of scrolling off above it
- the server answers **502** while Vite is down (`apps/server/src/client.ts:56`), so an `ok` response means *both* halves are ready, not merely spawned

`APP` is derived from `SERVER_HOST`/`PORT` with the same defaults as `apps/server/src/config.ts`. Importing `load()` would drag its `statSync` boot check into a supervisor with no use for one.

Quiet on timeout and quiet during shutdown — a child that failed has already explained itself better than a timeout could.

## Testing

- `bun run ci` — 0 warnings, 0 errors
- `bun run types` — clean across all six packages
- Ran `bun dev` end to end: line prints in the right place, Ctrl-C still leaves both ports clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)