### PR TITLE
Check what the model actually sent before believing the schema

### DIFF
--- a/apps/server/src/agent/arguments.test.ts
+++ b/apps/server/src/agent/arguments.test.ts
@@ -1,12 +1,6 @@
 /**
- * Validating `edit_plan` and `anchor_plan` arguments.
- *
- * The bug this guards: a model that sends `operations` as a JSON-encoded
- * string reaches `edit.apply` as a value that is not an array at all, and
- * `operations.some`/`operations.length` either throw or measure characters
- * instead of operations. These tests pin the rejection and its message, not
- * just that something throws — the message is what lets the model correct
- * itself.
+ * These pin the rejection message, not just that something throws — the
+ * message is what lets the model correct itself.
  */
 
 import { describe, expect, it } from "bun:test";
@@ -36,11 +30,7 @@ describe("editPlan", () => {
 		expect(() => editPlan(batch({ operations: source }))).toThrow(/`operations` must be an array/);
 	});
 
-	/**
-	 * A single-operation batch, JSON-encoded, is the case that used to sail
-	 * past `operations.length === 0` and `operations.length > 1` in `edit.ts`
-	 * because those measured characters in the string, not operations.
-	 */
+	/** The case that used to pass `edit.ts`'s length checks by measuring characters. */
 	it("rejects a single-operation batch sent as a JSON string", () => {
 		let source = JSON.stringify([{ op: "insert", index: 0, source: "Hi.\n" }]);
 		expect(() => editPlan(batch({ operations: source }))).toThrow(/`operations` must be an array/);
@@ -153,7 +143,6 @@ describe("anchorPlan", () => {
 		expect(() => anchorPlan({ anchors: anchors().anchors })).toThrow(/missing field: revision/);
 	});
 
-	/** An empty `blocks` list is a real answer — reviewed and unrelated — not malformed input. */
 	it("accepts an anchor with no blocks", () => {
 		let args = anchorPlan(anchors({ anchors: [{ thread: "t1", blocks: [] }] }));
 		expect(args.anchors[0]!.blocks).toEqual([]);

--- a/apps/server/src/agent/arguments.test.ts
+++ b/apps/server/src/agent/arguments.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Validating `edit_plan` and `anchor_plan` arguments.
+ *
+ * The bug this guards: a model that sends `operations` as a JSON-encoded
+ * string reaches `edit.apply` as a value that is not an array at all, and
+ * `operations.some`/`operations.length` either throw or measure characters
+ * instead of operations. These tests pin the rejection and its message, not
+ * just that something throws — the message is what lets the model correct
+ * itself.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+import { anchorPlan, ArgumentError, editPlan } from "./arguments";
+
+function batch(overrides: Record<string, unknown> = {}) {
+	return {
+		revision: 1,
+		operations: [{ op: "insert", index: 0, source: "Hi.\n" }],
+		...overrides,
+	};
+}
+
+describe("editPlan", () => {
+	it("accepts a well-formed batch and returns the operations unchanged", () => {
+		let args = editPlan(batch());
+
+		expect(args.revision).toBe(1);
+		expect(Array.isArray(args.operations)).toBe(true);
+		expect(args.operations).toEqual([{ op: "insert", index: 0, source: "Hi.\n" }]);
+	});
+
+	it("rejects operations sent as a JSON-encoded string", () => {
+		let source = JSON.stringify(batch().operations);
+		expect(() => editPlan(batch({ operations: source }))).toThrow(ArgumentError);
+		expect(() => editPlan(batch({ operations: source }))).toThrow(/`operations` must be an array/);
+	});
+
+	/**
+	 * A single-operation batch, JSON-encoded, is the case that used to sail
+	 * past `operations.length === 0` and `operations.length > 1` in `edit.ts`
+	 * because those measured characters in the string, not operations.
+	 */
+	it("rejects a single-operation batch sent as a JSON string", () => {
+		let source = JSON.stringify([{ op: "insert", index: 0, source: "Hi.\n" }]);
+		expect(() => editPlan(batch({ operations: source }))).toThrow(/`operations` must be an array/);
+	});
+
+	it("rejects an array-like object standing in for an array", () => {
+		let arrayLike = { 0: { op: "insert", index: 0, source: "Hi.\n" }, length: 1 };
+		expect(() => editPlan(batch({ operations: arrayLike }))).toThrow(
+			/`operations` must be an array/,
+		);
+	});
+
+	it("rejects a missing operations field", () => {
+		expect(() => editPlan({ revision: 1 })).toThrow(/missing field: operations/);
+	});
+
+	it("rejects an empty batch", () => {
+		expect(() => editPlan(batch({ operations: [] }))).toThrow(/at least 1 operation/);
+	});
+
+	it("rejects a batch over the fifty-operation limit", () => {
+		let operations = Array.from({ length: 51 }, () => ({ op: "delete", index: 0 }));
+		expect(() => editPlan(batch({ operations }))).toThrow(/at most 50 operations/);
+	});
+
+	it("rejects an unknown op", () => {
+		expect(() => editPlan(batch({ operations: [{ op: "vaporize", index: 0 }] })))
+			.toThrow(/must be one of/);
+	});
+
+	it("rejects a move with no destination", () => {
+		expect(() => editPlan(batch({ operations: [{ op: "move", index: 0 }] })))
+			.toThrow(/operations\[0\]\.to.*required/);
+	});
+
+	it("rejects a replace with no index", () => {
+		expect(() => editPlan(batch({ operations: [{ op: "replace", source: "x\n" }] })))
+			.toThrow(/operations\[0\]\.index.*required/);
+	});
+
+	it("rejects an insert with no source", () => {
+		expect(() => editPlan(batch({ operations: [{ op: "insert", index: 0 }] })))
+			.toThrow(/operations\[0\]\.source.*required/);
+	});
+
+	it("rejects a detach_question with no id", () => {
+		expect(() => editPlan(batch({ operations: [{ op: "detach_question" }] })))
+			.toThrow(/operations\[0\]\.id.*required/);
+	});
+
+	it("rejects a missing revision", () => {
+		expect(() => editPlan({ operations: batch().operations })).toThrow(/missing field: revision/);
+	});
+
+	it("rejects a revision that is not an integer", () => {
+		expect(() => editPlan(batch({ revision: 1.5 }))).toThrow(/`revision` must be/);
+	});
+
+	it("rejects an unknown top-level field", () => {
+		expect(() => editPlan(batch({ extra: true }))).toThrow(/unexpected field/);
+	});
+});
+
+function digest(byte = "a") {
+	return `sha256:${byte.repeat(64)}`;
+}
+
+describe("anchorPlan", () => {
+	function anchors(overrides: Record<string, unknown> = {}) {
+		return {
+			revision: 1,
+			anchors: [{ thread: "t1", blocks: [{ index: 0, digest: digest() }] }],
+			...overrides,
+		};
+	}
+
+	it("accepts a well-formed batch and returns the anchors unchanged", () => {
+		let args = anchorPlan(anchors());
+
+		expect(args.revision).toBe(1);
+		expect(Array.isArray(args.anchors)).toBe(true);
+		expect(args.anchors).toEqual(anchors().anchors);
+	});
+
+	it("rejects anchors sent as a JSON-encoded string", () => {
+		let source = JSON.stringify(anchors().anchors);
+		expect(() => anchorPlan(anchors({ anchors: source }))).toThrow(/`anchors` must be an array/);
+	});
+
+	it("rejects a missing anchors field", () => {
+		expect(() => anchorPlan({ revision: 1 })).toThrow(/missing field: anchors/);
+	});
+
+	it("rejects an empty batch", () => {
+		expect(() => anchorPlan(anchors({ anchors: [] }))).toThrow(/at least 1 anchor/);
+	});
+
+	it("rejects a batch over the hundred-anchor limit", () => {
+		let many = Array.from({ length: 101 }, () => ({ blocks: [] }));
+		expect(() => anchorPlan(anchors({ anchors: many }))).toThrow(/at most 100 anchors/);
+	});
+
+	it("rejects a digest that does not match the sha256 pattern", () => {
+		expect(() =>
+			anchorPlan(anchors({ anchors: [{ thread: "t1", blocks: [{ index: 0, digest: "abc" }] }] }))
+		).toThrow(/sha256/);
+	});
+
+	it("rejects a missing revision", () => {
+		expect(() => anchorPlan({ anchors: anchors().anchors })).toThrow(/missing field: revision/);
+	});
+
+	/** An empty `blocks` list is a real answer — reviewed and unrelated — not malformed input. */
+	it("accepts an anchor with no blocks", () => {
+		let args = anchorPlan(anchors({ anchors: [{ thread: "t1", blocks: [] }] }));
+		expect(args.anchors[0]!.blocks).toEqual([]);
+	});
+
+	it("rejects an anchor missing blocks entirely", () => {
+		expect(() => anchorPlan(anchors({ anchors: [{ thread: "t1" }] }))).toThrow(/missing field/);
+	});
+});

--- a/apps/server/src/agent/arguments.ts
+++ b/apps/server/src/agent/arguments.ts
@@ -1,0 +1,251 @@
+/**
+ * Validating an agent's tool call arguments before they reach the plan.
+ *
+ * `edit_plan` and `anchor_plan` receive `raw: unknown` from the SDK. The
+ * handlers used to cast it straight to the shape their JSON schema
+ * advertises, and `as` is erased at runtime: a model that sent `operations`
+ * as a JSON-encoded string sailed past every guard and only surfaced as
+ * `operations.some is not a function`, a message with nothing in it a model
+ * could act on. This module is the boundary that check belongs at — reject a
+ * malformed call with a message naming the field and the shape it needed, so
+ * the model can retry, exactly as `@chopin/question`'s `normalize` already
+ * does for `ask`.
+ *
+ * `@chopin/question`'s `fail`/`record`/`exact`/`text` are not reused here even
+ * though the shapes rhyme: that package is about questionnaires, not a home
+ * for a generic argument validator, and duplicating four small functions
+ * costs less than growing that package a public surface it was never designed
+ * for.
+ *
+ * Every check here mirrors a line of the JSON schema in `tools.ts` — the
+ * required fields, the `op` enum, `minItems`/`maxItems`, the digest pattern —
+ * so the two cannot quietly disagree. What the schema cannot express is
+ * enforced by hand: which fields an operation needs depends on its `op`, and
+ * the schema states that only in a description string, because one object
+ * shape covers every operation kind.
+ */
+
+import type { Operation } from "../plan/edit";
+
+/** Thrown for any malformed tool call; the message reaches the model. */
+export class ArgumentError extends Error {
+	override readonly name = "ArgumentError";
+}
+
+function fail(message: string): never {
+	throw new ArgumentError(message);
+}
+
+function record(value: unknown, name: string): Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		fail(`\`${name}\` must be an object.`);
+	}
+	return value as Record<string, unknown>;
+}
+
+/**
+ * No unknown fields, and every field in `required` present.
+ *
+ * `required` is not always all of `allowed`: an operation's shared object
+ * shape lists every field any op might use, but only `op` is universally
+ * required — the rest depend on which op it is, and that is checked
+ * separately by `operation`.
+ */
+function fields(
+	value: Record<string, unknown>,
+	allowed: string[],
+	required: string[],
+	name: string,
+): void {
+	let extra = Object.keys(value).filter(key => !allowed.includes(key));
+	if (extra.length > 0) {
+		fail(`\`${name}\` has unexpected field${extra.length > 1 ? "s" : ""}: ${extra.join(", ")}.`);
+	}
+	let missing = required.filter(key => !(key in value));
+	if (missing.length > 0) {
+		fail(
+			`\`${name}\` is missing ${missing.length > 1 ? "fields" : "field"}: ${missing.join(", ")}.`,
+		);
+	}
+}
+
+/**
+ * Reject anything that is not a real array, on purpose without trying to be
+ * helpful: a JSON-encoded string and an array-like object such as
+ * `{0: …, length: 1}` both fail `Array.isArray`, and coercing either back into
+ * an array would hide the mistake instead of telling the model to fix it.
+ */
+function array(value: unknown, name: string, of: string, min?: number, max?: number): unknown[] {
+	if (!Array.isArray(value)) fail(`\`${name}\` must be an array of ${of} objects.`);
+	if (min !== undefined && value.length < min) {
+		fail(`\`${name}\` requires at least ${min} ${of}${min === 1 ? "" : "s"}.`);
+	}
+	if (max !== undefined && value.length > max) {
+		fail(`\`${name}\` allows at most ${max} ${of}${max === 1 ? "" : "s"}.`);
+	}
+	return value;
+}
+
+function integer(value: unknown, name: string): number {
+	if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+		fail(`\`${name}\` must be a non-negative integer.`);
+	}
+	return value;
+}
+
+function text(value: unknown, name: string, max?: number): string {
+	if (typeof value !== "string") fail(`\`${name}\` must be text.`);
+	if (max !== undefined && value.length > max) fail(`\`${name}\` exceeds ${max} characters.`);
+	return value;
+}
+
+/** How much of an operation's `source` a batch may carry, matching `tools.ts`. */
+const MAX_SOURCE = 100_000;
+
+/** `tools.ts`'s `operations` limits. */
+const MAX_OPERATIONS = 50;
+
+/** `tools.ts`'s `anchors` limit. */
+const MAX_ANCHORS = 100;
+
+const OPS = [
+	"insert",
+	"insert_root",
+	"replace",
+	"replace_root",
+	"move",
+	"delete",
+	"detach_question",
+] as const;
+
+type Op = typeof OPS[number];
+
+const OPERATION_FIELDS = ["op", "index", "to", "source", "id"];
+
+function kind(value: unknown, name: string): Op {
+	if (typeof value !== "string" || !(OPS as readonly string[]).includes(value)) {
+		fail(`\`${name}\` must be one of ${OPS.join(", ")}.`);
+	}
+	return value as Op;
+}
+
+/**
+ * One operation, validated against exactly the fields its `op` needs.
+ *
+ * `tools.ts`'s schema cannot say "index is required unless the op is
+ * insert_root or replace_root" — it is one object shape shared by every op,
+ * with only `op` itself in `required` — so that conditional lives here,
+ * spelled out per op the same way the tool description spells it out for the
+ * model.
+ */
+function operation(raw: unknown, position: number): Operation {
+	let name = `operations[${position}]`;
+	let value = record(raw, name);
+	fields(value, OPERATION_FIELDS, ["op"], name);
+
+	let op = kind(value.op, `${name}.op`);
+
+	let index = "index" in value ? integer(value.index, `${name}.index`) : undefined;
+	let to = "to" in value ? integer(value.to, `${name}.to`) : undefined;
+	let source = "source" in value ? text(value.source, `${name}.source`, MAX_SOURCE) : undefined;
+	let id = "id" in value ? text(value.id, `${name}.id`) : undefined;
+
+	switch (op) {
+		case "insert":
+			if (index === undefined) fail(`\`${name}.index\` is required for "insert".`);
+			if (source === undefined) fail(`\`${name}.source\` is required for "insert".`);
+			return { op, index, source };
+		case "insert_root":
+			if (source === undefined) fail(`\`${name}.source\` is required for "insert_root".`);
+			return { op, source };
+		case "replace":
+			if (index === undefined) fail(`\`${name}.index\` is required for "replace".`);
+			if (source === undefined) fail(`\`${name}.source\` is required for "replace".`);
+			return { op, index, source };
+		case "replace_root":
+			if (source === undefined) fail(`\`${name}.source\` is required for "replace_root".`);
+			return { op, source };
+		case "move":
+			if (index === undefined) fail(`\`${name}.index\` is required for "move".`);
+			if (to === undefined) fail(`\`${name}.to\` is required for "move".`);
+			return { op, index, to };
+		case "delete":
+			if (index === undefined) fail(`\`${name}.index\` is required for "delete".`);
+			return { op, index };
+		case "detach_question":
+			if (id === undefined) fail(`\`${name}.id\` is required for "detach_question".`);
+			return { op, id };
+	}
+}
+
+/** Validate `edit_plan`'s tool input into the shape `edit.apply` expects. */
+export function editPlan(raw: unknown): { revision: number; operations: Operation[] } {
+	let args = record(raw, "edit_plan arguments");
+	fields(args, ["revision", "operations"], ["revision", "operations"], "edit_plan arguments");
+
+	let revision = integer(args.revision, "revision");
+	let operations = array(args.operations, "operations", "operation", 1, MAX_OPERATIONS)
+		.map((item, index) => operation(item, index));
+
+	return { revision, operations };
+}
+
+const DIGEST = /^sha256:[0-9a-f]{64}$/;
+
+function anchorDigest(value: unknown, name: string): string {
+	if (typeof value !== "string" || !DIGEST.test(value)) {
+		fail(`\`${name}\` must be a digest of the form "sha256:<64 hex characters>".`);
+	}
+	return value;
+}
+
+function block(raw: unknown, name: string): { index: number; digest: string } {
+	let value = record(raw, name);
+	fields(value, ["index", "digest"], ["index", "digest"], name);
+	return {
+		index: integer(value.index, `${name}.index`),
+		digest: anchorDigest(value.digest, `${name}.digest`),
+	};
+}
+
+const ANCHOR_FIELDS = ["widget", "question", "thread", "blocks"];
+
+type Anchor = {
+	widget?: string;
+	question?: string;
+	thread?: string;
+	blocks: Array<{ index: number; digest: string }>;
+};
+
+/**
+ * One anchor. Which of `widget`+`question` or `thread` is expected is a
+ * choice the handler makes, not the schema — `tools.ts` only requires
+ * `blocks`, so that is the only thing enforced here too.
+ */
+function anchor(raw: unknown, position: number): Anchor {
+	let name = `anchors[${position}]`;
+	let value = record(raw, name);
+	fields(value, ANCHOR_FIELDS, ["blocks"], name);
+
+	// No minimum: an empty list is reviewed-and-unrelated, a real answer.
+	let blocks = array(value.blocks, `${name}.blocks`, "block")
+		.map((item, index) => block(item, `${name}.blocks[${index}]`));
+
+	let result: Anchor = { blocks };
+	if ("widget" in value) result.widget = text(value.widget, `${name}.widget`);
+	if ("question" in value) result.question = text(value.question, `${name}.question`);
+	if ("thread" in value) result.thread = text(value.thread, `${name}.thread`);
+	return result;
+}
+
+/** Validate `anchor_plan`'s tool input into the shape its handler expects. */
+export function anchorPlan(raw: unknown): { revision: number; anchors: Anchor[] } {
+	let args = record(raw, "anchor_plan arguments");
+	fields(args, ["revision", "anchors"], ["revision", "anchors"], "anchor_plan arguments");
+
+	let revision = integer(args.revision, "revision");
+	let anchors = array(args.anchors, "anchors", "anchor", 1, MAX_ANCHORS)
+		.map((item, index) => anchor(item, index));
+
+	return { revision, anchors };
+}

--- a/apps/server/src/agent/arguments.ts
+++ b/apps/server/src/agent/arguments.ts
@@ -1,28 +1,12 @@
 /**
  * Validating an agent's tool call arguments before they reach the plan.
  *
- * `edit_plan` and `anchor_plan` receive `raw: unknown` from the SDK. The
- * handlers used to cast it straight to the shape their JSON schema
- * advertises, and `as` is erased at runtime: a model that sent `operations`
- * as a JSON-encoded string sailed past every guard and only surfaced as
- * `operations.some is not a function`, a message with nothing in it a model
- * could act on. This module is the boundary that check belongs at — reject a
- * malformed call with a message naming the field and the shape it needed, so
- * the model can retry, exactly as `@chopin/question`'s `normalize` already
- * does for `ask`.
- *
- * `@chopin/question`'s `fail`/`record`/`exact`/`text` are not reused here even
- * though the shapes rhyme: that package is about questionnaires, not a home
- * for a generic argument validator, and duplicating four small functions
- * costs less than growing that package a public surface it was never designed
- * for.
- *
- * Every check here mirrors a line of the JSON schema in `tools.ts` — the
- * required fields, the `op` enum, `minItems`/`maxItems`, the digest pattern —
- * so the two cannot quietly disagree. What the schema cannot express is
- * enforced by hand: which fields an operation needs depends on its `op`, and
- * the schema states that only in a description string, because one object
- * shape covers every operation kind.
+ * `edit_plan` and `anchor_plan` receive `raw: unknown`, and the `as` casts
+ * that used to stand in for checking it are erased at runtime: `operations`
+ * sent as a JSON-encoded string surfaced only as `operations.some is not a
+ * function`. Every check here mirrors a line of the JSON schema in `tools.ts`
+ * so the two cannot quietly disagree, and each failure names the field and
+ * the shape it needed so the model can retry.
  */
 
 import type { Operation } from "../plan/edit";
@@ -43,14 +27,7 @@ function record(value: unknown, name: string): Record<string, unknown> {
 	return value as Record<string, unknown>;
 }
 
-/**
- * No unknown fields, and every field in `required` present.
- *
- * `required` is not always all of `allowed`: an operation's shared object
- * shape lists every field any op might use, but only `op` is universally
- * required — the rest depend on which op it is, and that is checked
- * separately by `operation`.
- */
+/** No unknown fields, and every field in `required` present. */
 function fields(
 	value: Record<string, unknown>,
 	allowed: string[],
@@ -69,12 +46,7 @@ function fields(
 	}
 }
 
-/**
- * Reject anything that is not a real array, on purpose without trying to be
- * helpful: a JSON-encoded string and an array-like object such as
- * `{0: …, length: 1}` both fail `Array.isArray`, and coercing either back into
- * an array would hide the mistake instead of telling the model to fix it.
- */
+/** A JSON string and an array-like object both fail here, uncoerced on purpose. */
 function array(value: unknown, name: string, of: string, min?: number, max?: number): unknown[] {
 	if (!Array.isArray(value)) fail(`\`${name}\` must be an array of ${of} objects.`);
 	if (min !== undefined && value.length < min) {
@@ -99,13 +71,9 @@ function text(value: unknown, name: string, max?: number): string {
 	return value;
 }
 
-/** How much of an operation's `source` a batch may carry, matching `tools.ts`. */
+/** The limits `tools.ts` advertises in its schemas. */
 const MAX_SOURCE = 100_000;
-
-/** `tools.ts`'s `operations` limits. */
 const MAX_OPERATIONS = 50;
-
-/** `tools.ts`'s `anchors` limit. */
 const MAX_ANCHORS = 100;
 
 const OPS = [
@@ -130,13 +98,8 @@ function kind(value: unknown, name: string): Op {
 }
 
 /**
- * One operation, validated against exactly the fields its `op` needs.
- *
- * `tools.ts`'s schema cannot say "index is required unless the op is
- * insert_root or replace_root" — it is one object shape shared by every op,
- * with only `op` itself in `required` — so that conditional lives here,
- * spelled out per op the same way the tool description spells it out for the
- * model.
+ * One operation. Which fields it needs depends on its `op`, which one shared
+ * object shape cannot express in the schema, so the conditional lives here.
  */
 function operation(raw: unknown, position: number): Operation {
 	let name = `operations[${position}]`;
@@ -217,11 +180,7 @@ type Anchor = {
 	blocks: Array<{ index: number; digest: string }>;
 };
 
-/**
- * One anchor. Which of `widget`+`question` or `thread` is expected is a
- * choice the handler makes, not the schema — `tools.ts` only requires
- * `blocks`, so that is the only thing enforced here too.
- */
+/** One anchor. Only `blocks` is required; the handler decides the rest. */
 function anchor(raw: unknown, position: number): Anchor {
 	let name = `anchors[${position}]`;
 	let value = record(raw, name);

--- a/apps/server/src/agent/tools.ts
+++ b/apps/server/src/agent/tools.ts
@@ -11,6 +11,7 @@
  * by accident.
  */
 
+import * as Arguments from "./arguments";
 import * as Comments from "../comments/service";
 import * as edit from "../plan/edit";
 import * as Questions from "../questions/service";
@@ -149,7 +150,7 @@ export function toolbox(context: Context): Tool[] {
 			},
 			handler: raw =>
 				answer("edit_plan", () => {
-					let args = raw as { revision: number; operations: edit.Operation[] };
+					let args = Arguments.editPlan(raw);
 					let outcome = edit.apply(context.plan, args.revision, args.operations);
 					if (!outcome.ok) return outcome;
 
@@ -308,15 +309,7 @@ export function toolbox(context: Context): Tool[] {
 			},
 			handler: raw =>
 				answer("anchor_plan", () => {
-					let args = raw as {
-						revision: number;
-						anchors: Array<{
-							widget?: string;
-							question?: string;
-							thread?: string;
-							blocks: Array<{ index: number; digest: string }>;
-						}>;
-					};
+					let args = Arguments.anchorPlan(raw);
 
 					if (args.revision !== context.plan.revision) {
 						return {


### PR DESCRIPTION
Fixes a crash hit while running the app: `TypeError: operations.some is not a function` from `[agent/edit_plan]`.

Off `main`, unrelated to the design stack (#20, #21).

## Root cause

`apps/server/src/agent/tools.ts:152` cast the model's tool arguments instead of validating them:

```ts
let args = raw as { revision: number; operations: edit.Operation[] };
```

`raw` is `unknown` and `as` is erased at runtime. The JSON schema declaring `operations` as `type: "array"` is only *advertised* to the model, never *enforced* on the way back in. The model sent a JSON-encoded string, which reached `edit.apply` and crashed.

The two guards it passed are the tell — `operations.length === 0` and `> 1` were counting **characters**, so even a single-operation batch got through a check meant to catch multi-operation ones. Confirmed by replaying both guards:

```
JSON string:          THREW — ops.some is not a function
one-op JSON string:   THREW — ops.some is not a function
array-like object:    THREW — ops.some is not a function
real array:           passed both guards
```

**The second-order damage is worse than the crash.** `answer()` caught the `TypeError` and returned `Error: operations.some is not a function` to the model — naming nothing it could change, so it would retry the same malformed call.

## The fix

New `apps/server/src/agent/arguments.ts`: `editPlan(raw)` and `anchorPlan(raw)` take `unknown` and return validated values or throw a message the model can act on. Every rule in the JSON schema is mirrored in code beside a comment naming the schema line it enforces — the two disagreeing silently is the failure mode being fixed. The per-op conditionals the schema *can't* express (`index` required unless the op is `insert_root`/`replace_root`, and so on) are now in code rather than only in a description string.

Behaviour now:

```
REJECT operations as a JSON string   -> `operations` must be an array of operation objects.
REJECT single-op JSON string         -> `operations` must be an array of operation objects.
REJECT array-like object             -> `operations` must be an array of operation objects.
REJECT unknown op                    -> `operations[0].op` must be one of insert, insert_root, …
REJECT move without a destination    -> `operations[0].to` is required for "move".
REJECT empty batch                   -> `operations` requires at least 1 operation.
REJECT revision missing              -> `edit_plan arguments` is missing field: revision.
OK     well formed                   -> isArray=true n=2
```

**Nothing is coerced.** A JSON string could be `JSON.parse`d and the turn would succeed, but the model would keep sending strings and the next tool to trust its input would find out the hard way. This is the contract `ask` has always had via `@chopin/question`'s `normalize` — `edit_plan` was the tool that skipped it.

`anchor_plan` had the identical cast and is fixed alongside; it runs after every successful edit, so it's no less reachable.

`edit.apply` keeps its `Operation[]` signature — validation belongs where input arrives, and the type it always claimed is now true.

## Verification

| | |
|---|---|
| `bun run ci` | clean |
| `bun run types` | all packages + e2e, exit 0 |
| `bun test` | 551 pass, 0 fail (24 new) |

New `arguments.test.ts` covers the reported bug, the single-op character-length trap, array-like objects, missing/empty/over-limit arrays, unknown ops, missing per-op conditional fields, non-integer revisions, and bad digests — plus the happy paths asserting `Array.isArray` on the way out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)