### PR TITLE
Rebuild the chat rail

### DIFF
--- a/apps/server/src/chat/queue.test.ts
+++ b/apps/server/src/chat/queue.test.ts
@@ -13,8 +13,10 @@ import { describe, expect, it } from "bun:test";
 import * as Chat from "./service";
 
 import type { Server } from "bun";
+import type { Chat as Wire, Request } from "@chopin/protocol";
 import type { Config } from "../config";
 import type { Plan } from "../plan/service";
+import type { Socket } from "../wire";
 import type { SocketData } from "../wire";
 
 type Sent = { kind: string; [key: string]: unknown };
@@ -47,6 +49,88 @@ function said(sent: Sent[]): string[] {
 		.filter(frame => frame.kind === "chat:message")
 		.map(frame => (frame.entry as { text: string }).text);
 }
+
+function sender(handle = "ana"): Socket {
+	return { data: { handle } } as unknown as Socket;
+}
+
+function message(text: string, to: Wire.Destination): Request<Wire.Send> {
+	return { kind: "chat:send", rid: "request", text, to, ts: 0 };
+}
+
+describe("sending to a named destination", () => {
+	it("keeps a planner message in the queue until its turn begins", () => {
+		let { chat, context } = room({ busy: true });
+
+		Chat.send(context, sender(), message("draft the migration", "planner"));
+
+		expect(chat.entries).toHaveLength(0);
+		expect(chat.waiting).toMatchObject([{
+			handle: "ana",
+			text: "draft the migration",
+		}]);
+	});
+
+	it("sends to the room even when the prose contains the typing shortcut", () => {
+		let { chat, context } = room({ busy: true });
+
+		Chat.send(context, sender(), message("ask @ai about this later", "room"));
+
+		expect(chat.waiting).toHaveLength(0);
+		expect(chat.entries[0]).toMatchObject({
+			author: { kind: "member", handle: "ana" },
+			text: "ask @ai about this later",
+		});
+	});
+
+	it("removes the typing shortcut from a queued planner message", () => {
+		let { chat, context } = room({ busy: true });
+
+		Chat.send(context, sender(), message("@ai draft the migration", "planner"));
+
+		expect(chat.waiting[0]?.text).toBe("draft the migration");
+	});
+
+	it("moves a queued message into the transcript when it becomes pending", () => {
+		let { chat } = room();
+		chat.waiting.push({
+			id: "w1",
+			handle: "ana",
+			text: "draft the migration",
+			message: true,
+		});
+
+		Chat.pending(chat);
+
+		expect(chat.entries).toMatchObject([{
+			id: "w1",
+			author: { kind: "member", handle: "ana" },
+			text: "draft the migration",
+		}]);
+	});
+
+	it("ignores a destination the protocol does not name", () => {
+		let { chat, context } = room({ busy: true });
+
+		Chat.send(context, sender(), message("draft the migration", "later" as Wire.Destination));
+
+		expect(chat.entries).toHaveLength(0);
+		expect(chat.waiting).toHaveLength(0);
+	});
+
+	it("keeps planner requests out of a queue when the agent is off", () => {
+		let { chat, context, sent } = room({ agent: false });
+
+		Chat.send(context, sender(), message("draft the migration", "planner"));
+
+		expect(chat.busy).toBe(false);
+		expect(chat.waiting).toHaveLength(0);
+		expect(said(sent)).toEqual([
+			"draft the migration",
+			"The agent is not running, so the plan has not been revised.",
+		]);
+	});
+});
 
 describe("instructing the agent without a message", () => {
 	/**

--- a/apps/server/src/chat/service.test.ts
+++ b/apps/server/src/chat/service.test.ts
@@ -67,6 +67,16 @@ function tool(
 	} as unknown as SessionEvent;
 }
 
+function idle(): SessionEvent {
+	return {
+		type: "session.idle",
+		id: `event-${Math.random().toString(36).slice(2, 8)}`,
+		parentId: null,
+		timestamp: new Date().toISOString(),
+		data: {},
+	} as unknown as SessionEvent;
+}
+
 describe("a streamed message", () => {
 	it("becomes one entry, not one per event", () => {
 		let chat = create();
@@ -146,6 +156,28 @@ describe("a streamed message", () => {
 });
 
 describe("tool calls", () => {
+	it("announces a tool-only entry before updating it", () => {
+		let chat = create();
+		let { context, sent } = room(chat);
+
+		translate(context, tool("tool.execution_start", { toolCallId: "t1", toolName: "grep" }));
+
+		expect(sent.map(frame => frame.kind)).toEqual(["chat:message", "chat:tool"]);
+		expect(sent[1]?.entry).toBe((sent[0]!.entry as { id: string }).id);
+	});
+
+	it("starts a fresh tool run after a turn goes idle", () => {
+		let chat = create();
+		let { context } = room(chat);
+
+		translate(context, tool("tool.execution_start", { toolCallId: "t1", toolName: "grep" }));
+		translate(context, idle());
+		translate(context, tool("tool.execution_start", { toolCallId: "t2", toolName: "edit_plan" }));
+
+		expect(chat.entries).toHaveLength(2);
+		expect(chat.entries.map(entry => entry.tools?.[0]?.name)).toEqual(["grep", "edit_plan"]);
+	});
+
 	it("files them under the message that made them, with a duration", () => {
 		let chat = create();
 		let { context } = room(chat);

--- a/apps/server/src/chat/service.ts
+++ b/apps/server/src/chat/service.ts
@@ -21,7 +21,7 @@ import { ulid } from "@chopin/dialect";
 import * as Agent from "../agent/client";
 import { toolbox } from "../agent/tools";
 import * as Service from "../plan/service";
-import { addressed } from "@chopin/protocol/address";
+import { addressed, instruction } from "@chopin/protocol/address";
 
 import { compose, remember } from "./address";
 import { broadcast, tell } from "../wire";
@@ -50,6 +50,8 @@ const LINGER_MS = 5_000;
  */
 type Waiting = Wire.Waiting & {
 	spent?: () => boolean;
+	/** True when this came from the composer rather than another instruction. */
+	message?: boolean;
 	/** The comment thread this turn was started to act on, if one was. */
 	thread?: string;
 };
@@ -79,6 +81,8 @@ export type Chat = {
 	acting?: string;
 	/** The entry the agent is currently writing into. */
 	writing?: string;
+	/** The dedicated entry collecting tool calls for this turn. */
+	tooling?: string;
 	/** Detaches the event handler when a turn ends. */
 	release?: () => void;
 	/** Pending removal of the agent's cursor, cancelled if it edits again. */
@@ -157,8 +161,12 @@ function say(
 	entry: Wire.Entry,
 ): Wire.Entry {
 	chat.entries.push(entry);
-	broadcast(server, room, { kind: "chat:message", ts: 0, entry });
+	announce(server, room, entry);
 	return entry;
+}
+
+function announce(server: Server<SocketData>, room: string, entry: Wire.Entry): void {
+	broadcast(server, room, { kind: "chat:message", ts: 0, entry });
 }
 
 /** Everything said so far, for somebody who has just arrived. */
@@ -183,9 +191,10 @@ export type Room = {
 /**
  * Take a message.
  *
- * It appears in the transcript either way — what somebody said is not
- * contingent on the agent being ready to hear it, or on it being for the agent
- * at all. What differs is whether it starts a turn.
+ * A room message appears immediately. A planner message queued behind another
+ * turn stays visibly queued until that turn actually begins, then moves into
+ * the transcript exactly once. The destination, rather than its prose, decides
+ * which lifecycle it takes.
  */
 export function send(context: Room, ws: Socket, msg: Request<Wire.Send>): void {
 	let text = msg.text.trim();
@@ -193,19 +202,36 @@ export function send(context: Room, ws: Socket, msg: Request<Wire.Send>): void {
 
 	let { chat, room, server } = context;
 	let handle = ws.data.handle;
+	// The explicit destination is authoritative. Falling back to the typing
+	// shortcut keeps an older client predictable while rooms reconnect.
+	let destination = msg.to;
+	if (destination === undefined) destination = addressed(text) ? "planner" : "room";
+	else if (destination !== "room" && destination !== "planner") return;
+	let visible = destination === "planner" ? instruction(text) : text;
 
-	say(chat, server, room, {
-		id: ulid(),
-		author: { kind: "member", handle },
-		text,
-		ts: now(),
-	});
-
-	// Not for the agent: remembered, so the next turn arrives knowing it, but
-	// nothing runs and nothing queues. Nobody asked for anything.
-	if (!addressed(text)) {
-		chat.backscroll = remember(chat.backscroll, { handle, text });
+	if (destination === "room") {
+		say(chat, server, room, {
+			id: ulid(),
+			author: { kind: "member", handle },
+			text: visible,
+			ts: now(),
+		});
+		chat.backscroll = remember(chat.backscroll, { handle, text: visible });
 		return;
+	}
+	if (!context.config.agent) {
+		say(chat, server, room, {
+			id: ulid(),
+			author: { kind: "member", handle },
+			text: visible,
+			ts: now(),
+		});
+		return void say(chat, server, room, {
+			id: ulid(),
+			author: { kind: "system" },
+			text: "The agent is not running, so the plan has not been revised.",
+			ts: now(),
+		});
 	}
 
 	if (chat.busy) {
@@ -217,11 +243,17 @@ export function send(context: Room, ws: Socket, msg: Request<Wire.Send>): void {
 				ts: now(),
 			});
 		}
-		chat.waiting.push({ id: ulid(), handle, text });
+		chat.waiting.push({ id: ulid(), handle, text: visible, message: true });
 		return queued(chat, server, room);
 	}
 
-	void run(context, handle, text);
+	say(chat, server, room, {
+		id: ulid(),
+		author: { kind: "member", handle },
+		text: visible,
+		ts: now(),
+	});
+	void run(context, handle, visible);
 }
 
 /** Say something in the transcript without asking the agent for anything. */
@@ -409,6 +441,7 @@ async function run(context: Room, handle: string, text: string, thread?: string)
 		chat.release?.();
 		chat.release = undefined;
 		chat.writing = undefined;
+		chat.tooling = undefined;
 		settle(chat, server, room);
 		chat.busy = false;
 		chat.turn = undefined;
@@ -434,6 +467,8 @@ async function run(context: Room, handle: string, text: string, thread?: string)
 	let next = pending(chat);
 	if (next) {
 		queued(chat, server, room);
+		let entry = next.message ? chat.entries.find(item => item.id === next.id) : undefined;
+		if (entry) announce(server, room, entry);
 		await run(context, next.handle, next.text, next.thread);
 	}
 }
@@ -449,6 +484,14 @@ async function run(context: Room, handle: string, text: string, thread?: string)
 export function pending(chat: Chat): Waiting | undefined {
 	let next = chat.waiting.shift();
 	while (next?.spent?.()) next = chat.waiting.shift();
+	if (next?.message) {
+		chat.entries.push({
+			id: next.id,
+			author: { kind: "member", handle: next.handle },
+			text: next.text,
+			ts: now(),
+		});
+	}
 	return next;
 }
 
@@ -467,6 +510,10 @@ export function translate(context: Room, event: SessionEvent): void {
 	let { chat, room, server } = context;
 
 	switch (event.type) {
+		case "session.idle":
+			chat.tooling = undefined;
+			return;
+
 		// One entry per assistant message, identified by the id the deltas
 		// carry, so two messages in a turn do not run together.
 		case "assistant.message_delta": {
@@ -526,7 +573,7 @@ export function translate(context: Room, event: SessionEvent): void {
 			broadcast(server, room, {
 				kind: "chat:tool",
 				ts: 0,
-				entry: attach(chat, activity),
+				entry: attach(context, activity),
 				activity,
 			});
 			return;
@@ -552,7 +599,7 @@ export function translate(context: Room, event: SessionEvent): void {
 			broadcast(server, room, {
 				kind: "chat:tool",
 				ts: 0,
-				entry: attach(chat, activity),
+				entry: attach(context, activity),
 				activity,
 			});
 			return;
@@ -581,13 +628,14 @@ export function translate(context: Room, event: SessionEvent): void {
 			broadcast(server, room, {
 				kind: "chat:tool",
 				ts: 0,
-				entry: attach(chat, activity),
+				entry: attach(context, activity),
 				activity,
 			});
 			return;
 		}
 
 		case "session.error": {
+			chat.tooling = undefined;
 			say(chat, server, room, {
 				id: ulid(),
 				author: { kind: "system" },
@@ -616,13 +664,16 @@ function named(chat: Chat, id: string): string {
  * It gets an entry of its own so the work is visible while it happens rather
  * than appearing retrospectively once the agent finishes talking.
  */
-function attach(chat: Chat, activity: Wire.Activity): string {
-	let entry = chat.entries.find(item => item.id === chat.writing)
-		?? chat.entries.findLast(item => item.author.kind === "agent");
+function attach(context: Room, activity: Wire.Activity): string {
+	let { chat, room, server } = context;
+	let entry = chat.entries.find(item => item.id === chat.tooling)
+		?? chat.entries.find(item => item.id === chat.writing);
+	if (entry) chat.tooling = entry.id;
 
 	if (!entry) {
 		entry = { id: ulid(), author: { kind: "agent" }, text: "", ts: now(), tools: [] };
-		chat.entries.push(entry);
+		chat.tooling = entry.id;
+		say(chat, server, room, entry);
 	}
 
 	entry.tools ??= [];

--- a/apps/server/src/comments.wire.test.ts
+++ b/apps/server/src/comments.wire.test.ts
@@ -108,7 +108,7 @@ async function mark(who: Member, text = "Too long.") {
 beforeAll(async () => {
 	data = await mkdtemp(join(tmpdir(), "chopin-wire-"));
 	// Every room this file uses, seeded so there is prose worth marking.
-	for (let room of ["marking", "replies", "accepting", "joining"]) {
+	for (let room of ["marking", "replies", "accepting", "joining", "chatting"]) {
 		await mkdir(join(data, room), { recursive: true });
 		await writeFile(join(data, room, "plan.mdx"), SOURCE);
 	}
@@ -134,6 +134,28 @@ beforeAll(async () => {
 		}
 	}
 	throw new Error("server did not start");
+});
+
+describe("room messages", () => {
+	it("reach both members when the agent is off", async () => {
+		let ana = await member("chatting", "ana");
+		let kris = await member("chatting", "kris");
+		await ana.ask("plan:open", {});
+		await kris.ask("plan:open", {});
+
+		ana.send("chat:send", { text: "The room should see this.", to: "room" });
+
+		for (let each of [ana, kris]) {
+			let delivered = await until(seen(each.frames, "chat:message"), "room message");
+			expect(delivered.entry).toMatchObject({
+				author: { kind: "member", handle: "ana" },
+				text: "The room should see this.",
+			});
+		}
+
+		ana.socket.close();
+		kris.socket.close();
+	});
 });
 
 afterAll(async () => {

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -149,7 +149,7 @@ async function receive(ws: Socket, raw: string): Promise<void> {
 			return;
 
 		case "chat:send":
-			if (room.plan && config.agent) Chat.send(conversation(room), ws, frame);
+			if (room.plan) Chat.send(conversation(room), ws, frame);
 			return;
 
 		case "chat:abort":

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -190,8 +190,10 @@ function Room({ handle }: { handle: string }) {
 				<Chat
 					connected={status === "connected"}
 					handle={handle}
-					onReveal={widget =>
-						setReveal({ widget: widget || unanswered[0]?.id || "", token: Date.now() })}
+					onReveal={widget => {
+						setDecisionsOpen(true);
+						setReveal({ widget: widget || unanswered[0]?.id || "", token: Date.now() });
+					}}
 					waiting={unanswered.length}
 					wire={wire}
 				/>

--- a/apps/web/src/chat/chat.tsx
+++ b/apps/web/src/chat/chat.tsx
@@ -11,9 +11,9 @@
  * looks like a prompt and being met with silence.
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { addressed, MENTION } from "@chopin/protocol/address";
+import { addressed } from "@chopin/protocol/address";
 
 import { Transcript } from "./transcript";
 
@@ -30,48 +30,12 @@ export type ChatProps = {
 	waiting?: number;
 };
 
-function Queued(
-	{ handle, onWithdraw, waiting }: {
-		handle: string;
-		waiting: Wire.Waiting[];
-		onWithdraw: (id: string) => void;
-	},
-) {
-	if (waiting.length === 0) return null;
-
-	return (
-		<div className="flex shrink-0 flex-col gap-1 px-3 py-2 hairline-t">
-			<span className="text-sm font-semibold tracking-wide text-text-tertiary uppercase">
-				Queued
-			</span>
-			{waiting.map(item => (
-				<div className="animate-enter flex items-baseline gap-2 text-sm" key={item.id}>
-					<span className="text-text-tertiary">@{item.handle}</span>
-					<span className="min-w-0 flex-1 truncate">{item.text}</span>
-					{item.handle === handle && (
-						<button
-							className="btn btn-icon btn-ghost shrink-0"
-							onClick={() => onWithdraw(item.id)}
-							title="Withdraw"
-							type="button"
-						>
-							×
-						</button>
-					)}
-				</div>
-			))}
-		</div>
-	);
-}
-
 export function Chat({ connected, handle, onReveal, waiting, wire }: ChatProps) {
 	let [entries, setEntries] = useState<Wire.Entry[]>([]);
 	let [arrived, setArrived] = useState<ReadonlySet<string>>(new Set());
 	let [queue, setQueue] = useState<Wire.Waiting[]>([]);
 	let [busy, setBusy] = useState(false);
-	let [turn, setTurn] = useState<string>();
 	let [text, setText] = useState("");
-	let input = useRef<HTMLTextAreaElement>(null);
 
 	useEffect(() => {
 		if (!wire) return;
@@ -113,13 +77,12 @@ export function Chat({ connected, handle, onReveal, waiting, wire }: ChatProps) 
 			wire.on<Wire.Tool>("chat:tool", frame => {
 				setEntries(current => {
 					let index = current.findIndex(entry => entry.id === frame.entry);
-					let target = index < 0 ? current.length - 1 : index;
-					if (target < 0) return current;
+					if (index < 0) return current;
 					let next = [...current];
-					let entry = next[target]!;
+					let entry = next[index]!;
 					let tools = entry.tools ?? [];
 					let existing = tools.findIndex(item => item.id === frame.activity.id);
-					next[target] = {
+					next[index] = {
 						...entry,
 						tools: existing < 0
 							? [...tools, frame.activity]
@@ -130,7 +93,6 @@ export function Chat({ connected, handle, onReveal, waiting, wire }: ChatProps) 
 			}),
 			wire.on<Wire.State>("chat:state", frame => {
 				setBusy(frame.busy);
-				setTurn(frame.turn);
 			}),
 			wire.on<Wire.Queue>("chat:queue", frame => setQueue(frame.waiting)),
 		];
@@ -140,99 +102,83 @@ export function Chat({ connected, handle, onReveal, waiting, wire }: ChatProps) 
 		};
 	}, [wire]);
 
-	let submit = () => {
+	let submit = (to: Wire.Destination) => {
 		let value = text.trim();
 		if (!value || !wire || !connected) return;
-		wire.send("chat:send", { text: value });
+		wire.send("chat:send", { text: value, to });
 		setText("");
 	};
 
-	let asking = addressed(text);
-
 	return (
 		<div className="flex h-full min-h-0 flex-col">
-			<header className="flex shrink-0 items-center gap-2 px-3 py-2 hairline-b">
-				<span className="text-sm font-semibold tracking-wide text-text-tertiary uppercase">
-					Planner
-				</span>
-				{busy && (
-					<span className="text-sm text-text-tertiary">
-						working{turn && ` on @${turn}'s message`}
-					</span>
-				)}
-				{busy && (
-					<button
-						className="btn btn-sm btn-secondary ml-auto"
-						onClick={() => wire?.send("chat:abort")}
-						type="button"
-					>
-						Stop
-					</button>
-				)}
-			</header>
+			<Transcript
+				arrived={arrived}
+				entries={entries}
+				handle={handle}
+				onWithdraw={id => wire?.send("chat:unqueue", { id })}
+				queued={queue}
+			/>
 
 			{!!waiting && waiting > 0 && (
-				<button
-					className="btn btn-sm btn-ghost animate-enter flex w-full shrink-0 justify-start gap-2 text-left hairline-b"
-					data-press="wide"
-					onClick={() => onReveal?.("")}
-					type="button"
-				>
-					<span className="text-warning-ink">●</span>
+				<div className="animate-enter flex shrink-0 items-center gap-2 px-4 pb-2 text-sm text-text-secondary">
+					<span aria-hidden="true" className="text-warning-ink">●</span>
 					<span>
 						{waiting === 1 ? "A question is waiting" : `${waiting} questions are waiting`}
 					</span>
-					<span className="ml-auto text-text-secondary">Answer →</span>
-				</button>
+					<button
+						className="btn btn-sm btn-ghost ml-auto text-brand-ink"
+						onClick={() => onReveal?.("")}
+						type="button"
+					>
+						Answer
+					</button>
+				</div>
 			)}
 
-			<Transcript arrived={arrived} entries={entries} />
-
-			<Queued
-				handle={handle}
-				onWithdraw={id => wire?.send("chat:unqueue", { id })}
-				waiting={queue}
-			/>
-
-			<div className="flex shrink-0 flex-col gap-1 p-2 hairline-t">
+			<div className="flex shrink-0 flex-col gap-2 px-4 pb-4">
 				<textarea
-					className="field w-full resize-none px-2 py-1.5 text-sm"
+					className="field h-18 w-full resize-none px-2.5 py-1.5 text-base"
 					disabled={!connected}
 					onChange={event => setText(event.target.value)}
 					onKeyDown={event => {
 						// Enter sends; a newline needs a modifier, as everywhere else.
 						if (event.key !== "Enter" || event.shiftKey) return;
 						event.preventDefault();
-						submit();
+						submit(addressed(text) ? "planner" : "room");
 					}}
-					placeholder={`Talk to the room, or mention ${MENTION} to ask the planner…`}
-					ref={input}
+					placeholder="Say something…"
 					rows={3}
 					value={text}
 				/>
 
-				<div className="flex items-baseline gap-2 px-1 text-sm">
-					{asking
-						? (
-							<span className="text-brand">
-								→ planner{busy && ", after the current turn"}
-							</span>
-						)
-						: (
-							<span className="text-text-secondary">
-								room only — the planner will see it on its next turn
-							</span>
-						)}
-					<button
-						className="btn btn-sm btn-ghost ml-auto"
-						onClick={() => {
-							setText(current => (addressed(current) ? current : `${MENTION} ${current}`.trim()));
-							input.current?.focus();
-						}}
-						type="button"
-					>
-						{asking ? "" : `+ ${MENTION}`}
-					</button>
+				<div className="flex items-center gap-2">
+					{busy && (
+						<button
+							className="btn btn-md btn-secondary"
+							onClick={() => wire?.send("chat:abort")}
+							type="button"
+						>
+							Stop
+						</button>
+					)}
+					<div className="ml-auto flex items-center gap-2">
+						<button
+							className="btn btn-md btn-secondary"
+							disabled={!connected || !text.trim()}
+							onClick={() => submit("room")}
+							type="button"
+						>
+							Send to room
+						</button>
+						<button
+							className="btn btn-md btn-primary"
+							disabled={!connected || !text.trim()}
+							onClick={() => submit("planner")}
+							type="button"
+						>
+							Ask Planner
+						</button>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/apps/web/src/chat/model.test.ts
+++ b/apps/web/src/chat/model.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+
+import { displayText, duration, group, summarize } from "./model";
+
+import type { Chat } from "@chopin/protocol";
+
+function entry(id: string, author: Chat.Author, text = id): Chat.Entry {
+	return { id, author, text, ts: 1_700_000_000 };
+}
+
+describe("transcript groups", () => {
+	it("puts consecutive messages from one author in one group", () => {
+		let result = group([
+			entry("m1", { kind: "member", handle: "ana" }),
+			entry("m2", { kind: "member", handle: "ana" }),
+			entry("m3", { kind: "agent" }),
+		], []);
+
+		expect(result).toHaveLength(2);
+		expect(result[0]).toMatchObject({
+			kind: "messages",
+			messages: [{ id: "m1" }, { id: "m2" }],
+		});
+	});
+
+	it("starts a new group when a system line interrupts an author", () => {
+		let result = group([
+			entry("m1", { kind: "member", handle: "ana" }),
+			entry("s1", { kind: "system" }),
+			entry("m2", { kind: "member", handle: "ana" }),
+		], []);
+
+		expect(result.map(item => item.kind)).toEqual(["messages", "system", "messages"]);
+	});
+
+	it("groups queued messages separately from sent messages", () => {
+		let result = group(
+			[entry("m1", { kind: "member", handle: "ana" })],
+			[
+				{ id: "q1", handle: "ana", text: "one" },
+				{ id: "q2", handle: "ana", text: "two" },
+			],
+		);
+
+		expect(result).toHaveLength(2);
+		expect(result[1]).toMatchObject({ queued: true, messages: [{ id: "q1" }, { id: "q2" }] });
+	});
+});
+
+describe("rail copy", () => {
+	it("removes addressing symbols while leaving email addresses alone", () => {
+		expect(displayText("@ai ask @sam; email me@site.dev")).toBe("ask Sam; email me@site.dev");
+	});
+
+	it("formats subsecond and second durations compactly", () => {
+		expect([duration(38), duration(1_200), duration(9_200)]).toEqual(["38ms", "1.2s", "9.2s"]);
+	});
+});
+
+describe("tool-run summaries", () => {
+	it("names only the live tool while a run is active", () => {
+		expect(summarize([
+			{ id: "t1", name: "read_file", status: "done", took: 38 },
+			{ id: "t2", name: "edit_plan", status: "running" },
+		])).toEqual({ state: "running", name: "edit_plan", completed: 1 });
+	});
+
+	it("reports counts, failures and elapsed time after the run", () => {
+		expect(summarize([
+			{ id: "t1", name: "read_file", status: "done", took: 38 },
+			{ id: "t2", name: "edit_plan", status: "failed", took: 1_200 },
+		])).toEqual({ state: "finished", count: 2, failures: 1, elapsed: 1_238 });
+	});
+});

--- a/apps/web/src/chat/model.ts
+++ b/apps/web/src/chat/model.ts
@@ -1,0 +1,106 @@
+import { instruction } from "@chopin/protocol/address";
+
+import type { Chat } from "@chopin/protocol";
+
+type Speaker = Exclude<Chat.Author, { kind: "system" }>;
+
+export type Message = {
+	id: string;
+	author: Speaker;
+	text: string;
+	ts?: number;
+	streaming?: boolean;
+	tools?: Chat.Activity[];
+	queued: boolean;
+};
+
+export type Group =
+	| { kind: "messages"; author: Speaker; messages: Message[]; queued: boolean }
+	| { kind: "system"; id: string; text: string };
+
+export type ToolSummary =
+	| { state: "running"; name: string; completed: number }
+	| { state: "finished"; count: number; failures: number; elapsed: number };
+
+function speaker(author: Speaker): string {
+	return author.kind === "agent" ? "agent" : `member:${author.handle}`;
+}
+
+export function capitalize(value: string): string {
+	return value ? value[0]!.toUpperCase() + value.slice(1) : value;
+}
+
+/** Mentions remain useful input syntax, but are not part of rail typography. */
+export function displayText(value: string): string {
+	return instruction(value).replace(
+		/(^|[^\w@])@([a-z0-9][a-z0-9-]*)\b/gi,
+		(_match, before: string, handle: string) => `${before}${capitalize(handle)}`,
+	);
+}
+
+export function group(entries: Chat.Entry[], queued: Chat.Waiting[]): Group[] {
+	let rows: Array<Chat.Entry | Message> = [
+		...entries,
+		...queued.map(item => ({
+			id: item.id,
+			author: { kind: "member" as const, handle: item.handle },
+			text: item.text,
+			queued: true,
+		})),
+	];
+	let result: Group[] = [];
+
+	for (let row of rows) {
+		if ("queued" in row) {
+			append(result, row);
+			continue;
+		}
+		if (row.author.kind === "system") {
+			result.push({ kind: "system", id: row.id, text: row.text });
+			continue;
+		}
+		append(result, { ...row, author: row.author, queued: false });
+	}
+
+	return result;
+}
+
+function append(result: Group[], message: Message): void {
+	let previous = result.at(-1);
+	if (
+		previous?.kind === "messages"
+		&& previous.queued === message.queued
+		&& speaker(previous.author) === speaker(message.author)
+	) {
+		previous.messages.push(message);
+		return;
+	}
+	result.push({
+		kind: "messages",
+		author: message.author,
+		messages: [message],
+		queued: message.queued,
+	});
+}
+
+export function summarize(tools: Chat.Activity[]): ToolSummary {
+	let running = tools.findLast(tool => tool.status === "running");
+	if (running) {
+		return {
+			state: "running",
+			name: running.name,
+			completed: tools.filter(tool => tool.status !== "running").length,
+		};
+	}
+	return {
+		state: "finished",
+		count: tools.length,
+		failures: tools.filter(tool => tool.status === "failed").length,
+		elapsed: tools.reduce((total, tool) => total + (tool.took ?? 0), 0),
+	};
+}
+
+export function duration(milliseconds: number): string {
+	if (milliseconds < 1_000) return `${milliseconds}ms`;
+	return `${(milliseconds / 1_000).toFixed(1).replace(/\.0$/, "")}s`;
+}

--- a/apps/web/src/chat/transcript.tsx
+++ b/apps/web/src/chat/transcript.tsx
@@ -1,153 +1,257 @@
-/**
- * The conversation, as the room sees it.
- *
- * Shared rather than personal: every message carries who said it, and the
- * agent's tool calls are shown rather than hidden, because a plan changing
- * without visible cause is the confusing part of watching an agent work.
- *
- * Tool detail is one click away rather than always open. During a demo it is
- * noise; while building this it is the only way to see why a batch was refused.
- */
+/** The shared conversation, grouped for reading rather than event delivery. */
 
 import { useEffect, useRef, useState } from "react";
 
 import { AgentFace, Face } from "@chopin/editor";
 
+import { capitalize, displayText, duration, group, summarize } from "./model";
+
 import type { Chat } from "@chopin/protocol";
+import type { Group, Message } from "./model";
 
 function when(ts: number): string {
 	return new Date(ts * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-const TOOL_TONE: Record<Chat.ToolStatus, string> = {
-	running: "text-text-tertiary",
-	done: "text-text-tertiary",
-	failed: "text-destructive-ink",
-};
+function Spinner() {
+	return (
+		<svg
+			aria-hidden="true"
+			className="animate-spin"
+			fill="none"
+			height="16"
+			viewBox="0 0 16 16"
+			width="16"
+		>
+			<path d="M13 8a5 5 0 1 1-1.46-3.54" stroke="currentColor" strokeLinecap="round" />
+			<path d="M11.5 2.5v2h2" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" />
+		</svg>
+	);
+}
 
-function Activity({ activity }: { activity: Chat.Activity }) {
+function Caret({ open }: { open: boolean }) {
+	return (
+		<svg
+			aria-hidden="true"
+			className={`transition-transform ${open ? "rotate-90" : ""}`}
+			fill="none"
+			height="16"
+			viewBox="0 0 16 16"
+			width="16"
+		>
+			<path d="m6 4 4 4-4 4" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" />
+		</svg>
+	);
+}
+
+function ToolRun({ tools }: { tools: Chat.Activity[] }) {
 	let [open, setOpen] = useState(false);
-	let detail = activity.args || activity.result;
+	let summary = summarize(tools);
+	if (summary.state === "running") {
+		return (
+			<div className="flex h-7 items-center gap-2 py-1 text-sm text-text-quaternary">
+				<Spinner />
+				<span className="font-mono text-text-secondary">{summary.name}</span>
+				<span className="tabular-nums">{summary.completed} done</span>
+			</div>
+		);
+	}
 
 	return (
-		<div className="rounded-sm bg-inset ring-hairline shadow-resting">
+		<div>
 			<button
-				className={`btn btn-sm btn-ghost flex w-full justify-start gap-2 text-left ${
-					TOOL_TONE[activity.status]
-				}`}
-				data-press="wide"
-				disabled={!detail}
+				aria-expanded={open}
+				className="flex h-7 items-center gap-2 bg-transparent py-1 text-sm text-text-quaternary"
 				onClick={() => setOpen(value => !value)}
 				type="button"
 			>
-				<span
-					aria-hidden="true"
-					className={activity.status === "running" ? "animate-pulse" : undefined}
-				>
-					{activity.status === "failed" ? "×" : activity.status === "running" ? "•" : "✓"}
+				<Caret open={open} />
+				<span className="tabular-nums">
+					{summary.count} {summary.count === 1 ? "tool" : "tools"}
 				</span>
-				<span className="font-mono">{activity.name}</span>
-				{/* Tabular: this counts up as the tool runs, and the column is read down. */}
-				{activity.took !== undefined && (
-					<span className="ml-auto tabular-nums">{activity.took}ms</span>
+				{summary.failures > 0 && (
+					<span className="text-destructive-ink tabular-nums">
+						{summary.failures} failed
+					</span>
 				)}
+				<span className="tabular-nums">{duration(summary.elapsed)}</span>
 			</button>
 
-			{open && detail && (
-				<div className="px-2 py-1.5 hairline-t">
-					{activity.args && (
-						<pre className="m-0 overflow-x-auto font-mono text-sm whitespace-pre-wrap text-text-quaternary">
-{activity.args}
-						</pre>
-					)}
-					{activity.result && (
-						<pre className="m-0 mt-1 overflow-x-auto font-mono text-sm whitespace-pre-wrap text-text-quaternary">
-{activity.result}
-						</pre>
-					)}
-				</div>
+			{open && (
+				<ul
+					aria-label="Tool calls"
+					className="m-0 flex list-none flex-col pl-6 text-sm text-text-quaternary"
+				>
+					{tools.map(tool => (
+						<li className="flex h-6 items-center gap-3" key={tool.id}>
+							<span className="min-w-0 flex-1 truncate font-mono text-text-secondary">
+								{tool.name}
+							</span>
+							<span className="shrink-0 tabular-nums">
+								{tool.took === undefined ? "—" : duration(tool.took)}
+							</span>
+						</li>
+					))}
+				</ul>
 			)}
 		</div>
 	);
 }
 
-function Entry({ arrived, entry }: { arrived: boolean; entry: Chat.Entry }) {
-	if (entry.author.kind === "system") {
-		return (
-			<p
-				className={`m-0 px-1 text-sm text-text-secondary italic ${arrived ? "animate-enter" : ""}`}
-			>
-				{entry.text}
-			</p>
-		);
-	}
+function SystemIcon() {
+	return (
+		<svg aria-hidden="true" fill="none" height="20" viewBox="0 0 20 20" width="20">
+			<path
+				d="M3 10h9m-3-3 3 3-3 3M13 5h3v10h-3"
+				stroke="currentColor"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+		</svg>
+	);
+}
 
-	// Narrowed once, so the union does not have to be re-tested at each use.
-	let author = entry.author;
-	let agent = author.kind === "agent";
+function SystemEntry(
+	{ arrived, item }: { arrived: boolean; item: Extract<Group, { kind: "system" }> },
+) {
+	return (
+		<div
+			className={`flex items-start gap-3 text-text-tertiary ${arrived ? "animate-enter" : ""}`}
+			data-chat-system
+		>
+			<div className="shrink-0">
+				<SystemIcon />
+			</div>
+			<p className="m-0 text-base">{displayText(item.text)}</p>
+		</div>
+	);
+}
+
+function MessageBody(
+	{ handle, message, onWithdraw }: {
+		handle: string;
+		message: Message;
+		onWithdraw: (id: string) => void;
+	},
+) {
+	let text = displayText(message.text)
+		|| (message.author.kind === "member" ? "Ask Planner" : "");
 
 	return (
-		<div className={`flex gap-2 ${arrived ? "animate-enter" : ""}`}>
-			<div className="mt-0.5 shrink-0">
-				{agent
-					? <AgentFace size={20} />
-					: <Face handle={author.kind === "member" ? author.handle : "?"} size={20} />}
-			</div>
-
-			<div className="flex min-w-0 flex-1 flex-col gap-1">
-				<div className="flex items-baseline gap-2">
-					<span className="text-sm font-semibold">
-						{author.kind === "member" ? `@${author.handle}` : "Planner"}
-					</span>
-					<span className="text-sm text-text-tertiary tabular-nums">{when(entry.ts)}</span>
-				</div>
-
-				{entry.text && (
-					<p className="m-0 text-base whitespace-pre-wrap">
-						{entry.text}
-						{entry.streaming && <span className="ml-0.5 animate-pulse">▍</span>}
+		<div>
+			{text && (
+				<div className="flex items-start gap-1">
+					<p className="m-0 min-w-0 flex-1 text-base whitespace-pre-wrap">
+						{text}
+						{message.streaming && <span className="ml-0.5 animate-pulse">▍</span>}
 					</p>
-				)}
+					{message.queued && message.author.kind === "member" && message.author.handle === handle
+						&& (
+							<button
+								aria-label="Withdraw queued message"
+								className="btn btn-icon btn-ghost -my-1 shrink-0"
+								onClick={() => onWithdraw(message.id)}
+								title="Withdraw"
+								type="button"
+							>
+								×
+							</button>
+						)}
+				</div>
+			)}
+			{message.tools && message.tools.length > 0 && <ToolRun tools={message.tools} />}
+		</div>
+	);
+}
 
-				{entry.tools && entry.tools.length > 0 && (
-					<div className="flex flex-col gap-1">
-						{entry.tools.map(activity => <Activity activity={activity} key={activity.id} />)}
-					</div>
-				)}
+function MessageGroup(
+	{ arrived, group: item, handle, onWithdraw }: {
+		arrived: ReadonlySet<string>;
+		group: Extract<Group, { kind: "messages" }>;
+		handle: string;
+		onWithdraw: (id: string) => void;
+	},
+) {
+	let first = item.messages[0]!;
+	let name = item.author.kind === "agent" ? "Planner" : capitalize(item.author.handle);
+
+	return (
+		<div
+			className={`flex gap-3 ${item.queued ? "text-text-quaternary" : ""} ${
+				item.messages.some(message => arrived.has(message.id)) ? "animate-enter" : ""
+			}`}
+			data-chat-entry
+		>
+			<div className={`shrink-0 ${item.queued ? "opacity-45" : ""}`}>
+				{item.author.kind === "agent"
+					? <AgentFace size={20} />
+					: <Face handle={item.author.handle} size={20} />}
+			</div>
+			<div className={`flex min-w-0 flex-1 flex-col gap-1 ${item.queued ? "opacity-60" : ""}`}>
+				<div className="flex items-baseline gap-1.5 text-sm">
+					<span className="font-semibold">{name}</span>
+					<span className="text-text-tertiary tabular-nums">
+						{item.queued ? "queued" : when(first.ts!)}
+					</span>
+				</div>
+				{item.messages.map(message => (
+					<MessageBody handle={handle} key={message.id} message={message} onWithdraw={onWithdraw} />
+				))}
 			</div>
 		</div>
 	);
 }
 
 export function Transcript(
-	{ arrived, entries }: { arrived: ReadonlySet<string>; entries: Chat.Entry[] },
+	{
+		arrived,
+		entries,
+		handle,
+		onWithdraw,
+		queued,
+	}: {
+		arrived: ReadonlySet<string>;
+		entries: Chat.Entry[];
+		handle: string;
+		onWithdraw: (id: string) => void;
+		queued: Chat.Waiting[];
+	},
 ) {
 	let bottom = useRef<HTMLDivElement>(null);
-	let scroller = useRef<HTMLDivElement>(null);
 	let pinned = useRef(true);
+	let groups = group(entries, queued);
 
-	// Follow the conversation, unless the reader has scrolled up to look at
-	// something — in which case new output must not yank them away from it.
 	useEffect(() => {
 		if (pinned.current) bottom.current?.scrollIntoView({ block: "end" });
-	}, [entries]);
+	}, [entries, queued]);
 
 	return (
 		<div
-			className="flex min-h-0 flex-1 flex-col gap-3 overflow-auto p-3"
+			className="flex min-h-0 flex-1 flex-col gap-5 overflow-auto p-4"
 			onScroll={event => {
 				let element = event.currentTarget;
 				let distance = element.scrollHeight - element.scrollTop - element.clientHeight;
 				pinned.current = distance < 40;
 			}}
-			ref={scroller}
 		>
-			{entries.length === 0 && (
+			{groups.length === 0 && (
 				<p className="m-0 text-sm text-text-quaternary">
 					Ask the planner to draft something, or to read the repository first.
 				</p>
 			)}
-			{entries.map(entry => <Entry arrived={arrived.has(entry.id)} entry={entry} key={entry.id} />)}
+			{groups.map(item =>
+				item.kind === "system"
+					? <SystemEntry arrived={arrived.has(item.id)} item={item} key={item.id} />
+					: (
+						<MessageGroup
+							arrived={arrived}
+							group={item}
+							handle={handle}
+							key={`${item.queued ? "queued" : "sent"}-${item.messages[0]!.id}`}
+							onWithdraw={onWithdraw}
+						/>
+					)
+			)}
 			<div ref={bottom} />
 		</div>
 	);

--- a/apps/web/src/tokens.test.ts
+++ b/apps/web/src/tokens.test.ts
@@ -403,7 +403,7 @@ describe("migration", () => {
 			},
 			{
 				file: "apps/web/src/chat/chat.tsx",
-				marker: "Talk to the room, or mention",
+				marker: "Say something…",
 				name: "chat composer",
 				tag: "textarea",
 				utility: "field",
@@ -543,7 +543,7 @@ describe("migration", () => {
 					tiers: ["btn-ghost"],
 				},
 			],
-			["apps/web/src/chat/chat.tsx", {
+			["apps/web/src/chat/transcript.tsx", {
 				action: "Withdraw",
 				marker: 'title="Withdraw"',
 				size: "btn-icon",
@@ -552,7 +552,7 @@ describe("migration", () => {
 			["apps/web/src/chat/chat.tsx", {
 				action: "Stop",
 				marker: 'wire?.send("chat:abort")',
-				size: "btn-sm",
+				size: "btn-md",
 				tiers: ["btn-secondary"],
 			}],
 			["apps/web/src/chat/chat.tsx", {
@@ -562,16 +562,16 @@ describe("migration", () => {
 				tiers: ["btn-ghost"],
 			}],
 			["apps/web/src/chat/chat.tsx", {
-				action: "planner mention",
-				marker: "setText(current =>",
-				size: "btn-sm",
-				tiers: ["btn-ghost"],
+				action: "send to room",
+				marker: 'submit("room")',
+				size: "btn-md",
+				tiers: ["btn-secondary"],
 			}],
-			["apps/web/src/chat/transcript.tsx", {
-				action: "tool disclosure",
-				marker: "onClick={() => setOpen(value => !value)}",
-				size: "btn-sm",
-				tiers: ["btn-ghost"],
+			["apps/web/src/chat/chat.tsx", {
+				action: "ask Planner",
+				marker: 'submit("planner")',
+				size: "btn-md",
+				tiers: ["btn-primary"],
 			}],
 			["packages/editor/src/comments.tsx", {
 				action: "comment submit",

--- a/e2e/sidecar.e2e.ts
+++ b/e2e/sidecar.e2e.ts
@@ -42,6 +42,19 @@ test("a question the room was asked is waiting in the sidecar", async ({ join, s
 	await expect(card.getByRole("radio", { name: /In SQLite/ })).toBeVisible();
 });
 
+test("the waiting-question line reopens the decisions rail", async ({ join, seed }) => {
+	await seed(PROSE);
+	let page = await join("ana");
+
+	await page.getByRole("button", { name: "Hide decisions pane" }).click();
+	await expect(page.locator("#pane-decisions")).toBeHidden();
+
+	await page.locator("#pane-chat").getByRole("button", { name: "Answer" }).click();
+
+	await expect(page.locator("#pane-decisions")).toBeVisible();
+	await expect(questionnaire(page)).toBeInViewport();
+});
+
 test("answering both questions resolves the card and writes the decision", async ({ join, seed }) => {
 	await seed(PROSE);
 	let page = await join("ana");

--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -7,7 +7,35 @@
  * is worth one file that fails in one.
  */
 
+import { writeFile } from "node:fs/promises";
+import { join as path } from "node:path";
+
 import { content, expect, ready, test } from "./room";
+import { scratch } from "./servers";
+
+import type { Chat } from "../packages/protocol/index";
+import type { Page } from "@playwright/test";
+
+async function injectChatHistory(
+	page: Page,
+	change: (frame: Chat.History) => Chat.History,
+): Promise<void> {
+	await page.routeWebSocket("**/ws?**", route => {
+		let server = route.connectToServer();
+		route.onMessage(message => server.send(message));
+		server.onMessage(message => {
+			if (typeof message !== "string") return route.send(message);
+			try {
+				let frame = JSON.parse(message) as { kind?: string };
+				route.send(
+					frame.kind === "chat:history" ? JSON.stringify(change(frame as Chat.History)) : message,
+				);
+			} catch {
+				route.send(message);
+			}
+		});
+	});
+}
 
 test("a handle in the URL joins without the form", async ({ join, room }) => {
 	let page = await join("ana");
@@ -53,10 +81,174 @@ test("a path with no room becomes the default room", async ({ page }) => {
 test("the three panes are all present", async ({ join }) => {
 	let page = await join("ana");
 
-	await expect(page.getByText("Planner", { exact: true })).toBeVisible();
+	await expect(page.locator("#pane-chat")).toBeVisible();
 	await expect(content(page)).toBeVisible();
 	await expect(page.locator(".plan-decisions")).toBeVisible();
 });
+
+test("chat names both destinations at the moment of sending", async ({ join }) => {
+	let page = await join("ana");
+	let chat = page.locator("#pane-chat");
+
+	await expect(chat.locator("header")).toHaveCount(0);
+	await expect(chat.getByPlaceholder("Say something…")).toBeVisible();
+	await expect(chat.getByRole("button", { name: "Send to room" })).toBeVisible();
+	await expect(chat.getByRole("button", { name: "Ask Planner" })).toBeVisible();
+	await expect(chat.getByRole("button", { name: "Stop" })).toHaveCount(0);
+});
+
+test(
+	"chat keeps a running turn and its queue readable together",
+	async ({ join, page }, testInfo) => {
+		await injectChatHistory(page, frame => ({
+			...frame,
+			busy: true,
+			entries: [
+				{
+					id: "m1",
+					author: { kind: "member", handle: "maggie" },
+					text: "@ai Draft the migration plan.",
+					ts: 1_700_000_000,
+				},
+				{
+					id: "a1",
+					author: { kind: "agent" },
+					text: "I’m checking the implementation before I edit.",
+					ts: 1_700_000_001,
+					streaming: true,
+					tools: [
+						...Array.from({ length: 7 }, (_, index) => ({
+							id: `t${index}`,
+							name: "read_file",
+							status: "done" as const,
+							took: 20,
+						})),
+						{ id: "t7", name: "edit_plan", status: "running" },
+					],
+				},
+			],
+			queued: [
+				{ id: "q1", handle: "ana", text: "@ai" },
+				{ id: "q2", handle: "sam", text: "Check the rollback path too." },
+			],
+		}));
+
+		await join("ana");
+		let chat = page.locator("#pane-chat");
+		let live = chat.getByText("edit_plan", { exact: true }).locator("..");
+
+		await expect(live).toContainText("7 done");
+		expect((await live.boundingBox())?.height).toBe(28);
+		await expect(chat.getByRole("button", { name: /edit_plan/ })).toHaveCount(0);
+		await expect(chat.getByRole("button", { name: "Stop" })).toBeVisible();
+		let person = chat.getByRole("img", { name: "maggie" });
+		let planner = chat.getByRole("img", { name: "Planner" });
+		expect((await person.boundingBox())?.width).toBe(20);
+		expect((await person.boundingBox())?.height).toBe(20);
+		expect((await planner.boundingBox())?.width).toBe(20);
+		expect((await planner.boundingBox())?.height).toBe(20);
+		expect(await person.evaluate(element => getComputedStyle(element).borderRadius)).not.toBe(
+			await planner.evaluate(element => getComputedStyle(element).borderRadius),
+		);
+
+		let mine = chat.locator("[data-chat-entry]").filter({ hasText: "Ask Planner" });
+		let theirs = chat.locator("[data-chat-entry]").filter({
+			hasText: "Check the rollback path too.",
+		});
+		await expect(mine).toContainText("queued");
+		await expect(mine.getByRole("button", { name: "Withdraw queued message" })).toBeVisible();
+		await expect(theirs.getByRole("button", { name: "Withdraw queued message" })).toHaveCount(0);
+
+		await testInfo.attach("running-turn-with-queue", {
+			body: await chat.screenshot(),
+			contentType: "image/png",
+		});
+	},
+);
+
+test(
+	"chat groups authors and collapses a finished tool run",
+	async ({ baseURL, join, room, seed }, testInfo) => {
+		await seed("# Migration\n");
+		await writeFile(
+			path(scratch(Number(new URL(baseURL!).port)), room, "state.json"),
+			JSON.stringify({
+				revision: 0,
+				questions: [],
+				transcript: [
+					{
+						id: "m1",
+						author: { kind: "member", handle: "maggie" },
+						text: "@ai Can you draft the migration?",
+						ts: 1_700_000_000,
+					},
+					{
+						id: "m2",
+						author: { kind: "member", handle: "maggie" },
+						text: "Focus on rollback.",
+						ts: 1_700_000_001,
+					},
+					{
+						id: "a1",
+						author: { kind: "agent" },
+						text: "Drafted it.",
+						ts: 1_700_000_002,
+						tools: [
+							{ id: "t1", name: "read_file", status: "done", took: 38 },
+							{ id: "t2", name: "grep", status: "done", took: 12 },
+							{ id: "t3", name: "edit_plan", status: "done", took: 1_200 },
+							{ id: "t4", name: "run_tests", status: "failed" },
+						],
+					},
+					{
+						id: "s1",
+						author: { kind: "system" },
+						text: "@sam joined",
+						ts: 1_700_000_003,
+					},
+				],
+			}),
+		);
+
+		let page = await join("ana");
+		let chat = page.locator("#pane-chat");
+
+		await expect(chat.getByText("Maggie", { exact: true })).toHaveCount(1);
+		await expect(chat).toContainText("Can you draft the migration?");
+		await expect(chat).not.toContainText("@");
+		await expect(chat.getByText("read_file", { exact: true })).toHaveCount(0);
+
+		let run = chat.getByRole("button", { name: /4 tools.*1 failed.*1\.3s/ });
+		await expect(run).toBeVisible();
+		expect(
+			await run.evaluate(element => ({
+				background: getComputedStyle(element).backgroundColor,
+				border: getComputedStyle(element).borderTopWidth,
+				height: getComputedStyle(element).height,
+			})),
+		).toEqual({ background: "rgba(0, 0, 0, 0)", border: "0px", height: "28px" });
+		await expect(run.getByText("1 failed")).toHaveClass(/text-destructive-ink/);
+		await run.click();
+		await expect(chat.getByText("read_file", { exact: true })).toBeVisible();
+		await expect(chat.getByText("run_tests", { exact: true })).toBeVisible();
+		let firstTool = chat.getByRole("list", { name: "Tool calls" }).getByRole("listitem").first();
+		expect((await firstTool.getByText("read_file").boundingBox())!.x).toBeLessThan(
+			(await firstTool.getByText("38ms").boundingBox())!.x,
+		);
+
+		let system = chat.locator("[data-chat-system]");
+		await expect(system).toContainText("Sam joined");
+		expect(await system.evaluate(element => getComputedStyle(element).fontStyle)).toBe("normal");
+		expect(await system.locator("p").evaluate(element => getComputedStyle(element).fontSize)).toBe(
+			"15px",
+		);
+
+		await testInfo.attach("finished-turn-with-failure-open", {
+			body: await chat.screenshot(),
+			contentType: "image/png",
+		});
+	},
+);
 
 test("an empty room settles rather than loading forever", async ({ join }) => {
 	let page = await join("ana");

--- a/packages/editor/src/threads.ts
+++ b/packages/editor/src/threads.ts
@@ -183,6 +183,7 @@ export class ThreadStore {
 		if (!view || !this.#wire) return;
 		this.#wire.send("chat:send", {
 			text: `@ai apply the accepted comment on "${view.quote}" — it has not been actioned yet.`,
+			to: "planner",
 		});
 	}
 

--- a/packages/protocol/chat.d.ts
+++ b/packages/protocol/chat.d.ts
@@ -80,6 +80,7 @@ export declare namespace Chat {
 	};
 
 	export type Queue = KIND<"chat:queue"> & { waiting: Waiting[] };
+	export type Destination = "room" | "planner";
 
 	/**
 	 * Say something.
@@ -88,7 +89,7 @@ export declare namespace Chat {
 	 * queue and runs in order when the turn ends — nobody is made to wait in
 	 * silence because somebody else prompted first.
 	 */
-	export type Send = KIND<"chat:send"> & { text: string };
+	export type Send = KIND<"chat:send"> & { text: string; to: Destination };
 
 	/** Stop the running turn. Anyone may; the transcript records who did. */
 	export type Abort = KIND<"chat:abort">;


### PR DESCRIPTION
## Summary

- rebuild the chat transcript around grouped authors and 20px shape-coded identity marks
- collapse each tool run to one fixed-height status line with an expandable completed summary
- replace mention-driven chrome with explicit Room and Planner destinations, truthful queue promotion, and composer-level Stop and question controls
- keep tool ownership stable across live events and reloads, and allow Room conversation when the agent is off

## Evidence

The browser coverage captures both required states:

- a running turn with a queued Planner request
- a finished turn with a failed tool call expanded

Both states are asserted by `e2e/smoke.e2e.ts` and were visually checked from the generated Playwright captures.

## Test plan

- `bun run ci`
- `bun run types`
- `bun test` — 594 passed
- `bun run e2e` — 59 passed
