### PR TITLE
Render Markdown in chat messages

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,8 @@
 		"@chopin/protocol": "workspace:*",
 		"@fontsource-variable/inter": "^5.3.0",
 		"react": "catalog:react",
-		"react-dom": "catalog:react"
+		"react-dom": "catalog:react",
+		"react-markdown": "^10.1.0"
 	},
 	"devDependencies": {
 		"@tailwindcss/vite": "catalog:ui",

--- a/apps/web/src/chat/markdown.css
+++ b/apps/web/src/chat/markdown.css
@@ -1,0 +1,71 @@
+.chat-markdown {
+	min-width: 0;
+	overflow-wrap: anywhere;
+	font-size: var(--text-base);
+	line-height: 1.5;
+}
+
+.chat-markdown > :first-child {
+	margin-block-start: 0;
+}
+
+.chat-markdown > :last-child {
+	margin-block-end: 0;
+}
+
+.chat-markdown p,
+.chat-markdown ul,
+.chat-markdown ol,
+.chat-markdown blockquote,
+.chat-markdown pre {
+	margin-block: 0.5rem;
+}
+
+.chat-markdown ul,
+.chat-markdown ol {
+	padding-inline-start: 1.25rem;
+}
+
+.chat-markdown ul {
+	list-style: disc;
+}
+
+.chat-markdown ol {
+	list-style: decimal;
+}
+
+.chat-markdown li + li {
+	margin-block-start: 0.125rem;
+}
+
+.chat-markdown blockquote {
+	border-inline-start: 2px solid var(--color-edge);
+	padding-inline-start: 0.75rem;
+	color: var(--color-text-secondary);
+}
+
+.chat-markdown a {
+	color: var(--color-brand-ink);
+	text-decoration: underline;
+	text-underline-offset: 0.125rem;
+}
+
+.chat-markdown :not(pre) > code {
+	border-radius: var(--radius-sm);
+	background: var(--color-inset);
+	padding: 0.125rem 0.25rem;
+	font-family: var(--font-mono);
+	font-size: var(--text-sm);
+}
+
+.chat-markdown pre {
+	overflow-x: auto;
+	border-radius: var(--radius-md);
+	background: var(--color-inset);
+	padding: 0.75rem;
+}
+
+.chat-markdown pre code {
+	font-family: var(--font-mono);
+	font-size: var(--text-sm);
+}

--- a/apps/web/src/chat/markdown.tsx
+++ b/apps/web/src/chat/markdown.tsx
@@ -1,0 +1,57 @@
+import ReactMarkdown from "react-markdown";
+
+import "./markdown.css";
+
+import type { Components } from "react-markdown";
+
+let ELEMENTS = [
+	"a",
+	"blockquote",
+	"br",
+	"code",
+	"em",
+	"h1",
+	"h2",
+	"h3",
+	"h4",
+	"h5",
+	"h6",
+	"li",
+	"ol",
+	"p",
+	"pre",
+	"strong",
+	"ul",
+];
+
+let paragraph: NonNullable<Components["p"]> = ({ children }) => <p>{children}</p>;
+
+let COMPONENTS: Components = {
+	a: ({ children, href }) => (
+		<a href={href} rel="noopener noreferrer" target="_blank">
+			{children}
+		</a>
+	),
+	h1: paragraph,
+	h2: paragraph,
+	h3: paragraph,
+	h4: paragraph,
+	h5: paragraph,
+	h6: paragraph,
+};
+
+/** The deliberately small Markdown dialect understood by conversation. */
+export function MessageMarkdown({ source }: { source: string }) {
+	return (
+		<div className="chat-markdown" data-chat-markdown>
+			<ReactMarkdown
+				allowedElements={ELEMENTS}
+				components={COMPONENTS}
+				skipHtml
+				unwrapDisallowed
+			>
+				{source}
+			</ReactMarkdown>
+		</div>
+	);
+}

--- a/apps/web/src/chat/transcript.tsx
+++ b/apps/web/src/chat/transcript.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { AgentFace, Face } from "@chopin/editor";
 
+import { MessageMarkdown } from "./markdown";
 import { capitalize, displayText, duration, group, summarize } from "./model";
 
 import type { Chat } from "@chopin/protocol";
@@ -141,10 +142,10 @@ function MessageBody(
 		<div>
 			{text && (
 				<div className="flex items-start gap-1">
-					<p className="m-0 min-w-0 flex-1 text-base whitespace-pre-wrap">
-						{text}
+					<div className="min-w-0 flex-1">
+						<MessageMarkdown source={text} />
 						{message.streaming && <span className="ml-0.5 animate-pulse">▍</span>}
-					</p>
+					</div>
 					{message.queued && message.author.kind === "member" && message.author.handle === handle
 						&& (
 							<button

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "@fontsource-variable/inter": "^5.3.0",
         "react": "catalog:react",
         "react-dom": "catalog:react",
+        "react-markdown": "^10.1.0",
       },
       "devDependencies": {
         "@tailwindcss/vite": "catalog:ui",
@@ -905,6 +906,8 @@
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.11.5", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-xJo6a6YZnwZfnyGmQKWMbVOcii7XRibjOskRh+WJ9UHQoX16xrQrcIgAMQOzfvs8XiLMx6ih/fsLPF73iY2D1A=="],
 
     "browserslist": ["browserslist@4.28.7", "", { "dependencies": { "baseline-browser-mapping": "^2.10.44", "caniuse-lite": "^1.0.30001806", "electron-to-chromium": "^1.5.393", "node-releases": "^2.0.51", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw=="],
@@ -1067,6 +1070,8 @@
 
     "estree-util-visit": ["estree-util-visit@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/unist": "^3.0.0" } }, "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww=="],
 
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
     "fastest-stable-stringify": ["fastest-stable-stringify@2.0.2", "", {}, "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="],
 
     "fault": ["fault@2.0.1", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ=="],
@@ -1091,7 +1096,11 @@
 
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
+    "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
@@ -1102,6 +1111,8 @@
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "inline-style-prefixer": ["inline-style-prefixer@7.0.1", "", { "dependencies": { "css-in-js-utils": "^3.1.0" } }, "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw=="],
 
@@ -1114,6 +1125,8 @@
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "isomorphic.js": ["isomorphic.js@0.2.5", "", {}, "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw=="],
 
@@ -1345,6 +1358,8 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
+    "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
     "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
@@ -1358,6 +1373,10 @@
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
 
     "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
 
@@ -1401,6 +1420,10 @@
 
     "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
 
+    "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
+
+    "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
     "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
     "tabbable": ["tabbable@6.5.0", "", {}, "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA=="],
@@ -1419,6 +1442,8 @@
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
     "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
 
     "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
@@ -1430,6 +1455,8 @@
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unidiff": ["unidiff@1.0.4", "", { "dependencies": { "diff": "^5.1.0" } }, "sha512-ynU0vsAXw0ir8roa+xPCUHmnJ5goc5BTM2Kuc3IJd8UwgaeRs7VSD5+eeaQL+xp1JtB92hu/Zy/Lgy7RZcr1pQ=="],
+
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
     "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 

--- a/docs/superpowers/plans/2026-08-10-chat-markdown.md
+++ b/docs/superpowers/plans/2026-08-10-chat-markdown.md
@@ -26,7 +26,7 @@
 
 - [ ] **Step 1: Add a failing browser test after the existing chat transcript tests**
 
-```ts
+````ts
 test("chat renders participant Markdown without admitting document features", async ({ join, page }) => {
 	await injectChatHistory(page, frame => ({
 		...frame,
@@ -85,7 +85,7 @@ test("chat renders participant Markdown without admitting document features", as
 	await expect(member.locator('img[src*="example.invalid"]')).toHaveCount(0);
 	await expect(planner.locator("strong")).toHaveText("strongly");
 });
-```
+````
 
 - [ ] **Step 2: Run the focused test and verify it fails**
 
@@ -275,7 +275,7 @@ Replace the plain message paragraph inside `MessageBody` with:
 <div className="min-w-0 flex-1">
 	<MessageMarkdown source={text} />
 	{message.streaming && <span className="ml-0.5 animate-pulse">▍</span>}
-</div>
+</div>;
 ```
 
 Keep the queued-message withdraw button as the adjacent flex item. Leave `SystemEntry` unchanged so system lines remain plain application text.

--- a/docs/superpowers/plans/2026-08-10-chat-markdown.md
+++ b/docs/superpowers/plans/2026-08-10-chat-markdown.md
@@ -1,0 +1,360 @@
+# Chat Markdown Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render a deliberately small Markdown subset in every participant message without changing the composer or transcript data.
+
+**Architecture:** Add one `MessageMarkdown` view beside the transcript and keep `MessageBody` responsible only for message controls and streaming state. `react-markdown` parses standard Markdown with an explicit element allowlist; a colocated stylesheet gives those elements compact rail typography.
+
+**Tech Stack:** React 19, `react-markdown`, Tailwind theme tokens, Playwright
+
+---
+
+## File map
+
+- Create `apps/web/src/chat/markdown.tsx`: safe Markdown-to-React boundary and supported-element policy.
+- Create `apps/web/src/chat/markdown.css`: compact message typography using existing colour, radius and font tokens.
+- Modify `apps/web/src/chat/transcript.tsx`: render member and Planner message text through `MessageMarkdown`.
+- Modify `apps/web/package.json` and `bun.lock`: declare and lock `react-markdown`.
+- Modify `e2e/smoke.e2e.ts`: prove both participant kinds render the chosen semantics and unsafe content stays inert.
+
+### Task 1: Lock down the message contract
+
+**Files:**
+
+- Test: `e2e/smoke.e2e.ts`
+
+- [ ] **Step 1: Add a failing browser test after the existing chat transcript tests**
+
+```ts
+test("chat renders participant Markdown without admitting document features", async ({ join, page }) => {
+	await injectChatHistory(page, frame => ({
+		...frame,
+		entries: [
+			{
+				id: "m1",
+				author: { kind: "member", handle: "maggie" },
+				text: [
+					"**Bold** and *italic* with [the docs](https://example.com).",
+					"",
+					"- first",
+					"- second",
+					"",
+					"1. one",
+					"2. two",
+					"",
+					"> quoted",
+					"",
+					"Use `bun test`.",
+					"",
+					"```ts",
+					"let answer = 42;",
+					"```",
+					"",
+					"# Ordinary message text",
+					"",
+					"![remote](https://example.invalid/pixel.png)",
+					'<img src="https://example.invalid/raw.png" alt="raw">',
+				].join("\n"),
+				ts: 1_700_000_000,
+			},
+			{
+				id: "a1",
+				author: { kind: "agent" },
+				text: "Planner wrote **strongly**.",
+				ts: 1_700_000_001,
+			},
+		],
+	}));
+
+	await join("ana");
+	let chat = page.locator("#pane-chat");
+	let member = chat.locator("[data-chat-entry]").filter({ hasText: "Bold and italic" });
+	let planner = chat.locator("[data-chat-entry]").filter({ hasText: "Planner wrote strongly" });
+
+	await expect(member.locator("strong")).toHaveText("Bold");
+	await expect(member.locator("em")).toHaveText("italic");
+	await expect(member.locator("ul")).toContainText("first");
+	await expect(member.locator("ol")).toContainText("one");
+	await expect(member.locator("blockquote")).toHaveText("quoted");
+	await expect(member.getByRole("link", { name: "the docs" })).toHaveAttribute("target", "_blank");
+	await expect(member.locator("p code")).toHaveText("bun test");
+	await expect(member.locator("pre code")).toContainText("let answer = 42;");
+	await expect(member.getByRole("heading", { name: "Ordinary message text" })).toHaveCount(0);
+	await expect(member).toContainText("Ordinary message text");
+	await expect(member.locator('img[src*="example.invalid"]')).toHaveCount(0);
+	await expect(planner.locator("strong")).toHaveText("strongly");
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+bun run e2e -- --grep "chat renders participant Markdown"
+```
+
+Expected: FAIL because `strong`, `em`, lists, blockquotes, links and code elements do not yet exist in the transcript.
+
+### Task 2: Add the safe Markdown renderer
+
+**Files:**
+
+- Create: `apps/web/src/chat/markdown.tsx`
+- Create: `apps/web/src/chat/markdown.css`
+- Modify: `apps/web/src/chat/transcript.tsx`
+- Modify: `apps/web/package.json`
+- Modify: `bun.lock`
+- Test: `e2e/smoke.e2e.ts`
+
+- [ ] **Step 1: Add the renderer dependency to the web workspace**
+
+Run:
+
+```bash
+bun add react-markdown --cwd apps/web
+```
+
+Expected: `react-markdown` appears in `apps/web/package.json`; `bun.lock` records it and its parser dependencies.
+
+- [ ] **Step 2: Create the rendering boundary**
+
+Create `apps/web/src/chat/markdown.tsx`:
+
+```tsx
+import ReactMarkdown from "react-markdown";
+
+import "./markdown.css";
+
+import type { Components } from "react-markdown";
+
+const ELEMENTS = [
+	"a",
+	"blockquote",
+	"br",
+	"code",
+	"em",
+	"h1",
+	"h2",
+	"h3",
+	"h4",
+	"h5",
+	"h6",
+	"li",
+	"ol",
+	"p",
+	"pre",
+	"strong",
+	"ul",
+];
+
+let paragraph: Components["p"] = ({ children }) => <p>{children}</p>;
+
+const COMPONENTS: Components = {
+	a: ({ children, href }) => (
+		<a href={href} rel="noopener noreferrer" target="_blank">
+			{children}
+		</a>
+	),
+	h1: paragraph,
+	h2: paragraph,
+	h3: paragraph,
+	h4: paragraph,
+	h5: paragraph,
+	h6: paragraph,
+};
+
+export function MessageMarkdown({ source }: { source: string }) {
+	return (
+		<div className="chat-markdown" data-chat-markdown>
+			<ReactMarkdown
+				allowedElements={ELEMENTS}
+				components={COMPONENTS}
+				skipHtml
+				unwrapDisallowed
+			>
+				{source}
+			</ReactMarkdown>
+		</div>
+	);
+}
+```
+
+The allowlist admits only the approved chat syntax. Heading nodes are retained long enough to keep their text, then rendered as ordinary paragraphs. Images and horizontal rules are removed; raw HTML is skipped; the library's default URL transform rejects unsafe protocols.
+
+- [ ] **Step 3: Add compact rail typography**
+
+Create `apps/web/src/chat/markdown.css`:
+
+```css
+.chat-markdown {
+	min-width: 0;
+	overflow-wrap: anywhere;
+	font-size: var(--text-base);
+	line-height: 1.5;
+}
+
+.chat-markdown > :first-child {
+	margin-block-start: 0;
+}
+
+.chat-markdown > :last-child {
+	margin-block-end: 0;
+}
+
+.chat-markdown p,
+.chat-markdown ul,
+.chat-markdown ol,
+.chat-markdown blockquote,
+.chat-markdown pre {
+	margin-block: 0.5rem;
+}
+
+.chat-markdown ul,
+.chat-markdown ol {
+	padding-inline-start: 1.25rem;
+}
+
+.chat-markdown ul {
+	list-style: disc;
+}
+
+.chat-markdown ol {
+	list-style: decimal;
+}
+
+.chat-markdown li + li {
+	margin-block-start: 0.125rem;
+}
+
+.chat-markdown blockquote {
+	border-inline-start: 2px solid var(--color-edge);
+	padding-inline-start: 0.75rem;
+	color: var(--color-text-secondary);
+}
+
+.chat-markdown a {
+	color: var(--color-brand-ink);
+	text-decoration: underline;
+	text-underline-offset: 0.125rem;
+}
+
+.chat-markdown :not(pre) > code {
+	border-radius: var(--radius-sm);
+	background: var(--color-inset);
+	padding: 0.125rem 0.25rem;
+	font-family: var(--font-mono);
+	font-size: var(--text-sm);
+}
+
+.chat-markdown pre {
+	overflow-x: auto;
+	border-radius: var(--radius-md);
+	background: var(--color-inset);
+	padding: 0.75rem;
+}
+
+.chat-markdown pre code {
+	font-family: var(--font-mono);
+	font-size: var(--text-sm);
+}
+```
+
+- [ ] **Step 4: Route participant prose through the renderer**
+
+In `apps/web/src/chat/transcript.tsx`, import the new view:
+
+```tsx
+import { MessageMarkdown } from "./markdown";
+```
+
+Replace the plain message paragraph inside `MessageBody` with:
+
+```tsx
+<div className="min-w-0 flex-1">
+	<MessageMarkdown source={text} />
+	{message.streaming && <span className="ml-0.5 animate-pulse">▍</span>}
+</div>
+```
+
+Keep the queued-message withdraw button as the adjacent flex item. Leave `SystemEntry` unchanged so system lines remain plain application text.
+
+- [ ] **Step 5: Run the focused browser test and verify it passes**
+
+Run:
+
+```bash
+bun run e2e -- --grep "chat renders participant Markdown"
+```
+
+Expected: PASS. The participant and Planner entries contain semantic formatting, headings have no heading role, and no remote image element exists.
+
+- [ ] **Step 6: Run the web typecheck and production build**
+
+Run:
+
+```bash
+bun run types
+bun run build
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 7: Commit the vertical slice**
+
+```bash
+git add apps/web/src/chat/markdown.tsx apps/web/src/chat/markdown.css apps/web/src/chat/transcript.tsx apps/web/package.json bun.lock e2e/smoke.e2e.ts
+git commit -m "Render Markdown in chat messages"
+```
+
+### Task 3: Verify and deliver
+
+**Files:**
+
+- Verify only; fix files from Task 2 if a check exposes a regression.
+
+- [ ] **Step 1: Run the complete repository checks**
+
+Run:
+
+```bash
+bun run ci
+bun run types
+bun test
+bun run build
+bun run e2e
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 2: Inspect the final diff and whitespace**
+
+Run:
+
+```bash
+git diff origin/main...HEAD --stat
+git diff --check origin/main...HEAD
+git status --short
+```
+
+Expected: the diff contains only the design, plan, dependency, renderer, styles, transcript wiring and browser coverage; the whitespace check reports nothing; the working tree is clean.
+
+- [ ] **Step 3: Push and open the pull request**
+
+```bash
+git push -u origin bb/sanitize-planner-sidebar-markdown-thr_nc5yeewq67
+gh pr create --base main --title "Render Markdown in chat messages" --body "## Summary
+
+- render a safe, compact Markdown subset in participant and Planner messages
+- keep headings flat and exclude raw HTML, images, tables and task lists
+- cover member and agent output in the browser suite
+
+## Testing
+
+- bun run ci
+- bun run types
+- bun test
+- bun run build
+- bun run e2e"
+```

--- a/docs/superpowers/specs/2026-08-10-chat-markdown-design.md
+++ b/docs/superpowers/specs/2026-08-10-chat-markdown-design.md
@@ -1,0 +1,87 @@
+# Chat Markdown rendering
+
+## Goal
+
+Render the small set of Markdown people naturally use in conversation so
+Planner replies and participant messages do not show formatting punctuation.
+This slice changes how sent messages are displayed; it does not add formatting
+controls or a preview to the composer.
+
+## Architecture
+
+Add a focused `MessageMarkdown` component beside the existing chat transcript.
+It receives the message's stored text and renders it with `react-markdown`.
+`MessageBody` uses it for both member and Planner messages. System entries stay
+plain text because they are application events rather than participant prose.
+
+The renderer uses standard Markdown only. It does not enable GFM plugins or the
+plan's MDX dialect. This keeps plan components, tables, task lists and other
+document features out of the conversation surface.
+
+## Supported formatting
+
+Messages support:
+
+- bold and italic text;
+- ordered and unordered lists;
+- blockquotes;
+- links;
+- inline code;
+- fenced multiline code blocks.
+
+Headings are rendered as ordinary message paragraphs rather than introducing
+document hierarchy into the rail. Images, raw HTML, tables, task lists and
+strikethrough are not rendered as rich message content.
+
+## Presentation and behaviour
+
+Markdown uses compact chat typography. Paragraphs and list items retain the
+current message size and line height. Lists have enough indentation to make
+their markers legible without consuming the narrow rail. Blockquotes use a
+quiet edge and secondary text colour. Inline code has a subtle inset surface;
+fenced blocks use the monospace font and scroll horizontally rather than
+wrapping or widening the sidebar.
+
+Links use the existing brand colour and focus treatment. They open safely
+without allowing the message to replace the current room. Raw HTML remains
+disabled, unsafe URL protocols are rejected by the renderer, and remote images
+are not loaded.
+
+Queued member messages use the same renderer and keep their existing withdraw
+control. Streaming Planner messages re-render the source received so far; an
+unfinished delimiter remains literal until its closing delimiter arrives. The
+streaming caret stays after the rendered content. Mentions continue through
+`displayText` before Markdown parsing, preserving the rail's existing display
+names.
+
+## Scope boundary
+
+The composer remains a plain text input. People can type Markdown syntax, but
+this work adds no toolbar, shortcuts, rich editing, syntax highlighting, copy
+button, or live preview. Transcript storage, grouping, transport and message
+types do not change.
+
+## Verification
+
+Browser coverage will send a participant message containing emphasis, both
+list kinds, a blockquote, a link, inline code and a fenced block, then assert
+that the transcript exposes the corresponding semantic elements. The same
+renderer path covers Planner messages, so a focused Planner assertion will
+confirm that agent output is not left as literal Markdown.
+
+The browser test will also confirm that raw HTML and image syntax cannot create
+active elements or remote image requests. Existing transcript tests continue
+to cover grouping, mentions, queued messages and tool runs.
+
+The completed change must pass:
+
+- `bun run ci`
+- `bun run types`
+- `bun test`
+- the focused browser test
+- `bun run build`
+
+## Delivery
+
+This is one small vertical slice: dependency, renderer, chat-specific styles
+and behaviour coverage land together. Composer editing can follow separately.

--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -250,69 +250,75 @@ test(
 	},
 );
 
-test("chat renders participant Markdown without admitting document features", async ({ join, page }, testInfo) => {
-	await injectChatHistory(page, frame => ({
-		...frame,
-		entries: [
-			{
-				id: "m1",
-				author: { kind: "member", handle: "maggie" },
-				text: [
-					"**Bold** and *italic* with [the docs](https://example.com).",
-					"",
-					"- first",
-					"- second",
-					"",
-					"1. one",
-					"2. two",
-					"",
-					"> quoted",
-					"",
-					"Use `bun test`.",
-					"",
-					"```ts",
-					"let answer = 42;",
-					"```",
-					"",
-					"# Ordinary message text",
-					"",
-					"![remote](https://example.invalid/pixel.png)",
-					'<img src="https://example.invalid/raw.png" alt="raw">',
-				].join("\n"),
-				ts: 1_700_000_000,
-			},
-			{
-				id: "a1",
-				author: { kind: "agent" },
-				text: "Planner wrote **strongly**.",
-				ts: 1_700_000_001,
-			},
-		],
-	}));
+test(
+	"chat renders participant Markdown without admitting document features",
+	async ({ join, page }, testInfo) => {
+		await injectChatHistory(page, frame => ({
+			...frame,
+			entries: [
+				{
+					id: "m1",
+					author: { kind: "member", handle: "maggie" },
+					text: [
+						"**Bold** and *italic* with [the docs](https://example.com).",
+						"",
+						"- first",
+						"- second",
+						"",
+						"1. one",
+						"2. two",
+						"",
+						"> quoted",
+						"",
+						"Use `bun test`.",
+						"",
+						"```ts",
+						"let answer = 42;",
+						"```",
+						"",
+						"# Ordinary message text",
+						"",
+						"![remote](https://example.invalid/pixel.png)",
+						'<img src="https://example.invalid/raw.png" alt="raw">',
+					].join("\n"),
+					ts: 1_700_000_000,
+				},
+				{
+					id: "a1",
+					author: { kind: "agent" },
+					text: "Planner wrote **strongly**.",
+					ts: 1_700_000_001,
+				},
+			],
+		}));
 
-	await join("ana");
-	let chat = page.locator("#pane-chat");
-	let member = chat.locator("[data-chat-entry]").filter({ hasText: "Bold and italic" });
-	let planner = chat.locator("[data-chat-entry]").filter({ hasText: "Planner wrote strongly" });
+		await join("ana");
+		let chat = page.locator("#pane-chat");
+		let member = chat.locator("[data-chat-entry]").filter({ hasText: "Bold and italic" });
+		let planner = chat.locator("[data-chat-entry]").filter({ hasText: "Planner wrote strongly" });
 
-	await expect(member.locator("strong")).toHaveText("Bold");
-	await expect(member.locator("em")).toHaveText("italic");
-	await expect(member.locator("ul")).toContainText("first");
-	await expect(member.locator("ol")).toContainText("one");
-	await expect(member.locator("blockquote")).toHaveText("quoted");
-	await expect(member.getByRole("link", { name: "the docs" })).toHaveAttribute("target", "_blank");
-	await expect(member.locator("p code")).toHaveText("bun test");
-	await expect(member.locator("pre code")).toContainText("let answer = 42;");
-	await expect(member.getByRole("heading", { name: "Ordinary message text" })).toHaveCount(0);
-	await expect(member).toContainText("Ordinary message text");
-	await expect(member.locator('img[src*="example.invalid"]')).toHaveCount(0);
-	await expect(planner.locator("strong")).toHaveText("strongly");
+		await expect(member.locator("strong")).toHaveText("Bold");
+		await expect(member.locator("em")).toHaveText("italic");
+		await expect(member.locator("ul")).toContainText("first");
+		await expect(member.locator("ol")).toContainText("one");
+		await expect(member.locator("blockquote")).toHaveText("quoted");
+		await expect(member.getByRole("link", { name: "the docs" })).toHaveAttribute(
+			"target",
+			"_blank",
+		);
+		await expect(member.locator("p code")).toHaveText("bun test");
+		await expect(member.locator("pre code")).toContainText("let answer = 42;");
+		await expect(member.getByRole("heading", { name: "Ordinary message text" })).toHaveCount(0);
+		await expect(member).toContainText("Ordinary message text");
+		await expect(member.locator('img[src*="example.invalid"]')).toHaveCount(0);
+		await expect(planner.locator("strong")).toHaveText("strongly");
 
-	await testInfo.attach("participant-markdown", {
-		body: await chat.screenshot(),
-		contentType: "image/png",
-	});
-});
+		await testInfo.attach("participant-markdown", {
+			body: await chat.screenshot(),
+			contentType: "image/png",
+		});
+	},
+);
 
 test("an empty room settles rather than loading forever", async ({ join }) => {
 	let page = await join("ana");

--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -250,6 +250,70 @@ test(
 	},
 );
 
+test("chat renders participant Markdown without admitting document features", async ({ join, page }, testInfo) => {
+	await injectChatHistory(page, frame => ({
+		...frame,
+		entries: [
+			{
+				id: "m1",
+				author: { kind: "member", handle: "maggie" },
+				text: [
+					"**Bold** and *italic* with [the docs](https://example.com).",
+					"",
+					"- first",
+					"- second",
+					"",
+					"1. one",
+					"2. two",
+					"",
+					"> quoted",
+					"",
+					"Use `bun test`.",
+					"",
+					"```ts",
+					"let answer = 42;",
+					"```",
+					"",
+					"# Ordinary message text",
+					"",
+					"![remote](https://example.invalid/pixel.png)",
+					'<img src="https://example.invalid/raw.png" alt="raw">',
+				].join("\n"),
+				ts: 1_700_000_000,
+			},
+			{
+				id: "a1",
+				author: { kind: "agent" },
+				text: "Planner wrote **strongly**.",
+				ts: 1_700_000_001,
+			},
+		],
+	}));
+
+	await join("ana");
+	let chat = page.locator("#pane-chat");
+	let member = chat.locator("[data-chat-entry]").filter({ hasText: "Bold and italic" });
+	let planner = chat.locator("[data-chat-entry]").filter({ hasText: "Planner wrote strongly" });
+
+	await expect(member.locator("strong")).toHaveText("Bold");
+	await expect(member.locator("em")).toHaveText("italic");
+	await expect(member.locator("ul")).toContainText("first");
+	await expect(member.locator("ol")).toContainText("one");
+	await expect(member.locator("blockquote")).toHaveText("quoted");
+	await expect(member.getByRole("link", { name: "the docs" })).toHaveAttribute("target", "_blank");
+	await expect(member.locator("p code")).toHaveText("bun test");
+	await expect(member.locator("pre code")).toContainText("let answer = 42;");
+	await expect(member.getByRole("heading", { name: "Ordinary message text" })).toHaveCount(0);
+	await expect(member).toContainText("Ordinary message text");
+	await expect(member.locator('img[src*="example.invalid"]')).toHaveCount(0);
+	await expect(planner.locator("strong")).toHaveText("strongly");
+
+	await testInfo.attach("participant-markdown", {
+		body: await chat.screenshot(),
+		contentType: "image/png",
+	});
+});
+
 test("an empty room settles rather than loading forever", async ({ join }) => {
 	let page = await join("ana");
 


### PR DESCRIPTION
## Summary

- render compact Markdown for member and Planner messages
- support emphasis, ordered and unordered lists, blockquotes, links, inline code, and fenced code
- flatten headings and exclude raw HTML, images, tables, and task-list extensions
- keep system transcript entries and message composition unchanged

## Verification

- `bun run ci`
- `bun run types`
- `bun test` — 594 passed
- `bun run build`
- `bun run e2e` — 60 passed