### PR TITLE
Standardize font sizes across document and side rails

### DIFF
--- a/apps/web/src/chat/chat.tsx
+++ b/apps/web/src/chat/chat.tsx
@@ -137,7 +137,7 @@ export function Chat({ connected, handle, onReveal, waiting, wire }: ChatProps) 
 
 			<div className="flex shrink-0 flex-col gap-2 px-4 pb-4">
 				<textarea
-					className="field h-18 w-full resize-none px-2.5 py-1.5 text-base"
+					className="field h-18 w-full resize-none px-2.5 py-1.5 text-sm"
 					disabled={!connected}
 					onChange={event => setText(event.target.value)}
 					onKeyDown={event => {

--- a/apps/web/src/chat/markdown.css
+++ b/apps/web/src/chat/markdown.css
@@ -1,7 +1,7 @@
 .chat-markdown {
 	min-width: 0;
 	overflow-wrap: anywhere;
-	font-size: var(--text-base);
+	font-size: var(--text-sm);
 	line-height: 1.5;
 }
 

--- a/apps/web/src/chat/transcript.tsx
+++ b/apps/web/src/chat/transcript.tsx
@@ -123,7 +123,7 @@ function SystemEntry(
 			<div className="shrink-0">
 				<SystemIcon />
 			</div>
-			<p className="m-0 text-base">{displayText(item.text)}</p>
+			<p className="m-0 text-sm">{displayText(item.text)}</p>
 		</div>
 	);
 }

--- a/apps/web/src/theme.css
+++ b/apps/web/src/theme.css
@@ -78,11 +78,11 @@
 	 * inside the chrome rather than two more sizes below the legibility floor.
 	 */
 	--text-*: initial;
-	--text-sm: 0.8125rem; /* 13px — all chrome */
+	--text-sm: 0.8125rem; /* 13px — all chrome, chat and comment bodies */
 	--text-sm--line-height: 1.25rem;
-	--text-base: 0.9375rem; /* 15px — chat and comment bodies */
+	--text-base: 0.9375rem; /* 15px — document prose */
 	--text-base--line-height: 1.375rem;
-	--text-lg: 1.0625rem; /* 17px — document prose */
+	--text-lg: 1.0625rem; /* 17px — document h3 subheadings */
 	--text-lg--line-height: 1.6875rem;
 	--text-xl: 1.5rem; /* 24px — section headings and dialogs */
 	--text-xl--line-height: 1.875rem;

--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -240,7 +240,7 @@ test(
 		await expect(system).toContainText("Sam joined");
 		expect(await system.evaluate(element => getComputedStyle(element).fontStyle)).toBe("normal");
 		expect(await system.locator("p").evaluate(element => getComputedStyle(element).fontSize)).toBe(
-			"15px",
+			"13px",
 		);
 
 		await testInfo.attach("finished-turn-with-failure-open", {

--- a/packages/editor/src/comments.tsx
+++ b/packages/editor/src/comments.tsx
@@ -42,7 +42,7 @@ function Note({ note }: { note: Comment.Note }) {
 				<Who handle={note.handle} />
 				<span className="text-sm text-text-tertiary tabular-nums">{when(note.ts)}</span>
 			</div>
-			<p className="m-0 text-base whitespace-pre-wrap text-text-primary">{note.text}</p>
+			<p className="m-0 text-sm whitespace-pre-wrap text-text-primary">{note.text}</p>
 		</li>
 	);
 }

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -17,13 +17,15 @@
 	 */
 	--plan-measure: 40rem;
 	/*
-	 * Resolved out here because MDXEditor declares `--text-base`, `--text-sm`
+	 * Document body text, one step down from the old 17px so prose sits
+	 * closer to chrome and chat sizes. Resolved out here because MDXEditor
+	 * declares `--text-base`, `--text-sm`
 	 * and `--text-xs` on its own root, which sits between `:root` and the
 	 * document — so reading the theme token inside the editor gets its 1rem
 	 * rather than ours. `.plan` is outside that root, so this catches the
 	 * theme's value on the way past.
 	 */
-	--plan-body: var(--text-lg);
+	--plan-body: var(--text-base);
 }
 
 /* Decisions pane -------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- Document prose (`--plan-body`) drops from 17px (`--text-lg`) to 15px (`--text-base`); h3 subheadings keep 17px.
- Chat pane (left rail) message text, input, and markdown body drop from 15px to 13px (`--text-sm`).
- Decisions pane (right rail) comment text also drops to 13px so both rails match, per design intent.
- Updated stale token-role comments in `theme.css` and `styles.css` to reflect new usage.

## Test plan
- [x] `bun test apps/web/src/tokens.test.ts` — 27 passing
- [x] `bun scripts/check-tokens.ts` — tokens consistent
- [ ] Visual check in browser