### PR TITLE
Add authenticated MCP document reads

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -18,6 +18,7 @@ import { proxy, serve } from "./client";
 import { describe, load } from "./config";
 import { GitHubError } from "./github/client";
 import { Router } from "./http/router";
+import { registerMcpRoutes } from "./mcp/routes";
 import * as Service from "./plan/service";
 import * as Inject from "./questions/inject";
 import * as Marks from "./comments/inject";
@@ -486,6 +487,7 @@ let hostedAuth = registerAuthRoutes(router, {
 			"GitHub credentials refreshed, so the Planner session was restarted. Ask it to continue.",
 		),
 });
+registerMcpRoutes(router, hostedAuth);
 registerChannelRoutes(router, hostedAuth, {
 	onAgentReset: channelId => resetOpenAgents(room => room.id === channelId),
 });

--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -124,6 +124,18 @@ describe("the MCP read protocol", () => {
 		]));
 	});
 
+	it("advertises the canonical repository and non-blank channel constraints it enforces", () => {
+		let list = TOOLS.find(tool => tool.name === "list_documents")!;
+		let read = TOOLS.find(tool => tool.name === "read_document")!;
+		expect((list.inputSchema.properties as Record<string, { pattern: string }>).repository.pattern)
+			.toBe(
+				"^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}/(?!\\.\\.?$)[A-Za-z0-9._-]{1,100}$",
+			);
+		expect((read.inputSchema.properties as Record<string, { pattern: string }>).id.pattern).toBe(
+			"\\S",
+		);
+	});
+
 	it("does not reveal documents to an unauthenticated caller", async () => {
 		let response = await endpoint()(request({
 			jsonrpc: "2.0",
@@ -157,25 +169,47 @@ describe("the MCP read protocol", () => {
 		);
 	});
 
+	it("rejects non-scalar JSON-RPC ids and scalar initialize or tools-list parameters", async () => {
+		let mcp = endpoint();
+		for (
+			let [request_, id] of [
+				[{ jsonrpc: "2.0", id: { invalid: true }, method: "tools/list" }, null],
+				[{ jsonrpc: "2.0", id: 5, method: "initialize", params: "invalid" }, 5],
+				[{ jsonrpc: "2.0", id: 6, method: "tools/list", params: 1 }, 6],
+			]
+		) {
+			expect(await json(await mcp(request(request_)))).toEqual({
+				jsonrpc: "2.0",
+				id,
+				error: { code: -32600, message: "invalid request" },
+			});
+		}
+	});
+
 	it("rejects malformed tool arguments and unknown tools without consulting the reader", async () => {
 		let mcp = endpoint();
-		let invalid = await json(
-			await mcp(request({
-				jsonrpc: "2.0",
-				id: 5,
-				method: "tools/call",
-				params: { name: "list_documents", arguments: { repository: "./chopin" } },
-			})),
-		);
-		expect(invalid.error).toEqual({
-			code: -32602,
-			message: "list_documents requires a repository",
-		});
+		for (
+			let [id, name, arguments_, error] of [
+				[5, "list_documents", { repository: "./chopin" }, "list_documents requires a repository"],
+				[6, "list_documents", { repository: "owner/.." }, "list_documents requires a repository"],
+				[7, "read_document", { id: " \t" }, "read_document requires an id"],
+			]
+		) {
+			let invalid = await json(
+				await mcp(request({
+					jsonrpc: "2.0",
+					id,
+					method: "tools/call",
+					params: { name, arguments: arguments_ },
+				})),
+			);
+			expect(invalid.error).toEqual({ code: -32602, message: error });
+		}
 
 		let unknown = await json(
 			await mcp(request({
 				jsonrpc: "2.0",
-				id: 6,
+				id: 8,
 				method: "tools/call",
 				params: { name: "write_document", arguments: {} },
 			})),
@@ -184,7 +218,7 @@ describe("the MCP read protocol", () => {
 	});
 
 	it("returns tool-level absence for a missing or inaccessible channel", async () => {
-		let response = await json(
+		let missing = await json(
 			await endpoint()(request({
 				jsonrpc: "2.0",
 				id: 7,
@@ -192,7 +226,26 @@ describe("the MCP read protocol", () => {
 				params: { name: "read_document", arguments: { id: "missing" } },
 			})),
 		);
-		expect(response.result).toEqual({ content: [], isError: true });
+		let inaccessible = await json(
+			await handler({
+				caller: () => "octocat",
+				documents: {
+					async list() {
+						return [];
+					},
+					async read() {
+						return undefined;
+					},
+				},
+			})(request({
+				jsonrpc: "2.0",
+				id: 8,
+				method: "tools/call",
+				params: { name: "read_document", arguments: { id: document.id } },
+			})),
+		);
+		expect(missing.result).toEqual({ content: [], isError: true });
+		expect(inaccessible.result).toEqual(missing.result);
 	});
 
 	it("does not reply to notifications and rejects unknown methods", async () => {

--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "bun:test";
+
+import { handler, TOOLS } from "./mcp";
+
+import type { Document, DocumentReader } from "./mcp";
+
+const document: Document = {
+	id: "f401c8d6-3717-4f1d-8473-cfdd0af894e4",
+	title: "Release readiness",
+	source: "# Release readiness\n",
+	revision: 4,
+};
+
+function request(
+	body: unknown,
+	init: RequestInit = {},
+): Request {
+	let headers = new Headers({
+		authorization: "Bearer allowed",
+		"content-type": "application/json",
+		...init.headers,
+	});
+	return new Request("https://chopin.test/mcp", {
+		method: "POST",
+		...init,
+		headers,
+		body: JSON.stringify(body),
+	});
+}
+
+function reader(): DocumentReader<string> {
+	return {
+		async list(caller, repository) {
+			return caller === "octocat" && repository === "githubnext/chopin"
+				? [{ id: document.id, title: document.title }]
+				: [];
+		},
+		async read(caller, id) {
+			return caller === "octocat" && id === document.id ? document : undefined;
+		},
+	};
+}
+
+function endpoint() {
+	return handler({
+		caller: request =>
+			request.headers.get("authorization") === "Bearer allowed"
+				? "octocat"
+				: undefined,
+		documents: reader(),
+	});
+}
+
+async function json(response: Response): Promise<Record<string, unknown>> {
+	return await response.json() as Record<string, unknown>;
+}
+
+describe("the MCP read protocol", () => {
+	it("authenticates initialize, lists repository documents, and reads canonical source", async () => {
+		let mcp = endpoint();
+
+		let initialized = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "initialize",
+				params: {},
+			})),
+		);
+		expect(initialized).toMatchObject({
+			jsonrpc: "2.0",
+			id: 1,
+			result: {
+				protocolVersion: "2025-03-26",
+				capabilities: { tools: {} },
+				serverInfo: { name: "chopin" },
+			},
+		});
+		let tools = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 2,
+				method: "tools/list",
+			})),
+		);
+		expect((tools.result as { tools: unknown[] }).tools).toEqual(TOOLS);
+
+		let listed = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 3,
+				method: "tools/call",
+				params: { name: "list_documents", arguments: { repository: "githubnext/chopin" } },
+			})),
+		);
+		expect((listed.result as { structuredContent: unknown }).structuredContent).toEqual({
+			documents: [{ id: document.id, title: document.title }],
+		});
+
+		let read = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 4,
+				method: "tools/call",
+				params: { name: "read_document", arguments: { id: document.id } },
+			})),
+		);
+		expect((read.result as { structuredContent: unknown }).structuredContent).toEqual(document);
+	});
+
+	it("keeps the repository-scoped tool schemas static", async () => {
+		expect(TOOLS).toEqual(expect.arrayContaining([
+			expect.objectContaining({
+				name: "list_documents",
+				inputSchema: expect.objectContaining({
+					required: ["repository"],
+					additionalProperties: false,
+				}),
+			}),
+			expect.objectContaining({
+				name: "read_document",
+				inputSchema: expect.objectContaining({ required: ["id"], additionalProperties: false }),
+			}),
+		]));
+	});
+
+	it("does not reveal documents to an unauthenticated caller", async () => {
+		let response = await endpoint()(request({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "tools/call",
+			params: { name: "list_documents", arguments: { repository: "githubnext/chopin" } },
+		}, { headers: { authorization: "Bearer denied" } }));
+
+		expect(response.status).toBe(401);
+		expect(await response.text()).not.toContain(document.title);
+	});
+
+	it("reports parse errors and invalid requests with JSON-RPC errors", async () => {
+		let mcp = endpoint();
+		let malformed = new Request("https://chopin.test/mcp", {
+			method: "POST",
+			headers: { authorization: "Bearer allowed", "content-type": "application/json" },
+			body: "{",
+		});
+		expect(await json(await mcp(malformed))).toEqual({
+			jsonrpc: "2.0",
+			id: null,
+			error: { code: -32700, message: "parse error" },
+		});
+		expect(await json(await mcp(request({ jsonrpc: "1.0", id: 4, method: "tools/list" })))).toEqual(
+			{
+				jsonrpc: "2.0",
+				id: 4,
+				error: { code: -32600, message: "invalid request" },
+			},
+		);
+	});
+
+	it("rejects malformed tool arguments and unknown tools without consulting the reader", async () => {
+		let mcp = endpoint();
+		let invalid = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 5,
+				method: "tools/call",
+				params: { name: "list_documents", arguments: { repository: "./chopin" } },
+			})),
+		);
+		expect(invalid.error).toEqual({
+			code: -32602,
+			message: "list_documents requires a repository",
+		});
+
+		let unknown = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 6,
+				method: "tools/call",
+				params: { name: "write_document", arguments: {} },
+			})),
+		);
+		expect(unknown.error).toEqual({ code: -32601, message: "tool not found" });
+	});
+
+	it("returns tool-level absence for a missing or inaccessible channel", async () => {
+		let response = await json(
+			await endpoint()(request({
+				jsonrpc: "2.0",
+				id: 7,
+				method: "tools/call",
+				params: { name: "read_document", arguments: { id: "missing" } },
+			})),
+		);
+		expect(response.result).toEqual({ content: [], isError: true });
+	});
+
+	it("does not reply to notifications and rejects unknown methods", async () => {
+		let mcp = endpoint();
+		let notification = await mcp(request({
+			jsonrpc: "2.0",
+			method: "tools/call",
+			params: { name: "list_documents", arguments: { repository: "githubnext/chopin" } },
+		}));
+		expect(notification.status).toBe(202);
+		expect(await notification.text()).toBe("");
+
+		let unknown = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 8,
+				method: "resources/list",
+			})),
+		);
+		expect(unknown.error).toEqual({ code: -32601, message: "method not found" });
+	});
+
+	it("negotiates authenticated GET event streams and refuses unsupported methods", async () => {
+		let mcp = endpoint();
+		let stream = await mcp(
+			new Request("https://chopin.test/mcp", {
+				headers: { authorization: "Bearer allowed", accept: "text/event-stream" },
+			}),
+		);
+		expect(stream.status).toBe(200);
+		expect(stream.headers.get("content-type")).toBe("text/event-stream");
+
+		let unacceptable = await mcp(
+			new Request("https://chopin.test/mcp", {
+				headers: { authorization: "Bearer allowed", accept: "application/json" },
+			}),
+		);
+		expect(unacceptable.status).toBe(406);
+
+		let unsupported = await mcp(
+			new Request("https://chopin.test/mcp", {
+				method: "PUT",
+				headers: { authorization: "Bearer allowed" },
+			}),
+		);
+		expect(unsupported.status).toBe(405);
+		expect(unsupported.headers.get("allow")).toBe("GET, POST");
+	});
+});

--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -134,6 +134,8 @@ describe("the MCP read protocol", () => {
 		expect((read.inputSchema.properties as Record<string, { pattern: string }>).id.pattern).toBe(
 			"\\S",
 		);
+		expect((read.inputSchema.properties as Record<string, { maxLength: number }>).id.maxLength)
+			.toBe(128);
 	});
 
 	it("does not reveal documents to an unauthenticated caller", async () => {
@@ -169,6 +171,43 @@ describe("the MCP read protocol", () => {
 		);
 	});
 
+	it("rejects declared and streamed request bodies beyond the read-only transport budget", async () => {
+		let mcp = endpoint();
+		let declared = await mcp(
+			new Request("https://chopin.test/mcp", {
+				method: "POST",
+				headers: {
+					authorization: "Bearer allowed",
+					"content-length": "65537",
+					"content-type": "application/json",
+				},
+				body: "{}",
+			}),
+		);
+		let streamed = await mcp(
+			new Request("https://chopin.test/mcp", {
+				method: "POST",
+				headers: {
+					authorization: "Bearer allowed",
+					"content-type": "application/json",
+				},
+				body: new ReadableStream({
+					start(controller) {
+						for (let index = 0; index < 3; index++) {
+							controller.enqueue(new Uint8Array(32_768));
+						}
+						controller.close();
+					},
+				}),
+			}),
+		);
+
+		for (let response of [declared, streamed]) {
+			expect(response.status).toBe(413);
+			expect(await response.text()).toBe("request too large");
+		}
+	});
+
 	it("rejects non-scalar JSON-RPC ids and scalar initialize or tools-list parameters", async () => {
 		let mcp = endpoint();
 		for (
@@ -193,6 +232,7 @@ describe("the MCP read protocol", () => {
 				[5, "list_documents", { repository: "./chopin" }, "list_documents requires a repository"],
 				[6, "list_documents", { repository: "owner/.." }, "list_documents requires a repository"],
 				[7, "read_document", { id: " \t" }, "read_document requires an id"],
+				[9, "read_document", { id: "x".repeat(129) }, "read_document requires an id"],
 			]
 		) {
 			let invalid = await json(
@@ -215,6 +255,20 @@ describe("the MCP read protocol", () => {
 			})),
 		);
 		expect(unknown.error).toEqual({ code: -32601, message: "tool not found" });
+	});
+
+	it("counts read-document ids by JSON Schema characters", async () => {
+		let boundary = await json(
+			await endpoint()(request({
+				jsonrpc: "2.0",
+				id: 10,
+				method: "tools/call",
+				params: { name: "read_document", arguments: { id: "😀".repeat(128) } },
+			})),
+		);
+
+		expect(boundary.error).toBeUndefined();
+		expect(boundary.result).toEqual({ content: [], isError: true });
 	});
 
 	it("returns tool-level absence for a missing or inaccessible channel", async () => {
@@ -293,5 +347,31 @@ describe("the MCP read protocol", () => {
 		);
 		expect(unsupported.status).toBe(405);
 		expect(unsupported.headers.get("allow")).toBe("GET, POST");
+	});
+
+	it("honors event-stream Accept quality values", async () => {
+		let mcp = endpoint();
+		for (
+			let accept of [
+				"text/event-stream;q=0",
+				"application/json, text/event-stream; q=0",
+				"text/event-stream;q=0, */*;q=1",
+				"*/*;q=0",
+			]
+		) {
+			let response = await mcp(
+				new Request("https://chopin.test/mcp", {
+					headers: { authorization: "Bearer allowed", accept },
+				}),
+			);
+			expect(response.status).toBe(406);
+		}
+
+		let accepted = await mcp(
+			new Request("https://chopin.test/mcp", {
+				headers: { authorization: "Bearer allowed", accept: "text/event-stream;q=0.25" },
+			}),
+		);
+		expect(accepted.status).toBe(200);
 	});
 });

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -33,6 +33,12 @@ type Tool = {
 	outputSchema: Record<string, unknown>;
 };
 
+const OWNER_PATTERN = "[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}";
+const REPOSITORY_PATTERN = "(?!\\.\\.?$)[A-Za-z0-9._-]{1,100}";
+const REPOSITORY_PATH_PATTERN = `^${OWNER_PATTERN}/${REPOSITORY_PATTERN}$`;
+const OWNER = new RegExp(`^${OWNER_PATTERN}$`);
+const REPOSITORY = new RegExp(`^${REPOSITORY_PATTERN}$`);
+
 const DOCUMENT = {
 	type: "object",
 	properties: {
@@ -51,7 +57,7 @@ export const TOOLS: Tool[] = [
 		inputSchema: {
 			type: "object",
 			properties: {
-				repository: { type: "string", pattern: "^[^/\\s]+/[^/\\s]+$" },
+				repository: { type: "string", pattern: REPOSITORY_PATH_PATTERN },
 			},
 			required: ["repository"],
 			additionalProperties: false,
@@ -68,7 +74,7 @@ export const TOOLS: Tool[] = [
 		description: "Read a Chopin channel's canonical source and revision.",
 		inputSchema: {
 			type: "object",
-			properties: { id: { type: "string", minLength: 1 } },
+			properties: { id: { type: "string", minLength: 1, pattern: "\\S" } },
 			required: ["id"],
 			additionalProperties: false,
 		},
@@ -131,9 +137,6 @@ function toolCall(
 	return arguments_ ? { name: value.name, arguments: arguments_ } : undefined;
 }
 
-const OWNER = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
-const REPOSITORY = /^[A-Za-z0-9._-]{1,100}$/;
-
 function isRepository(value: unknown): value is string {
 	if (typeof value !== "string") return false;
 	let parts = value.split("/");
@@ -142,6 +145,16 @@ function isRepository(value: unknown): value is string {
 
 function isId(value: unknown): value is string {
 	return typeof value === "string" && value.trim().length > 0;
+}
+
+function isJsonRpcId(value: unknown): value is string | number | null {
+	return value === null || typeof value === "string" || typeof value === "number";
+}
+
+function hasObjectParams(call: Call): boolean {
+	return call.params === undefined
+		|| (call.method !== "initialize" && call.method !== "tools/list")
+		|| record(call.params) !== undefined;
 }
 
 function acceptsEvents(request: Request): boolean {
@@ -160,6 +173,10 @@ export function handler<Caller>(
 		if (!call || call.jsonrpc !== "2.0" || typeof call.method !== "string") {
 			return error(call?.id, -32600, "invalid request");
 		}
+		if (Object.hasOwn(call, "id") && !isJsonRpcId(call.id)) {
+			return error(null, -32600, "invalid request");
+		}
+		if (!hasObjectParams(call)) return error(call.id, -32600, "invalid request");
 		let notification = !Object.hasOwn(call, "id");
 		let respond = (result: unknown) => notification ? undefined : reply(call.id, result);
 

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -38,6 +38,9 @@ const REPOSITORY_PATTERN = "(?!\\.\\.?$)[A-Za-z0-9._-]{1,100}";
 const REPOSITORY_PATH_PATTERN = `^${OWNER_PATTERN}/${REPOSITORY_PATTERN}$`;
 const OWNER = new RegExp(`^${OWNER_PATTERN}$`);
 const REPOSITORY = new RegExp(`^${REPOSITORY_PATTERN}$`);
+const MAX_DOCUMENT_ID_LENGTH = 128;
+/** Read-only JSON-RPC calls need arguments, not document-sized request bodies. */
+const MAX_REQUEST_BYTES = 64 * 1_024;
 
 const DOCUMENT = {
 	type: "object",
@@ -74,7 +77,14 @@ export const TOOLS: Tool[] = [
 		description: "Read a Chopin channel's canonical source and revision.",
 		inputSchema: {
 			type: "object",
-			properties: { id: { type: "string", minLength: 1, pattern: "\\S" } },
+			properties: {
+				id: {
+					type: "string",
+					minLength: 1,
+					maxLength: MAX_DOCUMENT_ID_LENGTH,
+					pattern: "\\S",
+				},
+			},
 			required: ["id"],
 			additionalProperties: false,
 		},
@@ -144,7 +154,9 @@ function isRepository(value: unknown): value is string {
 }
 
 function isId(value: unknown): value is string {
-	return typeof value === "string" && value.trim().length > 0;
+	return typeof value === "string"
+		&& Array.from(value).length <= MAX_DOCUMENT_ID_LENGTH
+		&& value.trim().length > 0;
 }
 
 function isJsonRpcId(value: unknown): value is string | number | null {
@@ -158,10 +170,65 @@ function hasObjectParams(call: Call): boolean {
 }
 
 function acceptsEvents(request: Request): boolean {
-	return (request.headers.get("accept") ?? "*/*")
-		.split(",")
-		.map(value => value.trim().split(";", 1)[0])
-		.some(value => value === "text/event-stream" || value === "*/*");
+	let selected: { specificity: number; quality: number } | undefined;
+	for (let item of (request.headers.get("accept") ?? "*/*").split(",")) {
+		let [media, ...parameters] = item.split(";").map(value => value.trim());
+		let specificity = media?.toLowerCase() === "text/event-stream"
+			? 2
+			: media?.toLowerCase() === "text/*"
+			? 1
+			: media === "*/*"
+			? 0
+			: -1;
+		if (specificity < 0) continue;
+		let quality = 1;
+		let parameter = parameters.find(value => value.split("=", 1)[0]?.trim().toLowerCase() === "q");
+		if (parameter) {
+			let value = parameter.slice(parameter.indexOf("=") + 1).trim();
+			quality = /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/.test(value) ? Number(value) : 0;
+		}
+		if (
+			!selected
+			|| specificity > selected.specificity
+			|| (specificity === selected.specificity && quality > selected.quality)
+		) selected = { specificity, quality };
+	}
+	return (selected?.quality ?? 0) > 0;
+}
+
+async function requestBody(request: Request): Promise<{ body?: unknown; tooLarge: boolean }> {
+	let declared = request.headers.get("content-length");
+	if (declared && /^\d+$/.test(declared) && Number(declared) > MAX_REQUEST_BYTES) {
+		return { tooLarge: true };
+	}
+
+	let reader = request.body?.getReader();
+	if (!reader) throw new Error("request has no body");
+	let chunks: Uint8Array[] = [];
+	let length = 0;
+	try {
+		while (true) {
+			let { done, value } = await reader.read();
+			if (done) break;
+			if (!value) continue;
+			length += value.byteLength;
+			if (length > MAX_REQUEST_BYTES) {
+				await reader.cancel().catch(() => {});
+				return { tooLarge: true };
+			}
+			chunks.push(value);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+
+	let bytes = new Uint8Array(length);
+	let offset = 0;
+	for (let chunk of chunks) {
+		bytes.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return { body: JSON.parse(new TextDecoder().decode(bytes)), tooLarge: false };
 }
 
 /** A stateless JSON-response Streamable HTTP MCP handler for read-only tools. */
@@ -246,7 +313,9 @@ export function handler<Caller>(
 
 		let body: unknown;
 		try {
-			body = await request.json();
+			let read = await requestBody(request);
+			if (read.tooLarge) return new Response("request too large", { status: 413 });
+			body = read.body;
 		} catch {
 			return Response.json(error(null, -32700, "parse error"));
 		}

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -1,0 +1,239 @@
+/**
+ * Backend-neutral MCP read protocol.
+ *
+ * Hosts authenticate callers and resolve repository-scoped documents. This
+ * module only validates and presents their results through MCP.
+ */
+
+export type DocumentSummary = {
+	id: string;
+	title: string;
+};
+
+export type Document = DocumentSummary & {
+	source: string;
+	revision: number;
+};
+
+export type DocumentReader<Caller> = {
+	list(caller: Caller, repository: string): Promise<DocumentSummary[]>;
+	read(caller: Caller, id: string): Promise<Document | undefined>;
+};
+
+export type McpOptions<Caller> = {
+	/** The host owns authentication; MCP only receives its result. */
+	caller(request: Request): Promise<Caller | undefined> | Caller | undefined;
+	documents: DocumentReader<Caller>;
+};
+
+type Tool = {
+	name: string;
+	description: string;
+	inputSchema: Record<string, unknown>;
+	outputSchema: Record<string, unknown>;
+};
+
+const DOCUMENT = {
+	type: "object",
+	properties: {
+		id: { type: "string" },
+		title: { type: "string" },
+	},
+	required: ["id", "title"],
+	additionalProperties: false,
+};
+
+/** The host can change readers, but never the public tool contract. */
+export const TOOLS: Tool[] = [
+	{
+		name: "list_documents",
+		description: "List Chopin documents available in a repository.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				repository: { type: "string", pattern: "^[^/\\s]+/[^/\\s]+$" },
+			},
+			required: ["repository"],
+			additionalProperties: false,
+		},
+		outputSchema: {
+			type: "object",
+			properties: { documents: { type: "array", items: DOCUMENT } },
+			required: ["documents"],
+			additionalProperties: false,
+		},
+	},
+	{
+		name: "read_document",
+		description: "Read a Chopin channel's canonical source and revision.",
+		inputSchema: {
+			type: "object",
+			properties: { id: { type: "string", minLength: 1 } },
+			required: ["id"],
+			additionalProperties: false,
+		},
+		outputSchema: {
+			type: "object",
+			properties: {
+				...DOCUMENT.properties,
+				source: { type: "string" },
+				revision: { type: "integer", minimum: 0 },
+			},
+			required: ["id", "title", "source", "revision"],
+			additionalProperties: false,
+		},
+	},
+];
+
+type Call = {
+	jsonrpc?: unknown;
+	id?: unknown;
+	method?: unknown;
+	params?: unknown;
+};
+
+type Reply = {
+	jsonrpc: "2.0";
+	id: unknown;
+	result?: unknown;
+	error?: { code: number; message: string };
+};
+
+function reply(id: unknown, result: unknown): Reply {
+	return { jsonrpc: "2.0", id: id ?? null, result };
+}
+
+function error(id: unknown, code: number, message: string): Reply {
+	return { jsonrpc: "2.0", id: id ?? null, error: { code, message } };
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? value as Record<string, unknown>
+		: undefined;
+}
+
+function text(
+	value: unknown,
+): { content: Array<{ type: "text"; text: string }>; structuredContent: unknown } {
+	return {
+		content: [{ type: "text", text: JSON.stringify(value) }],
+		structuredContent: value,
+	};
+}
+
+function toolCall(
+	params: unknown,
+): { name: string; arguments: Record<string, unknown> } | undefined {
+	let value = record(params);
+	if (!value || typeof value.name !== "string") return undefined;
+	let arguments_ = value.arguments === undefined ? {} : record(value.arguments);
+	return arguments_ ? { name: value.name, arguments: arguments_ } : undefined;
+}
+
+const OWNER = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
+const REPOSITORY = /^[A-Za-z0-9._-]{1,100}$/;
+
+function isRepository(value: unknown): value is string {
+	if (typeof value !== "string") return false;
+	let parts = value.split("/");
+	return parts.length === 2 && OWNER.test(parts[0]!) && REPOSITORY.test(parts[1]!);
+}
+
+function isId(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function acceptsEvents(request: Request): boolean {
+	return (request.headers.get("accept") ?? "*/*")
+		.split(",")
+		.map(value => value.trim().split(";", 1)[0])
+		.some(value => value === "text/event-stream" || value === "*/*");
+}
+
+/** A stateless JSON-response Streamable HTTP MCP handler for read-only tools. */
+export function handler<Caller>(
+	options: McpOptions<Caller>,
+): (request: Request) => Promise<Response> {
+	async function dispatch(value: unknown, caller: Caller): Promise<Reply | undefined> {
+		let call = record(value) as Call | undefined;
+		if (!call || call.jsonrpc !== "2.0" || typeof call.method !== "string") {
+			return error(call?.id, -32600, "invalid request");
+		}
+		let notification = !Object.hasOwn(call, "id");
+		let respond = (result: unknown) => notification ? undefined : reply(call.id, result);
+
+		switch (call.method) {
+			case "initialize":
+				return respond({
+					protocolVersion: "2025-03-26",
+					capabilities: { tools: {} },
+					serverInfo: { name: "chopin", version: "0.0.0" },
+				});
+
+			case "notifications/initialized":
+				return undefined;
+
+			case "tools/list":
+				return respond({ tools: TOOLS });
+
+			case "tools/call": {
+				let tool = toolCall(call.params);
+				if (!tool) {
+					return notification
+						? undefined
+						: error(call.id, -32602, "invalid tool arguments");
+				}
+				if (tool.name === "list_documents") {
+					if (
+						Object.keys(tool.arguments).length !== 1 || !isRepository(tool.arguments.repository)
+					) {
+						return notification
+							? undefined
+							: error(call.id, -32602, "list_documents requires a repository");
+					}
+					return respond(
+						text({ documents: await options.documents.list(caller, tool.arguments.repository) }),
+					);
+				}
+				if (tool.name === "read_document") {
+					if (Object.keys(tool.arguments).length !== 1 || !isId(tool.arguments.id)) {
+						return notification
+							? undefined
+							: error(call.id, -32602, "read_document requires an id");
+					}
+					let document = await options.documents.read(caller, tool.arguments.id);
+					return document ? respond(text(document)) : respond({ content: [], isError: true });
+				}
+				return notification ? undefined : error(call.id, -32601, "tool not found");
+			}
+
+			default:
+				return notification ? undefined : error(call.id, -32601, "method not found");
+		}
+	}
+
+	return async request => {
+		let caller = await options.caller(request);
+		if (caller === undefined) return new Response("unauthorized", { status: 401 });
+
+		if (request.method === "GET") {
+			if (!acceptsEvents(request)) return new Response("not acceptable", { status: 406 });
+			return new Response(null, {
+				headers: { "cache-control": "no-cache", "content-type": "text/event-stream" },
+			});
+		}
+		if (request.method !== "POST") {
+			return new Response("method not allowed", { status: 405, headers: { allow: "GET, POST" } });
+		}
+
+		let body: unknown;
+		try {
+			body = await request.json();
+		} catch {
+			return Response.json(error(null, -32700, "parse error"));
+		}
+		let result = await dispatch(body, caller);
+		return result ? Response.json(result) : new Response(null, { status: 202 });
+	};
+}

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -12,7 +12,14 @@ import { hosted } from "./hosted";
 
 import type { Server } from "bun";
 import type { HostedAuth } from "../auth/routes";
-import type { GitHub, GitHubUser, Repository, RepositoryPage } from "../github/client";
+import type {
+	GitHub,
+	GitHubTokenGrant,
+	GitHubUser,
+	InstallationPage,
+	Repository,
+	RepositoryPage,
+} from "../github/client";
 import type { Socket, SocketData } from "../wire";
 
 class GitHubBoundary implements GitHub {
@@ -33,8 +40,12 @@ class GitHubBoundary implements GitHub {
 		return "";
 	}
 
-	async exchange(): Promise<string> {
-		return "";
+	async exchange(): Promise<GitHubTokenGrant> {
+		return grant("access-token");
+	}
+
+	async refresh(): Promise<GitHubTokenGrant> {
+		return grant("refreshed-access-token");
 	}
 
 	async user(token: string): Promise<GitHubUser> {
@@ -45,6 +56,14 @@ class GitHubBoundary implements GitHub {
 
 	async repositories(): Promise<RepositoryPage> {
 		return { repositories: [], nextPage: undefined };
+	}
+
+	async installations(): Promise<InstallationPage> {
+		return { installations: [], nextPage: undefined };
+	}
+
+	async installationRepositories(): Promise<RepositoryPage> {
+		return this.repositories();
 	}
 
 	async repository(_token: string, owner: string, name: string): Promise<Repository> {
@@ -59,6 +78,8 @@ class GitHubBoundary implements GitHub {
 		return this.accessible ? this.value(owner, name) : undefined;
 	}
 
+	invalidate(): void {}
+
 	private value(owner: string, name: string): Repository {
 		return {
 			...this.repositoryValue,
@@ -70,6 +91,15 @@ class GitHubBoundary implements GitHub {
 	}
 }
 
+function grant(accessToken: string): GitHubTokenGrant {
+	return {
+		accessToken,
+		accessExpiresIn: 28_800,
+		refreshToken: "refresh-token",
+		refreshExpiresIn: 15_897_600,
+	};
+}
+
 function setup() {
 	let now = new Date("2026-08-17T12:00:00.000Z");
 	let storage = new MemoryStorage();
@@ -78,13 +108,14 @@ function setup() {
 	let auth: HostedAuth = {
 		config: {
 			origin: "https://chopin.test",
+			appSlug: "chopin-test",
 			clientId: "client-id",
 			clientSecret: "client-secret",
 			encryptionKey: key,
 		},
 		storage,
 		github,
-		sessions: new Sessions(storage, key, true, () => now),
+		sessions: new Sessions(storage, true, () => now),
 		clock: () => now,
 	};
 	return { auth, github, now, storage };

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it } from "bun:test";
+
+import { ulid } from "@chopin/dialect";
+
+import { Sessions } from "../auth/session";
+import { GitHubError } from "../github/client";
+import * as Room from "../plan/room";
+import * as Service from "../plan/service";
+import * as Rooms from "../rooms";
+import { MemoryStorage } from "../storage/memory/adapter";
+import { hosted } from "./hosted";
+
+import type { Server } from "bun";
+import type { HostedAuth } from "../auth/routes";
+import type { GitHub, GitHubUser, Repository, RepositoryPage } from "../github/client";
+import type { Socket, SocketData } from "../wire";
+
+class GitHubBoundary implements GitHub {
+	readonly userTokens: string[] = [];
+	accessible = true;
+	repositoryValue: Repository = {
+		id: "R_score",
+		owner: "octo-org",
+		name: "score",
+		fullName: "octo-org/score",
+		private: true,
+		url: "https://github.test/octo-org/score",
+		defaultBranch: "main",
+		permissions: { pull: true, push: false, admin: false },
+	};
+
+	authorize(): string {
+		return "";
+	}
+
+	async exchange(): Promise<string> {
+		return "";
+	}
+
+	async user(token: string): Promise<GitHubUser> {
+		this.userTokens.push(token);
+		if (token === "denied") throw new GitHubError("bad credentials", 401);
+		return { id: `U_${token}`, login: token, avatarUrl: "https://github.test/avatar" };
+	}
+
+	async repositories(): Promise<RepositoryPage> {
+		return { repositories: [], nextPage: undefined };
+	}
+
+	async repository(_token: string, owner: string, name: string): Promise<Repository> {
+		return this.value(owner, name);
+	}
+
+	async repositoryAccess(
+		_token: string,
+		owner: string,
+		name: string,
+	): Promise<Repository | undefined> {
+		return this.accessible ? this.value(owner, name) : undefined;
+	}
+
+	private value(owner: string, name: string): Repository {
+		return {
+			...this.repositoryValue,
+			owner,
+			name,
+			fullName: `${owner}/${name}`,
+			url: `https://github.test/${owner}/${name}`,
+		};
+	}
+}
+
+function setup() {
+	let now = new Date("2026-08-17T12:00:00.000Z");
+	let storage = new MemoryStorage();
+	let github = new GitHubBoundary();
+	let key = new Uint8Array(32).fill(3);
+	let auth: HostedAuth = {
+		config: {
+			origin: "https://chopin.test",
+			clientId: "client-id",
+			clientSecret: "client-secret",
+			encryptionKey: key,
+		},
+		storage,
+		github,
+		sessions: new Sessions(storage, key, true, () => now),
+		clock: () => now,
+	};
+	return { auth, github, now, storage };
+}
+
+function request(authorization?: string | Headers): Request {
+	let headers = authorization instanceof Headers
+		? authorization
+		: authorization
+		? new Headers({ authorization })
+		: undefined;
+	return new Request("https://chopin.test/mcp", { headers });
+}
+
+async function plan(context: ReturnType<typeof setup>) {
+	await context.storage.users.put({
+		id: "U_allowed",
+		login: "allowed",
+		avatarUrl: "",
+		now: context.now,
+	});
+	let channel = await context.storage.channels.create({
+		id: crypto.randomUUID(),
+		repositoryId: "R_score",
+		repositoryOwner: "octo-org",
+		repositoryName: "score",
+		title: "Release readiness",
+		createdBy: "U_allowed",
+		now: context.now,
+	});
+	let lease = await context.storage.leases.acquire("writer", "mcp-test", 60_000);
+	if (!lease) throw new Error("could not acquire test lease");
+	let server = { publish() {} } as unknown as Server<SocketData>;
+	let backend: Service.Backend = {
+		storage: context.storage,
+		lease: () => lease,
+		fatal: err => {
+			throw err;
+		},
+	};
+	return { channel, lease, server, plan: await Service.open(channel.id, backend, server) };
+}
+
+describe("the hosted MCP adapter", () => {
+	it("accepts exactly one bearer token and validates its GitHub identity per request", async () => {
+		let { auth, github } = setup();
+		let adapter = hosted(auth);
+		let duplicate = new Headers();
+		duplicate.append("authorization", "Bearer first");
+		duplicate.append("authorization", "Bearer second");
+
+		expect(await adapter.caller(request())).toBeUndefined();
+		expect(await adapter.caller(request("Basic token"))).toBeUndefined();
+		expect(await adapter.caller(request(duplicate))).toBeUndefined();
+		expect(await adapter.caller(request("Bearer denied"))).toBeUndefined();
+		expect(await adapter.caller(request("Bearer allowed"))).toEqual({
+			oauthToken: "allowed",
+			user: {
+				id: "U_allowed",
+				login: "allowed",
+				avatarUrl: "https://github.test/avatar",
+			},
+		});
+		expect(await adapter.caller(request("bearer allowed"))).toBeDefined();
+		expect(await adapter.caller(request("Bearer token+/=="))).toBeDefined();
+		expect(github.userTokens).toEqual(["denied", "allowed", "allowed", "token+/=="]);
+	});
+
+	it("lists every channel under the currently readable repository node id", async () => {
+		let { auth, github, now, storage } = setup();
+		await storage.users.put({ id: "U_allowed", login: "allowed", avatarUrl: "", now });
+		for (let index = 0; index < 101; index++) {
+			await storage.channels.create({
+				id: crypto.randomUUID(),
+				repositoryId: "R_score",
+				repositoryOwner: "octo-org",
+				repositoryName: "score",
+				title: `Plan ${String(index).padStart(3, "0")}`,
+				createdBy: "U_allowed",
+				now,
+			});
+		}
+		await storage.channels.create({
+			id: crypto.randomUUID(),
+			repositoryId: "R_foreign",
+			repositoryOwner: "elsewhere",
+			repositoryName: "private",
+			title: "Foreign title",
+			createdBy: "U_allowed",
+			now,
+		});
+		let adapter = hosted(auth);
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller) throw new Error("test caller was not authenticated");
+
+		let listed = await adapter.documents.list(caller, "octo-org/score");
+		expect(listed).toHaveLength(101);
+		expect(listed.map(document => document.title)).not.toContain("Foreign title");
+
+		github.repositoryValue = {
+			...github.repositoryValue,
+			permissions: { pull: false, push: true, admin: false },
+		};
+		expect(await adapter.documents.list(caller, "octo-org/score")).toEqual([]);
+		github.accessible = false;
+		expect(await adapter.documents.list(caller, "octo-org/score")).toEqual([]);
+	});
+
+	it("reconstructs a stored checkpoint and journal with the validated plan revision", async () => {
+		let context = setup();
+		let opened = await plan(context);
+		let mutation = Room.insertDecision(opened.plan.document, {
+			id: ulid(),
+			quote: "Ship the release",
+			by: "allowed",
+			at: "2026-08-17T12:00:00.000Z",
+			notes: [{ by: "allowed", text: "The checks are green" }],
+		});
+		if (!mutation) throw new Error("test mutation was empty");
+		await Service.publish(opened.plan, opened.server, opened.channel.id, mutation);
+		let stored = await context.storage.collaboration.load(opened.channel.id, context.now);
+		expect(stored?.updates).toHaveLength(1);
+		let expectedSource = Service.source(opened.plan);
+		let adapter = hosted(context.auth);
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller) throw new Error("test caller was not authenticated");
+
+		expect(await adapter.documents.read(caller, opened.channel.id)).toEqual({
+			id: opened.channel.id,
+			title: "Release readiness",
+			source: expectedSource,
+			revision: 1,
+		});
+		await Service.close(opened.plan);
+	});
+
+	it("reads an open plan from its authoritative live document", async () => {
+		let context = setup();
+		let opened = await plan(context);
+		let mutation = Room.insertDecision(opened.plan.document, {
+			id: ulid(),
+			quote: "Live and not checkpointed",
+			by: "allowed",
+			at: "2026-08-17T12:00:00.000Z",
+			notes: [{ by: "allowed", text: "Read the live document" }],
+		});
+		if (!mutation) throw new Error("test mutation was empty");
+		opened.plan.revision = 9;
+		let socket = {
+			data: { room: opened.channel.id, client: "mcp-test" },
+		} as unknown as Socket;
+		let live = Rooms.join(socket);
+		live.plan = opened.plan;
+		let adapter = hosted(context.auth);
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller) throw new Error("test caller was not authenticated");
+
+		try {
+			expect(await adapter.documents.read(caller, opened.channel.id)).toEqual({
+				id: opened.channel.id,
+				title: "Release readiness",
+				source: Service.source(opened.plan),
+				revision: 9,
+			});
+		} finally {
+			Rooms.forget(live);
+			await Service.close(opened.plan);
+		}
+	});
+
+	it("makes an inaccessible channel indistinguishable from a missing channel", async () => {
+		let context = setup();
+		let opened = await plan(context);
+		await Service.close(opened.plan);
+		let adapter = hosted(context.auth);
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller) throw new Error("test caller was not authenticated");
+		let missing = await adapter.documents.read(caller, crypto.randomUUID());
+		context.github.repositoryValue = {
+			...context.github.repositoryValue,
+			id: "R_replaced",
+			permissions: { pull: true, push: true, admin: true },
+		};
+
+		expect(await adapter.documents.read(caller, opened.channel.id)).toBe(missing);
+		context.github.repositoryValue = {
+			...context.github.repositoryValue,
+			id: "R_score",
+			permissions: { pull: false, push: true, admin: true },
+		};
+		expect(await adapter.documents.read(caller, opened.channel.id)).toBe(missing);
+		expect(missing).toBeUndefined();
+	});
+
+	it("treats malformed durable state as an absent channel", async () => {
+		let context = setup();
+		let opened = await plan(context);
+		await Service.close(opened.plan);
+		let stored = await context.storage.collaboration.load(opened.channel.id, context.now);
+		if (!stored?.snapshot) throw new Error("test channel has no checkpoint");
+		await context.storage.collaboration.commit({
+			channelId: opened.channel.id,
+			lease: opened.lease,
+			expectedRevision: stored.channel.revision,
+			operationId: crypto.randomUUID(),
+			epoch: stored.snapshot.epoch,
+			sidecar: { version: 1, revision: 40 },
+			events: [],
+			now: context.now,
+		});
+		let adapter = hosted(context.auth);
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller) throw new Error("test caller was not authenticated");
+
+		expect(await adapter.documents.read(caller, opened.channel.id)).toBeUndefined();
+	});
+});

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -301,4 +301,40 @@ describe("the hosted MCP adapter", () => {
 
 		expect(await adapter.documents.read(caller, opened.channel.id)).toBeUndefined();
 	});
+
+	it("treats an invalid open questionnaire as absent durable state", async () => {
+		let context = setup();
+		let opened = await plan(context);
+		await Service.close(opened.plan);
+		let stored = await context.storage.collaboration.load(opened.channel.id, context.now);
+		if (!stored?.snapshot) throw new Error("test channel has no checkpoint");
+		await context.storage.collaboration.commit({
+			channelId: opened.channel.id,
+			lease: opened.lease,
+			expectedRevision: stored.channel.revision,
+			operationId: crypto.randomUUID(),
+			epoch: stored.snapshot.epoch,
+			sidecar: {
+				version: 1,
+				revision: 40,
+				documentSeq: 0,
+				questions: [{ id: "question-1", status: "open", definition: {} }],
+				openQuestions: [{
+					id: "question-1",
+					definition: {},
+					model: [],
+					revision: -1,
+				}],
+				threads: [],
+				transcript: [],
+			},
+			events: [],
+			now: context.now,
+		});
+		let adapter = hosted(context.auth);
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller) throw new Error("test caller was not authenticated");
+
+		expect(await adapter.documents.read(caller, opened.channel.id)).toBeUndefined();
+	});
 });

--- a/apps/server/src/mcp/hosted.ts
+++ b/apps/server/src/mcp/hosted.ts
@@ -41,7 +41,7 @@ export function hosted(auth: HostedAuth): McpOptions<HostedCaller> {
 				let documents = [];
 				let cursor;
 				do {
-					let page = await auth.storage.channels.list(resolved.id, 100, cursor);
+					let page = await auth.storage.channels.scan(resolved.id, 100, cursor);
 					documents.push(...page.channels.map(channel => ({
 						id: channel.id,
 						title: channel.title,

--- a/apps/server/src/mcp/hosted.ts
+++ b/apps/server/src/mcp/hosted.ts
@@ -1,0 +1,97 @@
+import { GitHubError } from "../github/client";
+import * as Plan from "../plan/service";
+import * as Rooms from "../rooms";
+
+import type { HostedAuth } from "../auth/routes";
+import type { GitHubUser } from "../github/client";
+import type { McpOptions } from "../mcp";
+
+export type HostedCaller = {
+	oauthToken: string;
+	user: GitHubUser;
+};
+
+const BEARER = new RegExp("^Bearer ([A-Za-z0-9._~+/-]+=*)$", "i");
+
+/** Bind the backend-neutral MCP surface to hosted GitHub authentication. */
+export function hosted(auth: HostedAuth): McpOptions<HostedCaller> {
+	return {
+		async caller(request) {
+			let match = request.headers.get("authorization")?.match(BEARER);
+			if (!match) return undefined;
+			let oauthToken = match[1]!;
+			try {
+				return { oauthToken, user: await auth.github.user(oauthToken) };
+			} catch (err) {
+				if (err instanceof GitHubError && err.status === 401) return undefined;
+				throw err;
+			}
+		},
+		documents: {
+			async list(caller, repository) {
+				let parts = repository.split("/");
+				if (parts.length !== 2 || !parts[0] || !parts[1]) return [];
+				let resolved = await auth.github.repositoryAccess(
+					caller.oauthToken,
+					parts[0],
+					parts[1],
+				);
+				if (!resolved?.permissions.pull) return [];
+
+				let documents = [];
+				let cursor;
+				do {
+					let page = await auth.storage.channels.list(resolved.id, 100, cursor);
+					documents.push(...page.channels.map(channel => ({
+						id: channel.id,
+						title: channel.title,
+					})));
+					cursor = page.next;
+				} while (cursor);
+				return documents;
+			},
+			async read(caller, id) {
+				let channel = await auth.storage.channels.get(id);
+				if (!channel) return undefined;
+				let repository = await auth.github.repositoryAccess(
+					caller.oauthToken,
+					channel.repositoryOwner,
+					channel.repositoryName,
+				);
+				if (
+					!repository?.permissions.pull
+					|| repository.id !== channel.repositoryId
+				) return undefined;
+
+				let live = Rooms.get(channel.id)?.plan;
+				if (live) {
+					try {
+						return {
+							id: channel.id,
+							title: channel.title,
+							source: Plan.source(live),
+							revision: live.revision,
+						};
+					} catch {
+						return undefined;
+					}
+				}
+
+				let stored = await auth.storage.collaboration.load(channel.id, auth.clock());
+				if (
+					!stored
+					|| stored.channel.id !== channel.id
+					|| stored.channel.repositoryId !== channel.repositoryId
+					|| stored.channel.repositoryOwner !== channel.repositoryOwner
+					|| stored.channel.repositoryName !== channel.repositoryName
+				) return undefined;
+				try {
+					let projected = await Plan.readStored(stored);
+					return { id: channel.id, title: channel.title, ...projected };
+				} catch {
+					return undefined;
+				}
+			},
+		},
+	};
+}

--- a/apps/server/src/mcp/routes.test.ts
+++ b/apps/server/src/mcp/routes.test.ts
@@ -6,7 +6,14 @@ import { MemoryStorage } from "../storage/memory/adapter";
 import { registerMcpRoutes } from "./routes";
 
 import type { HostedAuth } from "../auth/routes";
-import type { GitHub, GitHubUser, Repository, RepositoryPage } from "../github/client";
+import type {
+	GitHub,
+	GitHubTokenGrant,
+	GitHubUser,
+	InstallationPage,
+	Repository,
+	RepositoryPage,
+} from "../github/client";
 
 class GitHubBoundary implements GitHub {
 	failure: Error | undefined;
@@ -15,8 +22,12 @@ class GitHubBoundary implements GitHub {
 		return "";
 	}
 
-	async exchange(): Promise<string> {
-		return "";
+	async exchange(): Promise<GitHubTokenGrant> {
+		return grant("access-token");
+	}
+
+	async refresh(): Promise<GitHubTokenGrant> {
+		return grant("refreshed-access-token");
 	}
 
 	async user(): Promise<GitHubUser> {
@@ -28,6 +39,14 @@ class GitHubBoundary implements GitHub {
 		return { repositories: [], nextPage: undefined };
 	}
 
+	async installations(): Promise<InstallationPage> {
+		return { installations: [], nextPage: undefined };
+	}
+
+	async installationRepositories(): Promise<RepositoryPage> {
+		return this.repositories();
+	}
+
 	async repository(): Promise<Repository> {
 		throw new Error("not used by MCP route tests");
 	}
@@ -35,6 +54,17 @@ class GitHubBoundary implements GitHub {
 	async repositoryAccess(): Promise<Repository | undefined> {
 		throw new Error("not used by MCP route tests");
 	}
+
+	invalidate(): void {}
+}
+
+function grant(accessToken: string): GitHubTokenGrant {
+	return {
+		accessToken,
+		accessExpiresIn: 28_800,
+		refreshToken: "refresh-token",
+		refreshExpiresIn: 15_897_600,
+	};
 }
 
 function setup() {
@@ -45,13 +75,14 @@ function setup() {
 	let auth: HostedAuth = {
 		config: {
 			origin: "https://chopin.test",
+			appSlug: "chopin-test",
 			clientId: "client-id",
 			clientSecret: "client-secret",
 			encryptionKey: key,
 		},
 		storage,
 		github,
-		sessions: new Sessions(storage, key, true, () => now),
+		sessions: new Sessions(storage, true, () => now),
 		clock: () => now,
 	};
 	let router = new Router();

--- a/apps/server/src/mcp/routes.test.ts
+++ b/apps/server/src/mcp/routes.test.ts
@@ -64,6 +64,11 @@ function request(method: string, init: RequestInit = {}): Request {
 	return new Request("https://chopin.test/mcp", { method, ...init, headers });
 }
 
+function expectProtected(response: Response | undefined): void {
+	expect(response?.headers.get("cache-control")).toBe("no-store");
+	expect(response?.headers.get("x-content-type-options")).toBe("nosniff");
+}
+
 describe("the hosted MCP route", () => {
 	it("passes originless POST and same-origin GET requests to authenticated MCP", async () => {
 		let { router } = setup();
@@ -76,12 +81,14 @@ describe("the hosted MCP route", () => {
 		}));
 
 		expect(initialized?.status).toBe(200);
+		expectProtected(initialized);
 		expect(await initialized?.json()).toMatchObject({
 			jsonrpc: "2.0",
 			id: 1,
 			result: { serverInfo: { name: "chopin" } },
 		});
 		expect(stream?.status).toBe(200);
+		expectProtected(stream);
 		expect(stream?.headers.get("content-type")).toBe("text/event-stream");
 	});
 
@@ -94,6 +101,7 @@ describe("the hosted MCP route", () => {
 			}));
 
 			expect(response?.status).toBe(403);
+			expectProtected(response);
 			expect(await response?.text()).toBe("origin is not allowed");
 		}
 	});
@@ -108,6 +116,7 @@ describe("the hosted MCP route", () => {
 		let text = await response?.text();
 
 		expect(response?.status).toBe(500);
+		expectProtected(response);
 		expect(text).toBe("MCP request failed");
 		expect(text).not.toContain("access-token");
 		expect(text).not.toContain("Private roadmap");

--- a/apps/server/src/mcp/routes.test.ts
+++ b/apps/server/src/mcp/routes.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "bun:test";
+
+import { Sessions } from "../auth/session";
+import { Router } from "../http/router";
+import { MemoryStorage } from "../storage/memory/adapter";
+import { registerMcpRoutes } from "./routes";
+
+import type { HostedAuth } from "../auth/routes";
+import type { GitHub, GitHubUser, Repository, RepositoryPage } from "../github/client";
+
+class GitHubBoundary implements GitHub {
+	failure: Error | undefined;
+
+	authorize(): string {
+		return "";
+	}
+
+	async exchange(): Promise<string> {
+		return "";
+	}
+
+	async user(): Promise<GitHubUser> {
+		if (this.failure) throw this.failure;
+		return { id: "U_octocat", login: "octocat", avatarUrl: "" };
+	}
+
+	async repositories(): Promise<RepositoryPage> {
+		return { repositories: [], nextPage: undefined };
+	}
+
+	async repository(): Promise<Repository> {
+		throw new Error("not used by MCP route tests");
+	}
+
+	async repositoryAccess(): Promise<Repository | undefined> {
+		throw new Error("not used by MCP route tests");
+	}
+}
+
+function setup() {
+	let now = new Date("2026-08-17T12:00:00.000Z");
+	let storage = new MemoryStorage();
+	let github = new GitHubBoundary();
+	let key = new Uint8Array(32).fill(3);
+	let auth: HostedAuth = {
+		config: {
+			origin: "https://chopin.test",
+			clientId: "client-id",
+			clientSecret: "client-secret",
+			encryptionKey: key,
+		},
+		storage,
+		github,
+		sessions: new Sessions(storage, key, true, () => now),
+		clock: () => now,
+	};
+	let router = new Router();
+	registerMcpRoutes(router, auth);
+	return { github, router };
+}
+
+function request(method: string, init: RequestInit = {}): Request {
+	let headers = new Headers({ authorization: "Bearer access-token", ...init.headers });
+	return new Request("https://chopin.test/mcp", { method, ...init, headers });
+}
+
+describe("the hosted MCP route", () => {
+	it("passes originless POST and same-origin GET requests to authenticated MCP", async () => {
+		let { router } = setup();
+		let initialized = await router.handle(request("POST", {
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+		}));
+		let stream = await router.handle(request("GET", {
+			headers: { origin: "https://chopin.test", accept: "text/event-stream" },
+		}));
+
+		expect(initialized?.status).toBe(200);
+		expect(await initialized?.json()).toMatchObject({
+			jsonrpc: "2.0",
+			id: 1,
+			result: { serverInfo: { name: "chopin" } },
+		});
+		expect(stream?.status).toBe(200);
+		expect(stream?.headers.get("content-type")).toBe("text/event-stream");
+	});
+
+	it("rejects every supplied Origin except the configured one", async () => {
+		let { router } = setup();
+		for (let origin of ["https://attacker.test", ""]) {
+			let response = await router.handle(request("POST", {
+				headers: { "content-type": "application/json", origin },
+				body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+			}));
+
+			expect(response?.status).toBe(403);
+			expect(await response?.text()).toBe("origin is not allowed");
+		}
+	});
+
+	it("does not disclose hosted failures through MCP", async () => {
+		let { github, router } = setup();
+		github.failure = new Error("access-token foreign document: Private roadmap");
+		let response = await router.handle(request("POST", {
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+		}));
+		let text = await response?.text();
+
+		expect(response?.status).toBe(500);
+		expect(text).toBe("MCP request failed");
+		expect(text).not.toContain("access-token");
+		expect(text).not.toContain("Private roadmap");
+	});
+});

--- a/apps/server/src/mcp/routes.ts
+++ b/apps/server/src/mcp/routes.ts
@@ -1,0 +1,26 @@
+import { handler } from "../mcp";
+import { hosted } from "./hosted";
+
+import type { HostedAuth } from "../auth/routes";
+import type { Router } from "../http/router";
+
+function failure(): Response {
+	return new Response("MCP request failed", { status: 500 });
+}
+
+/** Register the hosted, read-only MCP endpoint. */
+export function registerMcpRoutes(router: Router, auth: HostedAuth): void {
+	let endpoint = handler(hosted(auth));
+	let route = async (request: Request): Promise<Response> => {
+		if (request.headers.has("origin") && request.headers.get("origin") !== auth.config.origin) {
+			return new Response("origin is not allowed", { status: 403 });
+		}
+		try {
+			return await endpoint(request);
+		} catch {
+			return failure();
+		}
+	};
+	router.on("GET", "/mcp", route);
+	router.on("POST", "/mcp", route);
+}

--- a/apps/server/src/mcp/routes.ts
+++ b/apps/server/src/mcp/routes.ts
@@ -8,17 +8,28 @@ function failure(): Response {
 	return new Response("MCP request failed", { status: 500 });
 }
 
+function protectedResponse(response: Response): Response {
+	let headers = new Headers(response.headers);
+	headers.set("cache-control", "no-store");
+	headers.set("x-content-type-options", "nosniff");
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers,
+	});
+}
+
 /** Register the hosted, read-only MCP endpoint. */
 export function registerMcpRoutes(router: Router, auth: HostedAuth): void {
 	let endpoint = handler(hosted(auth));
 	let route = async (request: Request): Promise<Response> => {
 		if (request.headers.has("origin") && request.headers.get("origin") !== auth.config.origin) {
-			return new Response("origin is not allowed", { status: 403 });
+			return protectedResponse(new Response("origin is not allowed", { status: 403 }));
 		}
 		try {
-			return await endpoint(request);
+			return protectedResponse(await endpoint(request));
 		} catch {
-			return failure();
+			return protectedResponse(failure());
 		}
 	};
 	router.on("GET", "/mcp", route);

--- a/apps/server/src/plan/room.test.ts
+++ b/apps/server/src/plan/room.test.ts
@@ -6,7 +6,7 @@
  * when an update leaves it in a state the dialect will not accept.
  */
 
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
 import { createHeadlessEditor } from "@lexical/headless";
 import { createYjsBinding, syncLexicalUpdateToYjs, syncYjsChangesToLexical } from "@lexical/yjs";
 import { $getRoot, $isElementNode, $isParagraphNode } from "lexical";
@@ -253,6 +253,24 @@ describe("concurrent editing", () => {
 });
 
 describe("recovery", () => {
+	it("destroys a scratch restoration when a journal update throws", async () => {
+		let document = await room.create("# Title\n");
+		let checkpoint = Y.encodeStateAsUpdate(document.doc);
+		let destroy = spyOn(Y.Doc.prototype, "destroy");
+		try {
+			await expect(
+				room.restore(document.epoch, checkpoint, "# Title\n", [{
+					epoch: document.epoch,
+					update: new Uint8Array([255]),
+				}]),
+			).rejects.toThrow();
+			expect(destroy).toHaveBeenCalledTimes(1);
+		} finally {
+			destroy.mockRestore();
+			document.doc.destroy();
+		}
+	});
+
 	/**
 	 * A rejected batch cannot be undone — Yjs has no such operation — so the
 	 * document is rebuilt from the last state that was known to be good.

--- a/apps/server/src/plan/room.ts
+++ b/apps/server/src/plan/room.ts
@@ -275,25 +275,28 @@ export async function restore(
 	journal: RestoredUpdate[],
 ): Promise<Document> {
 	let restored = build(epoch);
-	Y.applyUpdate(restored.doc, checkpoint, REMOTE);
-	await settle();
-	if (project(restored) !== source) {
-		restored.doc.destroy();
-		throw new Error("stored plan source does not match its Yjs checkpoint");
-	}
-
-	for (let item of journal) {
-		if (item.epoch !== restored.epoch) {
-			restored.doc.destroy();
-			throw new Error("stored plan journal changes epoch without a checkpoint");
-		}
-		Y.applyUpdate(restored.doc, item.update, REMOTE);
+	try {
+		Y.applyUpdate(restored.doc, checkpoint, REMOTE);
 		await settle();
-		project(restored);
+		if (project(restored) !== source) {
+			throw new Error("stored plan source does not match its Yjs checkpoint");
+		}
+
+		for (let item of journal) {
+			if (item.epoch !== restored.epoch) {
+				throw new Error("stored plan journal changes epoch without a checkpoint");
+			}
+			Y.applyUpdate(restored.doc, item.update, REMOTE);
+			await settle();
+			project(restored);
+		}
+		await settle();
+		restored.checkpoint = Y.encodeStateAsUpdate(restored.doc);
+		return restored;
+	} catch (err) {
+		restored.doc.destroy();
+		throw err;
 	}
-	await settle();
-	restored.checkpoint = Y.encodeStateAsUpdate(restored.doc);
-	return restored;
 }
 
 /** State the given client is missing, or the whole document when it has none. */

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -493,6 +493,7 @@ export async function readStored(
 ): Promise<{ source: string; revision: number }> {
 	let restored = await restoreHosted(loaded.channel.id, loaded);
 	try {
+		Questions.shutdown(Questions.restore(restored.sidecar.openQuestions));
 		return { source: room.project(restored.document), revision: restored.sidecar.revision };
 	} finally {
 		restored.document.doc.destroy();

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -29,7 +29,7 @@ import type { Presence } from "./presence";
 import type { Document } from "./room";
 import type * as edit from "./edit";
 import type { Block } from "./edit";
-import type { JsonValue, Lease } from "../storage/model";
+import type { JsonValue, Lease, StoredChannel } from "../storage/model";
 import type { StorageAdapter } from "../storage/port";
 
 /** Updates are grouped for this long before being applied together. */
@@ -434,16 +434,15 @@ export function persistExclusive(plan: Plan): Promise<void> {
 	return commitHosted(plan, undefined, `state:${crypto.randomUUID()}`, capture(plan));
 }
 
-/** Restore one durable channel into its authoritative in-memory document. */
-export async function open(
-	id: string,
-	backend: Backend,
-	server: Server<SocketData>,
-): Promise<Plan> {
+type RestoredHosted = {
+	document: Document;
+	needsInitialCheckpoint: boolean;
+	sidecar: Sidecar;
+};
+
+async function restoreHosted(id: string, loaded: StoredChannel): Promise<RestoredHosted> {
 	let document: Document;
 	let needsInitialCheckpoint = false;
-	let loaded = await backend.storage.collaboration.load(id, new Date());
-	if (!loaded) throw new Error(`channel ${id} does not exist`);
 	let pristine = loaded.channel.revision === 0
 		&& loaded.latestSequence === 0
 		&& !loaded.snapshot;
@@ -485,6 +484,30 @@ export async function open(
 		needsInitialCheckpoint = true;
 	}
 	document.seq = sidecar.documentSeq;
+	return { document, needsInitialCheckpoint, sidecar };
+}
+
+/** Project a closed channel without attaching it to the live room registry. */
+export async function readStored(
+	loaded: StoredChannel,
+): Promise<{ source: string; revision: number }> {
+	let restored = await restoreHosted(loaded.channel.id, loaded);
+	try {
+		return { source: room.project(restored.document), revision: restored.sidecar.revision };
+	} finally {
+		restored.document.doc.destroy();
+	}
+}
+
+/** Restore one durable channel into its authoritative in-memory document. */
+export async function open(
+	id: string,
+	backend: Backend,
+	server: Server<SocketData>,
+): Promise<Plan> {
+	let loaded = await backend.storage.collaboration.load(id, new Date());
+	if (!loaded) throw new Error(`channel ${id} does not exist`);
+	let { document, needsInitialCheckpoint, sidecar } = await restoreHosted(id, loaded);
 
 	let plan: Plan = {
 		id,

--- a/apps/server/src/storage/contract.ts
+++ b/apps/server/src/storage/contract.ts
@@ -153,6 +153,51 @@ export function storageContract(name: string, factory: Factory): void {
 			}
 		});
 
+		it("scans repository channels through updates without changing its creation cursor", async () => {
+			let storage = await opened(factory);
+			try {
+				let { userId, channelId, repositoryId, lease } = await userAndChannel(storage);
+				let second = id("channel");
+				let third = id("channel");
+				await storage.channels.create({
+					id: second,
+					repositoryId,
+					repositoryOwner: "octo-org",
+					repositoryName: "score",
+					title: "Second plan",
+					createdBy: userId,
+					now: new Date("2026-01-03T03:04:05.000Z"),
+				});
+				await storage.channels.create({
+					id: third,
+					repositoryId,
+					repositoryOwner: "octo-org",
+					repositoryName: "score",
+					title: "Third plan",
+					createdBy: userId,
+					now: new Date("2026-01-04T03:04:05.000Z"),
+				});
+
+				let first = await storage.channels.scan(repositoryId, 2);
+				await storage.collaboration.commit({
+					channelId,
+					lease,
+					expectedRevision: 0,
+					operationId: id("operation"),
+					epoch: "epoch-1",
+					events: [],
+					now: new Date("2026-01-05T03:04:05.000Z"),
+				});
+				let next = await storage.channels.scan(repositoryId, 2, first.next);
+
+				expect(first.channels.map(channel => channel.id)).toEqual([third, second]);
+				expect(next.channels.map(channel => channel.id)).toEqual([channelId]);
+				expect(next.next).toBeUndefined();
+			} finally {
+				await storage.close();
+			}
+		});
+
 		it("assigns the first active session as the agent owner", async () => {
 			let storage = await opened(factory);
 			try {

--- a/apps/server/src/storage/memory/adapter.ts
+++ b/apps/server/src/storage/memory/adapter.ts
@@ -5,6 +5,8 @@ import type {
 	ChannelCursor,
 	ChannelPage,
 	ChannelRecord,
+	ChannelScanCursor,
+	ChannelScanPage,
 	ChannelSnapshot,
 	ChannelUpdate,
 	CommitChannel,
@@ -146,6 +148,7 @@ export class MemoryStorage implements StorageAdapter {
 		create: input => this.#createChannel(input),
 		get: id => Promise.resolve(this.#channels.get(id)).then(value => value && channel(value)),
 		list: (repositoryId, limit, after) => this.#listChannels(repositoryId, limit, after),
+		scan: (repositoryId, limit, after) => this.#scanChannels(repositoryId, limit, after),
 		claimAgentOwner: (channelId, sessionId, now) =>
 			this.#claimAgentOwner(channelId, sessionId, now),
 		clearAgentOwner: (channelId, expectedSessionId, expectedGeneration, now) =>
@@ -224,6 +227,33 @@ export class MemoryStorage implements StorageAdapter {
 			channels: page.map(channel),
 			next: ordered.length > page.length && last
 				? { updatedAt: new Date(last.updatedAt), id: last.id }
+				: undefined,
+		});
+	}
+
+	#scanChannels(
+		repositoryId: string,
+		limit: number,
+		after?: ChannelScanCursor,
+	): Promise<ChannelScanPage> {
+		let count = Math.min(100, Math.max(1, limit));
+		let ordered = [...this.#channels.values()]
+			.filter(value => value.repositoryId === repositoryId)
+			.sort((left, right) =>
+				right.createdAt.getTime() - left.createdAt.getTime() || left.id.localeCompare(right.id)
+			);
+		if (after) {
+			ordered = ordered.filter(value =>
+				value.createdAt < after.createdAt
+				|| (value.createdAt.getTime() === after.createdAt.getTime() && value.id > after.id)
+			);
+		}
+		let page = ordered.slice(0, count);
+		let last = page.at(-1);
+		return Promise.resolve({
+			channels: page.map(channel),
+			next: ordered.length > page.length && last
+				? { createdAt: new Date(last.createdAt), id: last.id }
 				: undefined,
 		});
 	}

--- a/apps/server/src/storage/model.ts
+++ b/apps/server/src/storage/model.ts
@@ -55,6 +55,16 @@ export type ChannelPage = {
 	next?: ChannelCursor;
 };
 
+export type ChannelScanCursor = {
+	createdAt: Date;
+	id: string;
+};
+
+export type ChannelScanPage = {
+	channels: ChannelRecord[];
+	next?: ChannelScanCursor;
+};
+
 export type ChannelSnapshot = {
 	channelId: string;
 	generation: string;

--- a/apps/server/src/storage/port.ts
+++ b/apps/server/src/storage/port.ts
@@ -2,6 +2,8 @@ import type {
 	AgentState,
 	ChannelPage,
 	ChannelRecord,
+	ChannelScanCursor,
+	ChannelScanPage,
 	CommitChannel,
 	CommitResult,
 	CreateChannel,
@@ -40,6 +42,7 @@ export interface ChannelStore {
 		updatedAt: Date;
 		id: string;
 	}): Promise<ChannelPage>;
+	scan(repositoryId: string, limit: number, after?: ChannelScanCursor): Promise<ChannelScanPage>;
 	claimAgentOwner(channelId: string, sessionId: string, now: Date): Promise<AgentState>;
 	clearAgentOwner(
 		channelId: string,

--- a/apps/server/src/storage/postgres/adapter.ts
+++ b/apps/server/src/storage/postgres/adapter.ts
@@ -9,6 +9,8 @@ import type {
 	ChannelCursor,
 	ChannelPage,
 	ChannelRecord,
+	ChannelScanCursor,
+	ChannelScanPage,
 	ChannelSnapshot,
 	ChannelUpdate,
 	CommitChannel,
@@ -437,6 +439,7 @@ export class PostgresStorage implements StorageAdapter {
 				return found ? channel(found) : undefined;
 			}),
 		list: (repositoryId, limit, after) => this.#listChannels(repositoryId, limit, after),
+		scan: (repositoryId, limit, after) => this.#scanChannels(repositoryId, limit, after),
 		claimAgentOwner: (channelId, sessionId, now) =>
 			this.#claimAgentOwner(channelId, sessionId, now),
 		clearAgentOwner: (channelId, expectedSessionId, expectedGeneration, now) =>
@@ -537,6 +540,42 @@ export class PostgresStorage implements StorageAdapter {
 			return {
 				channels: page,
 				next: more && last ? { updatedAt: last.updatedAt, id: last.id } : undefined,
+			};
+		});
+	}
+
+	#scanChannels(
+		repositoryId: string,
+		limit: number,
+		after?: ChannelScanCursor,
+	): Promise<ChannelScanPage> {
+		return this.#run("scan channels", async () => {
+			let count = Math.min(100, Math.max(1, limit));
+			let rows = after
+				? await this.#sql<ChannelRow[]>`
+					SELECT ${this.#sql.unsafe(CHANNEL_COLUMNS)}
+					FROM channels
+					WHERE repository_id = ${repositoryId}
+						AND (
+							created_at < ${after.createdAt}
+							OR (created_at = ${after.createdAt} AND id > ${after.id})
+						)
+					ORDER BY created_at DESC, id ASC
+					LIMIT ${count + 1}
+				`
+				: await this.#sql<ChannelRow[]>`
+					SELECT ${this.#sql.unsafe(CHANNEL_COLUMNS)}
+					FROM channels
+					WHERE repository_id = ${repositoryId}
+					ORDER BY created_at DESC, id ASC
+					LIMIT ${count + 1}
+				`;
+			let more = rows.length > count;
+			let page = rows.slice(0, count).map(channel);
+			let last = page.at(-1);
+			return {
+				channels: page,
+				next: more && last ? { createdAt: last.createdAt, id: last.id } : undefined,
 			};
 		});
 	}


### PR DESCRIPTION
## Summary

Rebuilds Chopin's inbound MCP read boundary for the hosted backend. It exposes authenticated `list_documents` and `read_document` tools over `/mcp`, scoped by the caller's current GitHub repository access and durable repository channels.

## What changed

- Adds a backend-neutral Streamable HTTP MCP protocol with bounded request validation.
- Authenticates each request from the caller's GitHub bearer token and rechecks repository access and node identity.
- Lists documents through a stable repository scan; reads live plans authoritatively and closed plans by reconstructing their checkpoint and journal through `StorageAdapter`.
- Registers GET and POST `/mcp` routes with an exact supplied-Origin policy, `no-store`, `nosniff`, and non-disclosing failures.

## Contract note

`list_documents` requires `repository: "owner/name"` because a remote MCP client cannot infer a local checkout.

## Verification

- `bun run types`
- `bun run ci`
- `bun test` — 682 passing, 2 expected PostgreSQL skips
- Live PostgreSQL adapter contract — 10 passing
- `git diff --check`
