### PR TITLE
Publish local-agent MCP setup guidance

### DIFF
--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -89,60 +89,6 @@ async function json(response: Response): Promise<Record<string, unknown>> {
 }
 
 describe("the MCP read protocol", () => {
-	it("authenticates initialize, lists repository documents, and reads canonical source", async () => {
-		let mcp = endpoint();
-
-		let initialized = await json(
-			await mcp(request({
-				jsonrpc: "2.0",
-				id: 1,
-				method: "initialize",
-				params: {},
-			})),
-		);
-		expect(initialized).toMatchObject({
-			jsonrpc: "2.0",
-			id: 1,
-			result: {
-				protocolVersion: "2025-03-26",
-				capabilities: { tools: {} },
-				serverInfo: { name: "chopin" },
-			},
-		});
-		let tools = await json(
-			await mcp(request({
-				jsonrpc: "2.0",
-				id: 2,
-				method: "tools/list",
-			})),
-		);
-		expect((tools.result as { tools: unknown[] }).tools).toEqual(
-			TOOLS.filter(tool => ["list_documents", "read_document"].includes(tool.name)),
-		);
-
-		let listed = await json(
-			await mcp(request({
-				jsonrpc: "2.0",
-				id: 3,
-				method: "tools/call",
-				params: { name: "list_documents", arguments: { repository: "githubnext/chopin" } },
-			})),
-		);
-		expect((listed.result as { structuredContent: unknown }).structuredContent).toEqual({
-			documents: [{ id: document.id, title: document.title }],
-		});
-
-		let read = await json(
-			await mcp(request({
-				jsonrpc: "2.0",
-				id: 4,
-				method: "tools/call",
-				params: { name: "read_document", arguments: { id: document.id } },
-			})),
-		);
-		expect((read.result as { structuredContent: unknown }).structuredContent).toEqual(document);
-	});
-
 	it("reads and claims an implementation through its initialized client session", async () => {
 		let active: Run | undefined;
 		let implementations: Implementations<string> = {

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -34,7 +34,7 @@ export type Document = DocumentSummary & {
 };
 
 export type DocumentReader<Caller> = {
-	list(caller: Caller, repository: string): Promise<DocumentSummary[]>;
+	list(caller: Caller, repository: string): Promise<DocumentSummary[] | "forbidden">;
 	read(caller: Caller, id: string): Promise<Document | undefined>;
 };
 
@@ -500,9 +500,10 @@ export function handler<Caller>(
 							? undefined
 							: error(call.id, -32602, "list_documents requires a repository");
 					}
-					return respond(
-						text({ documents: await options.documents.list(caller, tool.arguments.repository) }),
-					);
+					let documents = await options.documents.list(caller, tool.arguments.repository);
+					return documents === "forbidden"
+						? respond(text({ code: "repository-forbidden" }, true))
+						: respond(text({ documents }));
 				}
 				if (tool.name === "read_document") {
 					if (Object.keys(tool.arguments).length !== 1 || !isId(tool.arguments.id)) {

--- a/apps/server/src/mcp/documents.test.ts
+++ b/apps/server/src/mcp/documents.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "bun:test";
+
+import { handler, TOOLS } from "../mcp";
+
+import type { Document, DocumentReader } from "../mcp";
+
+const document: Document = {
+	id: "f401c8d6-3717-4f1d-8473-cfdd0af894e4",
+	title: "Release readiness",
+	source: "# Release readiness\n",
+	revision: 4,
+};
+
+function request(body: unknown): Request {
+	return new Request("https://chopin.test/mcp", {
+		method: "POST",
+		headers: {
+			authorization: "Bearer allowed",
+			"content-type": "application/json",
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+function reader(): DocumentReader<string> {
+	return {
+		async list(caller, repository) {
+			return caller === "octocat" && repository === "githubnext/chopin"
+				? [{ id: document.id, title: document.title }]
+				: [];
+		},
+		async read(caller, id) {
+			return caller === "octocat" && id === document.id ? document : undefined;
+		},
+	};
+}
+
+function endpoint(documents = reader()) {
+	return handler({
+		caller: request =>
+			request.headers.get("authorization") === "Bearer allowed"
+				? "octocat"
+				: undefined,
+		documents,
+	});
+}
+
+async function json(response: Response): Promise<Record<string, unknown>> {
+	return await response.json() as Record<string, unknown>;
+}
+
+describe("the MCP document protocol", () => {
+	it("authenticates initialize, lists repository documents, and reads canonical source", async () => {
+		let mcp = endpoint();
+
+		let initialized = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "initialize",
+				params: {},
+			})),
+		);
+		expect(initialized).toMatchObject({
+			jsonrpc: "2.0",
+			id: 1,
+			result: {
+				protocolVersion: "2025-03-26",
+				capabilities: { tools: {} },
+				serverInfo: { name: "chopin" },
+			},
+		});
+		let tools = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 2,
+				method: "tools/list",
+			})),
+		);
+		expect((tools.result as { tools: unknown[] }).tools).toEqual(
+			TOOLS.filter(tool => ["list_documents", "read_document"].includes(tool.name)),
+		);
+
+		let listed = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 3,
+				method: "tools/call",
+				params: { name: "list_documents", arguments: { repository: "githubnext/chopin" } },
+			})),
+		);
+		expect((listed.result as { structuredContent: unknown }).structuredContent).toEqual({
+			documents: [{ id: document.id, title: document.title }],
+		});
+
+		let read = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 4,
+				method: "tools/call",
+				params: { name: "read_document", arguments: { id: document.id } },
+			})),
+		);
+		expect((read.result as { structuredContent: unknown }).structuredContent).toEqual(document);
+	});
+
+	it("reports a repository denial instead of an empty document list", async () => {
+		let result = await json(
+			await endpoint({
+				async list() {
+					return "forbidden";
+				},
+				async read() {
+					return undefined;
+				},
+			})(request({
+				jsonrpc: "2.0",
+				id: 5,
+				method: "tools/call",
+				params: { name: "list_documents", arguments: { repository: "githubnext/chopin" } },
+			})),
+		);
+
+		expect(result.result).toEqual({
+			content: [{ type: "text", text: '{"code":"repository-forbidden"}' }],
+			isError: true,
+			structuredContent: { code: "repository-forbidden" },
+		});
+	});
+});

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -224,6 +224,11 @@ describe("the hosted MCP adapter", () => {
 
 	it("lists every channel under the currently readable repository node id", async () => {
 		let { auth, github, now, storage } = setup();
+		let adapter = hosted(auth);
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller) throw new Error("test caller was not authenticated");
+
+		expect(await adapter.documents.list(caller, "octo-org/score")).toEqual([]);
 		await storage.users.put({ id: "U_allowed", login: "allowed", avatarUrl: "", now });
 		for (let index = 0; index < 101; index++) {
 			await storage.channels.create({
@@ -245,11 +250,8 @@ describe("the hosted MCP adapter", () => {
 			createdBy: "U_allowed",
 			now,
 		});
-		let adapter = hosted(auth);
-		let caller = await adapter.caller(request("Bearer allowed"));
-		if (!caller) throw new Error("test caller was not authenticated");
-
 		let listed = await adapter.documents.list(caller, "octo-org/score");
+		if (listed === "forbidden") throw new Error("readable repository was forbidden");
 		expect(listed).toHaveLength(101);
 		expect(listed.map(document => document.title)).not.toContain("Foreign title");
 
@@ -257,9 +259,9 @@ describe("the hosted MCP adapter", () => {
 			...github.repositoryValue,
 			permissions: { pull: false, push: true, admin: false },
 		};
-		expect(await adapter.documents.list(caller, "octo-org/score")).toEqual([]);
+		expect(await adapter.documents.list(caller, "octo-org/score")).toBe("forbidden");
 		github.accessible = false;
-		expect(await adapter.documents.list(caller, "octo-org/score")).toEqual([]);
+		expect(await adapter.documents.list(caller, "octo-org/score")).toBe("forbidden");
 	});
 
 	it("creates a durable repository channel for a caller with write access", async () => {

--- a/apps/server/src/mcp/hosted.ts
+++ b/apps/server/src/mcp/hosted.ts
@@ -146,13 +146,13 @@ export function hosted(
 		documents: {
 			async list(caller, repository) {
 				let parts = repository.split("/");
-				if (parts.length !== 2 || !parts[0] || !parts[1]) return [];
+				if (parts.length !== 2 || !parts[0] || !parts[1]) return "forbidden";
 				let resolved = await auth.github.repositoryAccess(
 					caller.oauthToken,
 					parts[0],
 					parts[1],
 				);
-				if (!resolved?.permissions.pull) return [];
+				if (!resolved?.permissions.pull) return "forbidden";
 
 				let documents = [];
 				let cursor;

--- a/docs/local-agent-mcp.md
+++ b/docs/local-agent-mcp.md
@@ -1,0 +1,77 @@
+# Connect a local coding agent
+
+Connect your coding agent to Chopin's remote Streamable HTTP MCP service before
+using a copied prompt or optional Chopin skill. This configuration does not
+start a local Chopin server.
+
+Set the workspace origin and use the existing GitHub CLI credential for the
+GitHub account that needs repository access. Keep the token in your shell or
+user-level agent configuration — never commit it, add it to a repository
+`.env`, or copy it into a shared configuration file.
+
+```bash
+export CHOPIN_URL="https://your-chopin-workspace.example"
+export GITHUB_TOKEN="$(gh auth token)"
+```
+
+The MCP endpoint is `${CHOPIN_URL%/}/mcp`.
+
+## Claude Code
+
+Install and sign in to Claude Code, then add Chopin to your user configuration:
+
+```bash
+claude mcp add --scope user --transport http chopin "${CHOPIN_URL%/}/mcp" \
+  --header "Authorization: Bearer ${GITHUB_TOKEN}"
+```
+
+## Codex CLI
+
+Install and sign in to Codex CLI, then register the server. Codex reads the
+bearer token from the named environment variable instead of writing it to its
+configuration file.
+
+```bash
+codex mcp add chopin --url "${CHOPIN_URL%/}/mcp" \
+  --bearer-token-env-var GITHUB_TOKEN
+```
+
+## GitHub Copilot CLI
+
+Install and sign in to GitHub Copilot CLI, then add Chopin to its user-level
+MCP configuration. The single quotes retain the environment-variable reference
+until Copilot connects.
+
+```bash
+copilot mcp add --transport http chopin "${CHOPIN_URL%/}/mcp" \
+  --header 'Authorization: Bearer ${GITHUB_TOKEN}'
+```
+
+## Verify the connection
+
+Start the agent from the repository you want to inspect and ask:
+
+```text
+Use the Chopin list_documents tool to list the documents available for this repository. Return each document's id and title.
+```
+
+`{"documents":[]}` is a successful response for a repository with no Chopin
+documents. After the connection is established, the MCP `initialize`
+instructions and current tool descriptions are authoritative.
+
+## Access and troubleshooting
+
+HTTP `401` means bearer authentication failed: renew the GitHub CLI login with
+`gh auth login`, export `GITHUB_TOKEN` again, and reconnect the agent.
+
+`repository-forbidden` means the identity authenticated but lacks the
+operation's repository permission. Pull access is enough for
+`list_documents`, `read_document`, and `read_implementation`. Push or admin
+access is required for create, start, and report lifecycle operations. Use an
+account with the required access or ask a repository owner to grant it.
+
+## References
+
+- [Claude Code MCP servers](https://docs.anthropic.com/en/docs/claude-code/mcp)
+- [Codex CLI MCP servers](https://developers.openai.com/codex/mcp/)
+- [GitHub Copilot CLI MCP servers](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers)

--- a/docs/local-agent-mcp.md
+++ b/docs/local-agent-mcp.md
@@ -25,6 +25,10 @@ claude mcp add --scope user --transport http chopin "${CHOPIN_URL%/}/mcp" \
   --header "Authorization: Bearer ${GITHUB_TOKEN}"
 ```
 
+Claude stores the expanded header when this command runs. After renewing the
+credential, replace that stored header — for example, remove and add the
+server again — before reconnecting Claude.
+
 ## Codex CLI
 
 Install and sign in to Codex CLI, then register the server. Codex reads the
@@ -62,7 +66,8 @@ instructions and current tool descriptions are authoritative.
 ## Access and troubleshooting
 
 HTTP `401` means bearer authentication failed: renew the GitHub CLI login with
-`gh auth login`, export `GITHUB_TOKEN` again, and reconnect the agent.
+`gh auth login`, export `GITHUB_TOKEN` again, replace Claude's stored header if
+you use Claude Code, and reconnect the agent.
 
 `repository-forbidden` means the identity authenticated but lacks the
 operation's repository permission. Pull access is enough for

--- a/docs/superpowers/plans/2026-08-19-local-agent-mcp-tail.md
+++ b/docs/superpowers/plans/2026-08-19-local-agent-mcp-tail.md
@@ -1,0 +1,186 @@
+# Local Agent MCP Tail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild PRs #40 and #43 on the completed MCP stack with honest authorization guidance and canonical creation instructions.
+
+**Architecture:** PR #40 adds a typed forbidden outcome at the document-reader boundary and documents provider setup. PR #43 gives creation the same server-authoritative contract shape as implementation, publishes a portable skill bundle, and extracts creation tests from the nearly 1,000-line protocol test.
+
+**Tech Stack:** Bun, TypeScript, MCP Streamable HTTP, Agent Skills, Markdown.
+
+**Spec:** `docs/superpowers/specs/2026-08-19-local-agent-mcp-tail-design.md`
+
+---
+
+## Global constraints
+
+- Rebuild each PR from current `origin/main`; never merge its inherited pre-stack MCP code.
+- Tabs, `let`, double quotes, and dprint formatting remain repository conventions.
+- MCP/tool behavior is tested at the real handler boundary.
+- No changed file may exceed 1,000 lines.
+- A created document is an editable Chopin channel; only the creation operation is one-shot and idempotent.
+- The unrelated `docs/superpowers/plans/2026-08-18-graph-foundation-rewrite.md` remains untouched and untracked.
+
+### Task 1: Rebuild PR #40 — repository access and local-agent setup
+
+**Files:**
+- Modify: `apps/server/src/mcp.ts`
+- Modify: `apps/server/src/mcp/hosted.ts`
+- Modify: `apps/server/src/mcp/hosted.test.ts`
+- Create: `apps/server/src/mcp/documents.test.ts`
+- Modify: `apps/server/src/mcp.test.ts`
+- Create: `docs/local-agent-mcp.md`
+- Modify: `readme.md`
+
+- [ ] **Step 1: Write the failing document-boundary test**
+
+Move the existing list/read handler test into `apps/server/src/mcp/documents.test.ts`, then add a reader whose `list` returns `"forbidden"`. Assert that `tools/call` returns:
+
+```ts
+{
+	content: [{ type: "text", text: '{"code":"repository-forbidden"}' }],
+	isError: true,
+	structuredContent: { code: "repository-forbidden" },
+}
+```
+
+The production mutation this catches is collapsing denied access back into an empty document list.
+
+- [ ] **Step 2: Verify RED**
+
+Run: `bun test apps/server/src/mcp/documents.test.ts`
+
+Expected: type/runtime failure because `DocumentReader.list` accepts only arrays and the handler always wraps the result as `documents`.
+
+- [ ] **Step 3: Add the typed forbidden outcome**
+
+Change the reader contract to:
+
+```ts
+list(caller: Caller, repository: string): Promise<DocumentSummary[] | "forbidden">;
+```
+
+Return `"forbidden"` from the hosted adapter when the repository is absent or lacks pull permission. At the MCP boundary, translate it to `{ code: "repository-forbidden" }`; preserve `{ documents: [] }` only for an accessible empty repository.
+
+- [ ] **Step 4: Prove the hosted authorization distinction**
+
+Update the hosted adapter test so pull denial and an inaccessible repository both return `"forbidden"`, while a readable repository with no stored channels returns `[]`.
+
+Run: `bun test apps/server/src/mcp/documents.test.ts apps/server/src/mcp/hosted.test.ts`
+
+Expected: all focused tests pass.
+
+- [ ] **Step 5: Publish concise setup guidance**
+
+Port PR #40's provider commands, but share one verification and troubleshooting section. State:
+
+- HTTP `401` means bearer authentication failed;
+- `repository-forbidden` means the identity authenticated but lacks the operation's repository permission;
+- pull is enough for list/read/read-implementation;
+- push or admin is required for create/start/report lifecycle operations;
+- after connection, MCP initialize instructions and current tool descriptions are authoritative.
+
+Link the guide once from `readme.md`. Do not copy lifecycle steps into provider sections.
+
+- [ ] **Step 6: Verify and commit PR #40**
+
+Run:
+
+```bash
+bun test apps/server/src/mcp/documents.test.ts apps/server/src/mcp/hosted.test.ts
+bun run types
+bun run ci
+git diff --check
+```
+
+Expected: all commands pass. Commit the rebuilt PR #40 payload.
+
+### Task 2: Rebuild PR #43 — canonical creation skill and instructions
+
+**Files:**
+- Modify: `apps/server/src/mcp.ts`
+- Modify: `skills/implementing-chopin-plans/contract.test.ts`
+- Create: `skills/creating-chopin-plans/SKILL.md`
+- Create: `skills/creating-chopin-plans/prompt.md`
+- Create: `skills/creating-chopin-plans/contract.test.ts`
+- Create: `apps/server/src/mcp/create.test.ts`
+- Modify: `apps/server/src/mcp.test.ts`
+- Modify: `readme.md`
+
+- [ ] **Step 1: Capture RED for the creation contract**
+
+Create a real initialize-boundary test using `handler` with a creation adapter and no implementation adapter. Require general MCP authority plus the advertised `create_document` workflow, and require that it does not tell creation agents to read a nonexistent implementation.
+
+Run: `bun test skills/creating-chopin-plans/contract.test.ts`
+
+Expected: fail because the directory/instructions do not exist and current initialize guidance is implementation-only.
+
+- [ ] **Step 2: Scope canonical initialize instructions**
+
+Make the common instruction apply to every advertised workflow:
+
+```text
+Chopin's MCP contract and current tool descriptions are authoritative.
+```
+
+Advertise creation semantics through the current `create_document` descriptor. Put the canonical-implementation requirement in a separate implementation-only sentence, followed by the implementation/lifecycle descriptors. Update the existing implementation contract test to assert the real response.
+
+- [ ] **Step 3: Verify GREEN for both instruction consumers**
+
+Run:
+
+```bash
+bun test skills/creating-chopin-plans/contract.test.ts skills/implementing-chopin-plans/contract.test.ts
+```
+
+Expected: both real initialize-boundary tests pass.
+
+- [ ] **Step 4: Capture RED for corrected creation retry**
+
+Extract the existing creation protocol cases from `apps/server/src/mcp.test.ts` into `apps/server/src/mcp/create.test.ts`. Add a test that first submits `<Chart />`, checks the returned `unknown-component` issue and zero adapter calls, then submits the corrected plan with the same idempotency key and checks exactly one adapter call carrying that key.
+
+Run: `bun test apps/server/src/mcp/create.test.ts`
+
+Expected before moving/adding the implementation: the new corrected-retry assertion fails or the test file is absent; after extraction, existing creation behavior remains covered without growing `mcp.test.ts` past 1,000 lines.
+
+- [ ] **Step 5: Publish the portable creation skill**
+
+Create `skills/creating-chopin-plans/` with:
+
+- a concise trigger-only description;
+- local workflow for synthesizing the brief, inspecting exact repository provenance, drafting supported MDX, repairing validation, and returning the canonical URL;
+- no copied lifecycle or mutable tool schema;
+- no claim that the channel is immutable;
+- no automatic URL opening;
+- a provider-neutral `prompt.md` that supplies the settled conversation and asks the agent to follow the installed skill plus current MCP instructions.
+
+Update the README to copy the whole directory into a runtime-supported Agent Skills location and distinguish this creation skill from the implementation skill.
+
+- [ ] **Step 6: Skill behavior check and focused GREEN**
+
+Run one fresh-agent baseline without the skill against a settled-conversation scenario and record whether it creates multiple documents, forwards the raw transcript, invents provenance, or calls creation again after success. Run the same scenario with the skill and confirm the corrected behavior. Save the evidence in the SDD report, not the repository.
+
+Run:
+
+```bash
+bun test apps/server/src/mcp/create.test.ts skills/creating-chopin-plans/contract.test.ts skills/implementing-chopin-plans/contract.test.ts
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 7: Verify and commit PR #43**
+
+Run:
+
+```bash
+bun test
+bun run types
+bun run ci
+git diff --check
+```
+
+Expected: 0 failures, with only the two expected PostgreSQL skips. Commit the rebuilt PR #43 payload.
+
+## Final integration
+
+After both task reviews pass, run a whole-feature review against each PR's base. Confirm the provider commands remain current, every initialize instruction matches an advertised capability, both PRs contain only their intended rebuilt payload, and the old inherited MCP stack is absent. Update the two existing remote PR branches with force-with-lease.

--- a/docs/superpowers/plans/2026-08-19-local-agent-mcp-tail.md
+++ b/docs/superpowers/plans/2026-08-19-local-agent-mcp-tail.md
@@ -24,6 +24,7 @@
 ### Task 1: Rebuild PR #40 — repository access and local-agent setup
 
 **Files:**
+
 - Modify: `apps/server/src/mcp.ts`
 - Modify: `apps/server/src/mcp/hosted.ts`
 - Modify: `apps/server/src/mcp/hosted.test.ts`
@@ -98,6 +99,7 @@ Expected: all commands pass. Commit the rebuilt PR #40 payload.
 ### Task 2: Rebuild PR #43 — canonical creation skill and instructions
 
 **Files:**
+
 - Modify: `apps/server/src/mcp.ts`
 - Modify: `skills/implementing-chopin-plans/contract.test.ts`
 - Create: `skills/creating-chopin-plans/SKILL.md`

--- a/docs/superpowers/specs/2026-08-19-local-agent-mcp-tail-design.md
+++ b/docs/superpowers/specs/2026-08-19-local-agent-mcp-tail-design.md
@@ -1,0 +1,72 @@
+# Local agent MCP tail design
+
+## Goal
+
+Rebuild PRs #40 and #43 on the completed MCP stack so local-agent setup,
+creation guidance, and the server's canonical instructions describe the same
+product.
+
+## Decisions
+
+### Repository access is explicit
+
+`list_documents` must distinguish an accessible repository with no documents
+from a repository the caller cannot read. The hosted adapter returns a typed
+forbidden outcome, and the MCP boundary exposes `repository-forbidden` without
+revealing whether an inaccessible repository exists.
+
+The setup guide states the permissions each workflow requires:
+
+- pull access for listing, reading, and reading an implementation;
+- push or admin access for creating a document, claiming implementation work,
+  and reporting lifecycle progress.
+
+Authentication failures remain HTTP `401`; repository authorization failures
+remain authenticated MCP tool errors.
+
+### Server and skills have separate authority
+
+The initialize response states that the MCP contract and current tool
+descriptions are authoritative for every tool. Its requirement to read the
+canonical implementation before acting applies only to implementation and
+lifecycle operations, never to `create_document`.
+
+The creation skill keeps local judgment: synthesize the conversation into a
+structured brief, inspect repository provenance, draft supported MDX, repair
+validation issues, and hand off the returned channel. It does not duplicate a
+mutable server protocol.
+
+### Creation creates an editable channel
+
+`create_document` is one-shot and idempotent, but the resulting Chopin channel
+is collaboratively editable. The skill says to create one initial document,
+stop calling the creation tool after success, and return the canonical URL. It
+does not call the document immutable or open the URL as an external side
+effect.
+
+### Portable artifacts share one shape
+
+The new skill lives at `skills/creating-chopin-plans/` beside
+`skills/implementing-chopin-plans/`, with `SKILL.md`, `prompt.md`, and a real
+boundary contract test. Installation copies the whole directory to a runtime's
+supported Agent Skills location.
+
+Creation protocol tests move out of the 999-line `apps/server/src/mcp.test.ts`
+into a focused test module. The corrected-retry test proves that validation
+does not consume an idempotency key: the invalid request returns a dialect
+issue without calling the adapter, and a corrected request with the same key
+reaches it exactly once.
+
+## PR boundaries
+
+PR #40 owns repository-forbidden listing behavior and the provider setup guide.
+PR #43 owns creation instructions, the portable creation skill, creation test
+extraction, and its README handoff. Both are rebuilt from current `main` and
+share only this design history.
+
+## Verification
+
+Each PR runs its focused tests, `bun run types`, `bun run ci`, and
+`git diff --check`. The combined feature also runs `bun test`; browser coverage
+is unnecessary because the changes are MCP, documentation, and skill
+boundaries.

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,9 @@ the multiplayer half. Ctrl-C stops the web and server processes;
 
 Set `AGENT=off` to run the editor without Copilot.
 
+For a local coding agent connection, see
+[Connect a local coding agent](docs/local-agent-mcp.md).
+
 For proxied VM development and remote HMR, see
 [Remote development](docs/exe-dev.md).
 


### PR DESCRIPTION
## Summary

- Documents Claude Code, Codex CLI, and GitHub Copilot CLI setup for Chopin's hosted MCP endpoint.
- Distinguishes a readable repository with no documents from `repository-forbidden` at the MCP boundary.
- Documents the final permission model: pull for read operations; push or admin for creation and implementation lifecycle operations.
- Hands agents off to the MCP initialize instructions and current tool descriptions as the canonical workflow contract.

## Stack

Rebuilt directly on current `main` after the core MCP feature stack merged.

## Verification

- `bun test` — 800 pass, 2 expected PostgreSQL skips
- `bun run types`
- `bun run ci`
- `git diff --check origin/main...HEAD`
