### PR TITLE
Keep Planner activity status visible through streamed replies

### DIFF
--- a/apps/web/src/chat/chat.tsx
+++ b/apps/web/src/chat/chat.tsx
@@ -129,7 +129,7 @@ export function Chat({ connected, handle, wire }: ChatProps) {
 				handle={handle}
 				onWithdraw={id => wire?.send("chat:unqueue", { id })}
 				queued={queue}
-				working={connected && synchronized.current === wire && turn && !turn.responded
+				working={connected && synchronized.current === wire && turn
 					? turn
 					: undefined}
 			/>

--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -304,7 +304,7 @@ test("chat clears the Planner working row when a turn stops or fails", async ({ 
 	await expect(page.locator("#pane-chat .chat-working")).toHaveCount(0);
 });
 
-test("chat keeps Working on it through tool activity and replaces it with streamed prose", async ({ join, page }) => {
+test("chat keeps Working on it through tool activity and streamed prose", async ({ join, page }) => {
 	let planner = await scriptPlanner(page);
 	let chat = (await join("ana")).locator("#pane-chat");
 
@@ -318,11 +318,14 @@ test("chat keeps Working on it through tool activity and replaces it with stream
 	await expect(chat.locator(".chat-working")).toBeVisible();
 
 	planner.stream();
-	await expect(chat.locator(".chat-working")).toHaveCount(0);
+	await expect(chat.locator(".chat-working")).toBeVisible();
 	await expect(chat.getByText("I found it.")).toBeVisible();
+
+	await chat.getByRole("button", { name: "Stop" }).click();
+	await expect(chat.locator(".chat-working")).toHaveCount(0);
 });
 
-test("chat history does not revive Working on it after Planner prose and a later room message", async ({ join, page }) => {
+test("chat history keeps Working on it after Planner prose and a later room message", async ({ join, page }) => {
 	await injectChatHistory(page, frame => ({
 		...frame,
 		busy: true,
@@ -352,7 +355,7 @@ test("chat history does not revive Working on it after Planner prose and a later
 	let chat = (await join("ana")).locator("#pane-chat");
 	await expect(chat.getByText("I found the issue.")).toBeVisible();
 	await expect(chat.getByText("Please include the examples.")).toBeVisible();
-	await expect(chat.locator(".chat-working")).toHaveCount(0);
+	await expect(chat.locator(".chat-working")).toBeVisible();
 });
 
 test("chat ignores legacy active-turn frames during a rolling deploy", async ({ join, page }) => {


### PR DESCRIPTION
## Summary
- Keep the Planner working row visible throughout streamed prose and tool activity
- Clear the working row when the turn is stopped or fails
- Update end-to-end coverage for active-turn history and stopping behavior

## Testing
- Not run (not requested)