### PR TITLE
Create validated Chopin documents through MCP

### DIFF
--- a/.superpowers/sdd/2026-08-18-pr42-review-fixes/task-2-report.md
+++ b/.superpowers/sdd/2026-08-18-pr42-review-fixes/task-2-report.md
@@ -64,3 +64,34 @@ the four changed files pass dprint.
 
 None. The existing live-read test covers the live response path; the same
 shared projector now handles its metadata-bearing documents as well.
+
+## Review follow-up
+
+### Fixes
+
+- `restoredState` now accepts the former paired `brief` and `origin` sidecar
+  fields only when both are present and valid, then normalizes them to one
+  `CreationMetadata` value in memory. A later state persistence writes only
+  the cohesive `creation` field.
+- Added a live metadata-bearing channel test. Its exact public response keeps
+  the brief and excludes all provenance, including the idempotency fingerprint.
+
+### Evidence
+
+RED:
+
+```sh
+bun test apps/server/src/plan/creation.test.ts apps/server/src/mcp/hosted.test.ts
+```
+
+Result: 14 pass, 1 fail. The legacy sidecar was rejected as invalid before the
+normalization path was added.
+
+GREEN:
+
+```sh
+bun test apps/server/src/plan/creation.test.ts apps/server/src/mcp/hosted.test.ts
+```
+
+Result: 15 pass, 0 fail. The suite includes restoration and rewrite of a
+legacy sidecar plus exact public projection of a live created plan.

--- a/.superpowers/sdd/2026-08-18-pr42-review-fixes/task-2-report.md
+++ b/.superpowers/sdd/2026-08-18-pr42-review-fixes/task-2-report.md
@@ -1,0 +1,66 @@
+# Task 2: Creation metadata and hosted response projection
+
+## Status
+
+Complete. Creation metadata is a single validated `CreationMetadata` value at
+the plan and sidecar boundaries. Hosted document output now goes through one
+projection that keeps the public brief and omits idempotency, fingerprint, and
+repository provenance.
+
+## Implementation
+
+- Added `CreationMetadata` in `apps/server/src/plan/service.ts` and replaced
+  paired `brief` / `origin` plan and sidecar properties with `creation`.
+- Changed initial creation, persistence, restoration, and stored reads to carry
+  that one value. Restoration rejects malformed or partial creation metadata as
+  a unit.
+- Added a typed hosted `document` projection in `apps/server/src/mcp/hosted.ts`.
+  Live reads, stored reads, created responses, and replayed responses use it.
+  It only exposes `creation.brief`; provenance remains internal for conflict
+  checking.
+- Updated behavior tests to expect restored creation metadata and identical
+  public create, replay, and read documents.
+
+## Files
+
+- `apps/server/src/plan/service.ts`
+- `apps/server/src/plan/creation.test.ts`
+- `apps/server/src/mcp/hosted.ts`
+- `apps/server/src/mcp/hosted.test.ts`
+
+## TDD evidence
+
+RED:
+
+```sh
+bun test apps/server/src/plan/creation.test.ts apps/server/src/mcp/hosted.test.ts
+```
+
+Result: 10 pass, 3 fail. The creation tests failed because restoration expected
+paired fields; the hosted storage assertion failed because `readStored` still
+returned paired public values.
+
+GREEN:
+
+```sh
+bun test apps/server/src/plan/creation.test.ts apps/server/src/mcp/hosted.test.ts
+bun run types
+bunx dprint check apps/server/src/plan/service.ts apps/server/src/plan/creation.test.ts apps/server/src/mcp/hosted.ts apps/server/src/mcp/hosted.test.ts
+```
+
+Result: focused suite 13 pass, 0 fail; all package and e2e type checks pass;
+the four changed files pass dprint.
+
+## Self-review
+
+- Atomic channel creation and conflict/idempotency checks are unchanged; replay
+  still compares the stored provenance internally.
+- The shared projector is the only hosted document construction path and has a
+  URL-preserving overload for create/replay responses.
+- Exact public-document assertions ensure provenance and fingerprint cannot
+  leak through create, replay, or stored `read_document` responses.
+
+## Concerns
+
+None. The existing live-read test covers the live response path; the same
+shared projector now handles its metadata-bearing documents as well.

--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -437,7 +437,7 @@ describe("the MCP read protocol", () => {
 		expect(created).toBe(false);
 	});
 
-	it("replays creation when the same values arrive in a different member order", async () => {
+	it("replays reordered creation values and conflicts on a changed value", async () => {
 		let accepted: CreateDocumentInput | undefined;
 		let mcp = handler({
 			caller: () => "octocat",
@@ -490,16 +490,41 @@ describe("the MCP read protocol", () => {
 			expect((result.result as { structuredContent: { id: string } }).structuredContent.id)
 				.toBe("replayed");
 		}
+
+		let changed = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 15,
+				method: "tools/call",
+				params: {
+					name: "create_document",
+					arguments: { ...creation, title: "A changed title" },
+				},
+			})),
+		);
+		expect((changed.result as { isError: boolean }).isError).toBe(true);
+		expect((changed.result as { structuredContent: unknown }).structuredContent).toEqual({
+			code: "idempotency-conflict",
+		});
 	});
 
-	it("does not advertise creation from a read-only host", async () => {
+	it("does not advertise or dispatch creation from a read-only host", async () => {
 		let mcp = handler({ caller: () => "octocat", documents: reader() });
 		let tools = await json(
-			await mcp(request({ jsonrpc: "2.0", id: 15, method: "tools/list" })),
+			await mcp(request({ jsonrpc: "2.0", id: 16, method: "tools/list" })),
 		);
 
 		expect((tools.result as { tools: Array<{ name: string }> }).tools.map(tool => tool.name))
 			.toEqual(["list_documents", "read_document"]);
+		let creationAttempt = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 17,
+				method: "tools/call",
+				params: { name: "create_document", arguments: creation },
+			})),
+		);
+		expect(creationAttempt.error).toEqual({ code: -32601, message: "tool not found" });
 	});
 
 	it("rejects non-scalar JSON-RPC ids and scalar initialize or tools-list parameters", async () => {

--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
+import { limits } from "@chopin/dialect";
+
 import { handler, TOOLS } from "./mcp";
 
 import type { CreateDocument, CreateDocumentInput, Document, DocumentReader } from "./mcp";
@@ -72,7 +74,6 @@ function endpoint() {
 				? "octocat"
 				: undefined,
 		documents: reader(),
-		create: unavailable(),
 	});
 }
 
@@ -108,7 +109,9 @@ describe("the MCP read protocol", () => {
 				method: "tools/list",
 			})),
 		);
-		expect((tools.result as { tools: unknown[] }).tools).toEqual(TOOLS);
+		expect((tools.result as { tools: unknown[] }).tools).toEqual(
+			TOOLS.filter(tool => tool.name !== "create_document"),
+		);
 
 		let listed = await json(
 			await mcp(request({
@@ -398,6 +401,105 @@ describe("the MCP read protocol", () => {
 
 		expect(response.status).toBe(200);
 		expect((await json(response)).error).toBeUndefined();
+	});
+
+	it("rejects a UTF-8 canonical plan beyond the source limit before creating it", async () => {
+		let created = false;
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create() {
+					created = true;
+					return { kind: "forbidden" as const };
+				},
+			},
+		});
+		let result = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 12,
+				method: "tools/call",
+				params: {
+					name: "create_document",
+					arguments: {
+						...creation,
+						plan: `# ${"😀".repeat(limits.MAX_SOURCE_BYTES / 4)}\n`,
+					},
+				},
+			})),
+		);
+
+		expect((result.result as { isError: boolean }).isError).toBe(true);
+		expect(
+			(result.result as { structuredContent: { issues: unknown[] } }).structuredContent.issues,
+		).toEqual([expect.objectContaining({ code: "source-too-large", path: "root" })]);
+		expect(created).toBe(false);
+	});
+
+	it("replays creation when the same values arrive in a different member order", async () => {
+		let accepted: CreateDocumentInput | undefined;
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create(_caller, input) {
+					let document = {
+						id: "replayed",
+						title: input.title,
+						brief: input.brief,
+						source: input.plan,
+						revision: 0,
+						url: "/channels/replayed",
+					};
+					if (!accepted) {
+						accepted = input;
+						return { kind: "created" as const, document };
+					}
+					return accepted.fingerprint === input.fingerprint
+						? { kind: "replayed" as const, document }
+						: { kind: "conflict" as const };
+				},
+			},
+		});
+		let reordered = {
+			plan: creation.plan,
+			brief: {
+				repositoryFindings: creation.brief.repositoryFindings,
+				openQuestions: creation.brief.openQuestions,
+				settledDecisions: creation.brief.settledDecisions,
+				constraints: creation.brief.constraints,
+				goal: creation.brief.goal,
+			},
+			title: creation.title,
+			baseCommit: creation.baseCommit,
+			baseBranch: creation.baseBranch,
+			repository: creation.repository,
+			idempotencyKey: creation.idempotencyKey,
+		};
+
+		for (let [id, arguments_] of [[13, creation], [14, reordered]]) {
+			let result = await json(
+				await mcp(request({
+					jsonrpc: "2.0",
+					id,
+					method: "tools/call",
+					params: { name: "create_document", arguments: arguments_ },
+				})),
+			);
+			expect((result.result as { structuredContent: { id: string } }).structuredContent.id)
+				.toBe("replayed");
+		}
+	});
+
+	it("does not advertise creation from a read-only host", async () => {
+		let mcp = handler({ caller: () => "octocat", documents: reader() });
+		let tools = await json(
+			await mcp(request({ jsonrpc: "2.0", id: 15, method: "tools/list" })),
+		);
+
+		expect((tools.result as { tools: Array<{ name: string }> }).tools.map(tool => tool.name))
+			.toEqual(["list_documents", "read_document"]);
 	});
 
 	it("rejects non-scalar JSON-RPC ids and scalar initialize or tools-list parameters", async () => {

--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import { handler, TOOLS } from "./mcp";
 
-import type { CreateDocumentInput, Document, DocumentReader } from "./mcp";
+import type { CreateDocument, CreateDocumentInput, Document, DocumentReader } from "./mcp";
 
 const document: Document = {
 	id: "f401c8d6-3717-4f1d-8473-cfdd0af894e4",
@@ -57,6 +57,14 @@ function reader(): DocumentReader<string> {
 	};
 }
 
+function unavailable(): CreateDocument<string> {
+	return {
+		async create() {
+			return { kind: "forbidden" };
+		},
+	};
+}
+
 function endpoint() {
 	return handler({
 		caller: request =>
@@ -64,6 +72,7 @@ function endpoint() {
 				? "octocat"
 				: undefined,
 		documents: reader(),
+		create: unavailable(),
 	});
 }
 
@@ -218,6 +227,33 @@ describe("the MCP read protocol", () => {
 			offset: 0,
 		})]);
 		expect(created).toBe(false);
+	});
+
+	it("returns a structured issue for plan syntax that cannot be parsed", async () => {
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create() {
+					return { kind: "forbidden" as const };
+				},
+			},
+		});
+
+		let result = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 7,
+				method: "tools/call",
+				params: {
+					name: "create_document",
+					arguments: { ...creation, plan: "<Callout" },
+				},
+			})),
+		);
+
+		expect((result.result as { structuredContent: { issues: unknown[] } }).structuredContent.issues)
+			.toEqual([expect.objectContaining({ code: "parse", path: "root" })]);
 	});
 
 	it("reports a changed idempotent request as a tool conflict", async () => {
@@ -405,6 +441,7 @@ describe("the MCP read protocol", () => {
 		let inaccessible = await json(
 			await handler({
 				caller: () => "octocat",
+				create: unavailable(),
 				documents: {
 					async list() {
 						return [];

--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -439,11 +439,13 @@ describe("the MCP read protocol", () => {
 
 	it("replays reordered creation values and conflicts on a changed value", async () => {
 		let accepted: CreateDocumentInput | undefined;
+		let fingerprints: string[] = [];
 		let mcp = handler({
 			caller: () => "octocat",
 			documents: reader(),
 			create: {
 				async create(_caller, input) {
+					fingerprints.push(input.fingerprint);
 					let document = {
 						id: "replayed",
 						title: input.title,
@@ -506,6 +508,9 @@ describe("the MCP read protocol", () => {
 		expect((changed.result as { structuredContent: unknown }).structuredContent).toEqual({
 			code: "idempotency-conflict",
 		});
+		expect(fingerprints).toHaveLength(3);
+		expect(fingerprints[1]).toBe(fingerprints[0]);
+		expect(fingerprints[2]).not.toBe(fingerprints[0]);
 	});
 
 	it("does not advertise or dispatch creation from a read-only host", async () => {

--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -13,7 +13,7 @@ const document: Document = {
 	revision: 4,
 };
 
-const creation = {
+let creation = {
 	idempotencyKey: "create-plan-1",
 	repository: "githubnext/chopin",
 	baseBranch: "main",
@@ -480,13 +480,13 @@ describe("the MCP read protocol", () => {
 			idempotencyKey: creation.idempotencyKey,
 		};
 
-		for (let [id, arguments_] of [[13, creation], [14, reordered]]) {
+		for (let [id, createArguments] of [[13, creation], [14, reordered]]) {
 			let result = await json(
 				await mcp(request({
 					jsonrpc: "2.0",
 					id,
 					method: "tools/call",
-					params: { name: "create_document", arguments: arguments_ },
+					params: { name: "create_document", arguments: createArguments },
 				})),
 			);
 			expect((result.result as { structuredContent: { id: string } }).structuredContent.id)

--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -2,13 +2,29 @@ import { describe, expect, it } from "bun:test";
 
 import { handler, TOOLS } from "./mcp";
 
-import type { Document, DocumentReader } from "./mcp";
+import type { CreateDocumentInput, Document, DocumentReader } from "./mcp";
 
 const document: Document = {
 	id: "f401c8d6-3717-4f1d-8473-cfdd0af894e4",
 	title: "Release readiness",
 	source: "# Release readiness\n",
 	revision: 4,
+};
+
+const creation = {
+	idempotencyKey: "create-plan-1",
+	repository: "githubnext/chopin",
+	baseBranch: "main",
+	baseCommit: "0123456789abcdef0123456789abcdef01234567",
+	title: "Ship MCP creation",
+	brief: {
+		goal: "Create a collaborative plan.",
+		constraints: ["Keep plans immutable through MCP."],
+		settledDecisions: ["Use the documented dialect."],
+		openQuestions: ["Which reviewer owns the rollout?"],
+		repositoryFindings: ["The plan becomes a hosted channel."],
+	},
+	plan: '# Draft\n\n<Callout type="note">\nCreated through MCP.\n</Callout>\n',
 };
 
 function request(
@@ -122,6 +138,112 @@ describe("the MCP read protocol", () => {
 				inputSchema: expect.objectContaining({ required: ["id"], additionalProperties: false }),
 			}),
 		]));
+	});
+
+	it("creates a validated canonical document through the host adapter", async () => {
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create(_caller: string, input: CreateDocumentInput) {
+					return {
+						kind: "created" as const,
+						document: {
+							id: "created",
+							title: input.title,
+							brief: input.brief,
+							source: input.plan,
+							revision: 0,
+							url: "/channels/created",
+						},
+					};
+				},
+			},
+		});
+
+		let result = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 5,
+				method: "tools/call",
+				params: { name: "create_document", arguments: creation },
+			})),
+		);
+
+		expect(result.error).toBeUndefined();
+		expect((result.result as { structuredContent: Record<string, unknown> }).structuredContent)
+			.toMatchObject({
+				id: "created",
+				title: creation.title,
+				brief: creation.brief,
+				revision: 0,
+				url: "/channels/created",
+			});
+		expect(
+			(result.result as { structuredContent: { source: string } }).structuredContent.source,
+		).toMatch(/<Callout (?=[^>]*id="[0-7][0-9A-HJKMNP-TV-Z]{25}")(?=[^>]*type="note")/);
+	});
+
+	it("returns dialect issues without asking the host to persist an invalid plan", async () => {
+		let created = false;
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create() {
+					created = true;
+					return { kind: "forbidden" as const };
+				},
+			},
+		});
+
+		let result = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 6,
+				method: "tools/call",
+				params: {
+					name: "create_document",
+					arguments: { ...creation, plan: "<Chart />\n" },
+				},
+			})),
+		);
+
+		expect((result.result as { isError: boolean }).isError).toBe(true);
+		expect(
+			(result.result as { structuredContent: { issues: unknown[] } }).structuredContent.issues,
+		).toEqual([expect.objectContaining({
+			code: "unknown-component",
+			path: "root > Chart[0]",
+			offset: 0,
+		})]);
+		expect(created).toBe(false);
+	});
+
+	it("reports a changed idempotent request as a tool conflict", async () => {
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create() {
+					return { kind: "conflict" as const };
+				},
+			},
+		});
+
+		let result = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 7,
+				method: "tools/call",
+				params: { name: "create_document", arguments: creation },
+			})),
+		);
+
+		expect((result.result as { isError: boolean }).isError).toBe(true);
+		expect((result.result as { structuredContent: unknown }).structuredContent).toEqual({
+			code: "idempotency-conflict",
+		});
 	});
 
 	it("advertises the canonical repository and non-blank channel constraints it enforces", () => {

--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -329,14 +329,14 @@ describe("the MCP read protocol", () => {
 		);
 	});
 
-	it("rejects declared and streamed request bodies beyond the read-only transport budget", async () => {
+	it("rejects declared and streamed request bodies beyond the bounded transport budget", async () => {
 		let mcp = endpoint();
 		let declared = await mcp(
 			new Request("https://chopin.test/mcp", {
 				method: "POST",
 				headers: {
 					authorization: "Bearer allowed",
-					"content-length": "65537",
+					"content-length": "786433",
 					"content-type": "application/json",
 				},
 				body: "{}",
@@ -351,8 +351,8 @@ describe("the MCP read protocol", () => {
 				},
 				body: new ReadableStream({
 					start(controller) {
-						for (let index = 0; index < 3; index++) {
-							controller.enqueue(new Uint8Array(32_768));
+						for (let index = 0; index < 7; index++) {
+							controller.enqueue(new Uint8Array(131_072));
 						}
 						controller.close();
 					},
@@ -364,6 +364,40 @@ describe("the MCP read protocol", () => {
 			expect(response.status).toBe(413);
 			expect(await response.text()).toBe("request too large");
 		}
+	});
+
+	it("accepts a document-creation request beyond the former read-only budget", async () => {
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create(_caller, input) {
+					return {
+						kind: "created" as const,
+						document: {
+							id: "large-plan",
+							title: input.title,
+							brief: input.brief,
+							source: input.plan,
+							revision: 0,
+							url: "/channels/large-plan",
+						},
+					};
+				},
+			},
+		});
+		let response = await mcp(request({
+			jsonrpc: "2.0",
+			id: 11,
+			method: "tools/call",
+			params: {
+				name: "create_document",
+				arguments: { ...creation, plan: `# Large\n\n${"word ".repeat(14_000)}\n` },
+			},
+		}));
+
+		expect(response.status).toBe(200);
+		expect((await json(response)).error).toBeUndefined();
 	});
 
 	it("rejects non-scalar JSON-RPC ids and scalar initialize or tools-list parameters", async () => {

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -52,7 +52,7 @@ export type McpOptions<Caller> = {
 	/** The host owns authentication; MCP only receives its result. */
 	caller(request: Request): Promise<Caller | undefined> | Caller | undefined;
 	documents: DocumentReader<Caller>;
-	create: CreateDocument<Caller>;
+	create?: CreateDocument<Caller>;
 };
 
 type Tool = {
@@ -296,6 +296,9 @@ async function requestBody(request: Request): Promise<{ body?: unknown; tooLarge
 export function handler<Caller>(
 	options: McpOptions<Caller>,
 ): (request: Request) => Promise<Response> {
+	let creation = options.create;
+	let tools = creation ? TOOLS : TOOLS.filter(tool => tool.name !== "create_document");
+
 	async function dispatch(value: unknown, caller: Caller): Promise<Reply | undefined> {
 		let call = record(value) as Call | undefined;
 		if (!call || call.jsonrpc !== "2.0" || typeof call.method !== "string") {
@@ -320,7 +323,7 @@ export function handler<Caller>(
 				return undefined;
 
 			case "tools/list":
-				return respond({ tools: TOOLS });
+				return respond({ tools });
 
 			case "tools/call": {
 				let tool = toolCall(call.params);
@@ -350,7 +353,7 @@ export function handler<Caller>(
 					let document = await options.documents.read(caller, tool.arguments.id);
 					return document ? respond(text(document)) : respond({ content: [], isError: true });
 				}
-				if (tool.name === "create_document") {
+				if (tool.name === "create_document" && creation) {
 					let prepared = prepare(tool.arguments);
 					if (!prepared) {
 						return notification
@@ -358,7 +361,7 @@ export function handler<Caller>(
 							: error(call.id, -32602, "create_document requires a valid draft");
 					}
 					if ("issues" in prepared) return respond(text({ issues: prepared.issues }, true));
-					let outcome = await options.create.create(caller, prepared.input);
+					let outcome = await creation.create(caller, prepared.input);
 					if (outcome.kind === "created" || outcome.kind === "replayed") {
 						return respond(text(outcome.document));
 					}

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -69,7 +69,7 @@ export type McpOptions<Caller> = {
 	/** The host owns authentication; MCP only receives its result. */
 	caller(request: Request): Promise<Caller | undefined> | Caller | undefined;
 	documents: DocumentReader<Caller>;
-	create?: CreateDocument<Caller>;
+	create: CreateDocument<Caller>;
 };
 
 type Tool = {
@@ -346,7 +346,18 @@ function canonical(source: string):
 	| { source: string }
 	| { issues: Array<{ code: string; message: string; path: string; offset?: number }> }
 {
-	let tree = parse(source);
+	let tree: Root;
+	try {
+		tree = parse(source);
+	} catch (err) {
+		return {
+			issues: [{
+				code: "parse",
+				message: err instanceof Error ? err.message : String(err),
+				path: "root",
+			}],
+		};
+	}
 	identify(tree);
 	let result = validate(tree);
 	if (!result.ok) return { issues: result.issues };
@@ -498,7 +509,6 @@ export function handler<Caller>(
 					}
 					let prepared = canonical(input.plan);
 					if ("issues" in prepared) return respond(text({ issues: prepared.issues }, true));
-					if (!options.create) return respond({ content: [], isError: true });
 					let outcome = await options.create.create(caller, {
 						...input,
 						plan: prepared.source,

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -1,9 +1,17 @@
 /**
- * Backend-neutral MCP read protocol.
+ * Backend-neutral MCP document protocol.
  *
  * Hosts authenticate callers and resolve repository-scoped documents. This
  * module only validates and presents their results through MCP.
  */
+
+import { createHash } from "node:crypto";
+
+import { lookup, parse, serialize, ulid, validate } from "@chopin/dialect";
+
+import * as room from "./plan/room";
+
+import type { Nodes, Parent, Root } from "mdast";
 
 export type DocumentSummary = {
 	id: string;
@@ -11,6 +19,7 @@ export type DocumentSummary = {
 };
 
 export type Document = DocumentSummary & {
+	brief?: Brief;
 	source: string;
 	revision: number;
 };
@@ -20,10 +29,47 @@ export type DocumentReader<Caller> = {
 	read(caller: Caller, id: string): Promise<Document | undefined>;
 };
 
+export type Brief = {
+	goal: string;
+	constraints: string[];
+	settledDecisions: string[];
+	openQuestions: string[];
+	repositoryFindings: string[];
+};
+
+export type CreationOrigin = {
+	idempotencyKey: string;
+	fingerprint: string;
+	repository: string;
+	baseBranch: string;
+	baseCommit: string;
+	title: string;
+};
+
+export type CreateDocumentInput = CreationOrigin & {
+	brief: Brief;
+	plan: string;
+};
+
+export type CreatedDocument = Document & { url: string };
+
+export type CreateDocument<Caller> = {
+	create(
+		caller: Caller,
+		input: CreateDocumentInput,
+	): Promise<
+		| { kind: "created"; document: CreatedDocument }
+		| { kind: "replayed"; document: CreatedDocument }
+		| { kind: "conflict" }
+		| { kind: "forbidden" }
+	>;
+};
+
 export type McpOptions<Caller> = {
 	/** The host owns authentication; MCP only receives its result. */
 	caller(request: Request): Promise<Caller | undefined> | Caller | undefined;
 	documents: DocumentReader<Caller>;
+	create?: CreateDocument<Caller>;
 };
 
 type Tool = {
@@ -39,6 +85,7 @@ const REPOSITORY_PATH_PATTERN = `^${OWNER_PATTERN}/${REPOSITORY_PATTERN}$`;
 const OWNER = new RegExp(`^${OWNER_PATTERN}$`);
 const REPOSITORY = new RegExp(`^${REPOSITORY_PATTERN}$`);
 const MAX_DOCUMENT_ID_LENGTH = 128;
+const MAX_TITLE_LENGTH = 120;
 /** Read-only JSON-RPC calls need arguments, not document-sized request bodies. */
 const MAX_REQUEST_BYTES = 64 * 1_024;
 
@@ -49,6 +96,19 @@ const DOCUMENT = {
 		title: { type: "string" },
 	},
 	required: ["id", "title"],
+	additionalProperties: false,
+};
+
+const BRIEF = {
+	type: "object",
+	properties: {
+		goal: { type: "string", minLength: 1 },
+		constraints: { type: "array", items: { type: "string" } },
+		settledDecisions: { type: "array", items: { type: "string" } },
+		openQuestions: { type: "array", items: { type: "string" } },
+		repositoryFindings: { type: "array", items: { type: "string" } },
+	},
+	required: ["goal", "constraints", "settledDecisions", "openQuestions", "repositoryFindings"],
 	additionalProperties: false,
 };
 
@@ -92,10 +152,49 @@ export const TOOLS: Tool[] = [
 			type: "object",
 			properties: {
 				...DOCUMENT.properties,
+				brief: BRIEF,
 				source: { type: "string" },
 				revision: { type: "integer", minimum: 0 },
 			},
 			required: ["id", "title", "source", "revision"],
+			additionalProperties: false,
+		},
+	},
+	{
+		name: "create_document",
+		description: "Create a Chopin document from a structured brief and canonical plan.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				idempotencyKey: { type: "string", minLength: 1, maxLength: 128 },
+				repository: { type: "string", pattern: REPOSITORY_PATH_PATTERN },
+				baseBranch: { type: "string", minLength: 1, maxLength: 255 },
+				baseCommit: { type: "string", minLength: 1, maxLength: 64 },
+				title: { type: "string", minLength: 1, maxLength: MAX_TITLE_LENGTH },
+				brief: BRIEF,
+				plan: { type: "string", minLength: 1 },
+			},
+			required: [
+				"idempotencyKey",
+				"repository",
+				"baseBranch",
+				"baseCommit",
+				"title",
+				"brief",
+				"plan",
+			],
+			additionalProperties: false,
+		},
+		outputSchema: {
+			type: "object",
+			properties: {
+				...DOCUMENT.properties,
+				brief: BRIEF,
+				source: { type: "string" },
+				revision: { type: "integer", minimum: 0 },
+				url: { type: "string" },
+			},
+			required: ["id", "title", "brief", "source", "revision", "url"],
 			additionalProperties: false,
 		},
 	},
@@ -131,10 +230,16 @@ function record(value: unknown): Record<string, unknown> | undefined {
 
 function text(
 	value: unknown,
-): { content: Array<{ type: "text"; text: string }>; structuredContent: unknown } {
+	isError = false,
+): {
+	content: Array<{ type: "text"; text: string }>;
+	structuredContent: unknown;
+	isError?: true;
+} {
 	return {
 		content: [{ type: "text", text: JSON.stringify(value) }],
 		structuredContent: value,
+		...(isError ? { isError: true as const } : {}),
 	};
 }
 
@@ -157,6 +262,101 @@ function isId(value: unknown): value is string {
 	return typeof value === "string"
 		&& Array.from(value).length <= MAX_DOCUMENT_ID_LENGTH
 		&& value.trim().length > 0;
+}
+
+function strings(value: unknown): string[] | undefined {
+	return Array.isArray(value) && value.every(item => typeof item === "string") ? value : undefined;
+}
+
+function nonblank(value: unknown, maximum: number): string | undefined {
+	return typeof value === "string"
+			&& Array.from(value).length <= maximum
+			&& value.trim().length > 0
+		? value
+		: undefined;
+}
+
+type CreateArguments = Omit<CreateDocumentInput, "fingerprint">;
+
+function createArguments(value: Record<string, unknown>): CreateArguments | undefined {
+	let expected = [
+		"idempotencyKey",
+		"repository",
+		"baseBranch",
+		"baseCommit",
+		"title",
+		"brief",
+		"plan",
+	];
+	if (
+		Object.keys(value).length !== expected.length
+		|| expected.some(key => !Object.hasOwn(value, key))
+	) return undefined;
+	let brief = record(value.brief);
+	let goal = nonblank(brief?.goal, 4_096);
+	let constraints = strings(brief?.constraints);
+	let settledDecisions = strings(brief?.settledDecisions);
+	let openQuestions = strings(brief?.openQuestions);
+	let repositoryFindings = strings(brief?.repositoryFindings);
+	let idempotencyKey = nonblank(value.idempotencyKey, 128);
+	let baseBranch = nonblank(value.baseBranch, 255);
+	let baseCommit = nonblank(value.baseCommit, 64);
+	let title = nonblank(value.title, MAX_TITLE_LENGTH);
+	let plan = nonblank(value.plan, MAX_REQUEST_BYTES);
+	if (
+		!idempotencyKey
+		|| !isRepository(value.repository)
+		|| !baseBranch
+		|| !baseCommit
+		|| !title
+		|| !goal
+		|| !constraints
+		|| !settledDecisions
+		|| !openQuestions
+		|| !repositoryFindings
+		|| !plan
+	) return undefined;
+	return {
+		idempotencyKey,
+		repository: value.repository,
+		baseBranch,
+		baseCommit,
+		title,
+		brief: { goal, constraints, settledDecisions, openQuestions, repositoryFindings },
+		plan,
+	};
+}
+
+function identify(node: Nodes | Root): void {
+	if (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") {
+		let component = lookup(node.name);
+		if (
+			component?.attributes.id?.required
+			&& !node.attributes.some(attribute =>
+				attribute.type === "mdxJsxAttribute" && attribute.name === "id"
+			)
+		) node.attributes.unshift({ type: "mdxJsxAttribute", name: "id", value: ulid() });
+	}
+	if ("children" in node) {
+		for (let child of (node as Parent).children) identify(child);
+	}
+}
+
+function canonical(source: string):
+	| { source: string }
+	| { issues: Array<{ code: string; message: string; path: string; offset?: number }> }
+{
+	let tree = parse(source);
+	identify(tree);
+	let result = validate(tree);
+	if (!result.ok) return { issues: result.issues };
+	let output = serialize(tree);
+	room.validate(output);
+	return { source: output };
+}
+
+function fingerprint(input: CreateArguments): string {
+	return createHash("sha256").update(JSON.stringify(input)).digest("hex");
 }
 
 function isJsonRpcId(value: unknown): value is string | number | null {
@@ -288,6 +488,29 @@ export function handler<Caller>(
 					}
 					let document = await options.documents.read(caller, tool.arguments.id);
 					return document ? respond(text(document)) : respond({ content: [], isError: true });
+				}
+				if (tool.name === "create_document") {
+					let input = createArguments(tool.arguments);
+					if (!input) {
+						return notification
+							? undefined
+							: error(call.id, -32602, "create_document requires a valid draft");
+					}
+					let prepared = canonical(input.plan);
+					if ("issues" in prepared) return respond(text({ issues: prepared.issues }, true));
+					if (!options.create) return respond({ content: [], isError: true });
+					let outcome = await options.create.create(caller, {
+						...input,
+						plan: prepared.source,
+						fingerprint: fingerprint(input),
+					});
+					if (outcome.kind === "created" || outcome.kind === "replayed") {
+						return respond(text(outcome.document));
+					}
+					if (outcome.kind === "conflict") {
+						return respond(text({ code: "idempotency-conflict" }, true));
+					}
+					return respond({ content: [], isError: true });
 				}
 				return notification ? undefined : error(call.id, -32601, "tool not found");
 			}

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -5,13 +5,18 @@
  * module only validates and presents their results through MCP.
  */
 
-import { createHash } from "node:crypto";
+import {
+	BRIEF,
+	isRepository,
+	MAX_REQUEST_BYTES,
+	MAX_TITLE_LENGTH,
+	prepare,
+	REPOSITORY_PATH_PATTERN,
+} from "./mcp/create";
 
-import { lookup, parse, serialize, ulid, validate } from "@chopin/dialect";
+import type { Brief, CreateDocumentInput } from "./mcp/create";
 
-import * as room from "./plan/room";
-
-import type { Nodes, Parent, Root } from "mdast";
+export type { Brief, CreateDocumentInput, CreationOrigin } from "./mcp/create";
 
 export type DocumentSummary = {
 	id: string;
@@ -27,28 +32,6 @@ export type Document = DocumentSummary & {
 export type DocumentReader<Caller> = {
 	list(caller: Caller, repository: string): Promise<DocumentSummary[]>;
 	read(caller: Caller, id: string): Promise<Document | undefined>;
-};
-
-export type Brief = {
-	goal: string;
-	constraints: string[];
-	settledDecisions: string[];
-	openQuestions: string[];
-	repositoryFindings: string[];
-};
-
-export type CreationOrigin = {
-	idempotencyKey: string;
-	fingerprint: string;
-	repository: string;
-	baseBranch: string;
-	baseCommit: string;
-	title: string;
-};
-
-export type CreateDocumentInput = CreationOrigin & {
-	brief: Brief;
-	plan: string;
 };
 
 export type CreatedDocument = Document & { url: string };
@@ -79,15 +62,7 @@ type Tool = {
 	outputSchema: Record<string, unknown>;
 };
 
-const OWNER_PATTERN = "[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}";
-const REPOSITORY_PATTERN = "(?!\\.\\.?$)[A-Za-z0-9._-]{1,100}";
-const REPOSITORY_PATH_PATTERN = `^${OWNER_PATTERN}/${REPOSITORY_PATTERN}$`;
-const OWNER = new RegExp(`^${OWNER_PATTERN}$`);
-const REPOSITORY = new RegExp(`^${REPOSITORY_PATTERN}$`);
 const MAX_DOCUMENT_ID_LENGTH = 128;
-const MAX_TITLE_LENGTH = 120;
-/** Read-only JSON-RPC calls need arguments, not document-sized request bodies. */
-const MAX_REQUEST_BYTES = 64 * 1_024;
 
 const DOCUMENT = {
 	type: "object",
@@ -96,19 +71,6 @@ const DOCUMENT = {
 		title: { type: "string" },
 	},
 	required: ["id", "title"],
-	additionalProperties: false,
-};
-
-const BRIEF = {
-	type: "object",
-	properties: {
-		goal: { type: "string", minLength: 1 },
-		constraints: { type: "array", items: { type: "string" } },
-		settledDecisions: { type: "array", items: { type: "string" } },
-		openQuestions: { type: "array", items: { type: "string" } },
-		repositoryFindings: { type: "array", items: { type: "string" } },
-	},
-	required: ["goal", "constraints", "settledDecisions", "openQuestions", "repositoryFindings"],
 	additionalProperties: false,
 };
 
@@ -252,122 +214,10 @@ function toolCall(
 	return arguments_ ? { name: value.name, arguments: arguments_ } : undefined;
 }
 
-function isRepository(value: unknown): value is string {
-	if (typeof value !== "string") return false;
-	let parts = value.split("/");
-	return parts.length === 2 && OWNER.test(parts[0]!) && REPOSITORY.test(parts[1]!);
-}
-
 function isId(value: unknown): value is string {
 	return typeof value === "string"
 		&& Array.from(value).length <= MAX_DOCUMENT_ID_LENGTH
 		&& value.trim().length > 0;
-}
-
-function strings(value: unknown): string[] | undefined {
-	return Array.isArray(value) && value.every(item => typeof item === "string") ? value : undefined;
-}
-
-function nonblank(value: unknown, maximum: number): string | undefined {
-	return typeof value === "string"
-			&& Array.from(value).length <= maximum
-			&& value.trim().length > 0
-		? value
-		: undefined;
-}
-
-type CreateArguments = Omit<CreateDocumentInput, "fingerprint">;
-
-function createArguments(value: Record<string, unknown>): CreateArguments | undefined {
-	let expected = [
-		"idempotencyKey",
-		"repository",
-		"baseBranch",
-		"baseCommit",
-		"title",
-		"brief",
-		"plan",
-	];
-	if (
-		Object.keys(value).length !== expected.length
-		|| expected.some(key => !Object.hasOwn(value, key))
-	) return undefined;
-	let brief = record(value.brief);
-	let goal = nonblank(brief?.goal, 4_096);
-	let constraints = strings(brief?.constraints);
-	let settledDecisions = strings(brief?.settledDecisions);
-	let openQuestions = strings(brief?.openQuestions);
-	let repositoryFindings = strings(brief?.repositoryFindings);
-	let idempotencyKey = nonblank(value.idempotencyKey, 128);
-	let baseBranch = nonblank(value.baseBranch, 255);
-	let baseCommit = nonblank(value.baseCommit, 64);
-	let title = nonblank(value.title, MAX_TITLE_LENGTH);
-	let plan = nonblank(value.plan, MAX_REQUEST_BYTES);
-	if (
-		!idempotencyKey
-		|| !isRepository(value.repository)
-		|| !baseBranch
-		|| !baseCommit
-		|| !title
-		|| !goal
-		|| !constraints
-		|| !settledDecisions
-		|| !openQuestions
-		|| !repositoryFindings
-		|| !plan
-	) return undefined;
-	return {
-		idempotencyKey,
-		repository: value.repository,
-		baseBranch,
-		baseCommit,
-		title,
-		brief: { goal, constraints, settledDecisions, openQuestions, repositoryFindings },
-		plan,
-	};
-}
-
-function identify(node: Nodes | Root): void {
-	if (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") {
-		let component = lookup(node.name);
-		if (
-			component?.attributes.id?.required
-			&& !node.attributes.some(attribute =>
-				attribute.type === "mdxJsxAttribute" && attribute.name === "id"
-			)
-		) node.attributes.unshift({ type: "mdxJsxAttribute", name: "id", value: ulid() });
-	}
-	if ("children" in node) {
-		for (let child of (node as Parent).children) identify(child);
-	}
-}
-
-function canonical(source: string):
-	| { source: string }
-	| { issues: Array<{ code: string; message: string; path: string; offset?: number }> }
-{
-	let tree: Root;
-	try {
-		tree = parse(source);
-	} catch (err) {
-		return {
-			issues: [{
-				code: "parse",
-				message: err instanceof Error ? err.message : String(err),
-				path: "root",
-			}],
-		};
-	}
-	identify(tree);
-	let result = validate(tree);
-	if (!result.ok) return { issues: result.issues };
-	let output = serialize(tree);
-	room.validate(output);
-	return { source: output };
-}
-
-function fingerprint(input: CreateArguments): string {
-	return createHash("sha256").update(JSON.stringify(input)).digest("hex");
 }
 
 function isJsonRpcId(value: unknown): value is string | number | null {
@@ -501,19 +351,14 @@ export function handler<Caller>(
 					return document ? respond(text(document)) : respond({ content: [], isError: true });
 				}
 				if (tool.name === "create_document") {
-					let input = createArguments(tool.arguments);
-					if (!input) {
+					let prepared = prepare(tool.arguments);
+					if (!prepared) {
 						return notification
 							? undefined
 							: error(call.id, -32602, "create_document requires a valid draft");
 					}
-					let prepared = canonical(input.plan);
 					if ("issues" in prepared) return respond(text({ issues: prepared.issues }, true));
-					let outcome = await options.create.create(caller, {
-						...input,
-						plan: prepared.source,
-						fingerprint: fingerprint(input),
-					});
+					let outcome = await options.create.create(caller, prepared.input);
 					if (outcome.kind === "created" || outcome.kind === "replayed") {
 						return respond(text(outcome.document));
 					}

--- a/apps/server/src/mcp/create.ts
+++ b/apps/server/src/mcp/create.ts
@@ -1,0 +1,180 @@
+import { createHash } from "node:crypto";
+
+import { lookup, parse, serialize, ulid, validate } from "@chopin/dialect";
+
+import * as room from "../plan/room";
+
+import type { Issue } from "@chopin/dialect";
+import type { Nodes, Parent, Root } from "mdast";
+
+export type Brief = {
+	goal: string;
+	constraints: string[];
+	settledDecisions: string[];
+	openQuestions: string[];
+	repositoryFindings: string[];
+};
+
+export type CreationOrigin = {
+	idempotencyKey: string;
+	fingerprint: string;
+	repository: string;
+	baseBranch: string;
+	baseCommit: string;
+	title: string;
+};
+
+export type CreateDocumentInput = CreationOrigin & {
+	brief: Brief;
+	plan: string;
+};
+
+type CreateArguments = Omit<CreateDocumentInput, "fingerprint">;
+
+const OWNER_PATTERN = "[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}";
+const REPOSITORY_PATTERN = "(?!\\.\\.?$)[A-Za-z0-9._-]{1,100}";
+export const REPOSITORY_PATH_PATTERN = `^${OWNER_PATTERN}/${REPOSITORY_PATTERN}$`;
+export const MAX_REQUEST_BYTES = 64 * 1_024;
+export const MAX_TITLE_LENGTH = 120;
+
+const OWNER = new RegExp(`^${OWNER_PATTERN}$`);
+const REPOSITORY = new RegExp(`^${REPOSITORY_PATTERN}$`);
+
+export const BRIEF = {
+	type: "object",
+	properties: {
+		goal: { type: "string", minLength: 1 },
+		constraints: { type: "array", items: { type: "string" } },
+		settledDecisions: { type: "array", items: { type: "string" } },
+		openQuestions: { type: "array", items: { type: "string" } },
+		repositoryFindings: { type: "array", items: { type: "string" } },
+	},
+	required: ["goal", "constraints", "settledDecisions", "openQuestions", "repositoryFindings"],
+	additionalProperties: false,
+};
+
+function record(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? value as Record<string, unknown>
+		: undefined;
+}
+
+function strings(value: unknown): string[] | undefined {
+	return Array.isArray(value) && value.every(item => typeof item === "string") ? value : undefined;
+}
+
+function nonblank(value: unknown, maximum: number): string | undefined {
+	return typeof value === "string"
+			&& Array.from(value).length <= maximum
+			&& value.trim().length > 0
+		? value
+		: undefined;
+}
+
+export function isRepository(value: unknown): value is string {
+	if (typeof value !== "string") return false;
+	let parts = value.split("/");
+	return parts.length === 2 && OWNER.test(parts[0]!) && REPOSITORY.test(parts[1]!);
+}
+
+function arguments_(value: Record<string, unknown>): CreateArguments | undefined {
+	let expected = [
+		"idempotencyKey",
+		"repository",
+		"baseBranch",
+		"baseCommit",
+		"title",
+		"brief",
+		"plan",
+	];
+	if (
+		Object.keys(value).length !== expected.length
+		|| expected.some(key => !Object.hasOwn(value, key))
+	) return undefined;
+	let brief = record(value.brief);
+	let goal = nonblank(brief?.goal, 4_096);
+	let constraints = strings(brief?.constraints);
+	let settledDecisions = strings(brief?.settledDecisions);
+	let openQuestions = strings(brief?.openQuestions);
+	let repositoryFindings = strings(brief?.repositoryFindings);
+	let idempotencyKey = nonblank(value.idempotencyKey, 128);
+	let baseBranch = nonblank(value.baseBranch, 255);
+	let baseCommit = nonblank(value.baseCommit, 64);
+	let title = nonblank(value.title, MAX_TITLE_LENGTH);
+	let plan = nonblank(value.plan, MAX_REQUEST_BYTES);
+	if (
+		!idempotencyKey
+		|| !isRepository(value.repository)
+		|| !baseBranch
+		|| !baseCommit
+		|| !title
+		|| !goal
+		|| !constraints
+		|| !settledDecisions
+		|| !openQuestions
+		|| !repositoryFindings
+		|| !plan
+	) return undefined;
+	return {
+		idempotencyKey,
+		repository: value.repository,
+		baseBranch,
+		baseCommit,
+		title,
+		brief: { goal, constraints, settledDecisions, openQuestions, repositoryFindings },
+		plan,
+	};
+}
+
+function identify(node: Nodes | Root): void {
+	if (node.type === "mdxJsxFlowElement" || node.type === "mdxJsxTextElement") {
+		let component = lookup(node.name);
+		if (
+			component?.attributes.id?.required
+			&& !node.attributes.some(attribute =>
+				attribute.type === "mdxJsxAttribute" && attribute.name === "id"
+			)
+		) node.attributes.unshift({ type: "mdxJsxAttribute", name: "id", value: ulid() });
+	}
+	if ("children" in node) {
+		for (let child of (node as Parent).children) identify(child);
+	}
+}
+
+function canonical(source: string): { source: string } | { issues: Issue[] } {
+	let tree: Root;
+	try {
+		tree = parse(source);
+	} catch (err) {
+		return {
+			issues: [{
+				code: "parse",
+				message: err instanceof Error ? err.message : String(err),
+				path: "root",
+			}],
+		};
+	}
+	identify(tree);
+	let result = validate(tree);
+	if (!result.ok) return { issues: result.issues };
+	let output = serialize(tree);
+	room.validate(output);
+	return { source: output };
+}
+
+/** Turn untrusted tool arguments into the only input a host adapter can receive. */
+export function prepare(
+	value: Record<string, unknown>,
+): { input: CreateDocumentInput } | { issues: Issue[] } | undefined {
+	let input = arguments_(value);
+	if (!input) return undefined;
+	let prepared = canonical(input.plan);
+	if ("issues" in prepared) return prepared;
+	return {
+		input: {
+			...input,
+			plan: prepared.source,
+			fingerprint: createHash("sha256").update(JSON.stringify(input)).digest("hex"),
+		},
+	};
+}

--- a/apps/server/src/mcp/create.ts
+++ b/apps/server/src/mcp/create.ts
@@ -31,17 +31,17 @@ export type CreateDocumentInput = CreationOrigin & {
 
 type CreateArguments = Omit<CreateDocumentInput, "fingerprint">;
 
-const OWNER_PATTERN = "[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}";
-const REPOSITORY_PATTERN = "(?!\\.\\.?$)[A-Za-z0-9._-]{1,100}";
-export const REPOSITORY_PATH_PATTERN = `^${OWNER_PATTERN}/${REPOSITORY_PATTERN}$`;
+let OWNER_PATTERN = "[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}";
+let REPOSITORY_PATTERN = "(?!\\.\\.?$)[A-Za-z0-9._-]{1,100}";
+export let REPOSITORY_PATH_PATTERN = `^${OWNER_PATTERN}/${REPOSITORY_PATTERN}$`;
 /** Allows a maximally sized MDX plan plus JSON escaping and its structured brief. */
-export const MAX_REQUEST_BYTES = limits.MAX_SOURCE_BYTES * 3;
-export const MAX_TITLE_LENGTH = 120;
+export let MAX_REQUEST_BYTES = limits.MAX_SOURCE_BYTES * 3;
+export let MAX_TITLE_LENGTH = 120;
 
-const OWNER = new RegExp(`^${OWNER_PATTERN}$`);
-const REPOSITORY = new RegExp(`^${REPOSITORY_PATTERN}$`);
+let OWNER = new RegExp(`^${OWNER_PATTERN}$`);
+let REPOSITORY = new RegExp(`^${REPOSITORY_PATTERN}$`);
 
-export const BRIEF = {
+export let BRIEF = {
 	type: "object",
 	properties: {
 		goal: { type: "string", minLength: 1 },
@@ -78,7 +78,7 @@ export function isRepository(value: unknown): value is string {
 	return parts.length === 2 && OWNER.test(parts[0]!) && REPOSITORY.test(parts[1]!);
 }
 
-function arguments_(value: Record<string, unknown>): CreateArguments | undefined {
+function parseCreationArguments(value: Record<string, unknown>): CreateArguments | undefined {
 	let expected = [
 		"idempotencyKey",
 		"repository",
@@ -185,7 +185,7 @@ function fingerprint(input: CreateArguments): string {
 export function prepare(
 	value: Record<string, unknown>,
 ): { input: CreateDocumentInput } | { issues: Issue[] } | undefined {
-	let input = arguments_(value);
+	let input = parseCreationArguments(value);
 	if (!input) return undefined;
 	let prepared = canonical(input.plan);
 	if ("issues" in prepared) return prepared;

--- a/apps/server/src/mcp/create.ts
+++ b/apps/server/src/mcp/create.ts
@@ -156,11 +156,29 @@ function canonical(source: string): { source: string } | { issues: Issue[] } {
 		};
 	}
 	identify(tree);
-	let result = validate(tree);
-	if (!result.ok) return { issues: result.issues };
 	let output = serialize(tree);
+	let result = validate(tree, { bytes: Buffer.byteLength(output, "utf8") });
+	if (!result.ok) return { issues: result.issues };
 	room.validate(output);
 	return { source: output };
+}
+
+function fingerprint(input: CreateArguments): string {
+	return createHash("sha256").update(JSON.stringify({
+		idempotencyKey: input.idempotencyKey,
+		repository: input.repository,
+		baseBranch: input.baseBranch,
+		baseCommit: input.baseCommit,
+		title: input.title,
+		brief: {
+			goal: input.brief.goal,
+			constraints: input.brief.constraints,
+			settledDecisions: input.brief.settledDecisions,
+			openQuestions: input.brief.openQuestions,
+			repositoryFindings: input.brief.repositoryFindings,
+		},
+		plan: input.plan,
+	})).digest("hex");
 }
 
 /** Turn untrusted tool arguments into the only input a host adapter can receive. */
@@ -175,7 +193,7 @@ export function prepare(
 		input: {
 			...input,
 			plan: prepared.source,
-			fingerprint: createHash("sha256").update(JSON.stringify(input)).digest("hex"),
+			fingerprint: fingerprint(input),
 		},
 	};
 }

--- a/apps/server/src/mcp/create.ts
+++ b/apps/server/src/mcp/create.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 
-import { lookup, parse, serialize, ulid, validate } from "@chopin/dialect";
+import { limits, lookup, parse, serialize, ulid, validate } from "@chopin/dialect";
 
 import * as room from "../plan/room";
 
@@ -34,7 +34,8 @@ type CreateArguments = Omit<CreateDocumentInput, "fingerprint">;
 const OWNER_PATTERN = "[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}";
 const REPOSITORY_PATTERN = "(?!\\.\\.?$)[A-Za-z0-9._-]{1,100}";
 export const REPOSITORY_PATH_PATTERN = `^${OWNER_PATTERN}/${REPOSITORY_PATTERN}$`;
-export const MAX_REQUEST_BYTES = 64 * 1_024;
+/** Allows a maximally sized MDX plan plus JSON escaping and its structured brief. */
+export const MAX_REQUEST_BYTES = limits.MAX_SOURCE_BYTES * 3;
 export const MAX_TITLE_LENGTH = 120;
 
 const OWNER = new RegExp(`^${OWNER_PATTERN}$`);

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -402,6 +402,44 @@ describe("the hosted MCP adapter", () => {
 		}
 	});
 
+	it("reads a live created plan with its public brief but not provenance", async () => {
+		let context = setup();
+		context.github.repositoryValue = {
+			...context.github.repositoryValue,
+			permissions: { pull: true, push: true, admin: false },
+		};
+		let adapter = hosted(context.auth);
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller) throw new Error("test caller was not authenticated");
+		if (!adapter.create) throw new Error("hosted creation adapter is unavailable");
+		let result = await adapter.create.create(caller, creation);
+		if (result.kind !== "created") throw new Error("test plan was not created");
+		let lease = await context.storage.leases.acquire("writer", "mcp-test", 60_000);
+		if (!lease) throw new Error("could not acquire test lease");
+		let server = { publish() {} } as unknown as Server<SocketData>;
+		let opened = await Service.open(result.document.id, {
+			storage: context.storage,
+			lease: () => lease,
+			fatal: error => {
+				throw error;
+			},
+		}, server);
+		let socket = {
+			data: { room: result.document.id, client: "mcp-test" },
+		} as unknown as Socket;
+		let live = Rooms.join(socket);
+		live.plan = opened;
+
+		try {
+			expect(await adapter.documents.read(caller, result.document.id)).toEqual(
+				createdDocument(result.document.id),
+			);
+		} finally {
+			Rooms.forget(live);
+			await Service.close(opened);
+		}
+	});
+
 	it("makes an inaccessible channel indistinguishable from a missing channel", async () => {
 		let context = setup();
 		let opened = await plan(context);

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -20,7 +20,25 @@ import type {
 	Repository,
 	RepositoryPage,
 } from "../github/client";
+import type { CreateDocumentInput } from "../mcp";
 import type { Socket, SocketData } from "../wire";
+
+const creation: CreateDocumentInput = {
+	idempotencyKey: "create-plan-1",
+	fingerprint: "request-1",
+	repository: "octo-org/score",
+	baseBranch: "main",
+	baseCommit: "0123456789abcdef0123456789abcdef01234567",
+	title: "Created plan",
+	brief: {
+		goal: "Create a collaborative plan.",
+		constraints: ["Keep the source canonical."],
+		settledDecisions: ["Use hosted storage."],
+		openQuestions: ["Who reviews the rollout?"],
+		repositoryFindings: ["The repository uses Bun."],
+	},
+	plan: "# Created\n",
+};
 
 class GitHubBoundary implements GitHub {
 	readonly userTokens: string[] = [];
@@ -222,6 +240,97 @@ describe("the hosted MCP adapter", () => {
 		expect(await adapter.documents.list(caller, "octo-org/score")).toEqual([]);
 		github.accessible = false;
 		expect(await adapter.documents.list(caller, "octo-org/score")).toEqual([]);
+	});
+
+	it("creates a durable repository channel for a caller with write access", async () => {
+		let context = setup();
+		context.github.repositoryValue = {
+			...context.github.repositoryValue,
+			permissions: { pull: true, push: true, admin: false },
+		};
+		let adapter = hosted(context.auth);
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller) throw new Error("test caller was not authenticated");
+		if (!adapter.create) throw new Error("hosted creation adapter is unavailable");
+
+		let result = await adapter.create.create(caller, creation);
+		expect(result.kind).toBe("created");
+		if (result.kind !== "created") return;
+		expect(result.document).toMatchObject({
+			title: creation.title,
+			brief: creation.brief,
+			source: creation.plan,
+			revision: 0,
+			url: `/channels/${result.document.id}`,
+		});
+		let stored = await context.storage.collaboration.load(result.document.id, context.now);
+		if (!stored) throw new Error("created channel was not stored");
+		expect(await Service.readStored(stored)).toMatchObject({
+			brief: creation.brief,
+			origin: expect.objectContaining({
+				idempotencyKey: creation.idempotencyKey,
+				fingerprint: creation.fingerprint,
+			}),
+		});
+		expect(await adapter.documents.read(caller, result.document.id)).toEqual({
+			id: result.document.id,
+			title: creation.title,
+			brief: creation.brief,
+			source: creation.plan,
+			revision: 0,
+		});
+	});
+
+	it("requires repository write access before creating a channel", async () => {
+		let context = setup();
+		let adapter = hosted(context.auth);
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller) throw new Error("test caller was not authenticated");
+		if (!adapter.create) throw new Error("hosted creation adapter is unavailable");
+
+		expect(await adapter.create.create(caller, creation)).toEqual({ kind: "forbidden" });
+		expect((await context.storage.channels.scan("R_score", 10)).channels).toEqual([]);
+	});
+
+	it("replays an accepted idempotent creation request", async () => {
+		let context = setup();
+		context.github.repositoryValue = {
+			...context.github.repositoryValue,
+			permissions: { pull: true, push: true, admin: false },
+		};
+		let adapter = hosted(context.auth);
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller) throw new Error("test caller was not authenticated");
+		if (!adapter.create) throw new Error("hosted creation adapter is unavailable");
+
+		let first = await adapter.create.create(caller, creation);
+		expect(first.kind).toBe("created");
+		if (first.kind !== "created") return;
+		expect(await adapter.create.create(caller, creation)).toEqual({
+			kind: "replayed",
+			document: first.document,
+		});
+	});
+
+	it("rejects changed content under an accepted idempotency key", async () => {
+		let context = setup();
+		context.github.repositoryValue = {
+			...context.github.repositoryValue,
+			permissions: { pull: true, push: true, admin: false },
+		};
+		let adapter = hosted(context.auth);
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller) throw new Error("test caller was not authenticated");
+		if (!adapter.create) throw new Error("hosted creation adapter is unavailable");
+		await adapter.create.create(caller, creation);
+
+		expect(
+			await adapter.create.create(caller, {
+				...creation,
+				fingerprint: "changed-request",
+				title: "Changed title",
+			}),
+		).toEqual({ kind: "conflict" });
 	});
 
 	it("reconstructs a stored checkpoint and journal with the validated plan revision", async () => {

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -40,6 +40,16 @@ const creation: CreateDocumentInput = {
 	plan: "# Created\n",
 };
 
+function createdDocument(id: string) {
+	return {
+		id,
+		title: creation.title,
+		brief: creation.brief,
+		source: creation.plan,
+		revision: 0,
+	};
+}
+
 class GitHubBoundary implements GitHub {
 	readonly userTokens: string[] = [];
 	accessible = true;
@@ -256,29 +266,23 @@ describe("the hosted MCP adapter", () => {
 		let result = await adapter.create.create(caller, creation);
 		expect(result.kind).toBe("created");
 		if (result.kind !== "created") return;
-		expect(result.document).toMatchObject({
-			title: creation.title,
-			brief: creation.brief,
-			source: creation.plan,
-			revision: 0,
+		let expected = createdDocument(result.document.id);
+		expect(result.document).toEqual({
+			...expected,
 			url: `/channels/${result.document.id}`,
 		});
 		let stored = await context.storage.collaboration.load(result.document.id, context.now);
 		if (!stored) throw new Error("created channel was not stored");
 		expect(await Service.readStored(stored)).toMatchObject({
-			brief: creation.brief,
-			origin: expect.objectContaining({
-				idempotencyKey: creation.idempotencyKey,
-				fingerprint: creation.fingerprint,
-			}),
+			creation: {
+				brief: creation.brief,
+				origin: expect.objectContaining({
+					idempotencyKey: creation.idempotencyKey,
+					fingerprint: creation.fingerprint,
+				}),
+			},
 		});
-		expect(await adapter.documents.read(caller, result.document.id)).toEqual({
-			id: result.document.id,
-			title: creation.title,
-			brief: creation.brief,
-			source: creation.plan,
-			revision: 0,
-		});
+		expect(await adapter.documents.read(caller, result.document.id)).toEqual(expected);
 	});
 
 	it("requires repository write access before creating a channel", async () => {
@@ -308,7 +312,10 @@ describe("the hosted MCP adapter", () => {
 		if (first.kind !== "created") return;
 		expect(await adapter.create.create(caller, creation)).toEqual({
 			kind: "replayed",
-			document: first.document,
+			document: {
+				...createdDocument(first.document.id),
+				url: `/channels/${first.document.id}`,
+			},
 		});
 	});
 

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -23,7 +23,7 @@ import type {
 import type { CreateDocumentInput } from "../mcp";
 import type { Socket, SocketData } from "../wire";
 
-const creation: CreateDocumentInput = {
+let creation: CreateDocumentInput = {
 	idempotencyKey: "create-plan-1",
 	fingerprint: "request-1",
 	repository: "octo-org/score",

--- a/apps/server/src/mcp/hosted.ts
+++ b/apps/server/src/mcp/hosted.ts
@@ -29,6 +29,33 @@ function channelId(repositoryId: string, idempotencyKey: string): string {
 	}`;
 }
 
+type Document = {
+	id: string;
+	title: string;
+	creation?: Plan.CreationMetadata;
+	source: string;
+	revision: number;
+	url?: string;
+};
+
+type PublicDocument = Omit<Document, "creation" | "url"> & {
+	brief?: Plan.CreationMetadata["brief"];
+};
+
+/** Strip durable idempotency and repository provenance from MCP responses. */
+function document(value: Document & { url: string }): PublicDocument & { url: string };
+function document(value: Document): PublicDocument;
+function document(value: Document): PublicDocument & { url?: string } {
+	return {
+		id: value.id,
+		title: value.title,
+		...(value.creation ? { brief: value.creation.brief } : {}),
+		source: value.source,
+		revision: value.revision,
+		...(value.url ? { url: value.url } : {}),
+	};
+}
+
 /** Bind the backend-neutral MCP surface to hosted GitHub authentication. */
 export function hosted(auth: HostedAuth): McpOptions<HostedCaller> {
 	return {
@@ -82,13 +109,13 @@ export function hosted(auth: HostedAuth): McpOptions<HostedCaller> {
 				let live = Rooms.get(channel.id)?.plan;
 				if (live) {
 					try {
-						return {
+						return document({
 							id: channel.id,
 							title: channel.title,
-							...(live.brief ? { brief: live.brief } : {}),
+							creation: live.creation,
 							source: Plan.source(live),
 							revision: live.revision,
-						};
+						});
 					} catch {
 						return undefined;
 					}
@@ -104,13 +131,13 @@ export function hosted(auth: HostedAuth): McpOptions<HostedCaller> {
 				) return undefined;
 				try {
 					let projected = await Plan.readStored(stored);
-					return {
+					return document({
 						id: channel.id,
 						title: channel.title,
-						...(projected.brief ? { brief: projected.brief } : {}),
+						creation: projected.creation,
 						source: projected.source,
 						revision: projected.revision,
-					};
+					});
 				} catch {
 					return undefined;
 				}
@@ -135,7 +162,8 @@ export function hosted(auth: HostedAuth): McpOptions<HostedCaller> {
 					now: auth.clock(),
 				});
 				let { brief, plan, ...origin } = input;
-				let initial = await Plan.initial(plan, origin, brief);
+				let creation: Plan.CreationMetadata = { brief, origin };
+				let initial = await Plan.initial(plan, creation);
 				let id = channelId(repository.id, input.idempotencyKey);
 				try {
 					await auth.storage.channels.create({
@@ -156,32 +184,32 @@ export function hosted(auth: HostedAuth): McpOptions<HostedCaller> {
 					}
 					let restored = await Plan.readStored(stored);
 					if (
-						restored.origin?.idempotencyKey !== input.idempotencyKey
-						|| restored.origin.fingerprint !== input.fingerprint
-						|| !restored.brief
+						!restored.creation
+						|| restored.creation.origin.idempotencyKey !== input.idempotencyKey
+						|| restored.creation.origin.fingerprint !== input.fingerprint
 					) return { kind: "conflict" };
 					return {
 						kind: "replayed",
-						document: {
+						document: document({
 							id,
 							title: stored.channel.title,
-							brief: restored.brief,
+							creation: restored.creation,
 							source: restored.source,
 							revision: restored.revision,
 							url: `/channels/${id}`,
-						},
+						}),
 					};
 				}
 				return {
 					kind: "created",
-					document: {
+					document: document({
 						id,
 						title: input.title,
-						brief,
+						creation,
 						source: initial.source,
 						revision: 0,
 						url: `/channels/${id}`,
-					},
+					}),
 				};
 			},
 		},

--- a/apps/server/src/mcp/hosted.ts
+++ b/apps/server/src/mcp/hosted.ts
@@ -1,6 +1,8 @@
 import { GitHubError } from "../github/client";
+import { createHash } from "node:crypto";
 import * as Plan from "../plan/service";
 import * as Rooms from "../rooms";
+import { StorageError } from "../storage/errors";
 
 import type { HostedAuth } from "../auth/routes";
 import type { GitHubUser } from "../github/client";
@@ -12,6 +14,20 @@ export type HostedCaller = {
 };
 
 const BEARER = new RegExp("^Bearer ([A-Za-z0-9._~+/-]+=*)$", "i");
+
+function channelId(repositoryId: string, idempotencyKey: string): string {
+	let bytes = createHash("sha256")
+		.update(repositoryId)
+		.update("\0")
+		.update(idempotencyKey)
+		.digest();
+	bytes[6] = (bytes[6]! & 0x0f) | 0x50;
+	bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+	let hex = bytes.toString("hex", 0, 16);
+	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${
+		hex.slice(20)
+	}`;
+}
 
 /** Bind the backend-neutral MCP surface to hosted GitHub authentication. */
 export function hosted(auth: HostedAuth): McpOptions<HostedCaller> {
@@ -69,6 +85,7 @@ export function hosted(auth: HostedAuth): McpOptions<HostedCaller> {
 						return {
 							id: channel.id,
 							title: channel.title,
+							...(live.brief ? { brief: live.brief } : {}),
 							source: Plan.source(live),
 							revision: live.revision,
 						};
@@ -87,10 +104,85 @@ export function hosted(auth: HostedAuth): McpOptions<HostedCaller> {
 				) return undefined;
 				try {
 					let projected = await Plan.readStored(stored);
-					return { id: channel.id, title: channel.title, ...projected };
+					return {
+						id: channel.id,
+						title: channel.title,
+						...(projected.brief ? { brief: projected.brief } : {}),
+						source: projected.source,
+						revision: projected.revision,
+					};
 				} catch {
 					return undefined;
 				}
+			},
+		},
+		create: {
+			async create(caller, input) {
+				let parts = input.repository.split("/");
+				if (parts.length !== 2 || !parts[0] || !parts[1]) return { kind: "forbidden" };
+				let repository = await auth.github.repositoryAccess(
+					caller.oauthToken,
+					parts[0],
+					parts[1],
+				);
+				if (!repository || (!repository.permissions.push && !repository.permissions.admin)) {
+					return { kind: "forbidden" };
+				}
+				await auth.storage.users.put({
+					id: caller.user.id,
+					login: caller.user.login,
+					avatarUrl: caller.user.avatarUrl,
+					now: auth.clock(),
+				});
+				let { brief, plan, ...origin } = input;
+				let initial = await Plan.initial(plan, origin, brief);
+				let id = channelId(repository.id, input.idempotencyKey);
+				try {
+					await auth.storage.channels.create({
+						id,
+						repositoryId: repository.id,
+						repositoryOwner: repository.owner,
+						repositoryName: repository.name,
+						title: input.title,
+						createdBy: caller.user.id,
+						now: auth.clock(),
+						initial,
+					});
+				} catch (err) {
+					if (!(err instanceof StorageError) || err.failure !== "conflict") throw err;
+					let stored = await auth.storage.collaboration.load(id, auth.clock());
+					if (!stored || stored.channel.repositoryId !== repository.id) {
+						return { kind: "conflict" };
+					}
+					let restored = await Plan.readStored(stored);
+					if (
+						restored.origin?.idempotencyKey !== input.idempotencyKey
+						|| restored.origin.fingerprint !== input.fingerprint
+						|| !restored.brief
+					) return { kind: "conflict" };
+					return {
+						kind: "replayed",
+						document: {
+							id,
+							title: stored.channel.title,
+							brief: restored.brief,
+							source: restored.source,
+							revision: restored.revision,
+							url: `/channels/${id}`,
+						},
+					};
+				}
+				return {
+					kind: "created",
+					document: {
+						id,
+						title: input.title,
+						brief,
+						source: initial.source,
+						revision: 0,
+						url: `/channels/${id}`,
+					},
+				};
 			},
 		},
 	};

--- a/apps/server/src/plan/creation.test.ts
+++ b/apps/server/src/plan/creation.test.ts
@@ -1,0 +1,82 @@
+import { expect, it } from "bun:test";
+
+import * as Service from "./service";
+import { MemoryStorage } from "../storage/memory/adapter";
+
+import type { Server } from "bun";
+import type { Brief, CreationOrigin } from "../mcp";
+import type { SocketData } from "../wire";
+
+const now = new Date("2026-08-17T15:00:00.000Z");
+const brief: Brief = {
+	goal: "Create a collaborative plan.",
+	constraints: ["Keep the initial source canonical."],
+	settledDecisions: ["Use hosted storage."],
+	openQuestions: ["Who reviews the rollout?"],
+	repositoryFindings: ["The repository uses Bun."],
+};
+const origin: CreationOrigin = {
+	idempotencyKey: "create-plan-1",
+	fingerprint: "request-1",
+	repository: "octo-org/score",
+	baseBranch: "main",
+	baseCommit: "0123456789abcdef0123456789abcdef01234567",
+	title: "Created plan",
+};
+
+async function created(): Promise<MemoryStorage> {
+	let storage = new MemoryStorage();
+	await storage.users.put({
+		id: "U_octocat",
+		login: "octocat",
+		avatarUrl: "https://example.test/octocat",
+		now,
+	});
+	let initial = await Service.initial("# Created\n", origin, brief);
+	await storage.channels.create({
+		id: "created-plan",
+		repositoryId: "R_score",
+		repositoryOwner: "octo-org",
+		repositoryName: "score",
+		title: "Created plan",
+		createdBy: "U_octocat",
+		now,
+		initial,
+	});
+	return storage;
+}
+
+it("restores an MCP-created plan with its brief and provenance", async () => {
+	let storage = await created();
+	let stored = await storage.collaboration.load("created-plan", now);
+	if (!stored) throw new Error("created plan was not stored");
+
+	expect(await Service.readStored(stored)).toEqual({
+		source: "# Created\n",
+		revision: 0,
+		brief,
+		origin,
+	});
+});
+
+it("retains creation metadata after the plan is persisted", async () => {
+	let storage = await created();
+	let lease = await storage.leases.acquire("channel-writer", "creation-test", 60_000);
+	if (!lease) throw new Error("could not acquire test lease");
+	let backend: Service.Backend = {
+		storage,
+		lease: () => lease,
+		fatal: error => {
+			throw error;
+		},
+	};
+	let server = { publish() {} } as unknown as Server<SocketData>;
+	let plan = await Service.open("created-plan", backend, server);
+	plan.revision = 1;
+	await Service.persist(plan);
+	await Service.close(plan);
+	let stored = await storage.collaboration.load("created-plan", now);
+	if (!stored) throw new Error("created plan was not stored");
+
+	expect(await Service.readStored(stored)).toMatchObject({ brief, origin });
+});

--- a/apps/server/src/plan/creation.test.ts
+++ b/apps/server/src/plan/creation.test.ts
@@ -47,6 +47,39 @@ async function created(): Promise<MemoryStorage> {
 	return storage;
 }
 
+async function legacyCreated(): Promise<MemoryStorage> {
+	let storage = new MemoryStorage();
+	await storage.users.put({
+		id: "U_octocat",
+		login: "octocat",
+		avatarUrl: "https://example.test/octocat",
+		now,
+	});
+	let initial = await Service.initial("# Created\n", creation);
+	initial.sidecar = {
+		version: 1,
+		revision: 0,
+		documentSeq: 0,
+		brief: creation.brief,
+		origin: creation.origin,
+		questions: [],
+		openQuestions: [],
+		threads: [],
+		transcript: [],
+	};
+	await storage.channels.create({
+		id: "legacy-created-plan",
+		repositoryId: "R_score",
+		repositoryOwner: "octo-org",
+		repositoryName: "score",
+		title: "Created plan",
+		createdBy: "U_octocat",
+		now,
+		initial,
+	});
+	return storage;
+}
+
 it("restores an MCP-created plan with its creation metadata", async () => {
 	let storage = await created();
 	let stored = await storage.collaboration.load("created-plan", now);
@@ -59,8 +92,20 @@ it("restores an MCP-created plan with its creation metadata", async () => {
 	});
 });
 
-it("retains creation metadata after the plan is persisted", async () => {
-	let storage = await created();
+it("normalizes legacy paired creation metadata when restoring a plan", async () => {
+	let storage = await legacyCreated();
+	let stored = await storage.collaboration.load("legacy-created-plan", now);
+	if (!stored) throw new Error("legacy plan was not stored");
+
+	expect(await Service.readStored(stored)).toEqual({
+		source: "# Created\n",
+		revision: 0,
+		creation,
+	});
+});
+
+it("rewrites legacy creation metadata cohesively when the plan is persisted", async () => {
+	let storage = await legacyCreated();
 	let lease = await storage.leases.acquire("channel-writer", "creation-test", 60_000);
 	if (!lease) throw new Error("could not acquire test lease");
 	let backend: Service.Backend = {
@@ -71,12 +116,15 @@ it("retains creation metadata after the plan is persisted", async () => {
 		},
 	};
 	let server = { publish() {} } as unknown as Server<SocketData>;
-	let plan = await Service.open("created-plan", backend, server);
+	let plan = await Service.open("legacy-created-plan", backend, server);
 	plan.revision = 1;
 	await Service.persist(plan);
 	await Service.close(plan);
-	let stored = await storage.collaboration.load("created-plan", now);
-	if (!stored) throw new Error("created plan was not stored");
+	let stored = await storage.collaboration.load("legacy-created-plan", now);
+	if (!stored) throw new Error("legacy plan was not stored");
 
+	expect(stored.sidecar).toMatchObject({ creation });
+	expect(stored.sidecar).not.toHaveProperty("brief");
+	expect(stored.sidecar).not.toHaveProperty("origin");
 	expect(await Service.readStored(stored)).toMatchObject({ creation });
 });

--- a/apps/server/src/plan/creation.test.ts
+++ b/apps/server/src/plan/creation.test.ts
@@ -6,8 +6,8 @@ import { MemoryStorage } from "../storage/memory/adapter";
 import type { Server } from "bun";
 import type { SocketData } from "../wire";
 
-const now = new Date("2026-08-17T15:00:00.000Z");
-const creation: Service.CreationMetadata = {
+let now = new Date("2026-08-17T15:00:00.000Z");
+let creation: Service.CreationMetadata = {
 	brief: {
 		goal: "Create a collaborative plan.",
 		constraints: ["Keep the initial source canonical."],

--- a/apps/server/src/plan/creation.test.ts
+++ b/apps/server/src/plan/creation.test.ts
@@ -4,24 +4,25 @@ import * as Service from "./service";
 import { MemoryStorage } from "../storage/memory/adapter";
 
 import type { Server } from "bun";
-import type { Brief, CreationOrigin } from "../mcp";
 import type { SocketData } from "../wire";
 
 const now = new Date("2026-08-17T15:00:00.000Z");
-const brief: Brief = {
-	goal: "Create a collaborative plan.",
-	constraints: ["Keep the initial source canonical."],
-	settledDecisions: ["Use hosted storage."],
-	openQuestions: ["Who reviews the rollout?"],
-	repositoryFindings: ["The repository uses Bun."],
-};
-const origin: CreationOrigin = {
-	idempotencyKey: "create-plan-1",
-	fingerprint: "request-1",
-	repository: "octo-org/score",
-	baseBranch: "main",
-	baseCommit: "0123456789abcdef0123456789abcdef01234567",
-	title: "Created plan",
+const creation: Service.CreationMetadata = {
+	brief: {
+		goal: "Create a collaborative plan.",
+		constraints: ["Keep the initial source canonical."],
+		settledDecisions: ["Use hosted storage."],
+		openQuestions: ["Who reviews the rollout?"],
+		repositoryFindings: ["The repository uses Bun."],
+	},
+	origin: {
+		idempotencyKey: "create-plan-1",
+		fingerprint: "request-1",
+		repository: "octo-org/score",
+		baseBranch: "main",
+		baseCommit: "0123456789abcdef0123456789abcdef01234567",
+		title: "Created plan",
+	},
 };
 
 async function created(): Promise<MemoryStorage> {
@@ -32,7 +33,7 @@ async function created(): Promise<MemoryStorage> {
 		avatarUrl: "https://example.test/octocat",
 		now,
 	});
-	let initial = await Service.initial("# Created\n", origin, brief);
+	let initial = await Service.initial("# Created\n", creation);
 	await storage.channels.create({
 		id: "created-plan",
 		repositoryId: "R_score",
@@ -46,7 +47,7 @@ async function created(): Promise<MemoryStorage> {
 	return storage;
 }
 
-it("restores an MCP-created plan with its brief and provenance", async () => {
+it("restores an MCP-created plan with its creation metadata", async () => {
 	let storage = await created();
 	let stored = await storage.collaboration.load("created-plan", now);
 	if (!stored) throw new Error("created plan was not stored");
@@ -54,8 +55,7 @@ it("restores an MCP-created plan with its brief and provenance", async () => {
 	expect(await Service.readStored(stored)).toEqual({
 		source: "# Created\n",
 		revision: 0,
-		brief,
-		origin,
+		creation,
 	});
 });
 
@@ -78,5 +78,5 @@ it("retains creation metadata after the plan is persisted", async () => {
 	let stored = await storage.collaboration.load("created-plan", now);
 	if (!stored) throw new Error("created plan was not stored");
 
-	expect(await Service.readStored(stored)).toMatchObject({ brief, origin });
+	expect(await Service.readStored(stored)).toMatchObject({ creation });
 });

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -67,6 +67,12 @@ export type Backend = {
 	fatal: (error: unknown) => void;
 };
 
+/** Durable MCP context for a document created through the hosted surface. */
+export type CreationMetadata = {
+	brief: Brief;
+	origin: CreationOrigin;
+};
+
 type Persistence = Backend & {
 	channelId: string;
 	revision: number;
@@ -90,10 +96,8 @@ type Captured = {
 
 export type Plan = {
 	id: string;
-	/** Structured context retained for plans created through MCP. */
-	brief?: Brief;
-	/** Idempotency and repository provenance retained for plans created through MCP. */
-	origin?: CreationOrigin;
+	/** Context retained for plans created through MCP. */
+	creation?: CreationMetadata;
 	server: Server<SocketData>;
 	document: Document;
 	presence: Presence;
@@ -154,8 +158,7 @@ type Sidecar = {
 	version: 1;
 	revision: number;
 	documentSeq: number;
-	brief?: Brief;
-	origin?: CreationOrigin;
+	creation?: CreationMetadata;
 	questions: Questions.Record[];
 	openQuestions: Questions.StoredOpen[];
 	threads: Comments.Record[];
@@ -167,7 +170,7 @@ function state(plan: Plan): Sidecar {
 		version: 1,
 		revision: plan.revision,
 		documentSeq: plan.document.seq,
-		...(plan.brief && plan.origin ? { brief: plan.brief, origin: plan.origin } : {}),
+		...(plan.creation ? { creation: plan.creation } : {}),
 		questions: [...plan.records.values()],
 		openQuestions: Questions.dump(plan.questions),
 		threads: [...plan.threads.values()],
@@ -212,21 +215,27 @@ function strings(value: JsonValue | undefined): string[] | undefined {
 		: undefined;
 }
 
-function creation(
-	briefValue: JsonValue | undefined,
-	originValue: JsonValue | undefined,
-): { brief?: Brief; origin?: CreationOrigin } {
-	if (briefValue === undefined && originValue === undefined) return {};
+function creation(value: JsonValue | undefined): CreationMetadata | undefined {
+	if (value === undefined) return undefined;
 	if (
-		!briefValue
-		|| typeof briefValue !== "object"
-		|| Array.isArray(briefValue)
-		|| !originValue
-		|| typeof originValue !== "object"
-		|| Array.isArray(originValue)
+		!value
+		|| typeof value !== "object"
+		|| Array.isArray(value)
 	) throw new Error("hosted channel has invalid creation metadata");
-	let brief = briefValue as Record<string, JsonValue>;
-	let origin = originValue as Record<string, JsonValue>;
+	let metadata = value as Record<string, JsonValue>;
+	if (
+		Object.keys(metadata).length !== 2
+		|| !Object.hasOwn(metadata, "brief")
+		|| !Object.hasOwn(metadata, "origin")
+		|| !metadata.brief
+		|| typeof metadata.brief !== "object"
+		|| Array.isArray(metadata.brief)
+		|| !metadata.origin
+		|| typeof metadata.origin !== "object"
+		|| Array.isArray(metadata.origin)
+	) throw new Error("hosted channel has invalid creation metadata");
+	let brief = metadata.brief as Record<string, JsonValue>;
+	let origin = metadata.origin as Record<string, JsonValue>;
 	let briefKeys = [
 		"constraints",
 		"goal",
@@ -288,7 +297,7 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 	}
 	let item = value as Record<string, JsonValue>;
 	let keys = Object.keys(item).sort();
-	let created = creation(item.brief, item.origin);
+	let created = creation(item.creation);
 	let expected = [
 		"documentSeq",
 		"openQuestions",
@@ -298,7 +307,7 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 		"transcript",
 		"version",
 	];
-	if (created.brief) expected.push("brief", "origin");
+	if (created) expected.push("creation");
 	expected.sort();
 	if (
 		keys.length !== expected.length
@@ -354,7 +363,7 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 		version: 1,
 		revision: item.revision,
 		documentSeq: item.documentSeq,
-		...created,
+		...(created ? { creation: created } : {}),
 		questions: questions as never[],
 		openQuestions: openQuestions as unknown as Questions.StoredOpen[],
 		threads: threads as never[],
@@ -369,8 +378,7 @@ function digest(source: string): string {
 /** Build the complete revision-zero state published with a newly created channel. */
 export async function initial(
 	source: string,
-	origin: CreationOrigin,
-	brief: Brief,
+	creation: CreationMetadata,
 ): Promise<InitialChannel> {
 	let document = await room.create(source);
 	try {
@@ -379,8 +387,7 @@ export async function initial(
 			version: 1,
 			revision: 0,
 			documentSeq: document.seq,
-			brief,
-			origin,
+			creation,
 			questions: [],
 			openQuestions: [],
 			threads: [],
@@ -600,16 +607,14 @@ async function restoreHosted(id: string, loaded: StoredChannel): Promise<Restore
 /** Project a closed channel without attaching it to the live room registry. */
 export async function readStored(
 	loaded: StoredChannel,
-): Promise<{ source: string; revision: number; brief?: Brief; origin?: CreationOrigin }> {
+): Promise<{ source: string; revision: number; creation?: CreationMetadata }> {
 	let restored = await restoreHosted(loaded.channel.id, loaded);
 	try {
 		Questions.shutdown(Questions.restore(restored.sidecar.openQuestions));
 		return {
 			source: room.project(restored.document),
 			revision: restored.sidecar.revision,
-			...(restored.sidecar.brief && restored.sidecar.origin
-				? { brief: restored.sidecar.brief, origin: restored.sidecar.origin }
-				: {}),
+			...(restored.sidecar.creation ? { creation: restored.sidecar.creation } : {}),
 		};
 	} finally {
 		restored.document.doc.destroy();
@@ -628,9 +633,7 @@ export async function open(
 
 	let plan: Plan = {
 		id,
-		...(sidecar.brief && sidecar.origin
-			? { brief: sidecar.brief, origin: sidecar.origin }
-			: {}),
+		...(sidecar.creation ? { creation: sidecar.creation } : {}),
 		server,
 		document,
 		presence: presence.create(),

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -29,7 +29,8 @@ import type { Presence } from "./presence";
 import type { Document } from "./room";
 import type * as edit from "./edit";
 import type { Block } from "./edit";
-import type { JsonValue, Lease, StoredChannel } from "../storage/model";
+import type { Brief, CreationOrigin } from "../mcp";
+import type { InitialChannel, JsonValue, Lease, StoredChannel } from "../storage/model";
 import type { StorageAdapter } from "../storage/port";
 
 /** Updates are grouped for this long before being applied together. */
@@ -89,6 +90,10 @@ type Captured = {
 
 export type Plan = {
 	id: string;
+	/** Structured context retained for plans created through MCP. */
+	brief?: Brief;
+	/** Idempotency and repository provenance retained for plans created through MCP. */
+	origin?: CreationOrigin;
 	server: Server<SocketData>;
 	document: Document;
 	presence: Presence;
@@ -149,6 +154,8 @@ type Sidecar = {
 	version: 1;
 	revision: number;
 	documentSeq: number;
+	brief?: Brief;
+	origin?: CreationOrigin;
 	questions: Questions.Record[];
 	openQuestions: Questions.StoredOpen[];
 	threads: Comments.Record[];
@@ -160,6 +167,7 @@ function state(plan: Plan): Sidecar {
 		version: 1,
 		revision: plan.revision,
 		documentSeq: plan.document.seq,
+		...(plan.brief && plan.origin ? { brief: plan.brief, origin: plan.origin } : {}),
 		questions: [...plan.records.values()],
 		openQuestions: Questions.dump(plan.questions),
 		threads: [...plan.threads.values()],
@@ -198,6 +206,71 @@ function objects(value: JsonValue[], label: string): Array<Record<string, JsonVa
 	});
 }
 
+function strings(value: JsonValue | undefined): string[] | undefined {
+	return Array.isArray(value) && value.every(item => typeof item === "string")
+		? value
+		: undefined;
+}
+
+function creation(
+	briefValue: JsonValue | undefined,
+	originValue: JsonValue | undefined,
+): { brief?: Brief; origin?: CreationOrigin } {
+	if (briefValue === undefined && originValue === undefined) return {};
+	if (
+		!briefValue
+		|| typeof briefValue !== "object"
+		|| Array.isArray(briefValue)
+		|| !originValue
+		|| typeof originValue !== "object"
+		|| Array.isArray(originValue)
+	) throw new Error("hosted channel has invalid creation metadata");
+	let brief = briefValue as Record<string, JsonValue>;
+	let origin = originValue as Record<string, JsonValue>;
+	let briefKeys = [
+		"constraints",
+		"goal",
+		"openQuestions",
+		"repositoryFindings",
+		"settledDecisions",
+	];
+	let originKeys = [
+		"baseBranch",
+		"baseCommit",
+		"fingerprint",
+		"idempotencyKey",
+		"repository",
+		"title",
+	];
+	let constraints = strings(brief.constraints);
+	let settledDecisions = strings(brief.settledDecisions);
+	let openQuestions = strings(brief.openQuestions);
+	let repositoryFindings = strings(brief.repositoryFindings);
+	if (
+		Object.keys(brief).sort().some((key, index) => key !== briefKeys[index])
+		|| Object.keys(brief).length !== briefKeys.length
+		|| typeof brief.goal !== "string"
+		|| !brief.goal.trim()
+		|| !constraints
+		|| !settledDecisions
+		|| !openQuestions
+		|| !repositoryFindings
+		|| Object.keys(origin).sort().some((key, index) => key !== originKeys[index])
+		|| Object.keys(origin).length !== originKeys.length
+		|| originKeys.some(key => typeof origin[key] !== "string" || !origin[key].trim())
+	) throw new Error("hosted channel has invalid creation metadata");
+	return {
+		brief: {
+			goal: brief.goal,
+			constraints,
+			settledDecisions,
+			openQuestions,
+			repositoryFindings,
+		},
+		origin: origin as CreationOrigin,
+	};
+}
+
 function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 	if (value === null && pristine) {
 		return {
@@ -215,6 +288,7 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 	}
 	let item = value as Record<string, JsonValue>;
 	let keys = Object.keys(item).sort();
+	let created = creation(item.brief, item.origin);
 	let expected = [
 		"documentSeq",
 		"openQuestions",
@@ -224,6 +298,8 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 		"transcript",
 		"version",
 	];
+	if (created.brief) expected.push("brief", "origin");
+	expected.sort();
 	if (
 		keys.length !== expected.length
 		|| keys.some((key, index) => key !== expected[index])
@@ -278,6 +354,7 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 		version: 1,
 		revision: item.revision,
 		documentSeq: item.documentSeq,
+		...created,
 		questions: questions as never[],
 		openQuestions: openQuestions as unknown as Questions.StoredOpen[],
 		threads: threads as never[],
@@ -287,6 +364,39 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 
 function digest(source: string): string {
 	return `sha256:${createHash("sha256").update(source).digest("hex")}`;
+}
+
+/** Build the complete revision-zero state published with a newly created channel. */
+export async function initial(
+	source: string,
+	origin: CreationOrigin,
+	brief: Brief,
+): Promise<InitialChannel> {
+	let document = await room.create(source);
+	try {
+		let canonical = room.project(document);
+		let sidecar: Sidecar = {
+			version: 1,
+			revision: 0,
+			documentSeq: document.seq,
+			brief,
+			origin,
+			questions: [],
+			openQuestions: [],
+			threads: [],
+			transcript: [],
+		};
+		return {
+			generation: crypto.randomUUID(),
+			epoch: document.epoch,
+			source: canonical,
+			sourceHash: digest(canonical),
+			document: Y.encodeStateAsUpdate(document.doc),
+			sidecar: JSON.parse(JSON.stringify(sidecar)) as JsonValue,
+		};
+	} finally {
+		document.doc.destroy();
+	}
 }
 
 function scheduleCheckpoint(plan: Plan): void {
@@ -490,11 +600,17 @@ async function restoreHosted(id: string, loaded: StoredChannel): Promise<Restore
 /** Project a closed channel without attaching it to the live room registry. */
 export async function readStored(
 	loaded: StoredChannel,
-): Promise<{ source: string; revision: number }> {
+): Promise<{ source: string; revision: number; brief?: Brief; origin?: CreationOrigin }> {
 	let restored = await restoreHosted(loaded.channel.id, loaded);
 	try {
 		Questions.shutdown(Questions.restore(restored.sidecar.openQuestions));
-		return { source: room.project(restored.document), revision: restored.sidecar.revision };
+		return {
+			source: room.project(restored.document),
+			revision: restored.sidecar.revision,
+			...(restored.sidecar.brief && restored.sidecar.origin
+				? { brief: restored.sidecar.brief, origin: restored.sidecar.origin }
+				: {}),
+		};
 	} finally {
 		restored.document.doc.destroy();
 	}
@@ -512,6 +628,9 @@ export async function open(
 
 	let plan: Plan = {
 		id,
+		...(sidecar.brief && sidecar.origin
+			? { brief: sidecar.brief, origin: sidecar.origin }
+			: {}),
 		server,
 		document,
 		presence: presence.create(),

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -280,6 +280,17 @@ function creation(value: JsonValue | undefined): CreationMetadata | undefined {
 	};
 }
 
+function legacyCreation(
+	brief: JsonValue | undefined,
+	origin: JsonValue | undefined,
+): CreationMetadata | undefined {
+	if (brief === undefined && origin === undefined) return undefined;
+	if (brief === undefined || origin === undefined) {
+		throw new Error("hosted channel has invalid creation metadata");
+	}
+	return creation({ brief, origin });
+}
+
 function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 	if (value === null && pristine) {
 		return {
@@ -297,7 +308,11 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 	}
 	let item = value as Record<string, JsonValue>;
 	let keys = Object.keys(item).sort();
-	let created = creation(item.creation);
+	let legacy = item.creation === undefined
+		&& (item.brief !== undefined || item.origin !== undefined);
+	let created = item.creation === undefined
+		? legacyCreation(item.brief, item.origin)
+		: creation(item.creation);
 	let expected = [
 		"documentSeq",
 		"openQuestions",
@@ -307,7 +322,7 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 		"transcript",
 		"version",
 	];
-	if (created) expected.push("creation");
+	if (created) expected.push(...(legacy ? ["brief", "origin"] : ["creation"]));
 	expected.sort();
 	if (
 		keys.length !== expected.length

--- a/apps/server/src/storage/contract.ts
+++ b/apps/server/src/storage/contract.ts
@@ -198,6 +198,59 @@ export function storageContract(name: string, factory: Factory): void {
 			}
 		});
 
+		it("publishes an initialized channel and checkpoint atomically", async () => {
+			let storage = await opened(factory);
+			try {
+				let now = new Date("2026-01-02T03:04:05.000Z");
+				let userId = id("user");
+				let channelId = id("channel");
+				let sidecar = {
+					version: 1,
+					revision: 0,
+					origin: { idempotencyKey: "create-plan-1", fingerprint: "request-1" },
+				};
+				await storage.users.put({
+					id: userId,
+					login: "octocat",
+					avatarUrl: "https://example.test/a",
+					now,
+				});
+				await storage.channels.create({
+					id: channelId,
+					repositoryId: id("repository"),
+					repositoryOwner: "octo-org",
+					repositoryName: "score",
+					title: "Created plan",
+					createdBy: userId,
+					now,
+					initial: {
+						generation: id("generation"),
+						epoch: "epoch-created",
+						source: "# Created\n",
+						sourceHash: "sha256:created",
+						document: new Uint8Array([1, 2, 3]),
+						sidecar,
+					},
+				});
+
+				let stored = await storage.collaboration.load(channelId, now);
+				expect(stored).toBeDefined();
+				expect(stored!.latestSequence).toBe(0);
+				expect(stored!.sidecar).toEqual(sidecar);
+				expect(stored!.snapshot).toMatchObject({
+					channelId,
+					revision: 0,
+					throughSequence: 0,
+					epoch: "epoch-created",
+					source: "# Created\n",
+					createdAt: now,
+				});
+				expect([...stored!.snapshot!.document]).toEqual([1, 2, 3]);
+			} finally {
+				await storage.close();
+			}
+		});
+
 		it("assigns the first active session as the agent owner", async () => {
 			let storage = await opened(factory);
 			try {

--- a/apps/server/src/storage/memory/adapter.ts
+++ b/apps/server/src/storage/memory/adapter.ts
@@ -192,15 +192,27 @@ export class MemoryStorage implements StorageAdapter {
 	#createChannel(input: CreateChannel): Promise<ChannelRecord> {
 		if (!this.#users.has(input.createdBy)) throw missing(`user ${input.createdBy} does not exist`);
 		if (this.#channels.has(input.id)) throw conflict(`channel ${input.id} already exists`);
+		let { initial, now, ...record } = input;
 		let saved: ChannelRecord = {
-			...input,
+			...record,
 			revision: 0,
-			createdAt: input.now,
-			updatedAt: input.now,
+			createdAt: now,
+			updatedAt: now,
 		};
 		this.#channels.set(saved.id, saved);
 		this.#sequences.set(saved.id, 1);
-		this.#sidecars.set(saved.id, null);
+		this.#sidecars.set(saved.id, initial ? json(initial.sidecar) : null);
+		if (initial) {
+			this.#snapshots.set(saved.id, {
+				channelId: saved.id,
+				...initial,
+				revision: 0,
+				throughSequence: 0,
+				document: bytes(initial.document),
+				sidecar: json(initial.sidecar),
+				createdAt: now,
+			});
+		}
 		return Promise.resolve(channel(saved));
 	}
 

--- a/apps/server/src/storage/model.ts
+++ b/apps/server/src/storage/model.ts
@@ -41,8 +41,15 @@ export type ChannelRecord = {
 	updatedAt: Date;
 };
 
+export type InitialChannel = Omit<
+	ChannelSnapshot,
+	"channelId" | "revision" | "throughSequence" | "createdAt"
+>;
+
 export type CreateChannel = Omit<ChannelRecord, "revision" | "createdAt" | "updatedAt"> & {
 	now: Date;
+	/** A complete revision-zero checkpoint published in the channel's creation transaction. */
+	initial?: InitialChannel;
 };
 
 export type ChannelCursor = {

--- a/apps/server/src/storage/postgres/adapter.ts
+++ b/apps/server/src/storage/postgres/adapter.ts
@@ -506,8 +506,25 @@ export class PostgresStorage implements StorageAdapter {
 			`;
 				if (!saved) throw corrupt("creating a channel returned no record");
 				await transaction`
-				INSERT INTO channel_state (channel_id, sidecar) VALUES (${input.id}, 'null'::jsonb)
+				INSERT INTO channel_state (channel_id, sidecar)
+				VALUES (
+					${input.id},
+					${input.initial ? JSON.stringify(input.initial.sidecar) : "null"}::jsonb
+				)
 			`;
+				if (input.initial) {
+					await transaction`
+						INSERT INTO channel_snapshots (
+							channel_id, generation, revision, through_sequence, epoch, source,
+							source_hash, document, sidecar, created_at
+						) VALUES (
+							${input.id}, ${input.initial.generation}, 0, 0, ${input.initial.epoch},
+							${input.initial.source}, ${input.initial.sourceHash},
+							${input.initial.document}, ${JSON.stringify(input.initial.sidecar)}::jsonb,
+							${input.now}
+						)
+					`;
+				}
 				return channel(saved);
 			}));
 	}


### PR DESCRIPTION
## Summary

- Adds a validated `create_document` tool to the hosted MCP endpoint.
- Requires repository write access and records the authenticated GitHub caller.
- Atomically creates the channel, canonical initial checkpoint, brief, and creation provenance.
- Makes creation idempotent per repository: exact replays return the existing document, while changed payloads conflict.
- Returns the brief from `read_document` without exposing internal provenance or fingerprints.

## Stack

Built directly on #39.

## Verification

- `bun run types`
- `bun run ci`
- `bun test` — 696 pass, 2 expected PostgreSQL skips
- Live PostgreSQL adapter contract — 11 pass
- `git diff --check`
