### PR TITLE
Add a shared skill for creating Chopin plans from agent conversations

### DIFF
--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -1,16 +1,8 @@
 import { describe, expect, it } from "bun:test";
 
-import { limits } from "@chopin/dialect";
-
 import { handler, TOOLS } from "./mcp";
 
-import type {
-	CreateDocument,
-	CreateDocumentInput,
-	Document,
-	DocumentReader,
-	Implementations,
-} from "./mcp";
+import type { Document, DocumentReader, Implementations } from "./mcp";
 import type { Run } from "./tasks/graphs";
 
 const document: Document = {
@@ -18,22 +10,6 @@ const document: Document = {
 	title: "Release readiness",
 	source: "# Release readiness\n",
 	revision: 4,
-};
-
-let creation = {
-	idempotencyKey: "create-plan-1",
-	repository: "githubnext/chopin",
-	baseBranch: "main",
-	baseCommit: "0123456789abcdef0123456789abcdef01234567",
-	title: "Ship MCP creation",
-	brief: {
-		goal: "Create a collaborative plan.",
-		constraints: ["Keep plans immutable through MCP."],
-		settledDecisions: ["Use the documented dialect."],
-		openQuestions: ["Which reviewer owns the rollout?"],
-		repositoryFindings: ["The plan becomes a hosted channel."],
-	},
-	plan: '# Draft\n\n<Callout type="note">\nCreated through MCP.\n</Callout>\n',
 };
 
 function request(
@@ -62,14 +38,6 @@ function reader(): DocumentReader<string> {
 		},
 		async read(caller, id) {
 			return caller === "octocat" && id === document.id ? document : undefined;
-		},
-	};
-}
-
-function unavailable(): CreateDocument<string> {
-	return {
-		async create() {
-			return { kind: "forbidden" };
 		},
 	};
 }
@@ -133,7 +101,6 @@ describe("the MCP read protocol", () => {
 		let mcp = handler({
 			caller: () => "octocat",
 			documents: reader(),
-			create: unavailable(),
 			implementations,
 		});
 		let initialized = await mcp(request({
@@ -395,139 +362,6 @@ describe("the MCP read protocol", () => {
 		]));
 	});
 
-	it("creates a validated canonical document through the host adapter", async () => {
-		let mcp = handler({
-			caller: () => "octocat",
-			documents: reader(),
-			create: {
-				async create(_caller: string, input: CreateDocumentInput) {
-					return {
-						kind: "created" as const,
-						document: {
-							id: "created",
-							title: input.title,
-							brief: input.brief,
-							source: input.plan,
-							revision: 0,
-							url: "/channels/created",
-						},
-					};
-				},
-			},
-		});
-
-		let result = await json(
-			await mcp(request({
-				jsonrpc: "2.0",
-				id: 5,
-				method: "tools/call",
-				params: { name: "create_document", arguments: creation },
-			})),
-		);
-
-		expect(result.error).toBeUndefined();
-		expect((result.result as { structuredContent: Record<string, unknown> }).structuredContent)
-			.toMatchObject({
-				id: "created",
-				title: creation.title,
-				brief: creation.brief,
-				revision: 0,
-				url: "/channels/created",
-			});
-		expect(
-			(result.result as { structuredContent: { source: string } }).structuredContent.source,
-		).toMatch(/<Callout (?=[^>]*id="[0-7][0-9A-HJKMNP-TV-Z]{25}")(?=[^>]*type="note")/);
-	});
-
-	it("returns dialect issues without asking the host to persist an invalid plan", async () => {
-		let created = false;
-		let mcp = handler({
-			caller: () => "octocat",
-			documents: reader(),
-			create: {
-				async create() {
-					created = true;
-					return { kind: "forbidden" as const };
-				},
-			},
-		});
-
-		let result = await json(
-			await mcp(request({
-				jsonrpc: "2.0",
-				id: 6,
-				method: "tools/call",
-				params: {
-					name: "create_document",
-					arguments: { ...creation, plan: "<Chart />\n" },
-				},
-			})),
-		);
-
-		expect((result.result as { isError: boolean }).isError).toBe(true);
-		expect(
-			(result.result as { structuredContent: { issues: unknown[] } }).structuredContent.issues,
-		).toEqual([expect.objectContaining({
-			code: "unknown-component",
-			path: "root > Chart[0]",
-			offset: 0,
-		})]);
-		expect(created).toBe(false);
-	});
-
-	it("returns a structured issue for plan syntax that cannot be parsed", async () => {
-		let mcp = handler({
-			caller: () => "octocat",
-			documents: reader(),
-			create: {
-				async create() {
-					return { kind: "forbidden" as const };
-				},
-			},
-		});
-
-		let result = await json(
-			await mcp(request({
-				jsonrpc: "2.0",
-				id: 7,
-				method: "tools/call",
-				params: {
-					name: "create_document",
-					arguments: { ...creation, plan: "<Callout" },
-				},
-			})),
-		);
-
-		expect((result.result as { structuredContent: { issues: unknown[] } }).structuredContent.issues)
-			.toEqual([expect.objectContaining({ code: "parse", path: "root" })]);
-	});
-
-	it("reports a changed idempotent request as a tool conflict", async () => {
-		let mcp = handler({
-			caller: () => "octocat",
-			documents: reader(),
-			create: {
-				async create() {
-					return { kind: "conflict" as const };
-				},
-			},
-		});
-
-		let result = await json(
-			await mcp(request({
-				jsonrpc: "2.0",
-				id: 7,
-				method: "tools/call",
-				params: { name: "create_document", arguments: creation },
-			})),
-		);
-
-		expect((result.result as { isError: boolean }).isError).toBe(true);
-		expect((result.result as { structuredContent: unknown }).structuredContent).toEqual({
-			code: "idempotency-conflict",
-		});
-	});
-
 	it("advertises the canonical repository and non-blank channel constraints it enforces", () => {
 		let list = TOOLS.find(tool => tool.name === "list_documents")!;
 		let read = TOOLS.find(tool => tool.name === "read_document")!;
@@ -612,169 +446,6 @@ describe("the MCP read protocol", () => {
 		}
 	});
 
-	it("accepts a document-creation request beyond the former read-only budget", async () => {
-		let mcp = handler({
-			caller: () => "octocat",
-			documents: reader(),
-			create: {
-				async create(_caller, input) {
-					return {
-						kind: "created" as const,
-						document: {
-							id: "large-plan",
-							title: input.title,
-							brief: input.brief,
-							source: input.plan,
-							revision: 0,
-							url: "/channels/large-plan",
-						},
-					};
-				},
-			},
-		});
-		let response = await mcp(request({
-			jsonrpc: "2.0",
-			id: 11,
-			method: "tools/call",
-			params: {
-				name: "create_document",
-				arguments: { ...creation, plan: `# Large\n\n${"word ".repeat(14_000)}\n` },
-			},
-		}));
-
-		expect(response.status).toBe(200);
-		expect((await json(response)).error).toBeUndefined();
-	});
-
-	it("rejects a UTF-8 canonical plan beyond the source limit before creating it", async () => {
-		let created = false;
-		let mcp = handler({
-			caller: () => "octocat",
-			documents: reader(),
-			create: {
-				async create() {
-					created = true;
-					return { kind: "forbidden" as const };
-				},
-			},
-		});
-		let result = await json(
-			await mcp(request({
-				jsonrpc: "2.0",
-				id: 12,
-				method: "tools/call",
-				params: {
-					name: "create_document",
-					arguments: {
-						...creation,
-						plan: `# ${"😀".repeat(limits.MAX_SOURCE_BYTES / 4)}\n`,
-					},
-				},
-			})),
-		);
-
-		expect((result.result as { isError: boolean }).isError).toBe(true);
-		expect(
-			(result.result as { structuredContent: { issues: unknown[] } }).structuredContent.issues,
-		).toEqual([expect.objectContaining({ code: "source-too-large", path: "root" })]);
-		expect(created).toBe(false);
-	});
-
-	it("replays reordered creation values and conflicts on a changed value", async () => {
-		let accepted: CreateDocumentInput | undefined;
-		let fingerprints: string[] = [];
-		let mcp = handler({
-			caller: () => "octocat",
-			documents: reader(),
-			create: {
-				async create(_caller, input) {
-					fingerprints.push(input.fingerprint);
-					let document = {
-						id: "replayed",
-						title: input.title,
-						brief: input.brief,
-						source: input.plan,
-						revision: 0,
-						url: "/channels/replayed",
-					};
-					if (!accepted) {
-						accepted = input;
-						return { kind: "created" as const, document };
-					}
-					return accepted.fingerprint === input.fingerprint
-						? { kind: "replayed" as const, document }
-						: { kind: "conflict" as const };
-				},
-			},
-		});
-		let reordered = {
-			plan: creation.plan,
-			brief: {
-				repositoryFindings: creation.brief.repositoryFindings,
-				openQuestions: creation.brief.openQuestions,
-				settledDecisions: creation.brief.settledDecisions,
-				constraints: creation.brief.constraints,
-				goal: creation.brief.goal,
-			},
-			title: creation.title,
-			baseCommit: creation.baseCommit,
-			baseBranch: creation.baseBranch,
-			repository: creation.repository,
-			idempotencyKey: creation.idempotencyKey,
-		};
-
-		for (let [id, createArguments] of [[13, creation], [14, reordered]]) {
-			let result = await json(
-				await mcp(request({
-					jsonrpc: "2.0",
-					id,
-					method: "tools/call",
-					params: { name: "create_document", arguments: createArguments },
-				})),
-			);
-			expect((result.result as { structuredContent: { id: string } }).structuredContent.id)
-				.toBe("replayed");
-		}
-
-		let changed = await json(
-			await mcp(request({
-				jsonrpc: "2.0",
-				id: 15,
-				method: "tools/call",
-				params: {
-					name: "create_document",
-					arguments: { ...creation, title: "A changed title" },
-				},
-			})),
-		);
-		expect((changed.result as { isError: boolean }).isError).toBe(true);
-		expect((changed.result as { structuredContent: unknown }).structuredContent).toEqual({
-			code: "idempotency-conflict",
-		});
-		expect(fingerprints).toHaveLength(3);
-		expect(fingerprints[1]).toBe(fingerprints[0]);
-		expect(fingerprints[2]).not.toBe(fingerprints[0]);
-	});
-
-	it("does not advertise or dispatch creation from a read-only host", async () => {
-		let mcp = handler({ caller: () => "octocat", documents: reader() });
-		let tools = await json(
-			await mcp(request({ jsonrpc: "2.0", id: 16, method: "tools/list" })),
-		);
-
-		expect((tools.result as { tools: Array<{ name: string }> }).tools.map(tool => tool.name))
-			.toEqual(["list_documents", "read_document"]);
-		let creationAttempt = await json(
-			await mcp(request({
-				jsonrpc: "2.0",
-				id: 17,
-				method: "tools/call",
-				params: { name: "create_document", arguments: creation },
-			})),
-		);
-		expect(creationAttempt.error).toEqual({ code: -32601, message: "tool not found" });
-	});
-
 	it("rejects non-scalar JSON-RPC ids and scalar initialize or tools-list parameters", async () => {
 		let mcp = endpoint();
 		for (
@@ -850,7 +521,6 @@ describe("the MCP read protocol", () => {
 		let inaccessible = await json(
 			await handler({
 				caller: () => "octocat",
-				create: unavailable(),
 				documents: {
 					async list() {
 						return [];

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -386,18 +386,23 @@ function acceptsEvents(request: Request): boolean {
 }
 
 function serviceInstructions(tools: Tool[]): string | undefined {
+	let creation = tools.filter(tool => tool.name === "create_document");
 	let implementation = tools
 		.filter(tool =>
 			tool.name === "read_implementation"
 			|| tool.name === "start_implementation"
 			|| isLifecycleTool(tool.name)
 		);
-	return implementation.length > 0
-		? [
-			"Chopin's MCP contract is authoritative. Read the canonical implementation and these current tool descriptions before every action; copied plans and lifecycle instructions are not substitutes.",
-			...implementation.map(tool => `${tool.name}: ${tool.description}`),
-		].join("\n")
-		: undefined;
+	return [
+		"Chopin's MCP contract and current tool descriptions are authoritative.",
+		...creation.map(tool => `${tool.name}: ${tool.description}`),
+		...(implementation.length > 0
+			? [
+				"Read the canonical implementation before every implementation or lifecycle action; copied plans and lifecycle instructions are not substitutes.",
+				...implementation.map(tool => `${tool.name}: ${tool.description}`),
+			]
+			: []),
+	].join("\n");
 }
 
 async function requestBody(request: Request): Promise<{ body?: unknown; tooLarge: boolean }> {

--- a/apps/server/src/mcp/create.test.ts
+++ b/apps/server/src/mcp/create.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it } from "bun:test";
+
+import { limits } from "@chopin/dialect";
+
+import { handler } from "../mcp";
+
+import type { CreateDocumentInput, Document, DocumentReader } from "../mcp";
+
+let document: Document = {
+	id: "f401c8d6-3717-4f1d-8473-cfdd0af894e4",
+	title: "Release readiness",
+	source: "# Release readiness\n",
+	revision: 4,
+};
+
+let creation = {
+	idempotencyKey: "create-plan-1",
+	repository: "githubnext/chopin",
+	baseBranch: "main",
+	baseCommit: "0123456789abcdef0123456789abcdef01234567",
+	title: "Ship MCP creation",
+	brief: {
+		goal: "Create a collaborative plan.",
+		constraints: ["Keep plans editable through Chopin."],
+		settledDecisions: ["Use the documented dialect."],
+		openQuestions: ["Which reviewer owns the rollout?"],
+		repositoryFindings: ["The plan becomes a hosted channel."],
+	},
+	plan: '# Draft\n\n<Callout type="note">\nCreated through MCP.\n</Callout>\n',
+};
+
+function request(body: unknown): Request {
+	return new Request("https://chopin.test/mcp", {
+		method: "POST",
+		headers: {
+			authorization: "Bearer allowed",
+			"content-type": "application/json",
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+function reader(): DocumentReader<string> {
+	return {
+		async list() {
+			return [];
+		},
+		async read(_caller, id) {
+			return id === document.id ? document : undefined;
+		},
+	};
+}
+
+async function json(response: Response): Promise<Record<string, unknown>> {
+	return await response.json() as Record<string, unknown>;
+}
+
+function call(id: number, arguments_: Record<string, unknown>): Request {
+	return request({
+		jsonrpc: "2.0",
+		id,
+		method: "tools/call",
+		params: { name: "create_document", arguments: arguments_ },
+	});
+}
+
+describe("the MCP creation protocol", () => {
+	it("creates a validated canonical document through the host adapter", async () => {
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create(_caller: string, input: CreateDocumentInput) {
+					return {
+						kind: "created" as const,
+						document: {
+							id: "created",
+							title: input.title,
+							brief: input.brief,
+							source: input.plan,
+							revision: 0,
+							url: "/channels/created",
+						},
+					};
+				},
+			},
+		});
+
+		let result = await json(await mcp(call(5, creation)));
+
+		expect(result.error).toBeUndefined();
+		expect((result.result as { structuredContent: Record<string, unknown> }).structuredContent)
+			.toMatchObject({
+				id: "created",
+				title: creation.title,
+				brief: creation.brief,
+				revision: 0,
+				url: "/channels/created",
+			});
+		expect(
+			(result.result as { structuredContent: { source: string } }).structuredContent.source,
+		).toMatch(/<Callout (?=[^>]*id="[0-7][0-9A-HJKMNP-TV-Z]{25}")(?=[^>]*type="note")/);
+	});
+
+	it("returns dialect issues without asking the host to persist an invalid plan", async () => {
+		let created = false;
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create() {
+					created = true;
+					return { kind: "forbidden" as const };
+				},
+			},
+		});
+
+		let result = await json(await mcp(call(6, { ...creation, plan: "<Chart />\n" })));
+
+		expect((result.result as { isError: boolean }).isError).toBe(true);
+		expect(
+			(result.result as { structuredContent: { issues: unknown[] } }).structuredContent.issues,
+		).toEqual([expect.objectContaining({
+			code: "unknown-component",
+			path: "root > Chart[0]",
+			offset: 0,
+		})]);
+		expect(created).toBe(false);
+	});
+
+	it("returns a structured issue for plan syntax that cannot be parsed", async () => {
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create() {
+					return { kind: "forbidden" as const };
+				},
+			},
+		});
+
+		let result = await json(await mcp(call(7, { ...creation, plan: "<Callout" })));
+
+		expect((result.result as { structuredContent: { issues: unknown[] } }).structuredContent.issues)
+			.toEqual([expect.objectContaining({ code: "parse", path: "root" })]);
+	});
+
+	it("allows a corrected retry with the same idempotency key after validation fails", async () => {
+		let received: CreateDocumentInput[] = [];
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create(_caller, input) {
+					received.push(input);
+					return {
+						kind: "created" as const,
+						document: {
+							id: "created",
+							title: input.title,
+							brief: input.brief,
+							source: input.plan,
+							revision: 0,
+							url: "/channels/created",
+						},
+					};
+				},
+			},
+		});
+
+		let rejected = await json(await mcp(call(8, { ...creation, plan: "<Chart />\n" })));
+		expect((rejected.result as { isError: boolean }).isError).toBe(true);
+		expect(
+			(rejected.result as { structuredContent: { issues: unknown[] } }).structuredContent.issues,
+		).toEqual([expect.objectContaining({ code: "unknown-component" })]);
+		expect(received).toHaveLength(0);
+
+		let corrected = await json(await mcp(call(9, creation)));
+		expect((corrected.result as { structuredContent: unknown }).structuredContent).toMatchObject({
+			id: "created",
+			url: "/channels/created",
+		});
+		expect(received).toHaveLength(1);
+		expect(received[0]!.idempotencyKey).toBe(creation.idempotencyKey);
+	});
+
+	it("reports a changed idempotent request as a tool conflict", async () => {
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create() {
+					return { kind: "conflict" as const };
+				},
+			},
+		});
+
+		let result = await json(await mcp(call(10, creation)));
+
+		expect((result.result as { isError: boolean }).isError).toBe(true);
+		expect((result.result as { structuredContent: unknown }).structuredContent).toEqual({
+			code: "idempotency-conflict",
+		});
+	});
+
+	it("accepts a document-creation request beyond the former read-only budget", async () => {
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create(_caller, input) {
+					return {
+						kind: "created" as const,
+						document: {
+							id: "large-plan",
+							title: input.title,
+							brief: input.brief,
+							source: input.plan,
+							revision: 0,
+							url: "/channels/large-plan",
+						},
+					};
+				},
+			},
+		});
+		let response = await mcp(call(11, {
+			...creation,
+			plan: `# Large\n\n${"word ".repeat(14_000)}\n`,
+		}));
+
+		expect(response.status).toBe(200);
+		expect((await json(response)).error).toBeUndefined();
+	});
+
+	it("rejects a UTF-8 canonical plan beyond the source limit before creating it", async () => {
+		let created = false;
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create() {
+					created = true;
+					return { kind: "forbidden" as const };
+				},
+			},
+		});
+		let result = await json(
+			await mcp(call(12, {
+				...creation,
+				plan: `# ${"😀".repeat(limits.MAX_SOURCE_BYTES / 4)}\n`,
+			})),
+		);
+
+		expect((result.result as { isError: boolean }).isError).toBe(true);
+		expect(
+			(result.result as { structuredContent: { issues: unknown[] } }).structuredContent.issues,
+		).toEqual([expect.objectContaining({ code: "source-too-large", path: "root" })]);
+		expect(created).toBe(false);
+	});
+
+	it("replays reordered creation values and conflicts on a changed value", async () => {
+		let accepted: CreateDocumentInput | undefined;
+		let fingerprints: string[] = [];
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: {
+				async create(_caller, input) {
+					fingerprints.push(input.fingerprint);
+					let created = {
+						id: "replayed",
+						title: input.title,
+						brief: input.brief,
+						source: input.plan,
+						revision: 0,
+						url: "/channels/replayed",
+					};
+					if (!accepted) {
+						accepted = input;
+						return { kind: "created" as const, document: created };
+					}
+					return accepted.fingerprint === input.fingerprint
+						? { kind: "replayed" as const, document: created }
+						: { kind: "conflict" as const };
+				},
+			},
+		});
+		let reordered = {
+			plan: creation.plan,
+			brief: {
+				repositoryFindings: creation.brief.repositoryFindings,
+				openQuestions: creation.brief.openQuestions,
+				settledDecisions: creation.brief.settledDecisions,
+				constraints: creation.brief.constraints,
+				goal: creation.brief.goal,
+			},
+			title: creation.title,
+			baseCommit: creation.baseCommit,
+			baseBranch: creation.baseBranch,
+			repository: creation.repository,
+			idempotencyKey: creation.idempotencyKey,
+		};
+
+		let attempts: Array<[number, Record<string, unknown>]> = [[13, creation], [14, reordered]];
+		for (let [id, arguments_] of attempts) {
+			let result = await json(await mcp(call(id, arguments_)));
+			expect((result.result as { structuredContent: { id: string } }).structuredContent.id)
+				.toBe("replayed");
+		}
+
+		let changed = await json(await mcp(call(15, { ...creation, title: "A changed title" })));
+		expect((changed.result as { isError: boolean }).isError).toBe(true);
+		expect((changed.result as { structuredContent: unknown }).structuredContent).toEqual({
+			code: "idempotency-conflict",
+		});
+		expect(fingerprints).toHaveLength(3);
+		expect(fingerprints[1]).toBe(fingerprints[0]);
+		expect(fingerprints[2]).not.toBe(fingerprints[0]);
+	});
+
+	it("does not advertise or dispatch creation from a read-only host", async () => {
+		let mcp = handler({ caller: () => "octocat", documents: reader() });
+		let tools = await json(
+			await mcp(request({ jsonrpc: "2.0", id: 16, method: "tools/list" })),
+		);
+
+		expect((tools.result as { tools: Array<{ name: string }> }).tools.map(tool => tool.name))
+			.toEqual(["list_documents", "read_document"]);
+		let creationAttempt = await json(await mcp(call(17, creation)));
+		expect(creationAttempt.error).toEqual({ code: -32601, message: "tool not found" });
+	});
+});

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,22 @@ ownership without losing plans or transcripts.
 Generate the session key with `openssl rand -hex 32`. `APP_ORIGIN` has no
 trailing slash and must match the GitHub App callback's origin exactly.
 
+## Creating a plan from an agent conversation
+
+The optional, provider-neutral
+[creating-chopin-plans skill](skills/creating-chopin-plans/SKILL.md) turns a
+settled coding-agent conversation into one initial Chopin document. Copy the
+whole directory into an Agent Skills location supported by the local runtime:
+
+```bash
+mkdir -p ~/.agents/skills
+cp -R skills/creating-chopin-plans ~/.agents/skills/
+```
+
+Use [implementing-chopin-plans](skills/implementing-chopin-plans/SKILL.md)
+instead when an approved Chopin implementation graph is ready for local work.
+Neither skill is needed to call Chopin's MCP tools directly.
+
 ## Sharing
 
 The client derives the application socket from the page origin, so a tunnel

--- a/skills/creating-chopin-plans/SKILL.md
+++ b/skills/creating-chopin-plans/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: creating-chopin-plans
+description: Use when a coding-agent conversation has settled enough context to create a new Chopin document through the create_document MCP tool.
+---
+
+# Creating a Chopin plan
+
+Create one initial Chopin document from the useful outcome of the settled
+conversation. Chopin's current MCP instructions and tool descriptions are
+authoritative.
+
+## Prepare the brief
+
+Synthesize the settled outcome instead of forwarding the raw transcript. Record
+the goal, constraints, settled decisions with their rationale, genuine open
+questions, and repository findings.
+
+Inspect the repository before creating: resolve its canonical identity, current
+branch, and full commit SHA with read-only commands. Use that exact provenance
+in the creation request.
+
+## Draft and create
+
+Write a supported Chopin MDX plan. Use normal Markdown by default; use only
+documented components when they clarify the plan. Do not add imports, exports,
+expressions, raw HTML, arbitrary JSX, or component ids owned by Chopin.
+
+Generate one idempotency key for the attempt, then use the current
+`create_document` descriptor to submit the brief, provenance, title, and plan.
+If it reports validation issues, repair the relevant content and retry with the
+same key. Once creation succeeds, do not call `create_document` again.
+
+## Hand off
+
+Return the created document's `url` as the canonical handoff, with its title
+and identifier. Do not open it automatically.

--- a/skills/creating-chopin-plans/contract.test.ts
+++ b/skills/creating-chopin-plans/contract.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+
+import { handler } from "../../apps/server/src/mcp";
+
+import type { CreateDocument } from "../../apps/server/src/mcp";
+
+function request(body: unknown): Request {
+	return new Request("https://chopin.test/mcp", {
+		method: "POST",
+		headers: {
+			authorization: "Bearer allowed",
+			"content-type": "application/json",
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+function creation(): CreateDocument<string> {
+	return {
+		async create() {
+			return { kind: "forbidden" };
+		},
+	};
+}
+
+test("the MCP service publishes its creation contract without implementation guidance", async () => {
+	let mcp = handler({
+		caller: () => "operator",
+		documents: {
+			async list() {
+				return [];
+			},
+			async read() {
+				return undefined;
+			},
+		},
+		create: creation(),
+	});
+	let initialized = await mcp(request({
+		jsonrpc: "2.0",
+		id: 1,
+		method: "initialize",
+		params: {},
+	}));
+	let initialization = await initialized.json() as {
+		result: { instructions?: string };
+	};
+	expect(initialization.result.instructions).toBe(
+		[
+			"Chopin's MCP contract and current tool descriptions are authoritative.",
+			"create_document: Create a Chopin document from a structured brief and canonical plan.",
+		].join("\n"),
+	);
+});

--- a/skills/creating-chopin-plans/prompt.md
+++ b/skills/creating-chopin-plans/prompt.md
@@ -1,0 +1,11 @@
+# Create a Chopin plan
+
+The conversation below has settled enough context for one initial Chopin
+document. Follow the installed `creating-chopin-plans` skill and the current
+Chopin MCP initialize instructions and tool descriptions.
+
+<SETTLED_CONVERSATION>
+
+...
+
+</SETTLED_CONVERSATION>

--- a/skills/implementing-chopin-plans/contract.test.ts
+++ b/skills/implementing-chopin-plans/contract.test.ts
@@ -53,7 +53,8 @@ test("the MCP service publishes its complete implementation contract", async () 
 	};
 	expect(initialization.result.instructions).toBe(
 		[
-			"Chopin's MCP contract is authoritative. Read the canonical implementation and these current tool descriptions before every action; copied plans and lifecycle instructions are not substitutes.",
+			"Chopin's MCP contract and current tool descriptions are authoritative.",
+			"Read the canonical implementation before every implementation or lifecycle action; copied plans and lifecycle instructions are not substitutes.",
 			"read_implementation: Read the approved implementation graph, plan and repository context.",
 			"start_implementation: Atomically claim the current approved implementation graph.",
 			"start_task: Mark one dependency-ready task as in progress for the active implementation run.",


### PR DESCRIPTION
## Summary

- Adds the provider-neutral `creating-chopin-plans` skill and prompt for creating one initial Chopin document, then handing off its editable channel.
- Keeps MCP initialize instructions and current tool descriptions authoritative, with implementation-only guidance scoped to implementation actions.
- Covers corrected same-key retries after validation failure and proves invalid requests never reach persistence.
- Documents copying each skill directory intact so its prompt ships with it.

## Stack

Rebuilt directly on current `main` after the core MCP feature stack merged. It has no dependency on PR #40.

## Verification

- `bun test` — 801 pass, 2 expected PostgreSQL skips
- `bun run types`
- `bun run ci`
- `git diff --check origin/main...HEAD`
