### PR TITLE
Persist versioned implementation graphs alongside plan revisions

### DIFF
--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -20,6 +20,7 @@ import * as room from "./room";
 import * as Chat from "../chat/service";
 import * as Comments from "../comments/service";
 import * as Questions from "../questions/service";
+import { restore as restoreGraph } from "../tasks/graphs";
 import { broadcast, relay, reply, tell } from "../wire";
 
 import type { Server } from "bun";
@@ -32,6 +33,7 @@ import type { Block } from "./edit";
 import type { Brief, CreationOrigin } from "../mcp";
 import type { InitialChannel, JsonValue, Lease, StoredChannel } from "../storage/model";
 import type { StorageAdapter } from "../storage/port";
+import type { Graph } from "../tasks/graphs";
 
 /** Updates are grouped for this long before being applied together. */
 const GROUP_MS = 5;
@@ -124,6 +126,8 @@ export type Plan = {
 	threads: Map<string, Comments.Record>;
 	/** Bumped on every committed change; the agent's concurrency token. */
 	revision: number;
+	/** Implementation work, stored beside rather than inside the plan. */
+	graph?: Graph;
 	/**
 	 * Block outlines by revision.
 	 *
@@ -159,6 +163,7 @@ type Sidecar = {
 	revision: number;
 	documentSeq: number;
 	creation?: CreationMetadata;
+	graph?: Graph;
 	questions: Questions.Record[];
 	openQuestions: Questions.StoredOpen[];
 	threads: Comments.Record[];
@@ -170,7 +175,9 @@ function state(plan: Plan): Sidecar {
 		version: 1,
 		revision: plan.revision,
 		documentSeq: plan.document.seq,
+<<<<<<< HEAD
 		...(plan.creation ? { creation: plan.creation } : {}),
+		...(plan.graph ? { graph: plan.graph } : {}),
 		questions: [...plan.records.values()],
 		openQuestions: Questions.dump(plan.questions),
 		threads: [...plan.threads.values()],
@@ -308,11 +315,13 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 	}
 	let item = value as Record<string, JsonValue>;
 	let keys = Object.keys(item).sort();
+<<<<<<< HEAD
 	let legacy = item.creation === undefined
 		&& (item.brief !== undefined || item.origin !== undefined);
 	let created = item.creation === undefined
 		? legacyCreation(item.brief, item.origin)
 		: creation(item.creation);
+	let graph = restoreGraph(item.graph);
 	let expected = [
 		"documentSeq",
 		"openQuestions",
@@ -322,7 +331,9 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 		"transcript",
 		"version",
 	];
+<<<<<<< HEAD
 	if (created) expected.push(...(legacy ? ["brief", "origin"] : ["creation"]));
+	if (Object.hasOwn(item, "graph")) expected.push("graph");
 	expected.sort();
 	if (
 		keys.length !== expected.length
@@ -378,7 +389,9 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 		version: 1,
 		revision: item.revision,
 		documentSeq: item.documentSeq,
+<<<<<<< HEAD
 		...(created ? { creation: created } : {}),
+		...(graph ? { graph } : {}),
 		questions: questions as never[],
 		openQuestions: openQuestions as unknown as Questions.StoredOpen[],
 		threads: threads as never[],
@@ -659,6 +672,7 @@ export async function open(
 		records: new Map(sidecar.questions.map(record => [record.id, record])),
 		threads: new Map(sidecar.threads.map(record => [record.id, record])),
 		revision: sidecar.revision,
+		graph: sidecar.graph,
 		queue: [],
 		timer: undefined,
 		attention: undefined,

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -175,7 +175,6 @@ function state(plan: Plan): Sidecar {
 		version: 1,
 		revision: plan.revision,
 		documentSeq: plan.document.seq,
-<<<<<<< HEAD
 		...(plan.creation ? { creation: plan.creation } : {}),
 		...(plan.graph ? { graph: plan.graph } : {}),
 		questions: [...plan.records.values()],
@@ -315,7 +314,6 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 	}
 	let item = value as Record<string, JsonValue>;
 	let keys = Object.keys(item).sort();
-<<<<<<< HEAD
 	let legacy = item.creation === undefined
 		&& (item.brief !== undefined || item.origin !== undefined);
 	let created = item.creation === undefined
@@ -331,7 +329,6 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 		"transcript",
 		"version",
 	];
-<<<<<<< HEAD
 	if (created) expected.push(...(legacy ? ["brief", "origin"] : ["creation"]));
 	if (Object.hasOwn(item, "graph")) expected.push("graph");
 	expected.sort();
@@ -389,7 +386,6 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 		version: 1,
 		revision: item.revision,
 		documentSeq: item.documentSeq,
-<<<<<<< HEAD
 		...(created ? { creation: created } : {}),
 		...(graph ? { graph } : {}),
 		questions: questions as never[],

--- a/apps/server/src/tasks/graphs.test.ts
+++ b/apps/server/src/tasks/graphs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { Graphs } from "./graphs";
+import { Graphs, restore } from "./graphs";
 
 import type { Definition, Graph, GraphAdapter } from "./graphs";
 
@@ -72,6 +72,10 @@ function changed(): Definition {
 	return next;
 }
 
+function stored(number: number, state: string): unknown {
+	return { number, planRevision: 0, state, definition: definition() };
+}
+
 async function expectGraph<T>(
 	value: Promise<{ ok: true; value: T } | { ok: false; reason: string }>,
 ): Promise<T> {
@@ -82,6 +86,13 @@ async function expectGraph<T>(
 }
 
 describe("implementation task graphs", () => {
+	it("ignores an unreachable version history while preserving graph revision compatibility", () => {
+		expect(restore({
+			versions: [stored(1, "locked"), stored(2, "approved")],
+		})).toBeUndefined();
+		expect(restore({ versions: [stored(1, "draft")] })?.versions[0].revision).toBe(1);
+	});
+
 	it("persists a draft graph against the document revision with independent and joined work", async () => {
 		let backend = new Memory();
 		backend.revisions.set("plan", 7);

--- a/apps/server/src/tasks/graphs.test.ts
+++ b/apps/server/src/tasks/graphs.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 
 import { Graphs, restore } from "./graphs";
 
-import type { Definition, Graph, GraphAdapter } from "./graphs";
+import type { Definition, Graph, GraphAdapter, Operation, Task } from "./graphs";
 
 class Memory implements GraphAdapter<string> {
 	graphs = new Map<string, Graph>();
@@ -72,6 +72,10 @@ function changed(): Definition {
 	return next;
 }
 
+function add(definition: Definition): Operation[] {
+	return definition.tasks.map(task => ({ op: "add", task }));
+}
+
 function stored(number: number, state: string): unknown {
 	return { number, planRevision: 0, state, definition: definition() };
 }
@@ -98,7 +102,11 @@ describe("implementation task graphs", () => {
 		backend.revisions.set("plan", 7);
 		let graphs = new Graphs(backend);
 
-		let graph = await expectGraph(graphs.create("plan", definition()));
+		let graph = await expectGraph(graphs.revise("plan", {
+			planRevision: 7,
+			graphRevision: 0,
+			operations: add(definition()),
+		}));
 
 		expect(graph.versions).toEqual([expect.objectContaining({
 			number: 1,
@@ -107,6 +115,27 @@ describe("implementation task graphs", () => {
 			definition: definition(),
 		})]);
 		expect(backend.graphs.get("plan")).toEqual(graph);
+	});
+
+	it("refuses a graph edit from an earlier graph read", async () => {
+		let backend = new Memory();
+		backend.revisions.set("plan", 7);
+		let graphs = new Graphs(backend);
+		let task = definition().tasks[0];
+		let first = await graphs.revise("plan", {
+			planRevision: 7,
+			graphRevision: 0,
+			operations: [{ op: "add", task }],
+		});
+		let stale = await graphs.revise("plan", {
+			planRevision: 7,
+			graphRevision: 0,
+			operations: [{ op: "add", task: definition().tasks[1] }],
+		});
+
+		expect(first.ok).toBe(true);
+		expect(stale).toEqual({ ok: false, reason: "stale-graph" });
+		expect(backend.graphs.get("plan")?.versions[0].definition.tasks).toEqual([task]);
 	});
 
 	it("refuses duplicate ids, missing predecessors, self dependencies and cycles", async () => {
@@ -130,7 +159,13 @@ describe("implementation task graphs", () => {
 		];
 
 		for (let [reason, invalid] of cases) {
-			expect(await graphs.create("plan", invalid)).toEqual({ ok: false, reason });
+			expect(
+				await graphs.revise("plan", {
+					planRevision: 1,
+					graphRevision: 0,
+					operations: add(invalid),
+				}),
+			).toEqual({ ok: false, reason });
 		}
 	});
 
@@ -146,8 +181,20 @@ describe("implementation task graphs", () => {
 			(_, index) => `Criterion ${index + 1}.`,
 		);
 
-		expect(await graphs.create("plan", tooFew)).toEqual({ ok: false, reason: "acceptance" });
-		expect(await graphs.create("plan", tooMany)).toEqual({ ok: false, reason: "acceptance" });
+		expect(
+			await graphs.revise("plan", {
+				planRevision: 1,
+				graphRevision: 0,
+				operations: add(tooFew),
+			}),
+		).toEqual({ ok: false, reason: "acceptance" });
+		expect(
+			await graphs.revise("plan", {
+				planRevision: 1,
+				graphRevision: 0,
+				operations: add(tooMany),
+			}),
+		).toEqual({ ok: false, reason: "acceptance" });
 	});
 
 	it("refuses malformed definition data instead of throwing at the persistence boundary", async () => {
@@ -155,7 +202,13 @@ describe("implementation task graphs", () => {
 		backend.revisions.set("plan", 1);
 		let graphs = new Graphs(backend);
 
-		expect(await graphs.create("plan", { tasks: null } as unknown as Definition)).toEqual({
+		expect(
+			await graphs.revise("plan", {
+				planRevision: 1,
+				graphRevision: 0,
+				operations: [{ op: "add", task: { tasks: null } as unknown as Task }],
+			}),
+		).toEqual({
 			ok: false,
 			reason: "task",
 		});
@@ -165,11 +218,19 @@ describe("implementation task graphs", () => {
 		let backend = new Memory();
 		backend.revisions.set("plan", 3);
 		let graphs = new Graphs(backend);
-		let created = await expectGraph(graphs.create("plan", definition()));
+		let created = await expectGraph(graphs.revise("plan", {
+			planRevision: 3,
+			graphRevision: 0,
+			operations: add(definition()),
+		}));
 		let approved = await expectGraph(graphs.approve("plan"));
 
 		expect(approved.versions[0]).toEqual({ ...created.versions[0], state: "approved" });
-		let edited = await expectGraph(graphs.edit("plan", changed()));
+		let edited = await expectGraph(graphs.revise("plan", {
+			planRevision: 3,
+			graphRevision: 1,
+			operations: [{ op: "replace", id: "model", task: changed().tasks[0] }],
+		}));
 
 		expect(edited.versions).toEqual([
 			{ ...created.versions[0], state: "approved" },
@@ -188,18 +249,32 @@ describe("implementation task graphs", () => {
 		let backend = new Memory();
 		backend.revisions.set("plan", 5);
 		let graphs = new Graphs(backend);
-		await expectGraph(graphs.create("plan", definition()));
+		await expectGraph(graphs.revise("plan", {
+			planRevision: 5,
+			graphRevision: 0,
+			operations: add(definition()),
+		}));
 		await expectGraph(graphs.approve("plan"));
 
 		backend.revisions.set("plan", 6);
 		expect(await graphs.start("plan")).toEqual({ ok: false, reason: "stale-plan" });
 
-		let replacement = await expectGraph(graphs.edit("plan", changed()));
+		let replacement = await expectGraph(graphs.revise("plan", {
+			planRevision: 6,
+			graphRevision: 1,
+			operations: [{ op: "replace", id: "model", task: changed().tasks[0] }],
+		}));
 		expect(replacement.versions[1]).toMatchObject({ state: "draft", planRevision: 6 });
 		await expectGraph(graphs.approve("plan"));
 		let locked = await expectGraph(graphs.start("plan"));
 
 		expect(locked.versions[1]).toMatchObject({ state: "locked", planRevision: 6 });
-		expect(await graphs.edit("plan", definition())).toEqual({ ok: false, reason: "locked" });
+		expect(
+			await graphs.revise("plan", {
+				planRevision: 6,
+				graphRevision: 1,
+				operations: [{ op: "add", task: definition().tasks[0] }],
+			}),
+		).toEqual({ ok: false, reason: "locked" });
 	});
 });

--- a/apps/server/src/tasks/graphs.test.ts
+++ b/apps/server/src/tasks/graphs.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "bun:test";
+
+import { Graphs } from "./graphs";
+
+import type { Definition, Graph, GraphAdapter } from "./graphs";
+
+class Memory implements GraphAdapter<string> {
+	graphs = new Map<string, Graph>();
+	revisions = new Map<string, number>();
+
+	async transact(
+		document: string,
+		change: (current: { graph: Graph | undefined; revision: number | undefined }) => {
+			ok: true;
+			value: Graph;
+		} | { ok: false; reason: string },
+	): Promise<{ ok: true; value: Graph } | { ok: false; reason: string }> {
+		let result = change({
+			graph: this.graphs.get(document),
+			revision: this.revisions.get(document),
+		});
+		if (result.ok) this.graphs.set(document, result.value);
+		return result;
+	}
+}
+
+function definition(): Definition {
+	return {
+		tasks: [
+			{
+				id: "model",
+				title: "Model the graph",
+				context: "The graph is durable document state.",
+				goal: "Define versioned task graphs.",
+				acceptance: ["The graph has versions.", "Versions retain their plan revision."],
+				dependsOn: [],
+			},
+			{
+				id: "validate",
+				title: "Validate task graphs",
+				context: "The model protects implementation runs.",
+				goal: "Reject invalid dependency graphs.",
+				acceptance: ["Dependencies name known tasks.", "Cycles are refused."],
+				dependsOn: ["model"],
+			},
+			{
+				id: "report",
+				title: "Report implementation progress",
+				context: "Reporting has two independent prerequisites.",
+				goal: "Connect reporting to the graph.",
+				acceptance: [
+					"The implementation can report progress.",
+					"The report waits for both inputs.",
+				],
+				dependsOn: ["model", "validate"],
+			},
+			{
+				id: "publish",
+				title: "Publish the graph",
+				context: "Publishing is unrelated to reporting.",
+				goal: "Show independent roots.",
+				acceptance: ["The graph can have multiple roots.", "Roots do not depend on each other."],
+				dependsOn: [],
+			},
+		],
+	};
+}
+
+function changed(): Definition {
+	let next = definition();
+	next.tasks[0].title = "Model approved task graphs";
+	return next;
+}
+
+async function expectGraph<T>(
+	value: Promise<{ ok: true; value: T } | { ok: false; reason: string }>,
+): Promise<T> {
+	let result = await value;
+	expect(result.ok).toBe(true);
+	if (!result.ok) throw new Error(result.reason);
+	return result.value;
+}
+
+describe("implementation task graphs", () => {
+	it("persists a draft graph against the document revision with independent and joined work", async () => {
+		let backend = new Memory();
+		backend.revisions.set("plan", 7);
+		let graphs = new Graphs(backend);
+
+		let graph = await expectGraph(graphs.create("plan", definition()));
+
+		expect(graph.versions).toEqual([expect.objectContaining({
+			number: 1,
+			state: "draft",
+			planRevision: 7,
+			definition: definition(),
+		})]);
+		expect(backend.graphs.get("plan")).toEqual(graph);
+	});
+
+	it("refuses duplicate ids, missing predecessors, self dependencies and cycles", async () => {
+		let backend = new Memory();
+		backend.revisions.set("plan", 1);
+		let graphs = new Graphs(backend);
+		let cases: Array<[string, Definition]> = [
+			["duplicate", { tasks: [...definition().tasks, { ...definition().tasks[0] }] }],
+			["missing", {
+				tasks: [{ ...definition().tasks[0], dependsOn: ["absent"] }],
+			}],
+			["self", {
+				tasks: [{ ...definition().tasks[0], dependsOn: ["model"] }],
+			}],
+			["cycle", {
+				tasks: [
+					{ ...definition().tasks[0], dependsOn: ["validate"] },
+					{ ...definition().tasks[1], dependsOn: ["model"] },
+				],
+			}],
+		];
+
+		for (let [reason, invalid] of cases) {
+			expect(await graphs.create("plan", invalid)).toEqual({ ok: false, reason });
+		}
+	});
+
+	it("requires every task to have from two through eight acceptance criteria", async () => {
+		let backend = new Memory();
+		backend.revisions.set("plan", 1);
+		let graphs = new Graphs(backend);
+		let tooFew = definition();
+		tooFew.tasks[0].acceptance = ["Only one."];
+		let tooMany = definition();
+		tooMany.tasks[0].acceptance = Array.from(
+			{ length: 9 },
+			(_, index) => `Criterion ${index + 1}.`,
+		);
+
+		expect(await graphs.create("plan", tooFew)).toEqual({ ok: false, reason: "acceptance" });
+		expect(await graphs.create("plan", tooMany)).toEqual({ ok: false, reason: "acceptance" });
+	});
+
+	it("refuses malformed definition data instead of throwing at the persistence boundary", async () => {
+		let backend = new Memory();
+		backend.revisions.set("plan", 1);
+		let graphs = new Graphs(backend);
+
+		expect(await graphs.create("plan", { tasks: null } as unknown as Definition)).toEqual({
+			ok: false,
+			reason: "task",
+		});
+	});
+
+	it("freezes an approved version and creates a new draft when it is edited", async () => {
+		let backend = new Memory();
+		backend.revisions.set("plan", 3);
+		let graphs = new Graphs(backend);
+		let created = await expectGraph(graphs.create("plan", definition()));
+		let approved = await expectGraph(graphs.approve("plan"));
+
+		expect(approved.versions[0]).toEqual({ ...created.versions[0], state: "approved" });
+		let edited = await expectGraph(graphs.edit("plan", changed()));
+
+		expect(edited.versions).toEqual([
+			{ ...created.versions[0], state: "approved" },
+			expect.objectContaining({
+				number: 2,
+				state: "draft",
+				planRevision: 3,
+				definition: changed(),
+			}),
+		]);
+		let replacement = await expectGraph(graphs.approve("plan"));
+		expect(replacement.versions.map(version => version.state)).toEqual(["superseded", "approved"]);
+	});
+
+	it("does not start an old graph and locks one that starts against its plan revision", async () => {
+		let backend = new Memory();
+		backend.revisions.set("plan", 5);
+		let graphs = new Graphs(backend);
+		await expectGraph(graphs.create("plan", definition()));
+		await expectGraph(graphs.approve("plan"));
+
+		backend.revisions.set("plan", 6);
+		expect(await graphs.start("plan")).toEqual({ ok: false, reason: "stale-plan" });
+
+		let replacement = await expectGraph(graphs.edit("plan", changed()));
+		expect(replacement.versions[1]).toMatchObject({ state: "draft", planRevision: 6 });
+		await expectGraph(graphs.approve("plan"));
+		let locked = await expectGraph(graphs.start("plan"));
+
+		expect(locked.versions[1]).toMatchObject({ state: "locked", planRevision: 6 });
+		expect(await graphs.edit("plan", definition())).toEqual({ ok: false, reason: "locked" });
+	});
+});

--- a/apps/server/src/tasks/graphs.ts
+++ b/apps/server/src/tasks/graphs.ts
@@ -1,0 +1,255 @@
+/**
+ * Durable implementation work belongs beside a plan, not inside its prose.
+ *
+ * The adapter owns document lookup and persistence. This model only decides
+ * whether a graph is valid and which version may change at a given plan
+ * revision, so a hosted backend can use the same rules as the local one.
+ */
+
+export type Task = {
+	id: string;
+	title: string;
+	context: string;
+	goal: string;
+	acceptance: string[];
+	dependsOn: string[];
+};
+
+export type Definition = {
+	tasks: Task[];
+};
+
+export type State = "draft" | "approved" | "locked" | "superseded";
+
+export type Version = {
+	number: number;
+	planRevision: number;
+	state: State;
+	definition: Definition;
+};
+
+export type Graph = {
+	versions: Version[];
+};
+
+export type GraphAdapter<Document> = {
+	/** Runs the change against one current graph and plan revision. */
+	transact(
+		document: Document,
+		change: (current: { graph: Graph | undefined; revision: number | undefined }) => Result<Graph>,
+	): Promise<Result<Graph>>;
+};
+
+export type Result<T> = { ok: true; value: T } | { ok: false; reason: string };
+
+type Validation = Exclude<Result<Definition>, { ok: true }>;
+
+function copy<T>(value: T): T {
+	return structuredClone(value);
+}
+
+function invalid(reason: string): Validation {
+	return { ok: false, reason };
+}
+
+function text(value: string): boolean {
+	return value.trim().length > 0;
+}
+
+/** Validate references before looking for cycles, for useful refusal reasons. */
+export function validate(definition: unknown): Result<Definition> {
+	if (
+		!definition || typeof definition !== "object"
+		|| !Array.isArray((definition as Definition).tasks)
+	) {
+		return invalid("task");
+	}
+	let valid = definition as Definition;
+	let ids = new Set<string>();
+	for (let task of valid.tasks) {
+		if (
+			!task || typeof task !== "object" || !Array.isArray(task.acceptance)
+			|| !Array.isArray(task.dependsOn)
+		) {
+			return invalid("task");
+		}
+		if (
+			typeof task.id !== "string" || typeof task.title !== "string"
+			|| typeof task.context !== "string"
+			|| typeof task.goal !== "string" || task.dependsOn.some(item => typeof item !== "string")
+		) {
+			return invalid("task");
+		}
+		if (!text(task.id) || !text(task.title) || !text(task.context) || !text(task.goal)) {
+			return invalid("task");
+		}
+		if (ids.has(task.id)) return invalid("duplicate");
+		ids.add(task.id);
+		if (
+			task.acceptance.length < 2 || task.acceptance.length > 8
+			|| task.acceptance.some(criterion => typeof criterion !== "string" || !text(criterion))
+		) return invalid("acceptance");
+	}
+
+	for (let task of valid.tasks) {
+		for (let dependency of task.dependsOn) {
+			if (!ids.has(dependency)) return invalid("missing");
+			if (dependency === task.id) return invalid("self");
+		}
+	}
+	let visiting = new Set<string>();
+	let visited = new Set<string>();
+	let tasks = new Map(valid.tasks.map(task => [task.id, task]));
+	function visit(id: string): boolean {
+		if (visiting.has(id)) return true;
+		if (visited.has(id)) return false;
+		visiting.add(id);
+		let cycle = tasks.get(id)?.dependsOn.some(visit) ?? false;
+		visiting.delete(id);
+		visited.add(id);
+		return cycle;
+	}
+
+	if (valid.tasks.some(task => visit(task.id))) return invalid("cycle");
+	if (
+		valid.tasks.length === 0 || !valid.tasks.some(task => task.dependsOn.length === 0)
+	) {
+		return invalid("root");
+	}
+	return { ok: true, value: copy(valid) };
+}
+
+function current(graph: Graph): Version | undefined {
+	return graph.versions.at(-1);
+}
+
+/** Read a graph back from a sidecar without trusting handwritten JSON. */
+export function restore(value: unknown): Graph | undefined {
+	if (!value || typeof value !== "object" || !Array.isArray((value as Graph).versions)) {
+		return undefined;
+	}
+	let graph = value as Graph;
+	if (graph.versions.length === 0) return undefined;
+	for (let [index, version] of graph.versions.entries()) {
+		if (
+			!version || typeof version !== "object" || version.number !== index + 1
+			|| !Number.isInteger(version.planRevision) || version.planRevision < 0
+			|| !["draft", "approved", "locked", "superseded"].includes(version.state)
+			|| !validate(version.definition).ok
+		) return undefined;
+	}
+	return copy(graph);
+}
+
+/**
+ * Mutations go through this service rather than directly to a snapshot. The
+ * caller gives it an adapter so graph state remains a backend concern and
+ * never becomes an MDX node.
+ */
+export class Graphs<Document> {
+	#adapter: GraphAdapter<Document>;
+
+	constructor(adapter: GraphAdapter<Document>) {
+		this.#adapter = adapter;
+	}
+
+	async #transact(
+		document: Document,
+		change: (current: { graph: Graph | undefined; revision: number | undefined }) => Result<Graph>,
+	): Promise<Result<Graph>> {
+		let result = await this.#adapter.transact(document, current => {
+			let next = change({
+				graph: current.graph && copy(current.graph),
+				revision: current.revision,
+			});
+			return next.ok ? { ok: true, value: copy(next.value) } : next;
+		});
+		return result.ok ? { ok: true, value: copy(result.value) } : result;
+	}
+
+	async create(document: Document, definition: Definition): Promise<Result<Graph>> {
+		return await this.#transact(document, ({ graph, revision }) => {
+			if (graph) return { ok: false, reason: "exists" };
+			if (revision === undefined) return { ok: false, reason: "missing-document" };
+			let checked = validate(definition);
+			if (!checked.ok) return checked;
+			return {
+				ok: true,
+				value: {
+					versions: [{
+						number: 1,
+						planRevision: revision,
+						state: "draft",
+						definition: checked.value,
+					}],
+				},
+			};
+		});
+	}
+
+	async edit(document: Document, definition: Definition): Promise<Result<Graph>> {
+		return await this.#transact(document, ({ graph, revision }) => {
+			let version = graph && current(graph);
+			if (!graph || !version) return { ok: false, reason: "missing" };
+			if (version.state === "locked") return { ok: false, reason: "locked" };
+			if (version.state === "superseded") return { ok: false, reason: "superseded" };
+			if (revision === undefined) return { ok: false, reason: "missing-document" };
+			let checked = validate(definition);
+			if (!checked.ok) return checked;
+
+			if (version.state === "draft") {
+				graph.versions[graph.versions.length - 1] = {
+					...graph.versions[graph.versions.length - 1],
+					planRevision: revision,
+					definition: checked.value,
+				};
+			} else {
+				graph.versions.push({
+					number: version.number + 1,
+					planRevision: revision,
+					state: "draft",
+					definition: checked.value,
+				});
+			}
+			return { ok: true, value: graph };
+		});
+	}
+
+	async approve(document: Document): Promise<Result<Graph>> {
+		return await this.#transact(document, ({ graph, revision }) => {
+			let version = graph && current(graph);
+			if (!graph || !version) return { ok: false, reason: "missing" };
+			if (version.state !== "draft") return { ok: false, reason: "not-draft" };
+			if (revision === undefined) return { ok: false, reason: "missing-document" };
+			if (version.planRevision !== revision) return { ok: false, reason: "stale-plan" };
+			let checked = validate(version.definition);
+			if (!checked.ok) return checked;
+
+			for (let prior of graph.versions) {
+				if (prior.state === "approved") prior.state = "superseded";
+			}
+			graph.versions[graph.versions.length - 1] = {
+				...graph.versions[graph.versions.length - 1],
+				state: "approved",
+				definition: checked.value,
+			};
+			return { ok: true, value: graph };
+		});
+	}
+
+	async start(document: Document): Promise<Result<Graph>> {
+		return await this.#transact(document, ({ graph, revision }) => {
+			let version = graph && current(graph);
+			if (!graph || !version) return { ok: false, reason: "missing" };
+			if (version.state !== "approved") return { ok: false, reason: "not-approved" };
+			if (revision === undefined) return { ok: false, reason: "missing-document" };
+			if (version.planRevision !== revision) return { ok: false, reason: "stale-plan" };
+
+			graph.versions[graph.versions.length - 1] = {
+				...graph.versions[graph.versions.length - 1],
+				state: "locked",
+			};
+			return { ok: true, value: graph };
+		});
+	}
+}

--- a/apps/server/src/tasks/graphs.ts
+++ b/apps/server/src/tasks/graphs.ts
@@ -44,6 +44,20 @@ export type GraphAdapter<Document> = {
 
 export type Result<T> = { ok: true; value: T } | { ok: false; reason: string };
 
+export type Operation =
+	| { op: "add"; task: Task }
+	| { op: "replace"; id: string; task: Task }
+	| { op: "reorder"; ids: string[] }
+	| { op: "remove"; id: string };
+
+export type Revision = {
+	/** The plan revision returned by the planner's graph read. */
+	planRevision: number;
+	/** The current draft revision, or zero before a graph exists. */
+	graphRevision: number;
+	operations: Operation[];
+};
+
 type Validation = Exclude<Result<Definition>, { ok: true }>;
 
 function copy<T>(value: T): T {
@@ -125,6 +139,12 @@ function current(graph: Graph): Version | undefined {
 	return graph.versions.at(-1);
 }
 
+function state(value: unknown): State | undefined {
+	return value === "draft" || value === "approved" || value === "locked" || value === "superseded"
+		? value
+		: undefined;
+}
+
 function item(value: unknown, keys: string[]): Record<string, unknown> | undefined {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
 	let record = value as Record<string, unknown>;
@@ -185,6 +205,50 @@ function history(versions: Version[]): boolean {
 	return prior.every(version => version.state === "superseded");
 }
 
+/** Apply a planner's whole graph batch before deciding whether it is valid. */
+function revise(definition: Definition, operations: unknown[]): Result<Definition> {
+	let next = copy(definition);
+	for (let operation of operations) {
+		if (!operation || typeof operation !== "object") return invalid("operation");
+		let value = operation as Partial<Operation>;
+		switch (value.op) {
+			case "add":
+				if (!value.task) return invalid("operation");
+				next.tasks.push(value.task);
+				break;
+			case "replace": {
+				if (typeof value.id !== "string" || !value.task) return invalid("operation");
+				let index = next.tasks.findIndex(task => task.id === value.id);
+				if (index < 0) return invalid("missing");
+				next.tasks[index] = value.task;
+				break;
+			}
+			case "remove": {
+				if (typeof value.id !== "string") return invalid("operation");
+				let index = next.tasks.findIndex(task => task.id === value.id);
+				if (index < 0) return invalid("missing");
+				next.tasks.splice(index, 1);
+				break;
+			}
+			case "reorder": {
+				if (!Array.isArray(value.ids) || value.ids.some(id => typeof id !== "string")) {
+					return invalid("operation");
+				}
+				let tasks = new Map(next.tasks.map(task => [task.id, task]));
+				if (
+					value.ids.length !== next.tasks.length || new Set(value.ids).size !== value.ids.length
+					|| value.ids.some(id => !tasks.has(id))
+				) return invalid("reorder");
+				next.tasks = value.ids.map(id => tasks.get(id)!);
+				break;
+			}
+			default:
+				return invalid("operation");
+		}
+	}
+	return validate(next);
+}
+
 /** Read a graph back from a sidecar without trusting handwritten JSON. */
 export function restore(value: unknown): Graph | undefined {
 	let stored = item(value, ["versions"]);
@@ -194,21 +258,28 @@ export function restore(value: unknown): Graph | undefined {
 		let version = item(value, ["definition", "number", "planRevision", "revision", "state"])
 			?? item(value, ["definition", "number", "planRevision", "state"]);
 		let checked = version && definition(version.definition);
+		let number = version?.number;
+		let revision = version?.revision ?? 1;
+		let planRevision = version?.planRevision;
+		let versionState = state(version?.state);
 		if (
 			!version
-			|| version.number !== index + 1
-			|| !Number.isInteger(version.revision ?? 1)
-			|| (version.revision ?? 1) < 1
-			|| !Number.isInteger(version.planRevision)
-			|| version.planRevision < 0
-			|| !["draft", "approved", "locked", "superseded"].includes(version.state as string)
+			|| typeof number !== "number"
+			|| number !== index + 1
+			|| typeof revision !== "number"
+			|| !Number.isInteger(revision)
+			|| revision < 1
+			|| typeof planRevision !== "number"
+			|| !Number.isInteger(planRevision)
+			|| planRevision < 0
+			|| !versionState
 			|| !checked
 		) return undefined;
 		versions.push({
-			number: version.number,
-			revision: version.revision ?? 1,
-			planRevision: version.planRevision,
-			state: version.state as State,
+			number,
+			revision,
+			planRevision,
+			state: versionState,
 			definition: checked,
 		});
 	}
@@ -241,40 +312,37 @@ export class Graphs<Document> {
 		return result.ok ? { ok: true, value: copy(result.value) } : result;
 	}
 
-	async create(document: Document, definition: Definition): Promise<Result<Graph>> {
+	/** Change a graph by operations from one particular planner read. */
+	async revise(document: Document, change: Revision): Promise<Result<Graph>> {
 		return await this.#transact(document, ({ graph, revision }) => {
-			if (graph) return { ok: false, reason: "exists" };
-			if (revision === undefined) return { ok: false, reason: "missing-document" };
-			let checked = validate(definition);
-			if (!checked.ok) return checked;
-			return {
-				ok: true,
-				value: {
-					versions: [{
-						number: 1,
-						revision: 1,
-						planRevision: revision,
-						state: "draft",
-						definition: checked.value,
-					}],
-				},
-			};
-		});
-	}
-
-	async edit(document: Document, definition: Definition): Promise<Result<Graph>> {
-		return await this.#transact(document, ({ graph, revision }) => {
+			if (revision !== change.planRevision) return { ok: false, reason: "stale-plan" };
 			let version = graph && current(graph);
-			if (!graph || !version) return { ok: false, reason: "missing" };
-			if (version.state === "locked") return { ok: false, reason: "locked" };
-			if (version.state === "superseded") return { ok: false, reason: "superseded" };
-			if (revision === undefined) return { ok: false, reason: "missing-document" };
-			let checked = validate(definition);
-			if (!checked.ok) return checked;
+			if ((version?.revision ?? 0) !== change.graphRevision) {
+				return { ok: false, reason: "stale-graph" };
+			}
+			if (version?.state === "locked") return { ok: false, reason: "locked" };
+			if (version?.state === "superseded") return { ok: false, reason: "superseded" };
+			if (change.operations.length === 0) return { ok: false, reason: "operation" };
 
+			let checked = revise(version?.definition ?? { tasks: [] }, change.operations);
+			if (!checked.ok) return checked;
+			if (!graph || !version) {
+				return {
+					ok: true,
+					value: {
+						versions: [{
+							number: 1,
+							revision: 1,
+							planRevision: revision,
+							state: "draft",
+							definition: checked.value,
+						}],
+					},
+				};
+			}
 			if (version.state === "draft") {
 				graph.versions[graph.versions.length - 1] = {
-					...graph.versions[graph.versions.length - 1],
+					...version,
 					revision: version.revision + 1,
 					planRevision: revision,
 					definition: checked.value,

--- a/apps/server/src/tasks/graphs.ts
+++ b/apps/server/src/tasks/graphs.ts
@@ -23,6 +23,8 @@ export type State = "draft" | "approved" | "locked" | "superseded";
 
 export type Version = {
 	number: number;
+	/** Changes whenever a draft definition changes. */
+	revision: number;
 	planRevision: number;
 	state: State;
 	definition: Definition;
@@ -123,22 +125,94 @@ function current(graph: Graph): Version | undefined {
 	return graph.versions.at(-1);
 }
 
+function item(value: unknown, keys: string[]): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	let record = value as Record<string, unknown>;
+	let found = Object.keys(record).sort();
+	let expected = [...keys].sort();
+	return found.length === expected.length && found.every((key, index) => key === expected[index])
+		? record
+		: undefined;
+}
+
+function definition(value: unknown): Definition | undefined {
+	let stored = item(value, ["tasks"]);
+	if (!stored || !Array.isArray(stored.tasks)) return undefined;
+	let tasks: Task[] = [];
+	for (let value of stored.tasks) {
+		let task = item(value, ["acceptance", "context", "dependsOn", "goal", "id", "title"]);
+		if (
+			!task
+			|| typeof task.id !== "string"
+			|| typeof task.title !== "string"
+			|| typeof task.context !== "string"
+			|| typeof task.goal !== "string"
+			|| !Array.isArray(task.acceptance)
+			|| !Array.isArray(task.dependsOn)
+			|| task.acceptance.some(value => typeof value !== "string")
+			|| task.dependsOn.some(value => typeof value !== "string")
+		) return undefined;
+		tasks.push({
+			id: task.id,
+			title: task.title,
+			context: task.context,
+			goal: task.goal,
+			acceptance: task.acceptance,
+			dependsOn: task.dependsOn,
+		});
+	}
+	let checked = validate({ tasks });
+	return checked.ok ? checked.value : undefined;
+}
+
+function history(versions: Version[]): boolean {
+	let latest = versions.at(-1);
+	if (!latest || latest.state === "superseded") return false;
+	if (
+		versions.some((version, index) =>
+			index > 0 && version.planRevision < versions[index - 1].planRevision
+		)
+	) {
+		return false;
+	}
+	let prior = versions.slice(0, -1);
+	if (latest.state === "draft") {
+		return prior.every((version, index) =>
+			version.state === "superseded"
+			|| index === prior.length - 1 && version.state === "approved"
+		);
+	}
+	return prior.every(version => version.state === "superseded");
+}
+
 /** Read a graph back from a sidecar without trusting handwritten JSON. */
 export function restore(value: unknown): Graph | undefined {
-	if (!value || typeof value !== "object" || !Array.isArray((value as Graph).versions)) {
-		return undefined;
-	}
-	let graph = value as Graph;
-	if (graph.versions.length === 0) return undefined;
-	for (let [index, version] of graph.versions.entries()) {
+	let stored = item(value, ["versions"]);
+	if (!stored || !Array.isArray(stored.versions) || stored.versions.length === 0) return undefined;
+	let versions: Version[] = [];
+	for (let [index, value] of stored.versions.entries()) {
+		let version = item(value, ["definition", "number", "planRevision", "revision", "state"])
+			?? item(value, ["definition", "number", "planRevision", "state"]);
+		let checked = version && definition(version.definition);
 		if (
-			!version || typeof version !== "object" || version.number !== index + 1
-			|| !Number.isInteger(version.planRevision) || version.planRevision < 0
-			|| !["draft", "approved", "locked", "superseded"].includes(version.state)
-			|| !validate(version.definition).ok
+			!version
+			|| version.number !== index + 1
+			|| !Number.isInteger(version.revision ?? 1)
+			|| (version.revision ?? 1) < 1
+			|| !Number.isInteger(version.planRevision)
+			|| version.planRevision < 0
+			|| !["draft", "approved", "locked", "superseded"].includes(version.state as string)
+			|| !checked
 		) return undefined;
+		versions.push({
+			number: version.number,
+			revision: version.revision ?? 1,
+			planRevision: version.planRevision,
+			state: version.state as State,
+			definition: checked,
+		});
 	}
-	return copy(graph);
+	return history(versions) ? { versions } : undefined;
 }
 
 /**
@@ -178,6 +252,7 @@ export class Graphs<Document> {
 				value: {
 					versions: [{
 						number: 1,
+						revision: 1,
 						planRevision: revision,
 						state: "draft",
 						definition: checked.value,
@@ -200,12 +275,14 @@ export class Graphs<Document> {
 			if (version.state === "draft") {
 				graph.versions[graph.versions.length - 1] = {
 					...graph.versions[graph.versions.length - 1],
+					revision: version.revision + 1,
 					planRevision: revision,
 					definition: checked.value,
 				};
 			} else {
 				graph.versions.push({
 					number: version.number + 1,
+					revision: 1,
 					planRevision: revision,
 					state: "draft",
 					definition: checked.value,

--- a/apps/server/src/tasks/plan-graphs.test.ts
+++ b/apps/server/src/tasks/plan-graphs.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
 
+import { implementationGraphs } from "./plan-graphs";
 import { MemoryStorage } from "../storage/memory/adapter";
-import { close, implementationGraphs, open } from "../plan/service";
+import { close, open } from "../plan/service";
 
 import type { Server } from "bun";
 import type { Backend } from "../plan/service";
@@ -51,7 +52,11 @@ describe("the plan graph adapter", () => {
 		let context = await hosted();
 		let first = await open(context.channel.id, context.backend, context.server);
 
-		let graph = await implementationGraphs().create(first, definition);
+		let graph = await implementationGraphs().revise(first, {
+			planRevision: 0,
+			graphRevision: 0,
+			operations: definition.tasks.map(task => ({ op: "add", task })),
+		});
 		expect(graph.ok).toBe(true);
 		await close(first);
 		let stored = await context.storage.collaboration.load(context.channel.id, now);
@@ -60,7 +65,13 @@ describe("the plan graph adapter", () => {
 		});
 
 		let restored = await open(context.channel.id, context.backend, context.server);
-		expect((await implementationGraphs().edit(restored, definition)).ok).toBe(true);
+		expect(
+			(await implementationGraphs().revise(restored, {
+				planRevision: 0,
+				graphRevision: 1,
+				operations: [{ op: "replace", id: "model", task: definition.tasks[0] }],
+			})).ok,
+		).toBe(true);
 		await close(restored);
 	});
 
@@ -88,7 +99,13 @@ describe("the plan graph adapter", () => {
 		});
 
 		let restored = await open(context.channel.id, context.backend, context.server);
-		expect(await implementationGraphs().create(restored, definition)).toMatchObject({ ok: true });
+		expect(
+			await implementationGraphs().revise(restored, {
+				planRevision: 0,
+				graphRevision: 0,
+				operations: definition.tasks.map(task => ({ op: "add", task })),
+			}),
+		).toMatchObject({ ok: true });
 		await close(restored);
 	});
 });

--- a/apps/server/src/tasks/plan-graphs.test.ts
+++ b/apps/server/src/tasks/plan-graphs.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+
+import { MemoryStorage } from "../storage/memory/adapter";
+import { close, implementationGraphs, open } from "../plan/service";
+
+import type { Server } from "bun";
+import type { Backend } from "../plan/service";
+import type { JsonValue } from "../storage/model";
+import type { SocketData } from "../wire";
+
+const now = new Date("2026-08-13T12:00:00.000Z");
+
+async function hosted() {
+	let storage = new MemoryStorage();
+	await storage.users.put({ id: "U_octocat", login: "octocat", avatarUrl: "", now });
+	let channel = await storage.channels.create({
+		id: crypto.randomUUID(),
+		repositoryId: "R_score",
+		repositoryOwner: "octo-org",
+		repositoryName: "score",
+		title: "Implementation plan",
+		createdBy: "U_octocat",
+		now,
+	});
+	let lease = await storage.leases.acquire("writer", "graph-test", 60_000);
+	if (!lease) throw new Error("could not acquire test lease");
+	let backend: Backend = {
+		storage,
+		lease: () => lease,
+		fatal: error => {
+			throw error;
+		},
+	};
+	let server = { publish() {} } as unknown as Server<SocketData>;
+	return { storage, channel, lease, backend, server };
+}
+
+const definition = {
+	tasks: [{
+		id: "model",
+		title: "Model graphs",
+		context: "The sidecar owns the graph.",
+		goal: "Persist implementation work.",
+		acceptance: ["The graph is durable.", "The plan remains MDX only."],
+		dependsOn: [],
+	}],
+};
+
+describe("the plan graph adapter", () => {
+	it("keeps a document graph in the hosted sidecar through a restart", async () => {
+		let context = await hosted();
+		let first = await open(context.channel.id, context.backend, context.server);
+
+		let graph = await implementationGraphs().create(first, definition);
+		expect(graph.ok).toBe(true);
+		await close(first);
+		let stored = await context.storage.collaboration.load(context.channel.id, now);
+		expect(stored?.sidecar).toMatchObject({
+			graph: { versions: [{ state: "draft", planRevision: 0, definition }] },
+		});
+
+		let restored = await open(context.channel.id, context.backend, context.server);
+		expect((await implementationGraphs().edit(restored, definition)).ok).toBe(true);
+		await close(restored);
+	});
+
+	it("ignores a malformed graph record while reopening the document", async () => {
+		let context = await hosted();
+		let first = await open(context.channel.id, context.backend, context.server);
+		await close(first);
+		let stored = await context.storage.collaboration.load(context.channel.id, now);
+		if (
+			!stored?.snapshot
+			|| !stored.snapshot.sidecar
+			|| typeof stored.snapshot.sidecar !== "object"
+		) {
+			throw new Error("channel was not initialized");
+		}
+		await context.storage.collaboration.commit({
+			channelId: context.channel.id,
+			lease: context.lease,
+			expectedRevision: stored.channel.revision,
+			operationId: "malformed-graph",
+			epoch: stored.snapshot.epoch,
+			sidecar: { ...stored.snapshot.sidecar, graph: {} } as JsonValue,
+			events: [],
+			now,
+		});
+
+		let restored = await open(context.channel.id, context.backend, context.server);
+		expect(await implementationGraphs().create(restored, definition)).toMatchObject({ ok: true });
+		await close(restored);
+	});
+});

--- a/apps/server/src/tasks/plan-graphs.ts
+++ b/apps/server/src/tasks/plan-graphs.ts
@@ -1,0 +1,33 @@
+/** The hosted persistence boundary for implementation graphs. */
+
+import { Graphs } from "./graphs";
+import { exclusive, persistExclusive } from "../plan/service";
+
+import type { Plan } from "../plan/service";
+import type { Graph, GraphAdapter, Result } from "./graphs";
+
+const adapter: GraphAdapter<Plan> = {
+	async transact(plan, change): Promise<Result<Graph>> {
+		return exclusive(plan, async () => {
+			// Reading the revisions, changing the graph, and committing its sidecar
+			// state are one room operation. A plan change therefore cannot land
+			// between the comparison and the durable record.
+			let result = change({ graph: plan.graph, revision: plan.revision });
+			if (!result.ok) return result;
+			let previous = plan.graph;
+			plan.graph = result.value;
+			try {
+				await persistExclusive(plan);
+				return result;
+			} catch (error) {
+				plan.graph = previous;
+				throw error;
+			}
+		});
+	},
+};
+
+/** The graph service for a live hosted plan. */
+export function implementationGraphs(): Graphs<Plan> {
+	return new Graphs(adapter);
+}


### PR DESCRIPTION
## Summary

- Adds validated, versioned implementation task graphs beside the plan rather than inside MDX.
- Supports draft, approval, locking, and supersession with exact plan-revision binding.
- Persists graph transitions through the hosted plan commit queue introduced on main.
- Restores valid graph state from the strict channel sidecar and safely ignores malformed graph records.

## Stack

Built directly on #42. #43 is an independent sibling and is not required by this stack.

## Verification

- `bun run types`
- `bun run ci`
- `bun test` — 704 pass, 2 expected PostgreSQL skips
- Focused graph model and hosted persistence tests — 8 pass
- `git diff --check`
