### PR TITLE
Let the planner draft and revise implementation graphs

### DIFF
--- a/apps/server/src/agent/arguments.ts
+++ b/apps/server/src/agent/arguments.ts
@@ -12,6 +12,7 @@
 import * as Question from "@chopin/question";
 
 import type { Operation } from "../plan/edit";
+import type { Operation as GraphOperation, Revision, Task } from "../tasks/graphs";
 
 /** Thrown for any malformed tool call; the message reaches the model. */
 export class ArgumentError extends Error {
@@ -264,4 +265,80 @@ export function askPlan(raw: unknown): { revision: number; questions: Positioned
 		});
 
 	return { revision, questions };
+}
+
+const GRAPH_OPERATION_FIELDS = ["op", "id", "task", "ids"];
+
+function graphTask(raw: unknown, name: string): Task {
+	let value = record(raw, name);
+	fields(value, ["id", "title", "context", "goal", "acceptance", "dependsOn"], [
+		"id",
+		"title",
+		"context",
+		"goal",
+		"acceptance",
+		"dependsOn",
+	], name);
+	let acceptance = array(value.acceptance, `${name}.acceptance`, "criterion", 2, 8)
+		.map((criterion, index) => text(criterion, `${name}.acceptance[${index}]`));
+	let dependsOn = array(value.dependsOn, `${name}.dependsOn`, "dependency")
+		.map((dependency, index) => text(dependency, `${name}.dependsOn[${index}]`));
+	return {
+		id: text(value.id, `${name}.id`),
+		title: text(value.title, `${name}.title`),
+		context: text(value.context, `${name}.context`),
+		goal: text(value.goal, `${name}.goal`),
+		acceptance,
+		dependsOn,
+	};
+}
+
+function graphOperation(raw: unknown, position: number): GraphOperation {
+	let name = `operations[${position}]`;
+	let value = record(raw, name);
+	fields(value, GRAPH_OPERATION_FIELDS, ["op"], name);
+	if (typeof value.op !== "string" || !["add", "replace", "reorder", "remove"].includes(value.op)) {
+		fail(`\`${name}.op\` must be one of add, replace, reorder, remove.`);
+	}
+	switch (value.op) {
+		case "add":
+			if (!("task" in value)) fail(`\`${name}.task\` is required for "add".`);
+			return { op: "add", task: graphTask(value.task, `${name}.task`) };
+		case "replace":
+			if (!("id" in value)) fail(`\`${name}.id\` is required for "replace".`);
+			if (!("task" in value)) fail(`\`${name}.task\` is required for "replace".`);
+			return {
+				op: "replace",
+				id: text(value.id, `${name}.id`),
+				task: graphTask(value.task, `${name}.task`),
+			};
+		case "reorder":
+			if (!("ids" in value)) fail(`\`${name}.ids\` is required for "reorder".`);
+			return {
+				op: "reorder",
+				ids: array(value.ids, `${name}.ids`, "task id", 1)
+					.map((id, index) => text(id, `${name}.ids[${index}]`)),
+			};
+		case "remove":
+			if (!("id" in value)) fail(`\`${name}.id\` is required for "remove".`);
+			return { op: "remove", id: text(value.id, `${name}.id`) };
+		default:
+			return fail(`\`${name}.op\` must be one of add, replace, reorder, remove.`);
+	}
+}
+
+/** Validate planner graph operations before they reach durable state. */
+export function graphPlan(raw: unknown): Revision {
+	let args = record(raw, "graph arguments");
+	fields(args, ["plan_revision", "graph_revision", "operations"], [
+		"plan_revision",
+		"graph_revision",
+		"operations",
+	], "graph arguments");
+	return {
+		planRevision: integer(args.plan_revision, "plan_revision"),
+		graphRevision: integer(args.graph_revision, "graph_revision"),
+		operations: array(args.operations, "operations", "operation", 1, MAX_OPERATIONS)
+			.map((operation, index) => graphOperation(operation, index)),
+	};
 }

--- a/apps/server/src/agent/planner.ts
+++ b/apps/server/src/agent/planner.ts
@@ -82,6 +82,22 @@ function reference(): string {
 export const PROMPT = `You are the planner. You produce and maintain the plan — the shared document
 the team works from. You do not implement.
 
+When asked to prepare implementation or revise its task graph, first call
+\`read_implementation_graph\`. It returns the current plan source and the plan and graph
+revisions your graph edit must quote. Then call \`edit_implementation_graph\` with one
+atomic batch. It refuses preparation until every questionnaire is answered,
+accepted comments have been reflected in the plan, no planner turn is active,
+and the plan revision is current; report its named blockers rather than working
+around them.
+
+Each task is one PR-sized vertical slice: give it the local context it needs, a
+single outcome, and two to eight observable acceptance criteria. State real
+dependencies only. Tasks with no dependency are independent roots and can run
+in parallel; a dependency means the later task cannot be safely completed
+first. Add, replace, reorder and remove definitions only through the graph
+tool. Never edit plan prose while preparing implementation, and never approve,
+lock or start implementation — those are decisions and actions for people.
+
 When a new room has no plan prose, settle genuinely blocking choices before writing the first draft.
 Inspect the request and repository. For genuinely blocking choices in a new empty room, call \`read_plan\` and pass its returned revision plus \`blocks: []\` for every question to \`ask\`.
 Wait for their shared answer, and write from it. Do not invent a question when repository evidence already settles it.

--- a/apps/server/src/agent/tools.test.ts
+++ b/apps/server/src/agent/tools.test.ts
@@ -279,3 +279,116 @@ test("a stale ask does not announce an anchor snapshot", async () => {
 	expect(plan.records.size).toBe(0);
 	expect(anchors).toBe(0);
 });
+
+test("planner graph edits draft a revision without changing plan prose", async () => {
+	let { plan, server } = await opened("Prepare the implementation.\n");
+	let before = room.project(plan.document);
+	let graph = toolbox({
+		plan,
+		server,
+		room: "test",
+		persist: () => Service.persist(plan),
+		exclusive: action => Service.exclusive(plan, action),
+		async publish() {},
+		anchors() {},
+		changes() {},
+	}).find(tool => tool.name === "edit_implementation_graph");
+	if (!graph?.handler) throw new Error("edit_implementation_graph is missing");
+	let args = {
+		plan_revision: plan.revision,
+		graph_revision: 0,
+		operations: [{
+			op: "add",
+			task: {
+				id: "graph-tools",
+				title: "Give the planner constrained graph tools",
+				context: "The shared plan is ready for implementation preparation.",
+				goal: "Create a draft implementation graph beside the plan.",
+				acceptance: [
+					"A draft graph is stored against the plan revision.",
+					"The planner does not change plan.mdx.",
+				],
+				dependsOn: [],
+			},
+		}],
+	};
+	let response = await graph.handler(args, {
+		sessionId: "session",
+		toolCallId: "call",
+		toolName: "edit_implementation_graph",
+		arguments: args,
+	});
+	if (typeof response !== "string") throw new Error("graph tool returned no text");
+
+	expect(JSON.parse(response)).toMatchObject({
+		ok: true,
+		graph: { versions: [{ state: "draft", planRevision: plan.revision }] },
+	});
+	expect(plan.graph?.versions[0]?.definition.tasks.map(task => task.id)).toEqual(["graph-tools"]);
+	expect(room.project(plan.document)).toBe(before);
+
+	let stale = await graph.handler({ ...args, graph_revision: 0 }, {
+		sessionId: "session",
+		toolCallId: "later",
+		toolName: "edit_implementation_graph",
+		arguments: args,
+	});
+	expect(JSON.parse(stale as string)).toEqual({ ok: false, reason: "stale-graph" });
+	expect(room.project(plan.document)).toBe(before);
+});
+
+test("planner graph edits name readiness blockers before changing a graph", async () => {
+	let { plan, server } = await opened("Prepare the implementation.\n");
+	plan.records.set("open", {
+		id: "open",
+		status: "open",
+		definition: {
+			questions: [{
+				id: "question",
+				header: "Readiness",
+				question: "May implementation begin?",
+				multiple: false,
+				options: [{ id: "yes", label: "Yes", description: "" }],
+			}],
+		},
+	} as never);
+	let graph = toolbox({
+		plan,
+		server,
+		room: "test",
+		persist: () => Service.persist(plan),
+		exclusive: action => Service.exclusive(plan, action),
+		async publish() {},
+		anchors() {},
+		changes() {},
+	}).find(tool => tool.name === "edit_implementation_graph");
+	if (!graph?.handler) throw new Error("edit_implementation_graph is missing");
+	let args = {
+		plan_revision: plan.revision,
+		graph_revision: 0,
+		operations: [{
+			op: "add",
+			task: {
+				id: "blocked",
+				title: "Blocked graph",
+				context: "The plan still has an open decision.",
+				goal: "Demonstrate that preparation is refused.",
+				acceptance: ["The tool names the blocker.", "No graph is created."],
+				dependsOn: [],
+			},
+		}],
+	};
+	let response = await graph.handler(args, {
+		sessionId: "session",
+		toolCallId: "call",
+		toolName: "edit_implementation_graph",
+		arguments: args,
+	});
+
+	expect(JSON.parse(response as string)).toEqual({
+		ok: false,
+		reason: "not-ready",
+		blockers: ["unanswered questionnaires"],
+	});
+	expect(plan.graph).toBeUndefined();
+});

--- a/apps/server/src/agent/tools.test.ts
+++ b/apps/server/src/agent/tools.test.ts
@@ -1,12 +1,17 @@
 import { afterEach, expect, test } from "bun:test";
 
 import { toolbox } from "./tools";
+import { Sessions } from "../auth/session";
+import * as Chat from "../chat/service";
 import * as room from "../plan/room";
 import * as Service from "../plan/service";
 import * as Store from "../questions/store";
 import { openPlan } from "../testing/plan";
 
+import type { HostedAuth } from "../auth/routes";
 import type { SeedState } from "../testing/plan";
+import type { Config } from "../config";
+import type { Socket } from "../wire";
 
 const WIDGET = "01K0N4TR8K7JGM4R1J7PW4R8YJ";
 const QUESTION = "01K0N4V4E7Y6P4MJ5WD8XZF3B2";
@@ -282,6 +287,11 @@ test("a stale ask does not announce an anchor snapshot", async () => {
 
 test("planner graph edits draft a revision without changing plan prose", async () => {
 	let { plan, server } = await opened("Prepare the implementation.\n");
+	// The graph tool is called from inside the planner turn that `chat:send`
+	// started. That turn is busy by definition; readiness must not mistake it
+	// for a competing request.
+	plan.chat.busy = true;
+	plan.chat.turn = { id: "turn", handle: "ana", started: 1, responded: false };
 	let before = room.project(plan.document);
 	let graph = toolbox({
 		plan,
@@ -335,6 +345,130 @@ test("planner graph edits draft a revision without changing plan prose", async (
 	});
 	expect(JSON.parse(stale as string)).toEqual({ ok: false, reason: "stale-graph" });
 	expect(room.project(plan.document)).toBe(before);
+});
+
+test("a chat-started planner turn can draft an implementation graph", async () => {
+	let { plan, server, storage, channel } = await opened("Prepare the implementation.\n");
+	let now = new Date();
+	let tools = toolbox({
+		plan,
+		server,
+		room: "test",
+		persist: () => Service.persist(plan),
+		exclusive: action => Service.exclusive(plan, action),
+		async publish() {},
+		anchors() {},
+		changes() {},
+	});
+	let graph = tools.find(tool => tool.name === "edit_implementation_graph");
+	if (!graph?.handler) throw new Error("edit_implementation_graph is missing");
+	let args = {
+		plan_revision: plan.revision,
+		graph_revision: 0,
+		operations: [{
+			op: "add",
+			task: {
+				id: "chat-graph",
+				title: "Draft from the chat turn",
+				context: "The planner turn began from the room conversation.",
+				goal: "Create a graph while the planner is busy.",
+				acceptance: ["The graph is drafted.", "The chat turn can complete."],
+				dependsOn: [],
+			},
+		}],
+	};
+	let response: string | undefined;
+	let event: ((value: { type: string }) => void) | undefined;
+	let sent = Promise.withResolvers<void>();
+	plan.chat.agent = {
+		id: "session",
+		session: {
+			on(listener: (value: { type: string }) => void) {
+				event = listener;
+				return () => {};
+			},
+			async send() {
+				let result = await graph.handler!(args, {
+					sessionId: "session",
+					toolCallId: "call",
+					toolName: "edit_implementation_graph",
+					arguments: args,
+				});
+				if (typeof result !== "string") throw new Error("graph tool returned no text");
+				response = result;
+				event?.({ type: "session.idle" });
+				sent.resolve();
+			},
+			async abort() {},
+			async disconnect() {},
+		} as never,
+	};
+	let key = new Uint8Array(32).fill(7);
+	let sessions = new Sessions(storage, true, () => now);
+	let claimant = await sessions.issue("U_test", {
+		accessToken: "gho_test",
+		accessExpiresIn: 28_800,
+		refreshToken: "ghr_test",
+		refreshExpiresIn: 15_897_600,
+	});
+	let repository = { id: "R_test", owner: "owner", name: "repository", defaultBranch: "main" };
+	let auth: HostedAuth = {
+		config: {
+			origin: "https://test",
+			appSlug: "chopin-test",
+			clientId: "id",
+			clientSecret: "secret",
+			encryptionKey: key,
+		},
+		storage,
+		github: {
+			async repositoryAccess() {
+				return {
+					...repository,
+					fullName: "owner/repository",
+					private: true,
+					url: "",
+					permissions: { pull: true, push: true, admin: false },
+				};
+			},
+		} as never,
+		sessions,
+		clock: () => now,
+	};
+	let ownership = await Chat.resolveOwner(auth, repository, channel.id, claimant.id);
+	plan.chat.owner = {
+		sessionId: claimant.id,
+		generation: ownership.ownership.generation,
+		revision: ownership.owner.access.revision,
+		expiresAt: Math.min(
+			ownership.owner.access.expiresAt.getTime(),
+			ownership.owner.session.expiresAt.getTime(),
+		),
+	};
+	let context: Chat.Room = {
+		chat: plan.chat,
+		plan,
+		server,
+		room: channel.id,
+		config: { agent: true } as Config,
+		auth,
+		claimantSessionId: claimant.id,
+		repository,
+		persist: () => Service.persist(plan),
+	};
+
+	await Chat.send(
+		context,
+		{ data: { handle: "ana" }, send() {} } as unknown as Socket,
+		{ kind: "chat:send", rid: "request", text: "prepare implementation", to: "planner", ts: 0 },
+	);
+	await sent.promise;
+
+	expect(JSON.parse(response ?? "")).toMatchObject({
+		ok: true,
+		graph: { versions: [{ state: "draft", planRevision: 0 }] },
+	});
+	expect(plan.graph?.versions[0]?.definition.tasks.map(task => task.id)).toEqual(["chat-graph"]);
 });
 
 test("planner graph edits name readiness blockers before changing a graph", async () => {

--- a/apps/server/src/agent/tools.ts
+++ b/apps/server/src/agent/tools.ts
@@ -1,9 +1,9 @@
 /**
  * What the planner can do.
  *
- * Three tools, and the shape of them is the design: read the plan, edit it by
- * block against the revision you read, and ask the people in the room when the
- * repository cannot settle something. Everything else the agent has is a way of
+ * Plan and graph tools are the design: plan prose is edited by block against
+ * the revision read, while implementation work is revised beside it against
+ * both the plan and graph revisions. Everything else the agent has is a way of
  * looking at the working directory.
  *
  * Tools are built per room, closing over its plan. A session belongs to one
@@ -15,6 +15,7 @@ import * as Arguments from "./arguments";
 import * as Comments from "../comments/service";
 import * as edit from "../plan/edit";
 import * as Questions from "../questions/service";
+import { implementationGraphs, implementationReadiness } from "../tasks/plan-graphs";
 
 import type { Server } from "bun";
 import type { Tool } from "@github/copilot-sdk";
@@ -291,6 +292,68 @@ export function toolbox(context: Context): Tool[] {
 					};
 				}),
 		},
+		{
+			name: "read_implementation_graph",
+			description: "Read the current plan revision and implementation graph before drafting or "
+				+ "revising tasks. The returned plan_revision and graph_revision are required by "
+				+ "edit_implementation_graph; a newer plan or graph refuses the whole edit.",
+			parameters: { type: "object", properties: {}, additionalProperties: false },
+			skipPermission: true,
+			handler: () =>
+				answer("read_implementation_graph", () => {
+					let version = context.plan.graph?.versions.at(-1);
+					return {
+						plan_revision: context.plan.revision,
+						source: edit.source(context.plan),
+						graph_revision: version?.revision ?? 0,
+						graph: context.plan.graph,
+					};
+				}),
+		},
+
+		{
+			name: "edit_implementation_graph",
+			description: "Create or revise the draft implementation graph against the plan and graph "
+				+ "revisions from read_implementation_graph. Submit one atomic batch of add, replace, "
+				+ "reorder and remove operations. This never changes plan content. Only people may "
+				+ "approve, lock or start implementation.",
+			parameters: {
+				type: "object",
+				properties: {
+					plan_revision: { type: "integer", minimum: 0 },
+					graph_revision: { type: "integer", minimum: 0 },
+					operations: {
+						type: "array",
+						minItems: 1,
+						maxItems: 50,
+						items: {
+							type: "object",
+							properties: {
+								op: { type: "string", enum: ["add", "replace", "reorder", "remove"] },
+								id: { type: "string" },
+								task: { type: "object" },
+								ids: { type: "array", items: { type: "string" } },
+							},
+							required: ["op"],
+							additionalProperties: false,
+						},
+					},
+				},
+				required: ["plan_revision", "graph_revision", "operations"],
+				additionalProperties: false,
+			},
+			handler: raw =>
+				answer("edit_implementation_graph", async () => {
+					let args = Arguments.graphPlan(raw);
+					let ready = implementationReadiness(context.plan, args.planRevision);
+					if (!ready.ok) return { ok: false, reason: "not-ready", blockers: ready.blockers };
+					let result = await implementationGraphs().revise(context.plan, args);
+					return result.ok
+						? { ok: true, graph: result.value }
+						: { ok: false, reason: result.reason };
+				}),
+		},
+
 		{
 			name: "anchor_plan",
 			description: "Say where in the plan each decision lives. Call it immediately after every "

--- a/apps/server/src/tasks/graphs.test.ts
+++ b/apps/server/src/tasks/graphs.test.ts
@@ -277,4 +277,83 @@ describe("implementation task graphs", () => {
 			}),
 		).toEqual({ ok: false, reason: "locked" });
 	});
+
+	it("applies planner task operations only against the graph revision it read", async () => {
+		let backend = new Memory();
+		backend.revisions.set("plan", 7);
+		let graphs = new Graphs(backend);
+		await expectGraph(graphs.revise("plan", {
+			planRevision: 7,
+			graphRevision: 0,
+			operations: definition().tasks.map(task => ({ op: "add", task })),
+		}));
+
+		let result = await expectGraph(graphs.revise("plan", {
+			planRevision: 7,
+			graphRevision: 1,
+			operations: [
+				{
+					op: "replace",
+					id: "model",
+					task: {
+						...definition().tasks[0],
+						title: "Model planner graph revisions",
+					},
+				},
+				{
+					op: "add",
+					task: {
+						id: "tools",
+						title: "Give the planner graph tools",
+						context: "The planner works through constrained server tools.",
+						goal: "Draft and revise task graphs without changing plan prose.",
+						acceptance: [
+							"The planner reads the current graph before editing it.",
+							"Planner graph edits leave plan source unchanged.",
+						],
+						dependsOn: ["model"],
+					},
+				},
+				{
+					op: "replace",
+					id: "report",
+					task: { ...definition().tasks[2], dependsOn: ["model"] },
+				},
+				{ op: "remove", id: "validate" },
+				{ op: "reorder", ids: ["publish", "model", "tools", "report"] },
+			],
+		}));
+
+		let current = result.versions.at(-1);
+		if (!current) throw new Error("planner revision was missing");
+		expect(current.planRevision).toBe(7);
+		expect(current.revision).toBe(2);
+		expect(current.definition.tasks.find(task => task.id === "model")?.title)
+			.toBe("Model planner graph revisions");
+		expect(current.definition.tasks.find(task => task.id === "tools")?.dependsOn).toEqual([
+			"model",
+		]);
+		expect(current.definition.tasks.map(task => task.id))
+			.toEqual(["publish", "model", "tools", "report"]);
+
+		let before = structuredClone(result);
+		backend.revisions.set("plan", 8);
+		expect(
+			await graphs.revise("plan", {
+				planRevision: 7,
+				graphRevision: 2,
+				operations: [],
+			}),
+		).toEqual({ ok: false, reason: "stale-plan" });
+		expect(backend.graphs.get("plan")).toEqual(before);
+
+		expect(
+			await graphs.revise("plan", {
+				planRevision: 8,
+				graphRevision: 1,
+				operations: [],
+			}),
+		).toEqual({ ok: false, reason: "stale-graph" });
+		expect(backend.graphs.get("plan")).toEqual(before);
+	});
 });

--- a/apps/server/src/tasks/plan-graphs.test.ts
+++ b/apps/server/src/tasks/plan-graphs.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "bun:test";
 
+import * as graphPlans from "./plan-graphs";
 import { implementationGraphs } from "./plan-graphs";
 import { MemoryStorage } from "../storage/memory/adapter";
 import { close, open } from "../plan/service";
 
 import type { Server } from "bun";
-import type { Backend } from "../plan/service";
+import type { Backend, Plan } from "../plan/service";
 import type { JsonValue } from "../storage/model";
 import type { SocketData } from "../wire";
 
@@ -48,6 +49,33 @@ const definition = {
 };
 
 describe("the plan graph adapter", () => {
+	it("keeps implementation preparation policy with graph persistence", async () => {
+		let context = await hosted();
+		let plan = await open(context.channel.id, context.backend, context.server);
+		let readiness = (graphPlans as typeof graphPlans & {
+			implementationReadiness?: (plan: Plan, revision: unknown) => unknown;
+		}).implementationReadiness;
+
+		expect(readiness).toBeTypeOf("function");
+		if (typeof readiness !== "function") return;
+
+		plan.records.set("open", { id: "open", status: "open" } as never);
+		plan.threads.set("accepted", { id: "accepted", status: "accepted", notes: [] } as never);
+		expect(readiness(plan, -1)).toEqual({
+			ok: false,
+			blockers: [
+				"unanswered questionnaires",
+				"accepted comments awaiting plan changes",
+				"invalid plan revision",
+			],
+		});
+
+		plan.records.clear();
+		plan.threads.clear();
+		expect(readiness(plan, plan.revision)).toEqual({ ok: true, revision: plan.revision });
+		await close(plan);
+	});
+
 	it("keeps a document graph in the hosted sidecar through a restart", async () => {
 		let context = await hosted();
 		let first = await open(context.channel.id, context.backend, context.server);

--- a/apps/server/src/tasks/plan-graphs.ts
+++ b/apps/server/src/tasks/plan-graphs.ts
@@ -1,6 +1,7 @@
 /** The hosted persistence boundary for implementation graphs. */
 
 import { Graphs } from "./graphs";
+import * as Comments from "../comments/service";
 import { exclusive, persistExclusive } from "../plan/service";
 
 import type { Plan } from "../plan/service";
@@ -30,4 +31,22 @@ const adapter: GraphAdapter<Plan> = {
 /** The graph service for a live hosted plan. */
 export function implementationGraphs(): Graphs<Plan> {
 	return new Graphs(adapter);
+}
+
+/** Whether the settled plan can be turned into implementation work. */
+export function implementationReadiness(
+	plan: Plan,
+	revision: unknown,
+): { ok: true; revision: number } | { ok: false; blockers: string[] } {
+	let blockers: string[] = [];
+	if ([...plan.records.values()].some(record => record.status === "open")) {
+		blockers.push("unanswered questionnaires");
+	}
+	if (Comments.outstanding(plan).length > 0) {
+		blockers.push("accepted comments awaiting plan changes");
+	}
+	if (typeof revision !== "number" || !Number.isInteger(revision) || revision !== plan.revision) {
+		blockers.push("invalid plan revision");
+	}
+	return blockers.length > 0 ? { ok: false, blockers } : { ok: true, revision: plan.revision };
 }


### PR DESCRIPTION
## Summary

- Adds planner tools that read and atomically revise draft implementation graphs against both plan and graph revisions.
- Blocks preparation until questionnaires are answered, accepted comments are reflected in the plan, and the supplied plan revision is current.
- Keeps graph persistence and preparation policy in the Tasks boundary; plan prose, graph drafting, and human approval/locking remain separate.
- Covers graph operation batches and drafting from a hosted planner turn.

## Stack

Built directly on #44.

## Verification

- `bun run types`
- `bun run ci`
- `bun test` — 763 pass, 2 expected PostgreSQL skips
- `bun run e2e`
- `git diff --check`