### PR TITLE
Allow authenticated agents to claim approved implementation graphs

### DIFF
--- a/apps/server/src/agent/tools.test.ts
+++ b/apps/server/src/agent/tools.test.ts
@@ -316,18 +316,15 @@ test("a stale ask does not announce an anchor snapshot", async () => {
 });
 
 test("ask refuses to create a questionnaire while implementation is active", async () => {
-	let directory = await mkdtemp(join(tmpdir(), "chopin-agent-tools-"));
-	directories.push(directory);
-	await writeFile(join(directory, "plan.mdx"), "Related prose.\n");
-	let server = { publish() {} } as unknown as Server<SocketData>;
-	let plan = await Service.open("test", directory, server);
-	plans.push(plan);
+	let { plan, server } = await opened("Related prose.\n");
 	let anchors = 0;
 	let ask = toolbox({
 		plan,
 		server,
 		room: "test",
-		publish() {},
+		persist: () => Service.persist(plan),
+		exclusive: action => Service.exclusive(plan, action),
+		async publish() {},
 		anchors: () => anchors++,
 		changes() {},
 	}).find(tool => tool.name === "ask");

--- a/apps/server/src/agent/tools.test.ts
+++ b/apps/server/src/agent/tools.test.ts
@@ -114,6 +114,36 @@ test("anchor_plan publishes moving a decision beside the validated prose", async
 		.toBeLessThan(source.indexOf("The second paragraph."));
 });
 
+test("edit_plan refuses while an implementation claim drains", async () => {
+	let { plan, server } = await opened("The plan is ready.\n");
+	(plan as typeof plan & { claiming: boolean }).claiming = true;
+	let editPlan = toolbox({
+		plan,
+		server,
+		room: "test",
+		persist: () => Service.persist(plan),
+		exclusive: action => Service.exclusive(plan, action),
+		async publish() {},
+		anchors() {},
+		changes() {},
+	}).find(tool => tool.name === "edit_plan");
+	if (!editPlan?.handler) throw new Error("edit_plan has no handler");
+	let args = {
+		revision: plan.revision,
+		operations: [{ op: "replace", index: 0, source: "The plan was changed.\n" }],
+	};
+
+	let response = await editPlan.handler(args, {
+		sessionId: "session",
+		toolCallId: "call",
+		toolName: "edit_plan",
+		arguments: args,
+	});
+
+	expect(JSON.parse(response as string)).toEqual({ ok: false, reason: "locked" });
+	expect(room.project(plan.document)).toBe("The plan is ready.\n");
+});
+
 test("anchor_plan keeps same-block decisions in original ask order", async () => {
 	let { plan, server } = await opened(
 		SOURCE.replace(

--- a/apps/server/src/agent/tools.test.ts
+++ b/apps/server/src/agent/tools.test.ts
@@ -315,6 +315,48 @@ test("a stale ask does not announce an anchor snapshot", async () => {
 	expect(anchors).toBe(0);
 });
 
+test("ask refuses to create a questionnaire while implementation is active", async () => {
+	let directory = await mkdtemp(join(tmpdir(), "chopin-agent-tools-"));
+	directories.push(directory);
+	await writeFile(join(directory, "plan.mdx"), "Related prose.\n");
+	let server = { publish() {} } as unknown as Server<SocketData>;
+	let plan = await Service.open("test", directory, server);
+	plans.push(plan);
+	let anchors = 0;
+	let ask = toolbox({
+		plan,
+		server,
+		room: "test",
+		publish() {},
+		anchors: () => anchors++,
+		changes() {},
+	}).find(tool => tool.name === "ask");
+	if (!ask?.handler) throw new Error("ask is missing");
+	let digest = room.digests(plan.document)[0]!;
+	let args = {
+		revision: plan.revision,
+		questions: [{
+			header: "Rollout",
+			question: "How should we deploy?",
+			multiple: false,
+			options: [{ label: "Canary", description: "Limit exposure." }],
+			blocks: [{ index: 0, digest }],
+		}],
+	};
+	plan.execution = { id: "run-1" } as never;
+
+	let response = await ask.handler(args, {
+		sessionId: "session",
+		toolCallId: "call",
+		toolName: "ask",
+		arguments: args,
+	});
+
+	expect(JSON.parse(response as string)).toEqual({ ok: false, reason: "locked" });
+	expect(plan.records.size).toBe(0);
+	expect(anchors).toBe(0);
+});
+
 test("planner graph edits draft a revision without changing plan prose", async () => {
 	let { plan, server } = await opened("Prepare the implementation.\n");
 	// The graph tool is called from inside the planner turn that `chat:send`

--- a/apps/server/src/agent/tools.ts
+++ b/apps/server/src/agent/tools.ts
@@ -156,6 +156,7 @@ export function toolbox(context: Context): Tool[] {
 			handler: raw =>
 				answer("edit_plan", () =>
 					context.exclusive(async () => {
+						if (context.plan.execution) return { ok: false, reason: "locked" };
 						let args = Arguments.editPlan(raw);
 						let outcome = edit.apply(context.plan, args.revision, args.operations);
 						if (!outcome.ok) return outcome;

--- a/apps/server/src/agent/tools.ts
+++ b/apps/server/src/agent/tools.ts
@@ -16,6 +16,7 @@ import * as Comments from "../comments/service";
 import * as edit from "../plan/edit";
 import * as Questions from "../questions/service";
 import { implementationGraphs, implementationReadiness } from "../tasks/plan-graphs";
+import { implementationActive } from "../plan/service";
 
 import type { Server } from "bun";
 import type { Tool } from "@github/copilot-sdk";
@@ -156,7 +157,7 @@ export function toolbox(context: Context): Tool[] {
 			handler: raw =>
 				answer("edit_plan", () =>
 					context.exclusive(async () => {
-						if (context.plan.execution) return { ok: false, reason: "locked" };
+						if (implementationActive(context.plan)) return { ok: false, reason: "locked" };
 						let args = Arguments.editPlan(raw);
 						let outcome = edit.apply(context.plan, args.revision, args.operations);
 						if (!outcome.ok) return outcome;
@@ -268,7 +269,7 @@ export function toolbox(context: Context): Tool[] {
 			skipPermission: true,
 			handler: raw =>
 				answer("ask", async () => {
-					if (context.plan.execution) return { ok: false, reason: "locked" };
+					if (implementationActive(context.plan)) return { ok: false, reason: "locked" };
 					let args = Arguments.askPlan(raw);
 					let definition = Questions.identify({
 						questions: args.questions.map(({ blocks, ...question }) => question),
@@ -411,7 +412,7 @@ export function toolbox(context: Context): Tool[] {
 			},
 			handler: raw =>
 				answer("anchor_plan", async () => {
-					if (context.plan.execution) return { ok: false, reason: "locked" };
+					if (implementationActive(context.plan)) return { ok: false, reason: "locked" };
 					let args = Arguments.anchorPlan(raw);
 
 					if (args.revision !== context.plan.revision) {

--- a/apps/server/src/agent/tools.ts
+++ b/apps/server/src/agent/tools.ts
@@ -268,6 +268,7 @@ export function toolbox(context: Context): Tool[] {
 			skipPermission: true,
 			handler: raw =>
 				answer("ask", async () => {
+					if (context.plan.execution) return { ok: false, reason: "locked" };
 					let args = Arguments.askPlan(raw);
 					let definition = Questions.identify({
 						questions: args.questions.map(({ blocks, ...question }) => question),

--- a/apps/server/src/agent/tools.ts
+++ b/apps/server/src/agent/tools.ts
@@ -411,6 +411,7 @@ export function toolbox(context: Context): Tool[] {
 			},
 			handler: raw =>
 				answer("anchor_plan", async () => {
+					if (context.plan.execution) return { ok: false, reason: "locked" };
 					let args = Arguments.anchorPlan(raw);
 
 					if (args.revision !== context.plan.revision) {

--- a/apps/server/src/comments.test.ts
+++ b/apps/server/src/comments.test.ts
@@ -441,6 +441,29 @@ describe("accepting, as the service orders it", () => {
 		expect(room.project(plan.document)).toContain(`<Decision id="${id}"`);
 	});
 
+	it("leaves an open thread and plan unchanged while implementation is active", async () => {
+		let { plan, server } = await opened();
+		let ana = member("ana");
+		let id = await mark(plan, server, ana);
+		let source = room.project(plan.document);
+		ana.replies.length = 0;
+		plan.execution = { id: "run-1" } as never;
+
+		await Comments.accept(
+			context(plan, server),
+			ana.socket,
+			ask({ kind: "comment:accept" as const, id }),
+		);
+
+		expect(ana.replies).toHaveLength(1);
+		expect(ana.replies[0]).toMatchObject({
+			kind: "session:error",
+			message: "implementation is active",
+		});
+		expect(plan.threads.get(id)?.status).toBe("open");
+		expect(room.project(plan.document)).toBe(source);
+	});
+
 	/**
 	 * Once the document holds the decision, committing is no longer optional.
 	 * Rolling back on a failed relay would leave a `<Decision>` in a plan whose

--- a/apps/server/src/comments/service.ts
+++ b/apps/server/src/comments/service.ts
@@ -21,7 +21,7 @@ import { limits, ulid } from "@chopin/dialect";
 
 import * as room from "../plan/room";
 import * as Store from "./store";
-import { broadcast, relay, reply, tell } from "../wire";
+import { broadcast, fail, relay, reply, tell } from "../wire";
 
 import * as Chat from "../chat/service";
 import * as Service from "../plan/service";
@@ -379,6 +379,7 @@ async function settle(
 	kind: Resolution,
 ): Promise<void> {
 	let { plan, room: roomId, server } = context;
+	if (kind === "accept" && plan.execution) return fail(ws, msg.rid, "implementation is active");
 
 	let held = plan.threads.get(msg.id);
 	// Read the passage before claiming: a decision records the prose as it read

--- a/apps/server/src/comments/service.ts
+++ b/apps/server/src/comments/service.ts
@@ -379,7 +379,9 @@ async function settle(
 	kind: Resolution,
 ): Promise<void> {
 	let { plan, room: roomId, server } = context;
-	if (kind === "accept" && plan.execution) return fail(ws, msg.rid, "implementation is active");
+	if (kind === "accept" && Service.implementationActive(plan)) {
+		return fail(ws, msg.rid, "implementation is active");
+	}
 
 	let held = plan.threads.get(msg.id);
 	// Read the passage before claiming: a decision records the prose as it read

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -487,7 +487,12 @@ let hostedAuth = registerAuthRoutes(router, {
 			"GitHub credentials refreshed, so the Planner session was restarted. Ask it to continue.",
 		),
 });
-registerMcpRoutes(router, hostedAuth);
+registerMcpRoutes(router, hostedAuth, {
+	lease() {
+		if (!heldLease) throw new Error("storage writer lease is unavailable");
+		return heldLease;
+	},
+});
 registerChannelRoutes(router, hostedAuth, {
 	onAgentReset: channelId => resetOpenAgents(room => room.id === channelId),
 });

--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -117,7 +117,9 @@ describe("the MCP read protocol", () => {
 			})),
 		);
 		expect((tools.result as { tools: unknown[] }).tools).toEqual(
-			TOOLS.filter(tool => tool.name !== "create_document"),
+			TOOLS.filter(tool =>
+				!["create_document", "read_implementation", "start_implementation"].includes(tool.name)
+			),
 		);
 
 		let listed = await json(

--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -4,7 +4,14 @@ import { limits } from "@chopin/dialect";
 
 import { handler, TOOLS } from "./mcp";
 
-import type { CreateDocument, CreateDocumentInput, Document, DocumentReader } from "./mcp";
+import type {
+	CreateDocument,
+	CreateDocumentInput,
+	Document,
+	DocumentReader,
+	Implementations,
+} from "./mcp";
+import type { Run } from "./tasks/graphs";
 
 const document: Document = {
 	id: "f401c8d6-3717-4f1d-8473-cfdd0af894e4",
@@ -134,6 +141,111 @@ describe("the MCP read protocol", () => {
 			})),
 		);
 		expect((read.result as { structuredContent: unknown }).structuredContent).toEqual(document);
+	});
+
+	it("reads and claims an implementation through its initialized client session", async () => {
+		let active: Run | undefined;
+		let implementations: Implementations<string> = {
+			async readImplementation(_caller, id) {
+				if (id !== document.id) return undefined;
+				return {
+					document,
+					repository: {
+						name: "githubnext/chopin",
+						baseBranch: "main",
+						baseCommit: "abc123",
+					},
+					graph: {
+						number: 1,
+						revision: 4,
+						planRevision: 4,
+						state: "approved",
+						definition: { tasks: [] },
+					},
+					execution: active ? { state: "active", run: active } : { state: "idle" },
+				};
+			},
+			async startImplementation(_caller, input) {
+				if (active) return { kind: "active", run: active };
+				active = {
+					id: "run-1",
+					user: "octocat",
+					client: { name: input.client.name, version: input.client.version },
+					session: input.client.session,
+					planRevision: input.planRevision,
+					graphRevision: input.graphRevision,
+					repository: input.repository,
+					branch: input.branch,
+					commit: input.commit,
+					startedAt: "2026-08-17T12:00:00.000Z",
+				};
+				return { kind: "started", run: active };
+			},
+		};
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			create: unavailable(),
+			implementations,
+		});
+		let initialized = await mcp(request({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "initialize",
+			params: { clientInfo: { name: "Codex", version: "1.2.3" } },
+		}));
+		let session = initialized.headers.get("mcp-session-id");
+		expect(session).toBeTruthy();
+
+		let read = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 2,
+				method: "tools/call",
+				params: { name: "read_implementation", arguments: { id: document.id } },
+			})),
+		);
+		expect((read.result as { structuredContent: unknown }).structuredContent).toMatchObject({
+			graph: { state: "approved", revision: 4 },
+			execution: { state: "idle" },
+		});
+
+		let arguments_ = {
+			id: document.id,
+			planRevision: 4,
+			graphRevision: 4,
+			repository: "githubnext/chopin",
+			branch: "tq/017",
+			commit: "deadbeef",
+		};
+		let withoutSession = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 3,
+				method: "tools/call",
+				params: { name: "start_implementation", arguments: arguments_ },
+			})),
+		);
+		expect((withoutSession.result as { structuredContent: unknown }).structuredContent).toEqual({
+			code: "session-required",
+		});
+
+		let claimed = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 4,
+				method: "tools/call",
+				params: { name: "start_implementation", arguments: arguments_ },
+			}, { headers: { "mcp-session-id": session! } })),
+		);
+		expect((claimed.result as { structuredContent: unknown }).structuredContent).toMatchObject({
+			state: "started",
+			run: {
+				id: "run-1",
+				client: { name: "Codex", version: "1.2.3" },
+				session,
+			},
+		});
 	});
 
 	it("keeps the repository-scoped tool schemas static", async () => {

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -15,6 +15,7 @@ import {
 } from "./mcp/create";
 
 import type { Brief, CreateDocumentInput } from "./mcp/create";
+import type { Run, Version } from "./tasks/graphs";
 
 export type { Brief, CreateDocumentInput, CreationOrigin } from "./mcp/create";
 
@@ -36,6 +37,36 @@ export type DocumentReader<Caller> = {
 
 export type CreatedDocument = Document & { url: string };
 
+export type Implementation = {
+	document: Document;
+	repository: { name: string; baseBranch: string; baseCommit: string };
+	graph: Version;
+	execution: { state: "idle" } | { state: "active"; run: Run };
+};
+
+export type ImplementationInput = {
+	id: string;
+	planRevision: number;
+	graphRevision: number;
+	repository: string;
+	branch: string;
+	commit: string;
+	client: { name: string; version: string; session: string };
+};
+
+export type Implementations<Caller> = {
+	readImplementation(caller: Caller, id: string): Promise<Implementation | undefined | "forbidden">;
+	startImplementation(
+		caller: Caller,
+		input: ImplementationInput,
+	): Promise<
+		| { kind: "started"; run: Run }
+		| { kind: "active"; run: Run }
+		| { kind: "forbidden" }
+		| { kind: "refused"; reason: string }
+	>;
+};
+
 export type CreateDocument<Caller> = {
 	create(
 		caller: Caller,
@@ -53,6 +84,7 @@ export type McpOptions<Caller> = {
 	caller(request: Request): Promise<Caller | undefined> | Caller | undefined;
 	documents: DocumentReader<Caller>;
 	create?: CreateDocument<Caller>;
+	implementations?: Implementations<Caller>;
 };
 
 type Tool = {
@@ -71,6 +103,20 @@ const DOCUMENT = {
 		title: { type: "string" },
 	},
 	required: ["id", "title"],
+	additionalProperties: false,
+};
+
+const IMPLEMENTATION = {
+	type: "object",
+	properties: {
+		id: { type: "string", minLength: 1, maxLength: MAX_DOCUMENT_ID_LENGTH },
+		planRevision: { type: "integer", minimum: 0 },
+		graphRevision: { type: "integer", minimum: 1 },
+		repository: { type: "string", pattern: REPOSITORY_PATH_PATTERN },
+		branch: { type: "string", minLength: 1, maxLength: 255 },
+		commit: { type: "string", minLength: 1, maxLength: 64 },
+	},
+	required: ["id", "planRevision", "graphRevision", "repository", "branch", "commit"],
 	additionalProperties: false,
 };
 
@@ -160,6 +206,23 @@ export const TOOLS: Tool[] = [
 			additionalProperties: false,
 		},
 	},
+	{
+		name: "read_implementation",
+		description: "Read the approved implementation graph, plan and repository context.",
+		inputSchema: {
+			type: "object",
+			properties: { id: { type: "string", minLength: 1, maxLength: MAX_DOCUMENT_ID_LENGTH } },
+			required: ["id"],
+			additionalProperties: false,
+		},
+		outputSchema: { type: "object", properties: {}, additionalProperties: true },
+	},
+	{
+		name: "start_implementation",
+		description: "Atomically claim the current approved implementation graph.",
+		inputSchema: IMPLEMENTATION,
+		outputSchema: { type: "object", properties: {}, additionalProperties: true },
+	},
 ];
 
 type Call = {
@@ -212,6 +275,37 @@ function toolCall(
 	if (!value || typeof value.name !== "string") return undefined;
 	let arguments_ = value.arguments === undefined ? {} : record(value.arguments);
 	return arguments_ ? { name: value.name, arguments: arguments_ } : undefined;
+}
+
+type StartArguments = Omit<ImplementationInput, "client">;
+
+function startArguments(value: Record<string, unknown>): StartArguments | undefined {
+	let expected = ["id", "planRevision", "graphRevision", "repository", "branch", "commit"];
+	if (
+		Object.keys(value).length !== expected.length
+		|| expected.some(key => !Object.hasOwn(value, key))
+	) return undefined;
+	if (
+		!isId(value.id)
+		|| !isRepository(value.repository)
+		|| typeof value.branch !== "string"
+		|| !value.branch.trim()
+		|| typeof value.commit !== "string"
+		|| !value.commit.trim()
+		|| !Number.isSafeInteger(value.planRevision)
+		|| (value.planRevision as number) < 0
+		|| !Number.isSafeInteger(value.graphRevision)
+		|| (value.graphRevision as number) < 1
+	) return undefined;
+	return value as StartArguments;
+}
+
+function clientInfo(value: unknown): { name: string; version: string } {
+	let info = record(record(value)?.clientInfo);
+	return {
+		name: typeof info?.name === "string" && info.name.trim() ? info.name : "unknown",
+		version: typeof info?.version === "string" && info.version.trim() ? info.version : "unknown",
+	};
 }
 
 function isId(value: unknown): value is string {
@@ -297,9 +391,19 @@ export function handler<Caller>(
 	options: McpOptions<Caller>,
 ): (request: Request) => Promise<Response> {
 	let creation = options.create;
-	let tools = creation ? TOOLS : TOOLS.filter(tool => tool.name !== "create_document");
+	let sessions = new Map<string, { name: string; version: string }>();
+	let tools = TOOLS.filter(tool =>
+		(tool.name !== "create_document" || creation)
+		&& (!["read_implementation", "start_implementation"].includes(tool.name)
+			|| options.implementations)
+	);
 
-	async function dispatch(value: unknown, caller: Caller): Promise<Reply | undefined> {
+	async function dispatch(
+		value: unknown,
+		caller: Caller,
+		client: { name: string; version: string; session: string },
+		created: { session?: string },
+	): Promise<Reply | undefined> {
 		let call = record(value) as Call | undefined;
 		if (!call || call.jsonrpc !== "2.0" || typeof call.method !== "string") {
 			return error(call?.id, -32600, "invalid request");
@@ -312,12 +416,16 @@ export function handler<Caller>(
 		let respond = (result: unknown) => notification ? undefined : reply(call.id, result);
 
 		switch (call.method) {
-			case "initialize":
+			case "initialize": {
+				let session = crypto.randomUUID();
+				sessions.set(session, clientInfo(call.params));
+				created.session = session;
 				return respond({
 					protocolVersion: "2025-03-26",
 					capabilities: { tools: {} },
 					serverInfo: { name: "chopin", version: "0.0.0" },
 				});
+			}
 
 			case "notifications/initialized":
 				return undefined;
@@ -370,6 +478,51 @@ export function handler<Caller>(
 					}
 					return respond({ content: [], isError: true });
 				}
+				if (tool.name === "read_implementation") {
+					if (Object.keys(tool.arguments).length !== 1 || !isId(tool.arguments.id)) {
+						return notification
+							? undefined
+							: error(call.id, -32602, "read_implementation requires an id");
+					}
+					if (!options.implementations) {
+						return respond(text({ code: "implementation-unavailable" }, true));
+					}
+					let implementation = await options.implementations.readImplementation(
+						caller,
+						tool.arguments.id,
+					);
+					if (implementation === "forbidden") {
+						return respond(text({ code: "repository-forbidden" }, true));
+					}
+					return implementation
+						? respond(text(implementation))
+						: respond(text({ code: "implementation-unavailable" }, true));
+				}
+				if (tool.name === "start_implementation") {
+					let input = startArguments(tool.arguments);
+					if (!input) {
+						return notification
+							? undefined
+							: error(call.id, -32602, "start_implementation requires current revisions");
+					}
+					if (!client.session || !sessions.has(client.session)) {
+						return respond(text({ code: "session-required" }, true));
+					}
+					if (!options.implementations) {
+						return respond(text({ code: "implementation-unavailable" }, true));
+					}
+					let outcome = await options.implementations.startImplementation(caller, {
+						...input,
+						client,
+					});
+					if (outcome.kind === "started" || outcome.kind === "active") {
+						return respond(text({ state: outcome.kind, run: outcome.run }));
+					}
+					if (outcome.kind === "forbidden") {
+						return respond(text({ code: "repository-forbidden" }, true));
+					}
+					return respond(text({ code: outcome.reason }, true));
+				}
 				return notification ? undefined : error(call.id, -32601, "tool not found");
 			}
 
@@ -392,6 +545,9 @@ export function handler<Caller>(
 			return new Response("method not allowed", { status: 405, headers: { allow: "GET, POST" } });
 		}
 
+		let session = request.headers.get("mcp-session-id") ?? "";
+		let client = { ...(sessions.get(session) ?? { name: "unknown", version: "unknown" }), session };
+		let created: { session?: string } = {};
 		let body: unknown;
 		try {
 			let read = await requestBody(request);
@@ -400,7 +556,11 @@ export function handler<Caller>(
 		} catch {
 			return Response.json(error(null, -32700, "parse error"));
 		}
-		let result = await dispatch(body, caller);
-		return result ? Response.json(result) : new Response(null, { status: 202 });
+		let result = await dispatch(body, caller, client, created);
+		return result
+			? Response.json(result, {
+				headers: created.session ? { "mcp-session-id": created.session } : undefined,
+			})
+			: new Response(null, { status: 202 });
 	};
 }

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -8,6 +8,7 @@ import * as Room from "../plan/room";
 import * as Service from "../plan/service";
 import * as Rooms from "../rooms";
 import { MemoryStorage } from "../storage/memory/adapter";
+import { implementationGraphs } from "../tasks/plan-graphs";
 import { hosted } from "./hosted";
 
 import type { Server } from "bun";
@@ -438,6 +439,81 @@ describe("the hosted MCP adapter", () => {
 			Rooms.forget(live);
 			await Service.close(opened);
 		}
+	});
+
+	it("atomically stores one implementation claim for a closed hosted plan", async () => {
+		let context = setup();
+		context.github.repositoryValue = {
+			...context.github.repositoryValue,
+			permissions: { pull: true, push: true, admin: false },
+		};
+		let opened = await plan(context);
+		opened.plan.creation = {
+			brief: creation.brief,
+			origin: {
+				idempotencyKey: creation.idempotencyKey,
+				fingerprint: creation.fingerprint,
+				repository: creation.repository,
+				baseBranch: creation.baseBranch,
+				baseCommit: creation.baseCommit,
+				title: creation.title,
+			},
+		};
+		let graph = await implementationGraphs().revise(opened.plan, {
+			planRevision: 0,
+			graphRevision: 0,
+			operations: [{
+				op: "add",
+				task: {
+					id: "claim",
+					title: "Claim the graph",
+					context: "The graph and run share one durable sidecar.",
+					goal: "Lock approved work for one external session.",
+					acceptance: ["The graph locks.", "The run is durable."],
+					dependsOn: [],
+				},
+			}],
+		});
+		expect(graph.ok).toBe(true);
+		expect((await implementationGraphs().approve(opened.plan)).ok).toBe(true);
+		await Service.close(opened.plan);
+
+		let adapter = hosted(context.auth, { lease: () => opened.lease });
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller || !adapter.implementations) throw new Error("implementation adapter unavailable");
+		let input = {
+			id: opened.channel.id,
+			planRevision: 0,
+			graphRevision: 1,
+			repository: "octo-org/score",
+			branch: "tq/017",
+			commit: "deadbeef",
+			client: { name: "Codex", version: "1.2.3", session: "session-1" },
+		};
+		expect(await adapter.implementations.startImplementation(caller, input)).toMatchObject({
+			kind: "started",
+			run: {
+				user: "allowed",
+				client: { name: "Codex", version: "1.2.3" },
+				session: "session-1",
+			},
+		});
+
+		let stored = await context.storage.collaboration.load(opened.channel.id, context.now);
+		if (!stored) throw new Error("claimed plan was not stored");
+		expect(await Service.readStored(stored)).toMatchObject({
+			graph: { versions: [{ state: "locked" }] },
+			execution: { branch: "tq/017", commit: "deadbeef" },
+		});
+		expect(await adapter.implementations.readImplementation(caller, opened.channel.id))
+			.toMatchObject({
+				graph: { state: "locked" },
+				execution: { state: "active", run: { session: "session-1" } },
+			});
+		expect(await adapter.implementations.startImplementation(caller, input)).toMatchObject({
+			kind: "active",
+			run: { session: "session-1" },
+		});
 	});
 
 	it("makes an inaccessible channel indistinguishable from a missing channel", async () => {

--- a/apps/server/src/mcp/hosted.ts
+++ b/apps/server/src/mcp/hosted.ts
@@ -6,12 +6,16 @@ import { StorageError } from "../storage/errors";
 
 import type { HostedAuth } from "../auth/routes";
 import type { GitHubUser } from "../github/client";
-import type { McpOptions } from "../mcp";
+import type { Implementation, ImplementationInput, McpOptions } from "../mcp";
+import type { ChannelRecord, Lease } from "../storage/model";
+import type { ClaimResult, Run } from "../tasks/graphs";
 
 export type HostedCaller = {
 	oauthToken: string;
 	user: GitHubUser;
 };
+
+export type ImplementationPersistence = { lease(): Lease };
 
 const BEARER = new RegExp("^Bearer ([A-Za-z0-9._~+/-]+=*)$", "i");
 
@@ -57,7 +61,59 @@ function document(value: Document): PublicDocument & { url?: string } {
 }
 
 /** Bind the backend-neutral MCP surface to hosted GitHub authentication. */
-export function hosted(auth: HostedAuth): McpOptions<HostedCaller> {
+export function hosted(
+	auth: HostedAuth,
+	persistence?: ImplementationPersistence,
+): McpOptions<HostedCaller> {
+	function exposed(
+		channel: ChannelRecord,
+		state: Awaited<ReturnType<typeof Plan.readStored>>,
+	): Implementation | undefined {
+		let version = state.graph?.versions.at(-1);
+		if (!state.origin || !version || (version.state !== "approved" && version.state !== "locked")) {
+			return undefined;
+		}
+		return {
+			document: {
+				id: channel.id,
+				title: channel.title,
+				...(state.brief ? { brief: state.brief } : {}),
+				source: state.source,
+				revision: state.revision,
+			},
+			repository: {
+				name: state.origin.repository,
+				baseBranch: state.origin.baseBranch,
+				baseCommit: state.origin.baseCommit,
+			},
+			graph: version,
+			execution: state.execution
+				? { state: "active", run: state.execution }
+				: { state: "idle" },
+		};
+	}
+
+	function run(caller: HostedCaller, input: ImplementationInput): Run {
+		return {
+			id: crypto.randomUUID(),
+			user: caller.user.login,
+			client: { name: input.client.name, version: input.client.version },
+			session: input.client.session,
+			planRevision: input.planRevision,
+			graphRevision: input.graphRevision,
+			repository: input.repository,
+			branch: input.branch,
+			commit: input.commit,
+			startedAt: auth.clock().toISOString(),
+		};
+	}
+
+	function result(value: ClaimResult) {
+		return value.kind === "started"
+			? { kind: "started" as const, run: value.run }
+			: value;
+	}
+
 	return {
 		async caller(request) {
 			let match = request.headers.get("authorization")?.match(BEARER);
@@ -213,5 +269,94 @@ export function hosted(auth: HostedAuth): McpOptions<HostedCaller> {
 				};
 			},
 		},
+		...(persistence
+			? {
+				implementations: {
+					async readImplementation(caller: HostedCaller, id: string) {
+						let channel = await auth.storage.channels.get(id);
+						if (!channel) return undefined;
+						let repository = await auth.github.repositoryAccess(
+							caller.oauthToken,
+							channel.repositoryOwner,
+							channel.repositoryName,
+						);
+						if (!repository?.permissions.pull || repository.id !== channel.repositoryId) {
+							return "forbidden" as const;
+						}
+						let live = Rooms.get(id)?.plan;
+						if (live) {
+							return exposed(channel, {
+								source: Plan.source(live),
+								revision: live.revision,
+								...(live.brief ? { brief: live.brief } : {}),
+								...(live.origin ? { origin: live.origin } : {}),
+								...(live.graph ? { graph: live.graph } : {}),
+								...(live.execution ? { execution: live.execution } : {}),
+							});
+						}
+						let stored = await auth.storage.collaboration.load(id, auth.clock());
+						return stored ? exposed(channel, await Plan.readStored(stored)) : undefined;
+					},
+					async startImplementation(caller: HostedCaller, input: ImplementationInput) {
+						let channel = await auth.storage.channels.get(input.id);
+						if (
+							!channel
+							|| `${channel.repositoryOwner}/${channel.repositoryName}` !== input.repository
+						) {
+							return { kind: "forbidden" as const };
+						}
+						let repository = await auth.github.repositoryAccess(
+							caller.oauthToken,
+							channel.repositoryOwner,
+							channel.repositoryName,
+						);
+						if (
+							!repository
+							|| repository.id !== channel.repositoryId
+							|| (!repository.permissions.push && !repository.permissions.admin)
+						) return { kind: "forbidden" as const };
+						let claimRun = run(caller, input);
+						let live = Rooms.get(input.id)?.plan;
+						if (live) {
+							return result(
+								await Plan.claimImplementation(live, {
+									planRevision: input.planRevision,
+									graphRevision: input.graphRevision,
+									run: claimRun,
+								}),
+							);
+						}
+						for (let attempt = 0; attempt < 2; attempt++) {
+							let stored = await auth.storage.collaboration.load(input.id, auth.clock());
+							if (!stored?.snapshot) return { kind: "refused" as const, reason: "missing" };
+							let prepared = Plan.claimStored(stored, {
+								planRevision: input.planRevision,
+								graphRevision: input.graphRevision,
+								run: claimRun,
+							});
+							if (prepared.result.kind !== "started" || !prepared.sidecar) {
+								return result(prepared.result);
+							}
+							try {
+								await auth.storage.collaboration.commit({
+									channelId: input.id,
+									lease: persistence.lease(),
+									expectedRevision: stored.channel.revision,
+									operationId: `implementation:${claimRun.id}`,
+									epoch: stored.snapshot.epoch,
+									sidecar: prepared.sidecar,
+									events: [],
+									now: auth.clock(),
+								});
+								return result(prepared.result);
+							} catch (err) {
+								if (!(err instanceof StorageError) || err.failure !== "conflict") throw err;
+							}
+						}
+						return { kind: "refused" as const, reason: "conflict" };
+					},
+				},
+			}
+			: {}),
 	};
 }

--- a/apps/server/src/mcp/hosted.ts
+++ b/apps/server/src/mcp/hosted.ts
@@ -2,6 +2,7 @@ import { GitHubError } from "../github/client";
 import { createHash } from "node:crypto";
 import * as Plan from "../plan/service";
 import * as Rooms from "../rooms";
+import { claimImplementation } from "../tasks/plan-graphs";
 import { StorageError } from "../storage/errors";
 
 import type { HostedAuth } from "../auth/routes";
@@ -292,8 +293,7 @@ export function hosted(
 							return exposed(channel, {
 								source: Plan.source(live),
 								revision: live.revision,
-								...(live.brief ? { brief: live.brief } : {}),
-								...(live.origin ? { origin: live.origin } : {}),
+								...(live.creation ? { creation: live.creation } : {}),
 								...(live.graph ? { graph: live.graph } : {}),
 								...(live.execution ? { execution: live.execution } : {}),
 							});
@@ -323,7 +323,7 @@ export function hosted(
 						let live = Rooms.get(input.id)?.plan;
 						if (live) {
 							return claimResult(
-								await Plan.claimImplementation(live, {
+								await claimImplementation(live, {
 									planRevision: input.planRevision,
 									graphRevision: input.graphRevision,
 									run: claimRun,

--- a/apps/server/src/mcp/hosted.ts
+++ b/apps/server/src/mcp/hosted.ts
@@ -60,39 +60,49 @@ function document(value: Document): PublicDocument & { url?: string } {
 	};
 }
 
+function exposed(
+	channel: ChannelRecord,
+	state: Awaited<ReturnType<typeof Plan.readStored>>,
+): Implementation | undefined {
+	let version = state.graph?.versions.at(-1);
+	if (
+		!state.creation
+		|| !version
+		|| (version.state !== "approved" && version.state !== "locked")
+	) {
+		return undefined;
+	}
+	return {
+		document: document({
+			id: channel.id,
+			title: channel.title,
+			creation: state.creation,
+			source: state.source,
+			revision: state.revision,
+		}),
+		repository: {
+			name: state.creation.origin.repository,
+			baseBranch: state.creation.origin.baseBranch,
+			baseCommit: state.creation.origin.baseCommit,
+		},
+		graph: version,
+		execution: state.execution
+			? { state: "active", run: state.execution }
+			: { state: "idle" },
+	};
+}
+
+function claimResult(value: ClaimResult) {
+	return value.kind === "started"
+		? { kind: "started" as const, run: value.run }
+		: value;
+}
+
 /** Bind the backend-neutral MCP surface to hosted GitHub authentication. */
 export function hosted(
 	auth: HostedAuth,
 	persistence?: ImplementationPersistence,
 ): McpOptions<HostedCaller> {
-	function exposed(
-		channel: ChannelRecord,
-		state: Awaited<ReturnType<typeof Plan.readStored>>,
-	): Implementation | undefined {
-		let version = state.graph?.versions.at(-1);
-		if (!state.origin || !version || (version.state !== "approved" && version.state !== "locked")) {
-			return undefined;
-		}
-		return {
-			document: {
-				id: channel.id,
-				title: channel.title,
-				...(state.brief ? { brief: state.brief } : {}),
-				source: state.source,
-				revision: state.revision,
-			},
-			repository: {
-				name: state.origin.repository,
-				baseBranch: state.origin.baseBranch,
-				baseCommit: state.origin.baseCommit,
-			},
-			graph: version,
-			execution: state.execution
-				? { state: "active", run: state.execution }
-				: { state: "idle" },
-		};
-	}
-
 	function run(caller: HostedCaller, input: ImplementationInput): Run {
 		return {
 			id: crypto.randomUUID(),
@@ -106,12 +116,6 @@ export function hosted(
 			commit: input.commit,
 			startedAt: auth.clock().toISOString(),
 		};
-	}
-
-	function result(value: ClaimResult) {
-		return value.kind === "started"
-			? { kind: "started" as const, run: value.run }
-			: value;
 	}
 
 	return {
@@ -318,7 +322,7 @@ export function hosted(
 						let claimRun = run(caller, input);
 						let live = Rooms.get(input.id)?.plan;
 						if (live) {
-							return result(
+							return claimResult(
 								await Plan.claimImplementation(live, {
 									planRevision: input.planRevision,
 									graphRevision: input.graphRevision,
@@ -335,7 +339,7 @@ export function hosted(
 								run: claimRun,
 							});
 							if (prepared.result.kind !== "started" || !prepared.sidecar) {
-								return result(prepared.result);
+								return claimResult(prepared.result);
 							}
 							try {
 								await auth.storage.collaboration.commit({
@@ -348,7 +352,7 @@ export function hosted(
 									events: [],
 									now: auth.clock(),
 								});
-								return result(prepared.result);
+								return claimResult(prepared.result);
 							} catch (err) {
 								if (!(err instanceof StorageError) || err.failure !== "conflict") throw err;
 							}

--- a/apps/server/src/mcp/routes.ts
+++ b/apps/server/src/mcp/routes.ts
@@ -3,6 +3,7 @@ import { hosted } from "./hosted";
 
 import type { HostedAuth } from "../auth/routes";
 import type { Router } from "../http/router";
+import type { ImplementationPersistence } from "./hosted";
 
 function failure(): Response {
 	return new Response("MCP request failed", { status: 500 });
@@ -20,8 +21,12 @@ function protectedResponse(response: Response): Response {
 }
 
 /** Register the hosted, read-only MCP endpoint. */
-export function registerMcpRoutes(router: Router, auth: HostedAuth): void {
-	let endpoint = handler(hosted(auth));
+export function registerMcpRoutes(
+	router: Router,
+	auth: HostedAuth,
+	persistence?: ImplementationPersistence,
+): void {
+	let endpoint = handler(hosted(auth, persistence));
 	let route = async (request: Request): Promise<Response> => {
 		if (request.headers.has("origin") && request.headers.get("origin") !== auth.config.origin) {
 			return protectedResponse(new Response("origin is not allowed", { status: 403 }));

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -20,8 +20,8 @@ import * as room from "./room";
 import * as Chat from "../chat/service";
 import * as Comments from "../comments/service";
 import * as Questions from "../questions/service";
-import { restore as restoreGraph } from "../tasks/graphs";
-import { broadcast, relay, reply, tell } from "../wire";
+import { claim, restore as restoreGraph, restoreRun } from "../tasks/graphs";
+import { broadcast, fail, relay, reply, tell } from "../wire";
 
 import type { Server } from "bun";
 import type { Plan as Wire, Request } from "@chopin/protocol";
@@ -33,7 +33,7 @@ import type { Block } from "./edit";
 import type { Brief, CreationOrigin } from "../mcp";
 import type { InitialChannel, JsonValue, Lease, StoredChannel } from "../storage/model";
 import type { StorageAdapter } from "../storage/port";
-import type { Graph } from "../tasks/graphs";
+import type { ClaimInput, ClaimResult, Graph, Run } from "../tasks/graphs";
 
 /** Updates are grouped for this long before being applied together. */
 const GROUP_MS = 5;
@@ -128,6 +128,10 @@ export type Plan = {
 	revision: number;
 	/** Implementation work, stored beside rather than inside the plan. */
 	graph?: Graph;
+	/** The external implementation run that freezes this plan. */
+	execution?: Run;
+	/** A claim has closed mutation ingress while accepted work drains. */
+	claiming: boolean;
 	/**
 	 * Block outlines by revision.
 	 *
@@ -164,6 +168,7 @@ type Sidecar = {
 	documentSeq: number;
 	creation?: CreationMetadata;
 	graph?: Graph;
+	execution?: Run;
 	questions: Questions.Record[];
 	openQuestions: Questions.StoredOpen[];
 	threads: Comments.Record[];
@@ -177,6 +182,7 @@ function state(plan: Plan): Sidecar {
 		documentSeq: plan.document.seq,
 		...(plan.creation ? { creation: plan.creation } : {}),
 		...(plan.graph ? { graph: plan.graph } : {}),
+		...(plan.execution ? { execution: plan.execution } : {}),
 		questions: [...plan.records.values()],
 		openQuestions: Questions.dump(plan.questions),
 		threads: [...plan.threads.values()],
@@ -331,6 +337,7 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 	];
 	if (created) expected.push(...(legacy ? ["brief", "origin"] : ["creation"]));
 	if (Object.hasOwn(item, "graph")) expected.push("graph");
+	if (Object.hasOwn(item, "execution")) expected.push("execution");
 	expected.sort();
 	if (
 		keys.length !== expected.length
@@ -347,6 +354,12 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 		|| !Array.isArray(item.threads)
 		|| !Array.isArray(item.transcript)
 	) throw new Error("hosted channel has an invalid sidecar");
+	let execution = Object.hasOwn(item, "execution")
+		? restoreRun(item.execution, graph, item.revision)
+		: undefined;
+	if (Object.hasOwn(item, "execution") && !execution) {
+		throw new Error("hosted channel has an invalid implementation run");
+	}
 	let questions = objects(item.questions, "question record");
 	for (let question of questions) {
 		if (
@@ -388,6 +401,7 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 		documentSeq: item.documentSeq,
 		...(created ? { creation: created } : {}),
 		...(graph ? { graph } : {}),
+		...(execution ? { execution } : {}),
 		questions: questions as never[],
 		openQuestions: openQuestions as unknown as Questions.StoredOpen[],
 		threads: threads as never[],
@@ -570,6 +584,20 @@ export function exclusive<T>(plan: Plan, action: () => Promise<T>): Promise<T> {
 	return operation;
 }
 
+/** Drain mutations already admitted before a claim closes the plan to new work. */
+export async function drain(plan: Plan): Promise<void> {
+	if (plan.timer) clearTimeout(plan.timer);
+	plan.timer = undefined;
+	let pending = () => commit(plan);
+	plan.flushing = plan.flushing.then(pending, pending);
+	await plan.flushing;
+}
+
+/** One gate for every path that can mutate a plan during implementation. */
+export function implementationActive(plan: Plan): boolean {
+	return plan.claiming || !!plan.execution;
+}
+
 /** Sidecar-only commit for a caller already holding `exclusive`. */
 export function persistExclusive(plan: Plan): Promise<void> {
 	return commitHosted(plan, undefined, `state:${crypto.randomUUID()}`, capture(plan));
@@ -580,6 +608,34 @@ type RestoredHosted = {
 	needsInitialCheckpoint: boolean;
 	sidecar: Sidecar;
 };
+
+/** Prepare the sidecar half of one atomic claim for a plan that is not live. */
+export function claimStored(
+	loaded: StoredChannel,
+	input: ClaimInput,
+): { result: ClaimResult; sidecar?: JsonValue } {
+	let pristine = loaded.channel.revision === 0 && loaded.latestSequence === 0 && !loaded.snapshot;
+	let sidecar = restoredState(
+		loaded.sidecar === null && loaded.snapshot && loaded.channel.revision === 0
+			? loaded.snapshot.sidecar
+			: loaded.sidecar,
+		pristine,
+	);
+	let result = claim({
+		graph: sidecar.graph,
+		revision: sidecar.revision,
+		execution: sidecar.execution,
+	}, input);
+	if (result.kind !== "started") return { result };
+	return {
+		result,
+		sidecar: JSON.parse(JSON.stringify({
+			...sidecar,
+			graph: result.graph,
+			execution: result.run,
+		})) as JsonValue,
+	};
+}
 
 async function restoreHosted(id: string, loaded: StoredChannel): Promise<RestoredHosted> {
 	let document: Document;
@@ -631,7 +687,13 @@ async function restoreHosted(id: string, loaded: StoredChannel): Promise<Restore
 /** Project a closed channel without attaching it to the live room registry. */
 export async function readStored(
 	loaded: StoredChannel,
-): Promise<{ source: string; revision: number; creation?: CreationMetadata }> {
+): Promise<{
+	source: string;
+	revision: number;
+	creation?: CreationMetadata;
+	graph?: Graph;
+	execution?: Run;
+}> {
 	let restored = await restoreHosted(loaded.channel.id, loaded);
 	try {
 		Questions.shutdown(Questions.restore(restored.sidecar.openQuestions));
@@ -639,6 +701,8 @@ export async function readStored(
 			source: room.project(restored.document),
 			revision: restored.sidecar.revision,
 			...(restored.sidecar.creation ? { creation: restored.sidecar.creation } : {}),
+			...(restored.sidecar.graph ? { graph: restored.sidecar.graph } : {}),
+			...(restored.sidecar.execution ? { execution: restored.sidecar.execution } : {}),
 		};
 	} finally {
 		restored.document.doc.destroy();
@@ -669,6 +733,8 @@ export async function open(
 		threads: new Map(sidecar.threads.map(record => [record.id, record])),
 		revision: sidecar.revision,
 		graph: sidecar.graph,
+		execution: sidecar.execution,
+		claiming: false,
 		queue: [],
 		timer: undefined,
 		attention: undefined,
@@ -740,6 +806,7 @@ function meter(plan: Plan, ws: Socket): Meter {
 
 /** Accept an update for the next batch, or say why not. */
 export function submit(plan: Plan, ws: Socket, msg: Request<Wire.Submit>): void {
+	if (implementationActive(plan)) return fail(ws, msg.rid, "implementation is active");
 	if (msg.epoch !== plan.document.epoch) {
 		// Nothing to correct: the client is describing a history that no longer
 		// exists and needs to re-open, which the reset already told it to do.
@@ -882,6 +949,7 @@ export async function publish(
 	roomId: string,
 	mutation: { update: Uint8Array; source: string },
 ): Promise<void> {
+	if (implementationActive(plan)) throw new Error("implementation is active");
 	plan.document.seq++;
 	plan.revision++;
 	let operationId = `server:${plan.document.epoch}:${

--- a/apps/server/src/questions.service.test.ts
+++ b/apps/server/src/questions.service.test.ts
@@ -272,3 +272,17 @@ test("an active implementation leaves an open questionnaire in the plan when can
 	});
 	await asked.waiting;
 });
+
+test("an active implementation refuses to create a questionnaire", async () => {
+	let plan = await opened();
+	let server = { publish() {} } as unknown as Server<SocketData>;
+	let revision = plan.revision;
+	plan.execution = { id: "run-1" } as never;
+
+	await expect(Questions.ask(plan, server, "test", definition()))
+		.rejects.toThrow("implementation is active");
+
+	expect(plan.revision).toBe(revision);
+	expect(plan.records.size).toBe(0);
+	expect(room.project(plan.document)).not.toContain("<Questionnaire");
+});

--- a/apps/server/src/questions.service.test.ts
+++ b/apps/server/src/questions.service.test.ts
@@ -10,7 +10,7 @@ import { openPlan } from "./testing/plan";
 
 import type { Server } from "bun";
 import type { Plan } from "./plan/service";
-import type { SocketData } from "./wire";
+import type { Socket, SocketData } from "./wire";
 
 let plans: Plan[] = [];
 
@@ -231,4 +231,44 @@ test("unplaced questions remain valid before any prose exists", async () => {
 
 	await answer(plan);
 	await Promise.all([first.waiting, second.waiting]);
+});
+
+test("an active implementation leaves an open questionnaire in the plan when cancellation is refused", async () => {
+	let plan = await opened();
+	let server = { publish() {} } as unknown as Server<SocketData>;
+	let asked = asking(plan, server, definition());
+	await asked.created;
+	let id = [...plan.records.keys()][0]!;
+	let replies: Array<{ kind: string; message?: string; rid?: string; ts?: number }> = [];
+	let ws = {
+		data: { handle: "ana", client: "client-ana", room: "test" },
+		send(raw: string) {
+			replies.push(JSON.parse(raw));
+		},
+	} as unknown as Socket;
+	plan.execution = { id: "run-1" } as never;
+
+	await Questions.cancel(plan, server, "test", ws, {
+		kind: "question:cancel",
+		ts: 0,
+		rid: "cancel",
+		id,
+	});
+
+	expect(replies).toEqual([{
+		kind: "session:error",
+		message: "implementation is active",
+		ts: expect.any(Number),
+		rid: "cancel",
+	}]);
+	expect(plan.records.get(id)?.status).toBe("open");
+	expect(room.project(plan.document)).toContain("<Questionnaire");
+	plan.execution = undefined;
+	await Questions.cancel(plan, server, "test", ws, {
+		kind: "question:cancel",
+		ts: 0,
+		rid: "cleanup",
+		id,
+	});
+	await asked.waiting;
 });

--- a/apps/server/src/questions/service.ts
+++ b/apps/server/src/questions/service.ts
@@ -263,6 +263,7 @@ export async function submit(
 	ws: Socket,
 	msg: Request<Wire.Submit.Ask>,
 ): Promise<void> {
+	if (plan.execution) return fail(ws, msg.rid, "implementation is active");
 	let claimed = Store.claimSubmit(plan.questions, msg.id, msg.revision, ws.data.handle);
 	if (!claimed.ok) {
 		return reply(ws, msg.rid, { kind: "question:submit", ts: 0, id: msg.id, ...claimed });

--- a/apps/server/src/questions/service.ts
+++ b/apps/server/src/questions/service.ts
@@ -99,7 +99,7 @@ export async function ask(
 	placement?: AskPlacement,
 	created?: () => void,
 ): Promise<Ended[]> {
-	if (plan.execution) throw new Error("implementation is active");
+	if (Service.implementationActive(plan)) throw new Error("implementation is active");
 	if (definition.questions.length === 0) {
 		Question.reject("A questionnaire needs at least one question");
 	}
@@ -264,7 +264,7 @@ export async function submit(
 	ws: Socket,
 	msg: Request<Wire.Submit.Ask>,
 ): Promise<void> {
-	if (plan.execution) return fail(ws, msg.rid, "implementation is active");
+	if (Service.implementationActive(plan)) return fail(ws, msg.rid, "implementation is active");
 	let claimed = Store.claimSubmit(plan.questions, msg.id, msg.revision, ws.data.handle);
 	if (!claimed.ok) {
 		return reply(ws, msg.rid, { kind: "question:submit", ts: 0, id: msg.id, ...claimed });
@@ -350,7 +350,7 @@ export async function cancel(
 	ws: Socket,
 	msg: Request<Wire.Cancel.Ask>,
 ): Promise<void> {
-	if (plan.execution) return fail(ws, msg.rid, "implementation is active");
+	if (Service.implementationActive(plan)) return fail(ws, msg.rid, "implementation is active");
 	let claimed = Store.claimCancel(plan.questions, msg.id, ws.data.handle);
 	if (!claimed.ok) {
 		return reply(ws, msg.rid, { kind: "question:cancel", ts: 0, id: msg.id, ...claimed });

--- a/apps/server/src/questions/service.ts
+++ b/apps/server/src/questions/service.ts
@@ -349,6 +349,7 @@ export async function cancel(
 	ws: Socket,
 	msg: Request<Wire.Cancel.Ask>,
 ): Promise<void> {
+	if (plan.execution) return fail(ws, msg.rid, "implementation is active");
 	let claimed = Store.claimCancel(plan.questions, msg.id, ws.data.handle);
 	if (!claimed.ok) {
 		return reply(ws, msg.rid, { kind: "question:cancel", ts: 0, id: msg.id, ...claimed });

--- a/apps/server/src/questions/service.ts
+++ b/apps/server/src/questions/service.ts
@@ -99,6 +99,7 @@ export async function ask(
 	placement?: AskPlacement,
 	created?: () => void,
 ): Promise<Ended[]> {
+	if (plan.execution) throw new Error("implementation is active");
 	if (definition.questions.length === 0) {
 		Question.reject("A questionnaire needs at least one question");
 	}

--- a/apps/server/src/tasks/graphs.test.ts
+++ b/apps/server/src/tasks/graphs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
+import * as Tasks from "./graphs";
 import { Graphs, restore } from "./graphs";
 
 import type { Definition, Graph, GraphAdapter, Operation, Task } from "./graphs";
@@ -80,6 +81,21 @@ function stored(number: number, state: string): unknown {
 	return { number, planRevision: 0, state, definition: definition() };
 }
 
+function run() {
+	return {
+		id: "run-1",
+		user: "octocat",
+		client: { name: "Codex", version: "1.2.3" },
+		session: "session-1",
+		planRevision: 7,
+		graphRevision: 3,
+		repository: "githubnext/chopin",
+		branch: "tq/017",
+		commit: "deadbeef",
+		startedAt: "2026-08-17T12:00:00.000Z",
+	};
+}
+
 async function expectGraph<T>(
 	value: Promise<{ ok: true; value: T } | { ok: false; reason: string }>,
 ): Promise<T> {
@@ -90,6 +106,43 @@ async function expectGraph<T>(
 }
 
 describe("implementation task graphs", () => {
+	it("locks exactly the graph revision an implementation run records", () => {
+		type Claim = (state: unknown, input: unknown) => unknown;
+		type RestoreRun = (value: unknown, graph: unknown, revision: number) => unknown;
+		let claim = (Tasks as typeof Tasks & { claim?: Claim }).claim;
+		let restoreRun = (Tasks as typeof Tasks & { restoreRun?: RestoreRun }).restoreRun;
+		expect(claim).toBeTypeOf("function");
+		expect(restoreRun).toBeTypeOf("function");
+		if (typeof claim !== "function" || typeof restoreRun !== "function") return;
+
+		let approved: Graph = {
+			versions: [{
+				number: 1,
+				revision: 3,
+				planRevision: 7,
+				state: "approved",
+				definition: definition(),
+			}],
+		};
+		let locked: Graph = {
+			versions: [{ ...approved.versions[0]!, state: "locked" }],
+		};
+		let implementation = run();
+
+		expect(claim(
+			{ graph: approved, revision: 7, execution: undefined },
+			{ planRevision: 7, graphRevision: 3, run: implementation },
+		)).toMatchObject({
+			kind: "started",
+			graph: { versions: [{ state: "locked" }] },
+			run: implementation,
+		});
+		expect(restoreRun(implementation, locked, 7)).toEqual(implementation);
+		expect(restoreRun({ ...implementation, extra: true }, locked, 7)).toBeUndefined();
+		expect(restoreRun(implementation, approved, 7)).toBeUndefined();
+		expect(restoreRun(implementation, locked, 8)).toBeUndefined();
+	});
+
 	it("ignores an unreachable version history while preserving graph revision compatibility", () => {
 		expect(restore({
 			versions: [stored(1, "locked"), stored(2, "approved")],

--- a/apps/server/src/tasks/graphs.ts
+++ b/apps/server/src/tasks/graphs.ts
@@ -34,6 +34,31 @@ export type Graph = {
 	versions: Version[];
 };
 
+/** Durable ownership of the external session implementing one locked graph. */
+export type Run = {
+	id: string;
+	user: string;
+	client: { name: string; version: string };
+	session: string;
+	planRevision: number;
+	graphRevision: number;
+	repository: string;
+	branch: string;
+	commit: string;
+	startedAt: string;
+};
+
+export type ClaimInput = {
+	planRevision: number;
+	graphRevision: number;
+	run: Run;
+};
+
+export type ClaimResult =
+	| { kind: "started"; graph: Graph; run: Run }
+	| { kind: "active"; run: Run }
+	| { kind: "refused"; reason: string };
+
 export type GraphAdapter<Document> = {
 	/** Runs the change against one current graph and plan revision. */
 	transact(
@@ -203,6 +228,97 @@ function history(versions: Version[]): boolean {
 		);
 	}
 	return prior.every(version => version.state === "superseded");
+}
+
+function run(value: unknown): Run | undefined {
+	let stored = item(value, [
+		"branch",
+		"client",
+		"commit",
+		"graphRevision",
+		"id",
+		"planRevision",
+		"repository",
+		"session",
+		"startedAt",
+		"user",
+	]);
+	let client = stored && item(stored.client, ["name", "version"]);
+	let strings = stored && client && [
+		stored.id,
+		stored.user,
+		stored.session,
+		stored.repository,
+		stored.branch,
+		stored.commit,
+		stored.startedAt,
+		client.name,
+		client.version,
+	];
+	if (
+		!stored
+		|| !client
+		|| !strings
+		|| strings.some(value => typeof value !== "string" || !value.trim())
+		|| !Number.isSafeInteger(stored.planRevision)
+		|| (stored.planRevision as number) < 0
+		|| !Number.isSafeInteger(stored.graphRevision)
+		|| (stored.graphRevision as number) < 1
+	) return undefined;
+	return {
+		id: stored.id as string,
+		user: stored.user as string,
+		client: { name: client.name as string, version: client.version as string },
+		session: stored.session as string,
+		planRevision: stored.planRevision as number,
+		graphRevision: stored.graphRevision as number,
+		repository: stored.repository as string,
+		branch: stored.branch as string,
+		commit: stored.commit as string,
+		startedAt: stored.startedAt as string,
+	};
+}
+
+/** Restore a run only when it names this sidecar's locked graph and revision. */
+export function restoreRun(
+	value: unknown,
+	graph: Graph | undefined,
+	revision: number,
+): Run | undefined {
+	let restored = run(value);
+	let version = graph?.versions.at(-1);
+	if (
+		!restored
+		|| !version
+		|| version.state !== "locked"
+		|| version.planRevision !== revision
+		|| restored.planRevision !== revision
+		|| restored.graphRevision !== version.revision
+	) return undefined;
+	return copy(restored);
+}
+
+/** Lock exactly one approved graph revision and record its owner atomically. */
+export function claim(
+	state: { graph: Graph | undefined; revision: number | undefined; execution: Run | undefined },
+	input: ClaimInput,
+): ClaimResult {
+	if (state.execution) return { kind: "active", run: copy(state.execution) };
+	if (state.revision !== input.planRevision) return { kind: "refused", reason: "stale-plan" };
+	let graph = state.graph && copy(state.graph);
+	let version = graph?.versions.at(-1);
+	let owner = run(input.run);
+	if (!graph || !version) return { kind: "refused", reason: "missing" };
+	if (!owner) return { kind: "refused", reason: "run" };
+	if (version.revision !== input.graphRevision) return { kind: "refused", reason: "stale-graph" };
+	if (version.state !== "approved") return { kind: "refused", reason: "not-approved" };
+	if (version.planRevision !== state.revision) return { kind: "refused", reason: "stale-plan" };
+	if (owner.planRevision !== input.planRevision || owner.graphRevision !== input.graphRevision) {
+		return { kind: "refused", reason: "run" };
+	}
+
+	graph.versions[graph.versions.length - 1] = { ...version, state: "locked" };
+	return { kind: "started", graph, run: copy(owner) };
 }
 
 /** Apply a planner's whole graph batch before deciding whether it is valid. */

--- a/apps/server/src/tasks/plan-graphs.test.ts
+++ b/apps/server/src/tasks/plan-graphs.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import * as graphPlans from "./plan-graphs";
-import { implementationGraphs } from "./plan-graphs";
+import { claimImplementation, implementationGraphs } from "./plan-graphs";
 import { MemoryStorage } from "../storage/memory/adapter";
 import { close, open } from "../plan/service";
 
@@ -47,6 +47,21 @@ const definition = {
 		dependsOn: [],
 	}],
 };
+
+function run(planRevision: number) {
+	return {
+		id: "run-1",
+		user: "octocat",
+		client: { name: "Codex", version: "1.2.3" },
+		session: "session-1",
+		planRevision,
+		graphRevision: 1,
+		repository: "octo-org/score",
+		branch: "tq/017",
+		commit: "deadbeef",
+		startedAt: "2026-08-17T12:00:00.000Z",
+	};
+}
 
 describe("the plan graph adapter", () => {
 	it("keeps implementation preparation policy with graph persistence", async () => {
@@ -135,5 +150,59 @@ describe("the plan graph adapter", () => {
 			}),
 		).toMatchObject({ ok: true });
 		await close(restored);
+	});
+
+	it("restores only a run paired with the locked graph revision", async () => {
+		let context = await hosted();
+		let plan = await open(context.channel.id, context.backend, context.server);
+		let drafted = await implementationGraphs().revise(plan, {
+			planRevision: plan.revision,
+			graphRevision: 0,
+			operations: definition.tasks.map(task => ({ op: "add", task })),
+		});
+		expect(drafted.ok).toBe(true);
+		expect((await implementationGraphs().approve(plan)).ok).toBe(true);
+		expect(
+			await claimImplementation(plan, {
+				planRevision: plan.revision,
+				graphRevision: 1,
+				run: run(plan.revision),
+			}),
+		).toMatchObject({ kind: "started" });
+		await close(plan);
+
+		let stored = await context.storage.collaboration.load(context.channel.id, now);
+		if (!stored?.snapshot || !stored.sidecar || typeof stored.sidecar !== "object") {
+			throw new Error("claimed plan was not stored");
+		}
+		expect(stored.sidecar).toMatchObject({
+			graph: { versions: [{ state: "locked" }] },
+			execution: { graphRevision: 1 },
+		});
+
+		let restored = await open(context.channel.id, context.backend, context.server);
+		expect(restored.execution?.id).toBe("run-1");
+		await close(restored);
+
+		let current = await context.storage.collaboration.load(context.channel.id, now);
+		if (!current?.snapshot || !current.sidecar || typeof current.sidecar !== "object") {
+			throw new Error("restored plan was not stored");
+		}
+		await context.storage.collaboration.commit({
+			channelId: context.channel.id,
+			lease: context.lease,
+			expectedRevision: current.channel.revision,
+			operationId: "mismatched-run",
+			epoch: current.snapshot.epoch,
+			sidecar: {
+				...current.sidecar,
+				execution: { ...run(0), graphRevision: 2 },
+			} as JsonValue,
+			events: [],
+			now,
+		});
+
+		await expect(open(context.channel.id, context.backend, context.server))
+			.rejects.toThrow("invalid implementation run");
 	});
 });

--- a/apps/server/src/tasks/plan-graphs.ts
+++ b/apps/server/src/tasks/plan-graphs.ts
@@ -1,11 +1,11 @@
 /** The hosted persistence boundary for implementation graphs. */
 
-import { Graphs } from "./graphs";
+import { claim, Graphs } from "./graphs";
 import * as Comments from "../comments/service";
-import { exclusive, persistExclusive } from "../plan/service";
+import { drain, exclusive, persistExclusive } from "../plan/service";
 
 import type { Plan } from "../plan/service";
-import type { Graph, GraphAdapter, Result } from "./graphs";
+import type { ClaimInput, ClaimResult, Graph, GraphAdapter, Result } from "./graphs";
 
 const adapter: GraphAdapter<Plan> = {
 	async transact(plan, change): Promise<Result<Graph>> {
@@ -31,6 +31,38 @@ const adapter: GraphAdapter<Plan> = {
 /** The graph service for a live hosted plan. */
 export function implementationGraphs(): Graphs<Plan> {
 	return new Graphs(adapter);
+}
+
+/** Drain accepted work, then durably lock one approved graph for implementation. */
+export async function claimImplementation(plan: Plan, input: ClaimInput): Promise<ClaimResult> {
+	if (plan.execution) {
+		return claim({ graph: plan.graph, revision: plan.revision, execution: plan.execution }, input);
+	}
+	plan.claiming = true;
+	try {
+		await drain(plan);
+		return await exclusive(plan, async () => {
+			let result = claim({
+				graph: plan.graph,
+				revision: plan.revision,
+				execution: plan.execution,
+			}, input);
+			if (result.kind !== "started") return result;
+			let previous = plan.graph;
+			plan.graph = result.graph;
+			plan.execution = result.run;
+			try {
+				await persistExclusive(plan);
+				return result;
+			} catch {
+				plan.graph = previous;
+				plan.execution = undefined;
+				return { kind: "refused", reason: "durability" };
+			}
+		});
+	} finally {
+		plan.claiming = false;
+	}
 }
 
 /** Whether the settled plan can be turned into implementation work. */


### PR DESCRIPTION
## Summary

Authenticated local agents can read and atomically claim the current approved implementation graph through MCP. A successful claim persists the GitHub identity and local execution details, locks the graph, and freezes plan mutations.

## What changed

- Expose approved implementation context and claim operations through MCP.
- Keep hosted graph policy in `tasks/plan-graphs.ts`; validate graph history and every restored run against the locked graph revision.
- Atomically persist graph locking and execution metadata for live and closed plans.
- Close every plan mutation path while a claim is draining or an implementation is active.
- Add graph, persistence, MCP, and hosted-adapter coverage for claim boundaries.

## Verification

- `bun test`: 771 passed, 2 skipped.
- `bun run types` and `bun run ci`: passed.
- Targeted hosted MCP and graph persistence tests: 17 passed.
- `bun run e2e` reaches 155 passing browser tests, then fails in the unchanged `origin/main` callout keyboard-path test; it is unrelated to this server-only PR.