### PR TITLE
Expose MCP task lifecycle reporting with durable progress state

### DIFF
--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -117,9 +117,7 @@ describe("the MCP read protocol", () => {
 			})),
 		);
 		expect((tools.result as { tools: unknown[] }).tools).toEqual(
-			TOOLS.filter(tool =>
-				!["create_document", "read_implementation", "start_implementation"].includes(tool.name)
-			),
+			TOOLS.filter(tool => ["list_documents", "read_document"].includes(tool.name)),
 		);
 
 		let listed = await json(
@@ -165,6 +163,7 @@ describe("the MCP read protocol", () => {
 						definition: { tasks: [] },
 					},
 					execution: active ? { state: "active", run: active } : { state: "idle" },
+					history: [],
 				};
 			},
 			async startImplementation(_caller, input) {
@@ -247,6 +246,76 @@ describe("the MCP read protocol", () => {
 				client: { name: "Codex", version: "1.2.3" },
 				session,
 			},
+		});
+	});
+
+	it("advertises and dispatches lifecycle tools from one implementation capability", async () => {
+		let received: unknown;
+		let implementations = {
+			async readImplementation() {
+				return undefined;
+			},
+			async startImplementation() {
+				return { kind: "refused" as const, reason: "unused" };
+			},
+			async reportLifecycle(_caller: string, input: unknown) {
+				received = input;
+				return { kind: "accepted" as const, lifecycle: { activity: "recorded" } };
+			},
+		};
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			implementations,
+		});
+		let initialized = await mcp(request({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "initialize",
+			params: { clientInfo: { name: "Codex", version: "1.2.3" } },
+		}));
+		let session = initialized.headers.get("mcp-session-id")!;
+		let listed = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 2,
+				method: "tools/list",
+			}, { headers: { "mcp-session-id": session } })),
+		);
+		expect((listed.result as { tools: Array<{ name: string }> }).tools.map(tool => tool.name))
+			.toEqual(expect.arrayContaining([
+				"start_task",
+				"block_task",
+				"report_pr",
+				"complete_task",
+				"request_revision",
+			]));
+
+		let result = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 3,
+				method: "tools/call",
+				params: {
+					name: "block_task",
+					arguments: {
+						id: document.id,
+						taskId: "model",
+						reason: "Waiting for CI.",
+						idempotencyKey: "block-model",
+					},
+				},
+			}, { headers: { "mcp-session-id": session } })),
+		);
+		expect(received).toEqual({
+			id: document.id,
+			kind: "block",
+			taskId: "model",
+			reason: "Waiting for CI.",
+			idempotencyKey: "block-model",
+		});
+		expect((result.result as { structuredContent: unknown }).structuredContent).toEqual({
+			activity: "recorded",
 		});
 	});
 

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -13,9 +13,12 @@ import {
 	prepare,
 	REPOSITORY_PATH_PATTERN,
 } from "./mcp/create";
+import { isLifecycleTool, LIFECYCLE_TOOLS, lifecycleCall } from "./mcp/lifecycle";
 
 import type { Brief, CreateDocumentInput } from "./mcp/create";
 import type { Run, Version } from "./tasks/graphs";
+import type { LifecycleArguments } from "./mcp/lifecycle";
+import type { HistoricalRun, Progress } from "./tasks/lifecycle";
 
 export type { Brief, CreateDocumentInput, CreationOrigin } from "./mcp/create";
 
@@ -42,6 +45,8 @@ export type Implementation = {
 	repository: { name: string; baseBranch: string; baseCommit: string };
 	graph: Version;
 	execution: { state: "idle" } | { state: "active"; run: Run };
+	activity?: Progress;
+	history: HistoricalRun[];
 };
 
 export type ImplementationInput = {
@@ -62,6 +67,14 @@ export type Implementations<Caller> = {
 	): Promise<
 		| { kind: "started"; run: Run }
 		| { kind: "active"; run: Run }
+		| { kind: "forbidden" }
+		| { kind: "refused"; reason: string }
+	>;
+	reportLifecycle?(
+		caller: Caller,
+		input: LifecycleArguments,
+	): Promise<
+		| { kind: "accepted" | "replayed"; lifecycle: unknown }
 		| { kind: "forbidden" }
 		| { kind: "refused"; reason: string }
 	>;
@@ -223,6 +236,7 @@ export const TOOLS: Tool[] = [
 		inputSchema: IMPLEMENTATION,
 		outputSchema: { type: "object", properties: {}, additionalProperties: true },
 	},
+	...LIFECYCLE_TOOLS,
 ];
 
 type Call = {
@@ -396,6 +410,7 @@ export function handler<Caller>(
 		(tool.name !== "create_document" || creation)
 		&& (!["read_implementation", "start_implementation"].includes(tool.name)
 			|| options.implementations)
+		&& (!isLifecycleTool(tool.name) || options.implementations?.reportLifecycle)
 	);
 
 	async function dispatch(
@@ -522,6 +537,29 @@ export function handler<Caller>(
 						return respond(text({ code: "repository-forbidden" }, true));
 					}
 					return respond(text({ code: outcome.reason }, true));
+				}
+				let lifecycle = lifecycleCall(tool.name, tool.arguments);
+				if (lifecycle.known) {
+					if (!lifecycle.input) {
+						return notification
+							? undefined
+							: error(call.id, -32602, `${tool.name} requires its documented arguments`);
+					}
+					if (!client.session || !sessions.has(client.session)) {
+						return respond(text({ code: "session-required" }, true));
+					}
+					let report = options.implementations?.reportLifecycle;
+					if (!report) return respond(text({ code: "implementation-unavailable" }, true));
+					let outcome = await report(caller, lifecycle.input);
+					if (outcome.kind === "accepted" || outcome.kind === "replayed") {
+						return respond(text(outcome.lifecycle));
+					}
+					if (outcome.kind === "forbidden") {
+						return respond(text({ code: "repository-forbidden" }, true));
+					}
+					return outcome.kind === "refused"
+						? respond(text({ code: outcome.reason }, true))
+						: respond(text({ code: "implementation-unavailable" }, true));
 				}
 				return notification ? undefined : error(call.id, -32601, "tool not found");
 			}

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -514,6 +514,48 @@ describe("the hosted MCP adapter", () => {
 			kind: "active",
 			run: { session: "session-1" },
 		});
+		let report = adapter.implementations.reportLifecycle;
+		expect(report).toBeTypeOf("function");
+		if (!report) return;
+		let start = {
+			id: opened.channel.id,
+			kind: "start" as const,
+			taskId: "claim",
+			idempotencyKey: "start-claim",
+		};
+		expect(await report(caller, start)).toMatchObject({
+			kind: "accepted",
+			lifecycle: {
+				activity: { tasks: [{ id: "claim", state: "in_progress" }] },
+			},
+		});
+		expect(await report(caller, start)).toMatchObject({ kind: "replayed" });
+		let progressed = await context.storage.collaboration.load(opened.channel.id, context.now);
+		if (!progressed) throw new Error("lifecycle progress was not stored");
+		expect((await Service.readStored(progressed)).lifecycle).toMatchObject({
+			events: [{ kind: "start", taskId: "claim", idempotencyKey: "start-claim" }],
+		});
+		expect(
+			await report(caller, {
+				id: opened.channel.id,
+				kind: "request_revision",
+				reason: "The graph needs another delivery step.",
+				idempotencyKey: "request-revision",
+			}),
+		).toMatchObject({
+			kind: "accepted",
+			lifecycle: {
+				execution: { state: "idle" },
+				history: [{ outcome: { kind: "revision_requested" } }],
+			},
+		});
+		let released = await context.storage.collaboration.load(opened.channel.id, context.now);
+		if (!released) throw new Error("released lifecycle was not stored");
+		expect(await Service.readStored(released)).toMatchObject({
+			graph: { versions: [{ state: "approved" }] },
+			lifecycle: { history: [{ outcome: { kind: "revision_requested" } }] },
+		});
+		expect((await Service.readStored(released)).execution).toBeUndefined();
 	});
 
 	it("makes an inaccessible channel indistinguishable from a missing channel", async () => {

--- a/apps/server/src/mcp/hosted.ts
+++ b/apps/server/src/mcp/hosted.ts
@@ -2,12 +2,14 @@ import { GitHubError } from "../github/client";
 import { createHash } from "node:crypto";
 import * as Plan from "../plan/service";
 import * as Rooms from "../rooms";
-import { claimImplementation } from "../tasks/plan-graphs";
+import { claimImplementation, reportImplementationLifecycle } from "../tasks/plan-graphs";
 import { StorageError } from "../storage/errors";
+import { historyFor, progressFor } from "../tasks/lifecycle";
 
 import type { HostedAuth } from "../auth/routes";
 import type { GitHubUser } from "../github/client";
 import type { Implementation, ImplementationInput, McpOptions } from "../mcp";
+import type { LifecycleArguments } from "./lifecycle";
 import type { ChannelRecord, Lease } from "../storage/model";
 import type { ClaimResult, Run } from "../tasks/graphs";
 
@@ -90,6 +92,22 @@ function exposed(
 		execution: state.execution
 			? { state: "active", run: state.execution }
 			: { state: "idle" },
+		activity: state.graph && state.lifecycle
+			? progressFor(state.graph, state.lifecycle, state.execution)
+			: undefined,
+		history: state.graph && state.lifecycle ? historyFor(state.graph, state.lifecycle) : [],
+	};
+}
+
+function lifecycle(state: {
+	graph: NonNullable<Awaited<ReturnType<typeof Plan.readStored>>["graph"]>;
+	execution?: Run;
+	lifecycle: NonNullable<Awaited<ReturnType<typeof Plan.readStored>>["lifecycle"]>;
+}) {
+	return {
+		execution: state.execution ? { state: "active" as const } : { state: "idle" as const },
+		activity: progressFor(state.graph, state.lifecycle, state.execution),
+		history: historyFor(state.graph, state.lifecycle),
 	};
 }
 
@@ -296,6 +314,7 @@ export function hosted(
 								...(live.creation ? { creation: live.creation } : {}),
 								...(live.graph ? { graph: live.graph } : {}),
 								...(live.execution ? { execution: live.execution } : {}),
+								lifecycle: live.lifecycle,
 							});
 						}
 						let stored = await auth.storage.collaboration.load(id, auth.clock());
@@ -353,6 +372,74 @@ export function hosted(
 									now: auth.clock(),
 								});
 								return claimResult(prepared.result);
+							} catch (err) {
+								if (!(err instanceof StorageError) || err.failure !== "conflict") throw err;
+							}
+						}
+						return { kind: "refused" as const, reason: "conflict" };
+					},
+					async reportLifecycle(caller: HostedCaller, input: LifecycleArguments) {
+						let channel = await auth.storage.channels.get(input.id);
+						if (!channel) return { kind: "forbidden" as const };
+						let repository = await auth.github.repositoryAccess(
+							caller.oauthToken,
+							channel.repositoryOwner,
+							channel.repositoryName,
+						);
+						if (
+							!repository
+							|| repository.id !== channel.repositoryId
+							|| (!repository.permissions.push && !repository.permissions.admin)
+						) return { kind: "forbidden" as const };
+						let { id: _id, ...event } = input;
+						let live = Rooms.get(input.id)?.plan;
+						if (live) {
+							let result = await reportImplementationLifecycle(live, event);
+							if (result.kind === "refused") return result;
+							return {
+								kind: result.kind,
+								lifecycle: lifecycle({
+									graph: result.state.graph,
+									execution: result.state.execution,
+									lifecycle: result.state.lifecycle,
+								}),
+							};
+						}
+						for (let attempt = 0; attempt < 2; attempt++) {
+							let stored = await auth.storage.collaboration.load(input.id, auth.clock());
+							if (!stored?.snapshot) return { kind: "refused" as const, reason: "inactive" };
+							let prepared = Plan.lifecycleStored(stored, event);
+							if (prepared.result.kind === "refused") return prepared.result;
+							if (prepared.result.kind === "replayed") {
+								return {
+									kind: "replayed" as const,
+									lifecycle: lifecycle({
+										graph: prepared.result.state.graph,
+										execution: prepared.result.state.execution,
+										lifecycle: prepared.result.state.lifecycle,
+									}),
+								};
+							}
+							if (!prepared.sidecar) return { kind: "refused" as const, reason: "inactive" };
+							try {
+								await auth.storage.collaboration.commit({
+									channelId: input.id,
+									lease: persistence.lease(),
+									expectedRevision: stored.channel.revision,
+									operationId: `lifecycle:${input.idempotencyKey}`,
+									epoch: stored.snapshot.epoch,
+									sidecar: prepared.sidecar,
+									events: [],
+									now: auth.clock(),
+								});
+								return {
+									kind: "accepted" as const,
+									lifecycle: lifecycle({
+										graph: prepared.result.state.graph,
+										execution: prepared.result.state.execution,
+										lifecycle: prepared.result.state.lifecycle,
+									}),
+								};
 							} catch (err) {
 								if (!(err instanceof StorageError) || err.failure !== "conflict") throw err;
 							}

--- a/apps/server/src/mcp/lifecycle.ts
+++ b/apps/server/src/mcp/lifecycle.ts
@@ -1,0 +1,127 @@
+import type { LifecycleInput } from "../tasks/lifecycle";
+
+export type LifecycleArguments = LifecycleInput & { id: string };
+
+type Schema = Record<string, unknown>;
+type Definition = {
+	description: string;
+	properties: Record<string, Schema>;
+	required: string[];
+	parse(value: Record<string, unknown>, required: string[]): LifecycleArguments | undefined;
+};
+
+const ID = { type: "string", minLength: 1, maxLength: 128 };
+const TASK = { type: "string", minLength: 1, maxLength: 128 };
+const KEY = { type: "string", minLength: 1, maxLength: 128 };
+const TEXT = { type: "string", minLength: 1, maxLength: 5000 };
+
+function bounded(value: unknown, maximum: number): string | undefined {
+	return typeof value === "string" && value.trim() && Array.from(value).length <= maximum
+		? value
+		: undefined;
+}
+
+function base(value: Record<string, unknown>, required: string[]) {
+	if (
+		Object.keys(value).length !== required.length
+		|| required.some(key => !Object.hasOwn(value, key))
+	) return undefined;
+	let id = bounded(value.id, 128);
+	let idempotencyKey = bounded(value.idempotencyKey, 128);
+	return id && idempotencyKey ? { id, idempotencyKey } : undefined;
+}
+
+function task(value: Record<string, unknown>, required: string[]) {
+	let common = base(value, required);
+	let taskId = bounded(value.taskId, 128);
+	return common && taskId ? { ...common, taskId } : undefined;
+}
+
+const definitions = {
+	start_task: {
+		description: "Mark one dependency-ready task as in progress for the active implementation run.",
+		properties: { id: ID, taskId: TASK, idempotencyKey: KEY },
+		required: ["id", "taskId", "idempotencyKey"],
+		parse(value, required) {
+			let input = task(value, required);
+			return input ? { ...input, kind: "start" } : undefined;
+		},
+	},
+	block_task: {
+		description: "Record a visible blocker for an in-progress implementation task.",
+		properties: { id: ID, taskId: TASK, reason: TEXT, idempotencyKey: KEY },
+		required: ["id", "taskId", "reason", "idempotencyKey"],
+		parse(value, required) {
+			let input = task(value, required);
+			let reason = bounded(value.reason, 5000);
+			return input && reason ? { ...input, kind: "block", reason } : undefined;
+		},
+	},
+	report_pr: {
+		description: "Report the open, merged, or closed pull request for an implementation task.",
+		properties: {
+			id: ID,
+			taskId: TASK,
+			url: { type: "string", minLength: 1, maxLength: 2048 },
+			state: { enum: ["open", "merged", "closed"] },
+			idempotencyKey: KEY,
+		},
+		required: ["id", "taskId", "url", "state", "idempotencyKey"],
+		parse(value, required) {
+			let input = task(value, required);
+			let url = bounded(value.url, 2048);
+			let state = value.state;
+			return input && url && (state === "open" || state === "merged" || state === "closed")
+				? { ...input, kind: "report_pr", url, state }
+				: undefined;
+		},
+	},
+	complete_task: {
+		description: "Complete an implementation task with its pull request and summary.",
+		properties: { id: ID, taskId: TASK, summary: TEXT, idempotencyKey: KEY },
+		required: ["id", "taskId", "summary", "idempotencyKey"],
+		parse(value, required) {
+			let input = task(value, required);
+			let summary = bounded(value.summary, 5000);
+			return input && summary ? { ...input, kind: "complete", summary } : undefined;
+		},
+	},
+	request_revision: {
+		description: "End the active implementation run and release its graph for revision.",
+		properties: { id: ID, reason: TEXT, idempotencyKey: KEY },
+		required: ["id", "reason", "idempotencyKey"],
+		parse(value, required) {
+			let input = base(value, required);
+			let reason = bounded(value.reason, 5000);
+			return input && reason ? { ...input, kind: "request_revision", reason } : undefined;
+		},
+	},
+} satisfies Record<string, Definition>;
+
+export type LifecycleToolName = keyof typeof definitions;
+
+export const LIFECYCLE_TOOLS = Object.entries(definitions).map(([name, definition]) => ({
+	name,
+	description: definition.description,
+	inputSchema: {
+		type: "object",
+		properties: definition.properties,
+		required: definition.required,
+		additionalProperties: false,
+	},
+	outputSchema: { type: "object", properties: {}, additionalProperties: true },
+}));
+
+export function lifecycleCall(
+	name: string,
+	value: Record<string, unknown>,
+): { known: false } | { known: true; input?: LifecycleArguments } {
+	let definition = definitions[name as LifecycleToolName];
+	return definition
+		? { known: true, input: definition.parse(value, definition.required) }
+		: { known: false };
+}
+
+export function isLifecycleTool(name: string): boolean {
+	return Object.hasOwn(definitions, name);
+}

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -21,6 +21,7 @@ import * as Chat from "../chat/service";
 import * as Comments from "../comments/service";
 import * as Questions from "../questions/service";
 import { claim, restore as restoreGraph, restoreRun } from "../tasks/graphs";
+import { restoreLifecycle, transition } from "../tasks/lifecycle";
 import { broadcast, fail, relay, reply, tell } from "../wire";
 
 import type { Server } from "bun";
@@ -34,6 +35,7 @@ import type { Brief, CreationOrigin } from "../mcp";
 import type { InitialChannel, JsonValue, Lease, StoredChannel } from "../storage/model";
 import type { StorageAdapter } from "../storage/port";
 import type { ClaimInput, ClaimResult, Graph, Run } from "../tasks/graphs";
+import type { Lifecycle, LifecycleInput, LifecycleResult } from "../tasks/lifecycle";
 
 /** Updates are grouped for this long before being applied together. */
 const GROUP_MS = 5;
@@ -130,6 +132,8 @@ export type Plan = {
 	graph?: Graph;
 	/** The external implementation run that freezes this plan. */
 	execution?: Run;
+	/** Mutable task progress and prior runs, separate from claim identity. */
+	lifecycle: Lifecycle;
 	/** A claim has closed mutation ingress while accepted work drains. */
 	claiming: boolean;
 	/**
@@ -169,6 +173,7 @@ type Sidecar = {
 	creation?: CreationMetadata;
 	graph?: Graph;
 	execution?: Run;
+	lifecycle?: Lifecycle;
 	questions: Questions.Record[];
 	openQuestions: Questions.StoredOpen[];
 	threads: Comments.Record[];
@@ -183,6 +188,9 @@ function state(plan: Plan): Sidecar {
 		...(plan.creation ? { creation: plan.creation } : {}),
 		...(plan.graph ? { graph: plan.graph } : {}),
 		...(plan.execution ? { execution: plan.execution } : {}),
+		...(plan.lifecycle.events?.length || plan.lifecycle.history.length > 0
+			? { lifecycle: plan.lifecycle }
+			: {}),
 		questions: [...plan.records.values()],
 		openQuestions: Questions.dump(plan.questions),
 		threads: [...plan.threads.values()],
@@ -338,6 +346,7 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 	if (created) expected.push(...(legacy ? ["brief", "origin"] : ["creation"]));
 	if (Object.hasOwn(item, "graph")) expected.push("graph");
 	if (Object.hasOwn(item, "execution")) expected.push("execution");
+	if (Object.hasOwn(item, "lifecycle")) expected.push("lifecycle");
 	expected.sort();
 	if (
 		keys.length !== expected.length
@@ -359,6 +368,12 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 		: undefined;
 	if (Object.hasOwn(item, "execution") && !execution) {
 		throw new Error("hosted channel has an invalid implementation run");
+	}
+	let lifecycle = Object.hasOwn(item, "lifecycle") && graph
+		? restoreLifecycle(item.lifecycle, graph, execution)
+		: undefined;
+	if (Object.hasOwn(item, "lifecycle") && !lifecycle) {
+		throw new Error("hosted channel has an invalid implementation lifecycle");
 	}
 	let questions = objects(item.questions, "question record");
 	for (let question of questions) {
@@ -402,6 +417,7 @@ function restoredState(value: JsonValue, pristine: boolean): Sidecar {
 		...(created ? { creation: created } : {}),
 		...(graph ? { graph } : {}),
 		...(execution ? { execution } : {}),
+		...(lifecycle ? { lifecycle } : {}),
 		questions: questions as never[],
 		openQuestions: openQuestions as unknown as Questions.StoredOpen[],
 		threads: threads as never[],
@@ -637,6 +653,37 @@ export function claimStored(
 	};
 }
 
+/** Prepare one atomic lifecycle sidecar change for a plan that is not live. */
+export function lifecycleStored(
+	loaded: StoredChannel,
+	input: LifecycleInput,
+): { result: LifecycleResult; sidecar?: JsonValue } {
+	let pristine = loaded.channel.revision === 0 && loaded.latestSequence === 0 && !loaded.snapshot;
+	let sidecar = restoredState(
+		loaded.sidecar === null && loaded.snapshot && loaded.channel.revision === 0
+			? loaded.snapshot.sidecar
+			: loaded.sidecar,
+		pristine,
+	);
+	if (!sidecar.graph) return { result: { kind: "refused", reason: "inactive" } };
+	let result = transition({
+		graph: sidecar.graph,
+		execution: sidecar.execution,
+		lifecycle: sidecar.lifecycle ?? { history: [] },
+	}, input);
+	if (result.kind !== "accepted") return { result };
+	let { graph: _graph, execution: _execution, lifecycle: _lifecycle, ...rest } = sidecar;
+	return {
+		result,
+		sidecar: JSON.parse(JSON.stringify({
+			...rest,
+			graph: result.state.graph,
+			...(result.state.execution ? { execution: result.state.execution } : {}),
+			lifecycle: result.state.lifecycle,
+		})) as JsonValue,
+	};
+}
+
 async function restoreHosted(id: string, loaded: StoredChannel): Promise<RestoredHosted> {
 	let document: Document;
 	let needsInitialCheckpoint = false;
@@ -693,6 +740,7 @@ export async function readStored(
 	creation?: CreationMetadata;
 	graph?: Graph;
 	execution?: Run;
+	lifecycle?: Lifecycle;
 }> {
 	let restored = await restoreHosted(loaded.channel.id, loaded);
 	try {
@@ -703,6 +751,7 @@ export async function readStored(
 			...(restored.sidecar.creation ? { creation: restored.sidecar.creation } : {}),
 			...(restored.sidecar.graph ? { graph: restored.sidecar.graph } : {}),
 			...(restored.sidecar.execution ? { execution: restored.sidecar.execution } : {}),
+			...(restored.sidecar.lifecycle ? { lifecycle: restored.sidecar.lifecycle } : {}),
 		};
 	} finally {
 		restored.document.doc.destroy();
@@ -734,6 +783,7 @@ export async function open(
 		revision: sidecar.revision,
 		graph: sidecar.graph,
 		execution: sidecar.execution,
+		lifecycle: sidecar.lifecycle ?? { history: [] },
 		claiming: false,
 		queue: [],
 		timer: undefined,

--- a/apps/server/src/tasks/graphs.ts
+++ b/apps/server/src/tasks/graphs.ts
@@ -298,6 +298,19 @@ export function restoreRun(
 	return copy(restored);
 }
 
+/** Restore a historical run against the graph version it originally claimed. */
+export function restoreRunVersion(value: unknown, graph: Graph): Run | undefined {
+	let restored = run(value);
+	if (
+		!restored
+		|| !graph.versions.some(version =>
+			version.planRevision === restored.planRevision
+			&& version.revision === restored.graphRevision
+		)
+	) return undefined;
+	return copy(restored);
+}
+
 /** Lock exactly one approved graph revision and record its owner atomically. */
 export function claim(
 	state: { graph: Graph | undefined; revision: number | undefined; execution: Run | undefined },

--- a/apps/server/src/tasks/lifecycle.test.ts
+++ b/apps/server/src/tasks/lifecycle.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "bun:test";
+
+import type { Graph, Run } from "./graphs";
+
+let tasks = [
+	{
+		id: "foundation",
+		title: "Lay the foundation",
+		context: "Delivery depends on this work.",
+		goal: "Finish the prerequisite.",
+		acceptance: ["The prerequisite completes.", "Its result is recorded."],
+		dependsOn: [],
+	},
+	{
+		id: "delivery",
+		title: "Deliver the feature",
+		context: "This work follows the foundation.",
+		goal: "Deliver the implementation.",
+		acceptance: ["The dependency is complete.", "Delivery is reported."],
+		dependsOn: ["foundation"],
+	},
+];
+
+let graph: Graph = {
+	versions: [{
+		number: 1,
+		revision: 1,
+		planRevision: 3,
+		state: "locked",
+		definition: { tasks },
+	}],
+};
+
+let execution: Run = {
+	id: "run-1",
+	user: "octocat",
+	client: { name: "Codex", version: "1.2.3" },
+	session: "session-1",
+	planRevision: 3,
+	graphRevision: 1,
+	repository: "githubnext/chopin",
+	branch: "tq/018",
+	commit: "deadbeef",
+	startedAt: "2026-08-13T20:00:00.000Z",
+};
+
+async function lifecycle() {
+	return await import("./lifecycle").catch(() => ({}));
+}
+
+describe("implementation task lifecycle", () => {
+	it("keeps mutable progress outside the immutable implementation run", async () => {
+		let module = await lifecycle() as {
+			transition?: (state: unknown, input: unknown) => any;
+			progressFor?: (graph: Graph, lifecycle: unknown, execution?: Run) => any;
+		};
+		expect(module.transition).toBeTypeOf("function");
+		if (!module.transition || !module.progressFor) return;
+
+		let state = { graph, execution, lifecycle: { history: [] } };
+		expect(module.transition(state, {
+			kind: "start",
+			taskId: "foundation",
+			idempotencyKey: " ",
+		})).toEqual({ kind: "refused", reason: "idempotency-key" });
+		expect(module.transition(state, {
+			kind: "start",
+			taskId: "delivery",
+			idempotencyKey: "start-delivery",
+		})).toEqual({ kind: "refused", reason: "dependency" });
+		let started = module.transition(state, {
+			kind: "start",
+			taskId: "foundation",
+			idempotencyKey: "start-foundation",
+		});
+
+		expect(started).toMatchObject({ kind: "accepted", state: { execution } });
+		expect(started.state.lifecycle).toEqual({
+			history: [],
+			events: [{ kind: "start", taskId: "foundation", idempotencyKey: "start-foundation" }],
+		});
+		expect(module.progressFor(graph, started.state.lifecycle, execution)?.tasks).toEqual([
+			{ id: "foundation", state: "in_progress" },
+			{ id: "delivery", state: "queued" },
+		]);
+		expect(started.state.execution).toEqual(execution);
+		expect(started.state.execution).not.toHaveProperty("progress");
+	});
+
+	it("rejects durable progress that does not exactly describe the locked graph", async () => {
+		let module = await lifecycle() as {
+			restoreLifecycle?: (value: unknown, graph: Graph, execution: Run | undefined) => unknown;
+		};
+		expect(module.restoreLifecycle).toBeTypeOf("function");
+		if (!module.restoreLifecycle) return;
+
+		let valid = {
+			events: [{ kind: "start", taskId: "foundation", idempotencyKey: "start-foundation" }],
+			history: [],
+		};
+		expect(module.restoreLifecycle(valid, graph, execution)).toEqual(valid);
+		expect(module.restoreLifecycle(
+			{
+				...valid,
+				events: [{ kind: "start", taskId: "missing", idempotencyKey: "start-missing" }],
+			},
+			graph,
+			execution,
+		)).toBeUndefined();
+		expect(module.restoreLifecycle(
+			{
+				...valid,
+				events: [{ kind: "start", taskId: "delivery", idempotencyKey: "start-delivery" }],
+			},
+			graph,
+			execution,
+		)).toBeUndefined();
+		expect(module.restoreLifecycle(
+			{
+				...valid,
+				history: [{
+					run: execution,
+					events: [{
+						kind: "request_revision",
+						reason: "Try again.",
+						idempotencyKey: "start-foundation",
+					}],
+					outcome: { kind: "revision_requested", reason: "Try again." },
+				}],
+			},
+			graph,
+			execution,
+		)).toBeUndefined();
+	});
+
+	it("records blockers and repository pull requests before completing work", async () => {
+		let module = await lifecycle() as {
+			transition: (state: any, input: any) => any;
+			progressFor: (graph: Graph, lifecycle: unknown, execution?: Run) => any;
+		};
+		let state: any = { graph, execution, lifecycle: { history: [] } };
+		let apply = (input: unknown) => {
+			let result = module.transition(state, input);
+			expect(result.kind).toBe("accepted");
+			state = result.state;
+		};
+
+		apply({ kind: "start", taskId: "foundation", idempotencyKey: "start-foundation" });
+		let block = {
+			kind: "block",
+			taskId: "foundation",
+			reason: "Waiting for repository access.",
+			idempotencyKey: "block-foundation",
+		};
+		apply(block);
+		expect(module.progressFor(graph, state.lifecycle, execution).tasks[0]).toEqual({
+			id: "foundation",
+			state: "blocked",
+			blocker: "Waiting for repository access.",
+		});
+		expect(module.transition(state, block)).toMatchObject({ kind: "replayed" });
+		expect(module.transition(state, {
+			...block,
+			reason: "Waiting for CI.",
+		})).toEqual({ kind: "refused", reason: "idempotency-conflict" });
+		apply({ kind: "start", taskId: "foundation", idempotencyKey: "restart-foundation" });
+		expect(module.transition(state, {
+			kind: "report_pr",
+			taskId: "foundation",
+			url: "https://github.com/elsewhere/other/pull/9",
+			state: "open",
+			idempotencyKey: "foreign-pr",
+		})).toEqual({ kind: "refused", reason: "repository" });
+		expect(module.transition(state, {
+			kind: "complete",
+			taskId: "foundation",
+			summary: "Implemented the prerequisite.",
+			idempotencyKey: "complete-without-pr",
+		})).toEqual({ kind: "refused", reason: "pull-request" });
+		apply({
+			kind: "report_pr",
+			taskId: "foundation",
+			url: "https://github.com/githubnext/chopin/pull/48",
+			state: "open",
+			idempotencyKey: "report-pr",
+		});
+		apply({
+			kind: "complete",
+			taskId: "foundation",
+			summary: "Implemented and verified the prerequisite.",
+			idempotencyKey: "complete-foundation",
+		});
+
+		expect(module.progressFor(graph, state.lifecycle, execution).tasks[0]).toEqual({
+			id: "foundation",
+			state: "completed",
+			summary: "Implemented and verified the prerequisite.",
+			pullRequest: { url: "https://github.com/githubnext/chopin/pull/48", state: "open" },
+		});
+	});
+
+	it("archives a revision request and validates that durable history against the graph", async () => {
+		let module = await lifecycle() as {
+			transition: (state: any, input: any) => any;
+			restoreLifecycle: (value: unknown, graph: Graph, execution: Run | undefined) => unknown;
+			progressFor: (graph: Graph, lifecycle: unknown, execution?: Run) => unknown;
+		};
+		let input = {
+			kind: "request_revision",
+			reason: "The graph needs another implementation step.",
+			idempotencyKey: "request-revision",
+		};
+		let result = module.transition({ graph, execution, lifecycle: { history: [] } }, input);
+
+		expect(result).toMatchObject({
+			kind: "accepted",
+			state: {
+				execution: undefined,
+				graph: { versions: [{ state: "approved" }] },
+				lifecycle: {
+					history: [{
+						run: execution,
+						outcome: {
+							kind: "revision_requested",
+							reason: "The graph needs another implementation step.",
+						},
+					}],
+				},
+			},
+		});
+		let archived = result.state.lifecycle;
+		expect(module.progressFor(result.state.graph, archived, undefined)).toBeUndefined();
+		expect(module.restoreLifecycle(archived, result.state.graph, undefined)).toEqual(archived);
+		expect(module.transition(result.state, input)).toMatchObject({ kind: "replayed" });
+		expect(module.restoreLifecycle(
+			{
+				...archived,
+				history: [{ ...archived.history[0], run: { ...execution, graphRevision: 9 } }],
+			},
+			result.state.graph,
+			undefined,
+		)).toBeUndefined();
+	});
+
+	it("matches repeated graph revision numbers to historical runs in order", async () => {
+		let module = await lifecycle() as {
+			transition: (state: any, input: any) => any;
+			restoreLifecycle: (value: unknown, graph: Graph, execution: Run | undefined) => unknown;
+		};
+		let revisedTasks = [{
+			id: "replacement",
+			title: "Replace the approach",
+			context: "The first run exposed a better route.",
+			goal: "Implement the replacement.",
+			acceptance: ["The replacement works.", "Its result is recorded."],
+			dependsOn: [],
+		}];
+		let revisedGraph: Graph = {
+			versions: [
+				{ ...graph.versions[0]!, state: "superseded" },
+				{
+					number: 2,
+					revision: 1,
+					planRevision: 3,
+					state: "locked",
+					definition: { tasks: revisedTasks },
+				},
+			],
+		};
+		let secondRun = { ...execution, id: "run-2" };
+		let released = module.transition(
+			{ graph: revisedGraph, execution: secondRun, lifecycle: { history: [] } },
+			{
+				kind: "request_revision",
+				reason: "A third graph is needed.",
+				idempotencyKey: "revise-second-run",
+			},
+		).state;
+		let archived = released.lifecycle;
+
+		expect(module.restoreLifecycle(archived, {
+			...revisedGraph,
+			versions: [revisedGraph.versions[0]!, {
+				...revisedGraph.versions[1]!,
+				state: "approved",
+			}],
+		}, undefined)).toEqual(archived);
+
+		let releasedAgain = module.transition({
+			...released,
+			graph: {
+				...released.graph,
+				versions: [released.graph.versions[0]!, {
+					...released.graph.versions[1]!,
+					state: "locked",
+				}],
+			},
+			execution: { ...secondRun, id: "run-3" },
+		}, {
+			kind: "request_revision",
+			reason: "The same graph still needs revision.",
+			idempotencyKey: "revise-third-run",
+		}).state;
+		expect(module.restoreLifecycle(
+			releasedAgain.lifecycle,
+			releasedAgain.graph,
+			undefined,
+		)).toEqual(releasedAgain.lifecycle);
+	});
+});

--- a/apps/server/src/tasks/lifecycle.ts
+++ b/apps/server/src/tasks/lifecycle.ts
@@ -1,0 +1,462 @@
+import { restoreRunVersion } from "./graphs";
+
+import type { Graph, Run, Task } from "./graphs";
+
+export type PullRequest = {
+	url: string;
+	state: "open" | "merged" | "closed";
+};
+
+type Working = {
+	id: string;
+	pullRequest?: PullRequest;
+};
+
+export type TaskProgress =
+	| { id: string; state: "queued" }
+	| (Working & { state: "in_progress" })
+	| (Working & { state: "blocked"; blocker: string })
+	| { id: string; state: "completed"; summary: string; pullRequest: PullRequest };
+
+export type ProgressEvent =
+	| { kind: "start"; taskId: string; idempotencyKey: string }
+	| { kind: "block"; taskId: string; reason: string; idempotencyKey: string }
+	| {
+		kind: "report_pr";
+		taskId: string;
+		pullRequest: PullRequest;
+		idempotencyKey: string;
+	}
+	| { kind: "complete"; taskId: string; summary: string; idempotencyKey: string }
+	| { kind: "request_revision"; reason: string; idempotencyKey: string };
+
+export type Progress = {
+	tasks: TaskProgress[];
+	events: ProgressEvent[];
+};
+
+export type ArchivedRun = {
+	run: Run;
+	events: ProgressEvent[];
+	outcome: { kind: "revision_requested"; reason: string };
+};
+
+export type HistoricalRun = {
+	run: Run;
+	progress: Progress;
+	outcome: ArchivedRun["outcome"];
+};
+
+export type Lifecycle = {
+	events?: ProgressEvent[];
+	history: ArchivedRun[];
+};
+
+export type LifecycleState = {
+	graph: Graph;
+	execution?: Run;
+	lifecycle: Lifecycle;
+};
+
+export type LifecycleInput =
+	| { kind: "start"; taskId: string; idempotencyKey: string }
+	| { kind: "block"; taskId: string; reason: string; idempotencyKey: string }
+	| {
+		kind: "report_pr";
+		taskId: string;
+		url: string;
+		state: PullRequest["state"];
+		idempotencyKey: string;
+	}
+	| { kind: "complete"; taskId: string; summary: string; idempotencyKey: string }
+	| { kind: "request_revision"; reason: string; idempotencyKey: string };
+
+export type LifecycleResult =
+	| { kind: "accepted" | "replayed"; state: LifecycleState }
+	| { kind: "refused"; reason: string };
+
+function copy<T>(value: T): T {
+	return structuredClone(value);
+}
+
+function current(graph: Graph): Task[] | undefined {
+	let version = graph.versions.at(-1);
+	return version?.state === "locked" ? version.definition.tasks : undefined;
+}
+
+function initial(tasks: Task[]): Progress {
+	return { tasks: tasks.map(task => ({ id: task.id, state: "queued" })), events: [] };
+}
+
+function exact(value: Record<string, unknown>, keys: string[]): boolean {
+	let actual = Object.keys(value).sort();
+	let expected = [...keys].sort();
+	return actual.length === expected.length
+		&& actual.every((key, index) => key === expected[index]);
+}
+
+function pullRequest(value: unknown): PullRequest | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	let item = value as Record<string, unknown>;
+	if (
+		!exact(item, ["state", "url"])
+		|| typeof item.url !== "string"
+		|| !item.url.trim()
+		|| (item.state !== "open" && item.state !== "merged" && item.state !== "closed")
+	) return undefined;
+	return { url: item.url, state: item.state };
+}
+
+function progressEvent(value: unknown): ProgressEvent | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	let item = value as Record<string, unknown>;
+	if (typeof item.idempotencyKey !== "string" || !item.idempotencyKey.trim()) return undefined;
+	let idempotencyKey = item.idempotencyKey;
+	if (item.kind === "request_revision") {
+		return exact(item, ["idempotencyKey", "kind", "reason"])
+				&& typeof item.reason === "string" && item.reason.trim()
+			? { kind: item.kind, reason: item.reason, idempotencyKey }
+			: undefined;
+	}
+	if (typeof item.taskId !== "string" || !item.taskId.trim()) return undefined;
+	let taskId = item.taskId;
+	if (item.kind === "start" && exact(item, ["idempotencyKey", "kind", "taskId"])) {
+		return { kind: item.kind, taskId, idempotencyKey };
+	}
+	if (
+		item.kind === "block"
+		&& exact(item, ["idempotencyKey", "kind", "reason", "taskId"])
+		&& typeof item.reason === "string"
+		&& item.reason.trim()
+	) return { kind: item.kind, taskId, reason: item.reason, idempotencyKey };
+	if (
+		item.kind === "report_pr" && exact(item, ["idempotencyKey", "kind", "pullRequest", "taskId"])
+	) {
+		let restored = pullRequest(item.pullRequest);
+		return restored
+			? { kind: item.kind, taskId, pullRequest: restored, idempotencyKey }
+			: undefined;
+	}
+	if (
+		item.kind === "complete"
+		&& exact(item, ["idempotencyKey", "kind", "summary", "taskId"])
+		&& typeof item.summary === "string"
+		&& item.summary.trim()
+	) return { kind: item.kind, taskId, summary: item.summary, idempotencyKey };
+	return undefined;
+}
+
+function inputFor(stored: Exclude<ProgressEvent, { kind: "request_revision" }>): Exclude<
+	LifecycleInput,
+	{ kind: "request_revision" }
+> {
+	return stored.kind === "report_pr"
+		? {
+			kind: stored.kind,
+			taskId: stored.taskId,
+			url: stored.pullRequest.url,
+			state: stored.pullRequest.state,
+			idempotencyKey: stored.idempotencyKey,
+		}
+		: stored;
+}
+
+function restoreEvents(value: unknown): ProgressEvent[] | undefined {
+	if (!Array.isArray(value) || value.length === 0) return undefined;
+	let restored = value.map(progressEvent);
+	return restored.some(event => !event) ? undefined : restored as ProgressEvent[];
+}
+
+function derive(
+	tasks: Task[],
+	run: Run,
+	events: ProgressEvent[],
+	revisionReason?: string,
+): Progress | undefined {
+	let revision = events.at(-1);
+	if (revisionReason === undefined) {
+		if (events.some(event => event.kind === "request_revision")) return undefined;
+	} else if (
+		revision?.kind !== "request_revision"
+		|| revision.reason !== revisionReason
+		|| events.slice(0, -1).some(event => event.kind === "request_revision")
+	) return undefined;
+	let work = revisionReason === undefined ? events : events.slice(0, -1);
+	let progress = initial(tasks);
+	for (let storedEvent of work) {
+		if (storedEvent.kind === "request_revision") return undefined;
+		let result = advance(progress, tasks, run, inputFor(storedEvent));
+		if (result.kind === "refused") return undefined;
+		progress = result.progress;
+	}
+	if (revisionReason !== undefined) progress.events.push(revision!);
+	return progress;
+}
+
+function projectHistory(graph: Graph, history: ArchivedRun[]): HistoricalRun[] | undefined {
+	let projected: HistoricalRun[] = [];
+	let nextVersion = 0;
+	for (let archived of history) {
+		let progress: Progress | undefined;
+		for (let index = nextVersion; index < graph.versions.length; index++) {
+			let version = graph.versions[index]!;
+			if (
+				version.planRevision !== archived.run.planRevision
+				|| version.revision !== archived.run.graphRevision
+			) continue;
+			progress = derive(
+				version.definition.tasks,
+				archived.run,
+				archived.events,
+				archived.outcome.reason,
+			);
+			if (progress) {
+				nextVersion = index;
+				break;
+			}
+		}
+		if (!progress) return undefined;
+		projected.push({ run: copy(archived.run), progress, outcome: copy(archived.outcome) });
+	}
+	return projected;
+}
+
+function restoreHistory(stored: unknown, graph: Graph): ArchivedRun[] | undefined {
+	if (!Array.isArray(stored)) return undefined;
+	let history: ArchivedRun[] = [];
+	for (let value of stored) {
+		if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+		let item = value as Record<string, unknown>;
+		if (!exact(item, ["events", "outcome", "run"])) return undefined;
+		let run = restoreRunVersion(item.run, graph);
+		let events = restoreEvents(item.events);
+		let outcome = item.outcome;
+		if (!outcome || typeof outcome !== "object" || Array.isArray(outcome)) return undefined;
+		let result = outcome as Record<string, unknown>;
+		if (
+			!run || !events
+			|| !exact(result, ["kind", "reason"])
+			|| result.kind !== "revision_requested"
+			|| typeof result.reason !== "string"
+			|| !result.reason.trim()
+		) return undefined;
+		history.push({
+			run,
+			events,
+			outcome: { kind: "revision_requested", reason: result.reason },
+		});
+	}
+	return projectHistory(graph, history) ? history : undefined;
+}
+
+/** Restore lifecycle data only when it describes this graph and claim exactly. */
+export function restoreLifecycle(
+	value: unknown,
+	graph: Graph,
+	execution: Run | undefined,
+): Lifecycle | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	let stored = value as Record<string, unknown>;
+	let keys = stored.events === undefined ? ["history"] : ["events", "history"];
+	if (!exact(stored, keys)) return undefined;
+	let history = restoreHistory(stored.history, graph);
+	if (!history) return undefined;
+	let events = stored.events === undefined ? undefined : restoreEvents(stored.events);
+	let tasks = execution && current(graph);
+	if (events && (!tasks || !execution || !derive(tasks, execution, events))) return undefined;
+	if (stored.events !== undefined && !events) return undefined;
+	let all = [...(events ?? []), ...history.flatMap(item => item.events)];
+	if (new Set(all.map(event => event.idempotencyKey)).size !== all.length) return undefined;
+	return { ...(events ? { events } : {}), history };
+}
+
+function event(input: LifecycleInput): ProgressEvent {
+	switch (input.kind) {
+		case "start":
+			return { ...input };
+		case "block":
+			return { ...input };
+		case "report_pr":
+			return {
+				kind: input.kind,
+				taskId: input.taskId,
+				pullRequest: { url: input.url, state: input.state },
+				idempotencyKey: input.idempotencyKey,
+			};
+		case "complete":
+			return { ...input };
+		case "request_revision":
+			return { ...input };
+	}
+}
+
+function same(stored: ProgressEvent, input: LifecycleInput): boolean {
+	if (stored.kind !== input.kind || stored.idempotencyKey !== input.idempotencyKey) return false;
+	switch (stored.kind) {
+		case "start":
+			return input.kind === "start" && stored.taskId === input.taskId;
+		case "block":
+			return input.kind === "block" && stored.taskId === input.taskId
+				&& stored.reason === input.reason;
+		case "report_pr":
+			return input.kind === "report_pr" && stored.taskId === input.taskId
+				&& stored.pullRequest.url === input.url && stored.pullRequest.state === input.state;
+		case "complete":
+			return input.kind === "complete" && stored.taskId === input.taskId
+				&& stored.summary === input.summary;
+		case "request_revision":
+			return input.kind === "request_revision" && stored.reason === input.reason;
+	}
+}
+
+function replay(state: LifecycleState, input: LifecycleInput): LifecycleResult | undefined {
+	let events = [
+		...(state.lifecycle.events ?? []),
+		...state.lifecycle.history.flatMap(item => item.events),
+	];
+	let prior = events.find(event => event.idempotencyKey === input.idempotencyKey);
+	return prior
+		? same(prior, input)
+			? { kind: "replayed", state: copy(state) }
+			: { kind: "refused", reason: "idempotency-conflict" }
+		: undefined;
+}
+
+function ownPullRequest(repository: string, url: string): boolean {
+	let match = /^https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/([1-9]\d*)\/?$/.exec(url);
+	return match?.[1] === repository;
+}
+
+type WorkInput = Exclude<LifecycleInput, { kind: "request_revision" }>;
+
+type AdvanceResult =
+	| { kind: "accepted"; progress: Progress }
+	| { kind: "refused"; reason: string };
+
+function advance(progress: Progress, tasks: Task[], run: Run, input: WorkInput): AdvanceResult {
+	let nextProgress = copy(progress);
+	let index = nextProgress.tasks.findIndex(item => item.id === input.taskId);
+	let task = tasks[index];
+	let item = nextProgress.tasks[index];
+	if (!task || !item) return { kind: "refused", reason: "task" };
+	let next: TaskProgress;
+	switch (input.kind) {
+		case "start":
+			if (item.state !== "queued" && item.state !== "blocked") {
+				return { kind: "refused", reason: "task-state" };
+			}
+			if (
+				task.dependsOn.some(id =>
+					nextProgress.tasks.find(item => item.id === id)?.state !== "completed"
+				)
+			) {
+				return { kind: "refused", reason: "dependency" };
+			}
+			next = {
+				id: item.id,
+				state: "in_progress",
+				...(item.state === "blocked" && item.pullRequest
+					? { pullRequest: item.pullRequest }
+					: {}),
+			};
+			break;
+		case "block":
+			if (item.state !== "in_progress") return { kind: "refused", reason: "task-state" };
+			if (!input.reason.trim()) return { kind: "refused", reason: "reason" };
+			next = {
+				id: item.id,
+				state: "blocked",
+				blocker: input.reason,
+				...(item.pullRequest ? { pullRequest: item.pullRequest } : {}),
+			};
+			break;
+		case "report_pr": {
+			if (item.state === "queued") return { kind: "refused", reason: "task-state" };
+			if (!ownPullRequest(run.repository, input.url)) {
+				return { kind: "refused", reason: "repository" };
+			}
+			let pullRequest = { url: input.url, state: input.state };
+			next = { ...item, pullRequest };
+			break;
+		}
+		case "complete":
+			if (item.state !== "in_progress") return { kind: "refused", reason: "task-state" };
+			if (!item.pullRequest) return { kind: "refused", reason: "pull-request" };
+			if (!input.summary.trim()) return { kind: "refused", reason: "summary" };
+			next = {
+				id: item.id,
+				state: "completed",
+				summary: input.summary,
+				pullRequest: item.pullRequest,
+			};
+			break;
+	}
+	nextProgress.tasks[index] = next;
+	nextProgress.events.push(event(input));
+	return { kind: "accepted", progress: nextProgress };
+}
+
+/** Apply one lifecycle event without mutating the graph or claim identity. */
+export function transition(state: LifecycleState, input: LifecycleInput): LifecycleResult {
+	if (!input.idempotencyKey.trim()) {
+		return { kind: "refused", reason: "idempotency-key" };
+	}
+	let prior = replay(state, input);
+	if (prior) return prior;
+	let tasks = current(state.graph);
+	let run = state.execution;
+	if (!tasks || !run) return { kind: "refused", reason: "inactive" };
+	let progress = derive(tasks, run, state.lifecycle.events ?? []);
+	if (!progress) return { kind: "refused", reason: "invalid-lifecycle" };
+
+	if (input.kind === "request_revision") {
+		if (!input.reason.trim()) return { kind: "refused", reason: "reason" };
+		let events = [...progress.events, event(input)];
+		let graph = copy(state.graph);
+		let version = graph.versions.at(-1)!;
+		graph.versions[graph.versions.length - 1] = { ...version, state: "approved" };
+		return {
+			kind: "accepted",
+			state: {
+				graph,
+				execution: undefined,
+				lifecycle: {
+					history: [...state.lifecycle.history, {
+						run: copy(run),
+						events,
+						outcome: { kind: "revision_requested", reason: input.reason },
+					}],
+				},
+			},
+		};
+	}
+
+	let advanced = advance(progress, tasks, run, input);
+	if (advanced.kind === "refused") return advanced;
+	return {
+		kind: "accepted",
+		state: {
+			...state,
+			lifecycle: { ...state.lifecycle, events: advanced.progress.events },
+		},
+	};
+}
+
+/** Project queued work before the first lifecycle event. */
+export function progressFor(
+	graph: Graph,
+	lifecycle: Lifecycle,
+	execution?: Run,
+): Progress | undefined {
+	let version = graph.versions.at(-1);
+	if (!version || !execution) return undefined;
+	let events = lifecycle.events ?? [];
+	return events.length === 0
+		? initial(version.definition.tasks)
+		: derive(version.definition.tasks, execution, events);
+}
+
+/** Project archived event logs against the graph versions they implemented. */
+export function historyFor(graph: Graph, lifecycle: Lifecycle): HistoricalRun[] {
+	return copy(projectHistory(graph, lifecycle.history) ?? []);
+}

--- a/apps/server/src/tasks/plan-graphs.test.ts
+++ b/apps/server/src/tasks/plan-graphs.test.ts
@@ -205,4 +205,59 @@ describe("the plan graph adapter", () => {
 		await expect(open(context.channel.id, context.backend, context.server))
 			.rejects.toThrow("invalid implementation run");
 	});
+
+	it("persists lifecycle activity before broadcasting it", async () => {
+		let report = (graphPlans as typeof graphPlans & {
+			reportImplementationLifecycle?: (plan: Plan, input: unknown) => Promise<any>;
+		}).reportImplementationLifecycle;
+		expect(report).toBeTypeOf("function");
+		if (!report) return;
+
+		let context = await hosted();
+		let frames: unknown[] = [];
+		let server = {
+			publish(_topic: string, frame: string) {
+				frames.push(JSON.parse(frame));
+			},
+		} as unknown as Server<SocketData>;
+		let plan = await open(context.channel.id, context.backend, server);
+		expect(
+			(await implementationGraphs().revise(plan, {
+				planRevision: plan.revision,
+				graphRevision: 0,
+				operations: definition.tasks.map(task => ({ op: "add", task })),
+			})).ok,
+		).toBe(true);
+		expect((await implementationGraphs().approve(plan)).ok).toBe(true);
+		expect(
+			await claimImplementation(plan, {
+				planRevision: plan.revision,
+				graphRevision: 1,
+				run: run(plan.revision),
+			}),
+		).toMatchObject({ kind: "started" });
+
+		expect(
+			await report(plan, {
+				kind: "start",
+				taskId: "model",
+				idempotencyKey: "start-model",
+			}),
+		).toMatchObject({ kind: "accepted" });
+		expect(frames).toContainEqual(expect.objectContaining({
+			kind: "plan:lifecycle",
+			activity: expect.objectContaining({
+				tasks: [{ id: "model", state: "in_progress" }],
+			}),
+		}));
+		await close(plan);
+
+		let restored = await open(context.channel.id, context.backend, context.server);
+		expect(restored.lifecycle.events).toEqual([{
+			kind: "start",
+			taskId: "model",
+			idempotencyKey: "start-model",
+		}]);
+		await close(restored);
+	});
 });

--- a/apps/server/src/tasks/plan-graphs.ts
+++ b/apps/server/src/tasks/plan-graphs.ts
@@ -1,11 +1,14 @@
 /** The hosted persistence boundary for implementation graphs. */
 
 import { claim, Graphs } from "./graphs";
+import { progressFor, transition } from "./lifecycle";
 import * as Comments from "../comments/service";
 import { drain, exclusive, persistExclusive } from "../plan/service";
+import { broadcast } from "../wire";
 
 import type { Plan } from "../plan/service";
 import type { ClaimInput, ClaimResult, Graph, GraphAdapter, Result } from "./graphs";
+import type { LifecycleInput, LifecycleResult } from "./lifecycle";
 
 const adapter: GraphAdapter<Plan> = {
 	async transact(plan, change): Promise<Result<Graph>> {
@@ -63,6 +66,46 @@ export async function claimImplementation(plan: Plan, input: ClaimInput): Promis
 	} finally {
 		plan.claiming = false;
 	}
+}
+
+/** Persist one lifecycle transition before publishing its projection. */
+export function reportImplementationLifecycle(
+	plan: Plan,
+	input: LifecycleInput,
+): Promise<LifecycleResult> {
+	return exclusive(plan, async () => {
+		if (!plan.graph) return { kind: "refused", reason: "inactive" };
+		let result = transition({
+			graph: plan.graph,
+			execution: plan.execution,
+			lifecycle: plan.lifecycle,
+		}, input);
+		if (result.kind !== "accepted") return result;
+		let previous = {
+			graph: plan.graph,
+			execution: plan.execution,
+			lifecycle: plan.lifecycle,
+		};
+		plan.graph = result.state.graph;
+		plan.execution = result.state.execution;
+		plan.lifecycle = result.state.lifecycle;
+		try {
+			await persistExclusive(plan);
+		} catch {
+			plan.graph = previous.graph;
+			plan.execution = previous.execution;
+			plan.lifecycle = previous.lifecycle;
+			return { kind: "refused", reason: "durability" };
+		}
+		broadcast(plan.server, plan.id, {
+			kind: "plan:lifecycle",
+			ts: 0,
+			execution: plan.execution ? { state: "active" } : { state: "idle" },
+			activity: progressFor(plan.graph, plan.lifecycle, plan.execution),
+			history: plan.lifecycle.history.length,
+		});
+		return result;
+	});
 }
 
 /** Whether the settled plan can be turned into implementation work. */

--- a/packages/protocol/plan.d.ts
+++ b/packages/protocol/plan.d.ts
@@ -23,7 +23,8 @@ export declare namespace Plan {
 		| (Awareness & { sender?: string })
 		| Anchors
 		| Changes
-		| Reset;
+		| Reset
+		| Lifecycle;
 
 	/**
 	 * A decision's place in the prose.
@@ -285,5 +286,21 @@ export declare namespace Plan {
 			| "compacted"
 			/** An update did not validate and the room was rebuilt. */
 			| "rebuilt";
+	};
+
+	/** Durable implementation activity, published only after persistence. */
+	export type Lifecycle = KIND<"plan:lifecycle"> & {
+		execution: { state: "idle" | "active" };
+		activity?: {
+			tasks: Array<{
+				id: string;
+				state: "queued" | "in_progress" | "blocked" | "completed";
+				blocker?: string;
+				summary?: string;
+				pullRequest?: { url: string; state: "open" | "merged" | "closed" };
+			}>;
+			events: Array<{ idempotencyKey: string; kind: string }>;
+		};
+		history: number;
 	};
 }


### PR DESCRIPTION
## Summary

Adds MCP operations for reporting task starts, blockers, pull requests, completion, and revision requests. Lifecycle activity is persisted separately from implementation and pull request state, replayed idempotently, retained across revision requests, and broadcast to connected clients.

## What changed

- Adds start_task, block_task, report_pr, complete_task, and request_revision MCP tools with validated arguments and idempotency keys.
- Adds lifecycle transition rules for dependency readiness, blockers, repository-owned pull requests, completion summaries, and revision release.
- Persists task progress and prior execution history in plan snapshots while exposing implementation state separately from pull request delivery state.
- Broadcasts accepted lifecycle changes through the plan protocol and supports the same transitions for live rooms and persisted rooms.

## How to test

- bun test — 698 unit tests passed, including MCP and lifecycle transition coverage.
- bun run types — type checks passed.
- bun run ci — formatting and lint checks passed.
- git diff --check — whitespace checks passed.
- Source review — all ten lifecycle acceptance criteria were checked against the implementation and protocol coverage.
- bun run e2e — the browser suite was attempted but Chromium could not launch because the sandbox denied Mach rendezvous registration; no browser result was recorded.

## Notes

- Stacked on [Claim an approved implementation graph through MCP](https://github.com/githubnext/chopin/pull/47), which should be reviewed and merged first.
- This change is backend and protocol focused; browser rendering for lifecycle activity is deferred.

Task: `active/018-report-implementation-pr-progress.md`
