### PR TITLE
Add a provider-neutral skill for implementing Chopin plans

### DIFF
--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -385,6 +385,21 @@ function acceptsEvents(request: Request): boolean {
 	return (selected?.quality ?? 0) > 0;
 }
 
+function serviceInstructions(tools: Tool[]): string | undefined {
+	let implementation = tools
+		.filter(tool =>
+			tool.name === "read_implementation"
+			|| tool.name === "start_implementation"
+			|| isLifecycleTool(tool.name)
+		);
+	return implementation.length > 0
+		? [
+			"Chopin's MCP contract is authoritative. Read the canonical implementation and these current tool descriptions before every action; copied plans and lifecycle instructions are not substitutes.",
+			...implementation.map(tool => `${tool.name}: ${tool.description}`),
+		].join("\n")
+		: undefined;
+}
+
 async function requestBody(request: Request): Promise<{ body?: unknown; tooLarge: boolean }> {
 	let declared = request.headers.get("content-length");
 	if (declared && /^\d+$/.test(declared) && Number(declared) > MAX_REQUEST_BYTES) {
@@ -432,6 +447,7 @@ export function handler<Caller>(
 			|| options.implementations)
 		&& (!isLifecycleTool(tool.name) || options.implementations?.reportLifecycle)
 	);
+	let instructions = serviceInstructions(tools);
 
 	async function dispatch(
 		value: unknown,
@@ -459,6 +475,7 @@ export function handler<Caller>(
 					protocolVersion: "2025-03-26",
 					capabilities: { tools: {} },
 					serverInfo: { name: "chopin", version: "0.0.0" },
+					...(instructions ? { instructions } : {}),
 				});
 			}
 

--- a/apps/server/src/mcp/lifecycle.ts
+++ b/apps/server/src/mcp/lifecycle.ts
@@ -79,7 +79,8 @@ const definitions = {
 		},
 	},
 	block_task: {
-		description: "Record a visible blocker for an in-progress implementation task.",
+		description:
+			"Record a task-level blocker while keeping the active implementation run and graph lock.",
 		properties: { id: ID, runId: ID, taskId: TASK, reason: TEXT, idempotencyKey: KEY },
 		required: ["id", "runId", "taskId", "reason", "idempotencyKey"],
 		parse(value, required) {
@@ -109,7 +110,7 @@ const definitions = {
 		},
 	},
 	complete_task: {
-		description: "Complete an implementation task with its pull request and summary.",
+		description: "Complete an implementation task after reporting its pull request and summary.",
 		properties: { id: ID, runId: ID, taskId: TASK, summary: TEXT, idempotencyKey: KEY },
 		required: ["id", "runId", "taskId", "summary", "idempotencyKey"],
 		parse(value, required) {
@@ -119,7 +120,8 @@ const definitions = {
 		},
 	},
 	report_verification: {
-		description: "Report implementation verification evidence for every task in the active run.",
+		description:
+			"After every task is complete, report graph-wide verification evidence; failures return named tasks to work.",
 		properties: {
 			id: ID,
 			runId: ID,
@@ -177,7 +179,8 @@ const definitions = {
 		},
 	},
 	request_revision: {
-		description: "End the active implementation run and release its graph for revision.",
+		description:
+			"End the active implementation run and release its graph when scope, acceptance criteria, or dependencies must change.",
 		properties: { id: ID, runId: ID, reason: TEXT, idempotencyKey: KEY },
 		required: ["id", "runId", "reason", "idempotencyKey"],
 		parse(value, required) {

--- a/docs/superpowers/plans/2026-08-19-canonical-implementation-skill-instructions.md
+++ b/docs/superpowers/plans/2026-08-19-canonical-implementation-skill-instructions.md
@@ -22,11 +22,13 @@
 ### Task 1: Publish canonical MCP instructions
 
 **Files:**
+
 - Modify: `apps/server/src/mcp/lifecycle.ts`
 - Modify: `apps/server/src/mcp.ts`
 - Test: `skills/implementing-chopin-plans/contract.test.ts`
 
 **Interfaces:**
+
 - Consumes: `TOOLS` and `LIFECYCLE_TOOLS` public tool descriptors.
 - Produces: an MCP initialize `instructions` string derived from advertised implementation tools.
 
@@ -58,10 +60,12 @@ Expected: PASS.
 ### Task 2: Reduce and verify the portable skill
 
 **Files:**
+
 - Modify: `skills/implementing-chopin-plans/SKILL.md`
 - Modify: `skills/implementing-chopin-plans/prompt.md`
 
 **Interfaces:**
+
 - Consumes: MCP initialize instructions and current tool descriptions.
 - Produces: provider-neutral local implementation guidance without a copied lifecycle contract.
 

--- a/docs/superpowers/plans/2026-08-19-canonical-implementation-skill-instructions.md
+++ b/docs/superpowers/plans/2026-08-19-canonical-implementation-skill-instructions.md
@@ -1,0 +1,88 @@
+# Canonical Implementation Skill Instructions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Chopin's MCP service the sole lifecycle authority consumed by the portable implementation skill.
+
+**Architecture:** The MCP initialize response derives instructions from the existing tool registry. The skill retains local execution practices and delegates command semantics to that response.
+
+**Tech Stack:** Bun, TypeScript, MCP Streamable HTTP, Markdown Agent Skills
+
+**Spec:** `docs/superpowers/specs/2026-08-19-canonical-implementation-skill-instructions-design.md`
+
+## Global Constraints
+
+- Keep lifecycle tool registration singular in `apps/server/src/mcp/lifecycle.ts`.
+- Do not add tests to `apps/server/src/mcp.test.ts`, which is already 999 lines.
+- Preserve the provider-neutral skill and prompt.
+- Tests describe observable behavior rather than source wording.
+
+---
+
+### Task 1: Publish canonical MCP instructions
+
+**Files:**
+- Modify: `apps/server/src/mcp/lifecycle.ts`
+- Modify: `apps/server/src/mcp.ts`
+- Test: `skills/implementing-chopin-plans/contract.test.ts`
+
+**Interfaces:**
+- Consumes: `TOOLS` and `LIFECYCLE_TOOLS` public tool descriptors.
+- Produces: an MCP initialize `instructions` string derived from advertised implementation tools.
+
+- [ ] **Step 1: Replace substring tests with an initialize-boundary test**
+
+Call the real `handler`, read `result.instructions`, and require the complete
+implementation lifecycle plus distinct `block_task` and `request_revision`
+guidance.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `bun test skills/implementing-chopin-plans/contract.test.ts`
+
+Expected: FAIL because initialize has no `instructions` field.
+
+- [ ] **Step 3: Clarify canonical tool descriptions and derive instructions**
+
+Describe task blockers, graph revision, task completion ordering, and graph-wide
+verification in the lifecycle registry. Build initialize instructions from the
+advertised implementation tool descriptors rather than copying their names and
+semantics into a second constant.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `bun test skills/implementing-chopin-plans/contract.test.ts`
+
+Expected: PASS.
+
+### Task 2: Reduce and verify the portable skill
+
+**Files:**
+- Modify: `skills/implementing-chopin-plans/SKILL.md`
+- Modify: `skills/implementing-chopin-plans/prompt.md`
+
+**Interfaces:**
+- Consumes: MCP initialize instructions and current tool descriptions.
+- Produces: provider-neutral local implementation guidance without a copied lifecycle contract.
+
+- [ ] **Step 1: Remove copied lifecycle semantics**
+
+Keep checkout validation, dependency-ready work, independent review,
+verification evidence, and one PR per task. Delegate tool choice and ordering to
+the MCP service instructions.
+
+- [ ] **Step 2: Run the same pressure scenario with a fresh agent**
+
+Expected: the agent selects `request_revision`, stops coding, and reports no
+contradiction in the skill.
+
+- [ ] **Step 3: Run repository verification**
+
+Run: `bun test`, `bun run types`, `bun run ci`, and `git diff --check`.
+
+Expected: all commands pass; only the documented PostgreSQL skips are allowed.
+
+- [ ] **Step 4: Commit and update PR #50**
+
+Commit the hardening changes and force-update `tq/020-teach-agents-implement-plans`
+with an exact lease after confirming its remote head has not changed.

--- a/docs/superpowers/specs/2026-08-19-canonical-implementation-skill-instructions-design.md
+++ b/docs/superpowers/specs/2026-08-19-canonical-implementation-skill-instructions-design.md
@@ -1,0 +1,35 @@
+# Canonical Implementation Skill Instructions
+
+## Problem
+
+The portable implementation skill says Chopin's MCP contract is authoritative,
+then repeats lifecycle policy in its own prose. That copy already drifted: it
+directs graph changes to `block_task`, while the rebuilt lifecycle requires
+`request_revision` to end the run and release the graph. The prompt also asks
+agents to read MCP service instructions that the initialize response does not
+currently provide.
+
+## Decision
+
+The MCP initialize response will publish concise implementation instructions.
+Those instructions will be assembled from the existing public tool registry,
+so tool names and descriptions remain the single lifecycle source of truth.
+Lifecycle tool descriptions will distinguish task blockers from graph revision
+and state the ordering constraints agents need to use the tools safely.
+
+The portable skill will retain only concerns the service cannot know: resolving
+the canonical document, validating the local checkout, dependency-aware local
+work, independent review, and one pull request per task. It will direct agents
+to the initialize instructions and current tool descriptions for lifecycle
+semantics instead of naming a second command sequence.
+
+## Verification
+
+A boundary test will call the real MCP initialize handler and assert that its
+instructions expose the complete implementation lifecycle, including the
+task-blocker/graph-revision distinction. The skill will also be exercised with
+a fresh-agent pressure scenario in which sunk work and a deadline tempt the
+agent to keep a claim whose graph must change.
+
+PR #50 must contain only the skill commit and this hardening work on the current
+PR #49 base; none of the obsolete stack history may remain.

--- a/skills/implementing-chopin-plans/SKILL.md
+++ b/skills/implementing-chopin-plans/SKILL.md
@@ -5,45 +5,38 @@ description: Use when implementing an approved Chopin task graph through its MCP
 
 # Implementing Chopin plans
 
-Chopin's MCP contract is authoritative. This skill supplies local work habits without changing the approved graph.
+Chopin's MCP initialize instructions and current tool descriptions are authoritative. This skill adds local work practices; it does not restate the lifecycle.
 
 ## Claim the canonical graph
 
-1. Resolve the supplied canonical document URL through the Chopin MCP server. Call `read_implementation` and read the graph, acceptance criteria, dependencies, repository context, current revisions, and service instructions.
-2. Before claiming anything, compare the graph's repository and base reference with the local checkout. Inspect the repository identity, branch, remotes, and requested base ref.
-3. If they differ, surface the mismatch to the operator and stop before claiming or changing code.
-4. Call `start_implementation` with the current revisions and checkout context. Re-read the returned state and begin only when the claim succeeds.
+1. Resolve the supplied canonical document URL through Chopin MCP and call `read_implementation`.
+2. Read the returned graph, acceptance criteria, dependencies, repository context, revisions, lifecycle state, MCP initialize instructions, and current tool descriptions. Copied plans and remembered command sequences are not substitutes.
+3. Compare the graph's repository, base branch, and base commit with the local checkout. Inspect repository identity, branch, remotes, commit, and working tree before claiming or editing.
+4. If the checkout does not match, surface the mismatch and stop.
+5. Call `start_implementation` with the returned revisions and current checkout context. Begin only when the claim succeeds, and retain the returned run identity for later calls.
 
-Use the canonical document throughout; copied plans and stale task lists are not substitutes.
+## Execute ready work
 
-## Execute dependency-ready tasks
+Re-read the implementation before every lifecycle action, then follow the service instructions for the current state.
 
-Work only on tasks whose dependencies are complete. Independent ready roots may be delegated when the runtime supports it, but the owning agent remains responsible for MCP reports, review, verification evidence, and one PR per task.
-
-For each task:
-
-1. Refresh `read_implementation`, then read the task and acceptance criteria.
-2. Call `start_task`; begin only when it accepts the task.
-3. Make only the required changes. Do not edit Chopin plan or graph content or start another top-level agent CLI session.
-4. When the graph must change or work cannot continue, call `block_task` with the cause and what is needed, then stop code changes for that task.
-5. Perform a separate review pass after implementation. Prefer a fresh reviewer sub-agent; otherwise review independently after stepping away. Resolve in-scope findings and run focused checks.
-6. Create exactly one pull request. Call `report_pr` before `complete_task`; include the implementation summary when completing. Both reports must succeed.
+- Work only on tasks whose dependencies are complete. Independent ready roots may be delegated when the runtime supports it; the owning agent remains responsible for MCP reporting, review, verification evidence, and one pull request per task.
+- Make only the required changes. Do not edit Chopin plan or graph content or start another top-level agent CLI session.
+- Stop code changes whenever the service requires a blocker or graph release. Explain what must change and wait for the next valid lifecycle state.
+- Perform a separate review pass after implementation. Prefer a fresh reviewer sub-agent; otherwise review independently after stepping away. Resolve in-scope findings and run focused checks.
+- Create exactly one pull request per task. Update that pull request if later verification returns the task to work.
 
 ## Verify the graph
 
-After every task is complete, perform an independent verification pass over the whole graph. Run all relevant checks and capture command names, outcomes, and limitations as verification evidence for every task.
-
-Call `report_verification` with the reviewer method, evidence, summary, and any tasks needing work. A failed report returns those tasks to work: re-read the implementation, update their existing PRs, complete them again, and repeat verification. Only an accepted passing report releases the implementation.
+After every task is complete, perform an independent whole-graph verification. Run all relevant checks and capture command names, outcomes, and limitations as evidence for every task. Submit that evidence through the current service contract and follow the returned lifecycle state; only an accepted passing result releases a successful implementation.
 
 ## Boundaries
 
-| Situation                                  | Required response                     |
-| ------------------------------------------ | ------------------------------------- |
-| MCP instructions conflict with this skill  | Follow MCP instructions.              |
-| Repository or base ref differs             | Surface it and stop before claiming.  |
-| Scope, criteria, or dependencies must move | Call `block_task` and stop that task. |
-| A dependency is incomplete                 | Leave the task waiting.               |
-| A task has no PR                           | Do not call `complete_task`.          |
-| Any task lacks verification evidence       | Do not pass `report_verification`.    |
+| Situation                                  | Required response                         |
+| ------------------------------------------ | ----------------------------------------- |
+| MCP instructions conflict with this skill  | Follow current MCP instructions.          |
+| Repository or base ref differs             | Stop before claiming or changing code.    |
+| Scope, criteria, or dependencies must move | Follow graph-release guidance; stop code. |
+| A dependency is incomplete                 | Leave the task waiting.                   |
+| Verification evidence is incomplete        | Do not report a passing result.           |
 
 Keep this provider-neutral Agent Skills directory intact when installing it in the shared skill location supported by the local runtime.

--- a/skills/implementing-chopin-plans/SKILL.md
+++ b/skills/implementing-chopin-plans/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: implementing-chopin-plans
+description: Use when implementing an approved Chopin task graph through its MCP contract from a local coding-agent workspace.
+---
+
+# Implementing Chopin plans
+
+Chopin's MCP contract is authoritative. This skill supplies local work habits without changing the approved graph.
+
+## Claim the canonical graph
+
+1. Resolve the supplied canonical document URL through the Chopin MCP server. Call `read_implementation` and read the graph, acceptance criteria, dependencies, repository context, current revisions, and service instructions.
+2. Before claiming anything, compare the graph's repository and base reference with the local checkout. Inspect the repository identity, branch, remotes, and requested base ref.
+3. If they differ, surface the mismatch to the operator and stop before claiming or changing code.
+4. Call `start_implementation` with the current revisions and checkout context. Re-read the returned state and begin only when the claim succeeds.
+
+Use the canonical document throughout; copied plans and stale task lists are not substitutes.
+
+## Execute dependency-ready tasks
+
+Work only on tasks whose dependencies are complete. Independent ready roots may be delegated when the runtime supports it, but the owning agent remains responsible for MCP reports, review, verification evidence, and one PR per task.
+
+For each task:
+
+1. Refresh `read_implementation`, then read the task and acceptance criteria.
+2. Call `start_task`; begin only when it accepts the task.
+3. Make only the required changes. Do not edit Chopin plan or graph content or start another top-level agent CLI session.
+4. When the graph must change or work cannot continue, call `block_task` with the cause and what is needed, then stop code changes for that task.
+5. Perform a separate review pass after implementation. Prefer a fresh reviewer sub-agent; otherwise review independently after stepping away. Resolve in-scope findings and run focused checks.
+6. Create exactly one pull request. Call `report_pr` before `complete_task`; include the implementation summary when completing. Both reports must succeed.
+
+## Verify the graph
+
+After every task is complete, perform an independent verification pass over the whole graph. Run all relevant checks and capture command names, outcomes, and limitations as verification evidence for every task.
+
+Call `report_verification` with the reviewer method, evidence, summary, and any tasks needing work. A failed report returns those tasks to work: re-read the implementation, update their existing PRs, complete them again, and repeat verification. Only an accepted passing report releases the implementation.
+
+## Boundaries
+
+| Situation                                  | Required response                     |
+| ------------------------------------------ | ------------------------------------- |
+| MCP instructions conflict with this skill  | Follow MCP instructions.              |
+| Repository or base ref differs             | Surface it and stop before claiming.  |
+| Scope, criteria, or dependencies must move | Call `block_task` and stop that task. |
+| A dependency is incomplete                 | Leave the task waiting.               |
+| A task has no PR                           | Do not call `complete_task`.          |
+| Any task lacks verification evidence       | Do not pass `report_verification`.    |
+
+Keep this provider-neutral Agent Skills directory intact when installing it in the shared skill location supported by the local runtime.

--- a/skills/implementing-chopin-plans/contract.test.ts
+++ b/skills/implementing-chopin-plans/contract.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+
+let skill = await Bun.file(new URL("./SKILL.md", import.meta.url)).text();
+let prompt = await Bun.file(new URL("./prompt.md", import.meta.url)).text();
+
+test("the copied prompt delegates the canonical document to the MCP contract", () => {
+	expect(prompt).toContain("<CANONICAL_CHOPIN_DOCUMENT_URL>");
+	expect(prompt).toContain("Chopin MCP contract");
+	expect(prompt).not.toMatch(/claude|codex|github copilot|bearer|token/i);
+});
+
+test("the skill stops unsafe graph execution", () => {
+	expect(skill).toContain("Before claiming anything");
+	expect(skill).toContain("repository and base reference");
+	expect(skill).toContain("call `block_task`");
+	expect(skill).not.toContain("request_revision");
+	expect(skill).toContain("stop code changes");
+	expect(skill).toContain("Do not edit Chopin plan or graph content");
+});
+
+test("the skill follows the implemented lifecycle through verification", () => {
+	expect(skill).toContain("Independent ready roots may be delegated");
+	expect(skill).toContain("separate review pass");
+	expect(skill).toContain("verification evidence");
+	expect(skill).toContain("exactly one pull request");
+
+	let start = skill.indexOf("`start_task`");
+	let report = skill.indexOf("`report_pr`");
+	let complete = skill.indexOf("`complete_task`");
+	let verify = skill.indexOf("`report_verification`");
+	expect(start).toBeGreaterThan(-1);
+	expect(report).toBeGreaterThan(start);
+	expect(complete).toBeGreaterThan(report);
+	expect(verify).toBeGreaterThan(complete);
+});

--- a/skills/implementing-chopin-plans/contract.test.ts
+++ b/skills/implementing-chopin-plans/contract.test.ts
@@ -1,35 +1,67 @@
 import { expect, test } from "bun:test";
 
-let skill = await Bun.file(new URL("./SKILL.md", import.meta.url)).text();
-let prompt = await Bun.file(new URL("./prompt.md", import.meta.url)).text();
+import { handler } from "../../apps/server/src/mcp";
 
-test("the copied prompt delegates the canonical document to the MCP contract", () => {
-	expect(prompt).toContain("<CANONICAL_CHOPIN_DOCUMENT_URL>");
-	expect(prompt).toContain("Chopin MCP contract");
-	expect(prompt).not.toMatch(/claude|codex|github copilot|bearer|token/i);
-});
+import type { Implementations } from "../../apps/server/src/mcp";
 
-test("the skill stops unsafe graph execution", () => {
-	expect(skill).toContain("Before claiming anything");
-	expect(skill).toContain("repository and base reference");
-	expect(skill).toContain("call `block_task`");
-	expect(skill).not.toContain("request_revision");
-	expect(skill).toContain("stop code changes");
-	expect(skill).toContain("Do not edit Chopin plan or graph content");
-});
+function request(body: unknown): Request {
+	return new Request("https://chopin.test/mcp", {
+		method: "POST",
+		headers: {
+			authorization: "Bearer allowed",
+			"content-type": "application/json",
+		},
+		body: JSON.stringify(body),
+	});
+}
 
-test("the skill follows the implemented lifecycle through verification", () => {
-	expect(skill).toContain("Independent ready roots may be delegated");
-	expect(skill).toContain("separate review pass");
-	expect(skill).toContain("verification evidence");
-	expect(skill).toContain("exactly one pull request");
+function implementations(): Implementations<string> {
+	return {
+		async readImplementation() {
+			return undefined;
+		},
+		async startImplementation() {
+			return { kind: "refused", reason: "missing" };
+		},
+		async reportLifecycle() {
+			return { kind: "refused", reason: "inactive" };
+		},
+	};
+}
 
-	let start = skill.indexOf("`start_task`");
-	let report = skill.indexOf("`report_pr`");
-	let complete = skill.indexOf("`complete_task`");
-	let verify = skill.indexOf("`report_verification`");
-	expect(start).toBeGreaterThan(-1);
-	expect(report).toBeGreaterThan(start);
-	expect(complete).toBeGreaterThan(report);
-	expect(verify).toBeGreaterThan(complete);
+test("the MCP service publishes its complete implementation contract", async () => {
+	let mcp = handler({
+		caller: () => "operator",
+		documents: {
+			async list() {
+				return [];
+			},
+			async read() {
+				return undefined;
+			},
+		},
+		implementations: implementations(),
+	});
+	let initialized = await mcp(request({
+		jsonrpc: "2.0",
+		id: 1,
+		method: "initialize",
+		params: {},
+	}));
+	let initialization = await initialized.json() as {
+		result: { instructions?: string };
+	};
+	expect(initialization.result.instructions).toBe(
+		[
+			"Chopin's MCP contract is authoritative. Read the canonical implementation and these current tool descriptions before every action; copied plans and lifecycle instructions are not substitutes.",
+			"read_implementation: Read the approved implementation graph, plan and repository context.",
+			"start_implementation: Atomically claim the current approved implementation graph.",
+			"start_task: Mark one dependency-ready task as in progress for the active implementation run.",
+			"block_task: Record a task-level blocker while keeping the active implementation run and graph lock.",
+			"report_pr: Report the open, merged, or closed pull request for an implementation task.",
+			"complete_task: Complete an implementation task after reporting its pull request and summary.",
+			"report_verification: After every task is complete, report graph-wide verification evidence; failures return named tasks to work.",
+			"request_revision: End the active implementation run and release its graph when scope, acceptance criteria, or dependencies must change.",
+		].join("\n"),
+	);
 });

--- a/skills/implementing-chopin-plans/prompt.md
+++ b/skills/implementing-chopin-plans/prompt.md
@@ -4,4 +4,4 @@ Use the Chopin MCP contract to implement the approved graph at:
 
 `<CANONICAL_CHOPIN_DOCUMENT_URL>`
 
-Read the document and the MCP service instructions, then follow the installed `implementing-chopin-plans` skill.
+Read the MCP initialize instructions, current tool descriptions, and canonical document, then follow the installed `implementing-chopin-plans` skill.

--- a/skills/implementing-chopin-plans/prompt.md
+++ b/skills/implementing-chopin-plans/prompt.md
@@ -1,0 +1,7 @@
+# Implement an approved Chopin graph
+
+Use the Chopin MCP contract to implement the approved graph at:
+
+`<CANONICAL_CHOPIN_DOCUMENT_URL>`
+
+Read the document and the MCP service instructions, then follow the installed `implementing-chopin-plans` skill.


### PR DESCRIPTION
## Summary

Adds a portable implementation skill and prompt template for carrying an approved Chopin task graph through the current MCP lifecycle contract.

## What changed

- Add the `implementing-chopin-plans` skill with canonical document discovery, repository validation, graph claiming, dependency-aware execution, and blocker reporting.
- Describe the implemented lifecycle explicitly: `start_task` → `report_pr` → `complete_task` → graph-wide `report_verification`.
- Add a provider-neutral prompt template without copied plan content, provider names, or credentials.
- Add contract tests for safety boundaries and lifecycle ordering.

## How to test

- `bun test skills/implementing-chopin-plans/contract.test.ts`: 3 passed.
- `bun run ci`: passed.
- `bun run types`: passed.
- `bun test`: 736 passed, 0 failed, 2 PostgreSQL tests skipped because `TEST_DATABASE_URL` was not set.
- `git diff --check`: passed.

Task: `active/020-teach-agents-implement-plans.md`