### PR TITLE
Pin Bun version for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "chopin",
 	"private": true,
+	"packageManager": "bun@1.3.2",
 	"type": "module",
 	"scripts": {
 		"dev": "bun scripts/dev.ts",

--- a/readme.md
+++ b/readme.md
@@ -10,8 +10,9 @@ prose they produced.
 
 ## Running it
 
-Chopin requires PostgreSQL and a GitHub OAuth App. Register this callback on the
-OAuth App:
+Chopin requires Bun 1.3.2, PostgreSQL, and a GitHub OAuth App. The Bun version
+matches CI and the production image; verify it with `bun --version`. Register
+this callback on the OAuth App:
 
 ```text
 http://127.0.0.1:8787/auth/github/callback

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -20,10 +20,16 @@
  */
 
 import { dirname, join } from "node:path";
+import manifest from "../package.json";
 
 import type { Subprocess } from "bun";
 
 const ROOT = dirname(import.meta.dir);
+
+if (`bun@${Bun.version}` !== manifest.packageManager) {
+	console.error(`[dev] ${manifest.packageManager} is required; found bun@${Bun.version}`);
+	process.exit(1);
+}
 
 /** How long a child gets to leave politely before it is made to. */
 const GRACE_MS = 2_000;


### PR DESCRIPTION
## Summary

- declare Bun 1.3.2 as the project package-manager version
- reject mismatched Bun versions before the development processes start
- document the local Bun requirement alongside setup instructions

## Why

Bun 1.3.14 regresses Lexical ESM top-level-await evaluation and crashes startup with a temporal-dead-zone error. CI and Docker already use 1.3.2; this makes local development match them.

Upstream: https://github.com/oven-sh/bun/issues/30634

## Testing

- `bun install --frozen-lockfile`
- `bun run ci`
- `bun run types`
- `bun test`
- `bun run build`
- `bun run dev`