### PR TITLE
Replace repository page with header picker

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { SidebarSimpleIcon } from "@phosphor-icons/react";
+import { ArrowClockwiseIcon, SidebarSimpleIcon } from "@phosphor-icons/react";
 import {
 	advanceDecisionView,
 	countUnanswered,
@@ -18,6 +18,7 @@ import { Chat } from "./chat/chat";
 import { decisionAttention, DecisionViewControl } from "./decision-view-control";
 import * as Api from "./api";
 import { HostedApp, HostedFailure, HostedLoading, HostedLogin } from "./hosted";
+import { RepositoryPicker } from "./repository-picker";
 import { Wire } from "./wire";
 import { paneId, usePaneOpen, Workspace } from "./workspace";
 
@@ -56,6 +57,7 @@ function Header(
 		onResetAgent,
 		reason,
 		label,
+		repository,
 		status,
 	}: {
 		chatOpen: boolean;
@@ -64,11 +66,13 @@ function Header(
 		onResetAgent?: () => Promise<void>;
 		reason?: string;
 		label: string;
+		repository: Api.Repository;
 		status: Status;
 	},
 ) {
 	let [resetting, setResetting] = useState(false);
 	let [resetError, setResetError] = useState(false);
+	let resetLabel = resetting ? "Resetting..." : resetError ? "Reset failed" : "New planner session";
 
 	async function resetAgent() {
 		if (!onResetAgent || resetting) return;
@@ -84,27 +88,34 @@ function Header(
 	}
 
 	return (
-		<header className="hairline-b flex h-12 shrink-0 items-center gap-3 px-4">
+		<header className="hairline-b flex min-h-12 shrink-0 flex-wrap items-center gap-x-2 px-2 py-2 sm:h-12 sm:flex-nowrap sm:gap-3 sm:px-4 sm:py-0">
 			<PaneToggle onToggle={onToggleChat} open={chatOpen} />
-			<span className="text-sm font-semibold">chopin</span>
-			<span className="truncate text-sm text-text-tertiary">{label}</span>
-			<span className={`text-sm ${TONE[status]}`}>
-				{status === "connected" ? reason : reason ?? status}
-			</span>
+			<a className="hidden text-sm font-semibold sm:inline" href="/">chopin</a>
+			<span aria-hidden="true" className="hidden h-4 hairline-l sm:block" />
+			<RepositoryPicker current={repository} />
+			<div className="order-last flex min-w-0 basis-full items-center gap-2 pl-9 pt-1 sm:order-none sm:basis-auto sm:flex-1 sm:pl-0 sm:pt-0">
+				<span aria-hidden="true" className="hidden text-sm text-text-tertiary sm:inline">/</span>
+				<span className="min-w-0 flex-1 truncate text-sm text-text-tertiary">{label}</span>
+				<span className={`shrink-0 text-sm ${TONE[status]}`}>
+					{status === "connected" ? reason : reason ?? status}
+				</span>
+			</div>
 			<div
 				aria-label={`People here: ${members.map(member => member.handle).join(", ")}`}
-				className="ml-auto flex items-center [&>*+*]:-ml-1.5"
+				className="ml-auto flex shrink-0 items-center [&>*+*]:-ml-1.5"
 			>
 				{members.map(member => <Face handle={member.handle} key={member.client} ring size={24} />)}
 			</div>
 			{onResetAgent && (
 				<button
+					aria-label={resetLabel}
 					className="btn btn-sm btn-ghost"
 					disabled={resetting}
 					onClick={() => void resetAgent()}
 					type="button"
 				>
-					{resetting ? "Resetting..." : resetError ? "Reset failed" : "New planner session"}
+					<ArrowClockwiseIcon aria-hidden="true" className="lg:hidden" size={16} />
+					<span className="hidden lg:inline">{resetLabel}</span>
 				</button>
 			)}
 		</header>
@@ -118,6 +129,7 @@ export function RoomWorkspace(
 		handle,
 		label,
 		onResetAgent,
+		repository,
 		room,
 	}: {
 		agent?: boolean;
@@ -125,6 +137,7 @@ export function RoomWorkspace(
 		handle: string;
 		label: string;
 		onResetAgent?: () => Promise<void>;
+		repository: Api.Repository;
 		room: string;
 	},
 ) {
@@ -242,6 +255,7 @@ export function RoomWorkspace(
 					onResetAgent={effectiveCanEdit ? onResetAgent : undefined}
 					reason={status === "connected" && !effectiveCanEdit ? "view only" : reason}
 					label={label}
+					repository={repository}
 					status={status}
 				/>
 			}

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import * as Api from "./api";
+import { RepositoryPicker } from "./repository-picker";
 
 import type { ComponentType, FormEvent, ReactNode } from "react";
 
@@ -8,6 +9,7 @@ export type HostedWorkspaceProps = {
 	room: string;
 	handle: string;
 	label: string;
+	repository: Api.Repository;
 	canEdit: boolean;
 	agent?: boolean;
 	onResetAgent?: () => Promise<void>;
@@ -40,7 +42,19 @@ export function hostedRoute(pathname: string): HostedRoute {
 	return { page: "missing" };
 }
 
-function Frame({ children, user }: { children: ReactNode; user: Api.User }) {
+function Frame(
+	{
+		children,
+		currentRepository,
+		openRepositoryPicker = false,
+		user,
+	}: {
+		children: ReactNode;
+		currentRepository?: Api.Repository | { owner: string; name: string; fullName: string };
+		openRepositoryPicker?: boolean;
+		user: Api.User;
+	},
+) {
 	async function signOut() {
 		await Api.logout();
 		location.assign("/");
@@ -48,10 +62,12 @@ function Frame({ children, user }: { children: ReactNode; user: Api.User }) {
 
 	return (
 		<div className="min-h-full bg-ground text-text-primary">
-			<header className="hairline-b flex h-14 items-center bg-page px-6">
+			<header className="hairline-b flex h-14 items-center bg-page px-3 sm:px-6">
 				<a className="text-sm font-semibold" href="/">chopin</a>
+				<span aria-hidden="true" className="mx-1 h-4 hairline-l sm:mx-2" />
+				<RepositoryPicker current={currentRepository} initialOpen={openRepositoryPicker} />
 				<div className="ml-auto flex items-center gap-3">
-					<span className="text-sm text-text-secondary">{user.login}</span>
+					<span className="hidden text-sm text-text-secondary sm:inline">{user.login}</span>
 					<button className="btn btn-sm btn-ghost" onClick={() => void signOut()} type="button">
 						Sign out
 					</button>
@@ -113,87 +129,13 @@ export function HostedLogin() {
 	);
 }
 
-function RepositoryList({ user }: { user: Api.User }) {
-	let [page, setPage] = useState<Api.RepositoryPage>();
-	let [error, setError] = useState<unknown>();
-	let [loadingMore, setLoadingMore] = useState(false);
-
-	useEffect(() => {
-		let active = true;
-		Api.repositories().then(value => {
-			if (active) setPage(value);
-		}, reason => {
-			if (active) setError(reason);
-		});
-		return () => {
-			active = false;
-		};
-	}, []);
-
-	async function more() {
-		if (!page?.nextPage || loadingMore) return;
-		setLoadingMore(true);
-		try {
-			let next = await Api.repositories(page.nextPage);
-			setPage({
-				repositories: [...page.repositories, ...next.repositories],
-				nextPage: next.nextPage,
-			});
-		} catch (reason) {
-			setError(reason);
-		} finally {
-			setLoadingMore(false);
-		}
-	}
-
-	if (error) return <Failure error={error} />;
+function RepositoryHome({ user }: { user: Api.User }) {
 	return (
-		<Frame user={user}>
-			<main className="mx-auto w-full max-w-5xl px-6 py-12">
-				<p className="text-sm font-medium text-brand-ink">Repositories</p>
-				<h1 className="mt-2 text-2xl font-semibold">Where are you planning?</h1>
-				<p className="mt-3 text-sm text-text-secondary">
-					Choose a repository. Its channels live in Chopin; its code stays in GitHub.
+		<Frame openRepositoryPicker user={user}>
+			<main className="mx-auto w-full max-w-4xl px-6 py-12">
+				<p className="text-sm text-text-tertiary">
+					Choose a repository from the menu to see its planning channels.
 				</p>
-				{!page
-					? <p className="mt-10 text-sm text-text-tertiary">Loading repositories...</p>
-					: (
-						<div className="mt-8 grid gap-3 sm:grid-cols-2">
-							{page.repositories.map(repository => (
-								<a
-									className="ring-hairline rounded-lg bg-page p-5 shadow-resting transition-shadow hover:shadow-raised"
-									href={`/repositories/${encodeURIComponent(repository.owner)}/${
-										encodeURIComponent(repository.name)
-									}`}
-									key={repository.id}
-								>
-									<div className="flex items-center gap-2">
-										<span className="text-sm font-semibold">{repository.fullName}</span>
-										{repository.private && (
-											<span className="rounded-sm bg-inset px-1.5 text-sm text-text-tertiary">
-												Private
-											</span>
-										)}
-									</div>
-									<p className="mt-4 text-sm text-text-tertiary">
-										{repository.permissions.push || repository.permissions.admin
-											? "Create and edit channels"
-											: "View channels"}
-									</p>
-								</a>
-							))}
-						</div>
-					)}
-				{page?.nextPage && (
-					<button
-						className="btn btn-md btn-secondary mt-6"
-						disabled={loadingMore}
-						onClick={() => void more()}
-						type="button"
-					>
-						{loadingMore ? "Loading..." : "More repositories"}
-					</button>
-				)}
 			</main>
 		</Frame>
 	);
@@ -248,13 +190,18 @@ function RepositoryChannels(
 
 	if (error) return <Failure error={error} />;
 	return (
-		<Frame user={user}>
+		<Frame
+			currentRepository={page?.repository ?? {
+				owner,
+				name: repository,
+				fullName: `${owner}/${repository}`,
+			}}
+			user={user}
+		>
 			<main className="mx-auto w-full max-w-4xl px-6 py-12">
-				<a className="text-sm text-brand-ink" href="/">Repositories</a>
-				<h1 className="mt-3 text-2xl font-semibold">{owner}/{repository}</h1>
-				<div className="mt-8 flex items-end justify-between gap-6">
+				<div className="flex items-end justify-between gap-6">
 					<div>
-						<h2 className="text-xl font-semibold">Planning channels</h2>
+						<h1 className="text-2xl font-semibold">Planning channels</h1>
 						<p className="mt-1 text-sm text-text-secondary">
 							One shared plan and conversation per channel.
 						</p>
@@ -357,8 +304,9 @@ function ChannelWorkspace(
 			agent={agent}
 			canEdit={detail.canEdit}
 			handle={user.login}
-			label={`${detail.repository.fullName} / ${detail.channel.title}`}
+			label={detail.channel.title}
 			onResetAgent={agent ? () => Api.resetAgent(id) : undefined}
+			repository={detail.repository}
 			room={detail.channel.id}
 		/>
 	);
@@ -374,7 +322,7 @@ export function HostedApp(
 	let route = hostedRoute(location.pathname);
 	switch (route.page) {
 		case "repositories":
-			return <RepositoryList user={user} />;
+			return <RepositoryHome user={user} />;
 		case "repository":
 			return <RepositoryChannels owner={route.owner} repository={route.repository} user={user} />;
 		case "channel":

--- a/apps/web/src/repository-picker.tsx
+++ b/apps/web/src/repository-picker.tsx
@@ -1,0 +1,341 @@
+import { CaretDownIcon, CheckIcon } from "@phosphor-icons/react";
+import { createPortal } from "react-dom";
+import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+
+import * as Api from "./api";
+
+import type { CSSProperties, KeyboardEvent as ReactKeyboardEvent } from "react";
+
+export type RepositoryIdentity = Pick<Api.Repository, "owner" | "name" | "fullName">;
+
+type Position = Pick<CSSProperties, "left" | "maxHeight" | "top" | "visibility" | "width">;
+
+function repositoryHref(repository: RepositoryIdentity): string {
+	return `/repositories/${encodeURIComponent(repository.owner)}/${
+		encodeURIComponent(repository.name)
+	}`;
+}
+
+function sameRepository(left: RepositoryIdentity | undefined, right: RepositoryIdentity): boolean {
+	return left?.owner.toLowerCase() === right.owner.toLowerCase()
+		&& left.name.toLowerCase() === right.name.toLowerCase();
+}
+
+function optionId(list: string, repository: Api.Repository): string {
+	return `${list}-option-${repository.id}`;
+}
+
+function reauthenticate(reason: unknown): boolean {
+	if (!(reason instanceof Api.ApiError) || reason.status !== 401) return false;
+	location.assign("/");
+	return true;
+}
+
+export function RepositoryPicker(
+	{ current, initialOpen = false }: { current?: RepositoryIdentity; initialOpen?: boolean },
+) {
+	let trigger = useRef<HTMLButtonElement>(null);
+	let panel = useRef<HTMLDivElement>(null);
+	let search = useRef<HTMLInputElement>(null);
+	let request = useRef<Promise<Api.RepositoryPage> | undefined>(undefined);
+	let mounted = useRef(true);
+	let panelId = useId();
+	let listId = useId();
+	let [open, setOpen] = useState(initialOpen);
+	let [position, setPosition] = useState<Position>({ visibility: "hidden" });
+	let [page, setPage] = useState<Api.RepositoryPage>();
+	let [error, setError] = useState<unknown>();
+	let [attempt, setAttempt] = useState(0);
+	let [loadingMore, setLoadingMore] = useState(false);
+	let [query, setQuery] = useState("");
+	let [active, setActive] = useState(0);
+
+	let normalized = query.trim().toLowerCase();
+	let repositories = page?.repositories ?? [];
+	let matches = normalized
+		? repositories.filter(repository => repository.fullName.toLowerCase().includes(normalized))
+		: repositories;
+	let activeIndex = matches.length === 0 ? -1 : Math.min(active, matches.length - 1);
+	let activeRepository = matches[activeIndex];
+
+	useEffect(() => {
+		mounted.current = true;
+		return () => {
+			mounted.current = false;
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!open || page) return;
+		let active = true;
+		let pending = request.current ??= Api.repositories();
+		pending.then(value => {
+			if (active) setPage(value);
+		}, reason => {
+			if (active && !reauthenticate(reason)) setError(reason);
+		});
+		return () => {
+			active = false;
+		};
+	}, [attempt, open, page]);
+
+	useLayoutEffect(() => {
+		if (!open) return;
+		function place() {
+			let rect = trigger.current?.getBoundingClientRect();
+			if (!rect) return;
+			let margin = 8;
+			let gap = 4;
+			let width = Math.max(0, Math.min(360, window.innerWidth - margin * 2));
+			let left = Math.max(margin, Math.min(rect.left, window.innerWidth - width - margin));
+			let top = rect.bottom + gap;
+			setPosition({
+				left,
+				maxHeight: Math.max(0, window.innerHeight - top - margin),
+				top,
+				visibility: "visible",
+				width,
+			});
+		}
+
+		place();
+		window.addEventListener("resize", place);
+		document.addEventListener("scroll", place, true);
+		return () => {
+			window.removeEventListener("resize", place);
+			document.removeEventListener("scroll", place, true);
+		};
+	}, [open]);
+
+	useEffect(() => {
+		if (!open) return;
+		let frame = requestAnimationFrame(() => {
+			if (!panel.current?.contains(document.activeElement)) search.current?.focus();
+		});
+		return () => cancelAnimationFrame(frame);
+	}, [open, page]);
+
+	useEffect(() => {
+		if (!open || !activeRepository) return;
+		document.getElementById(optionId(listId, activeRepository))?.scrollIntoView({
+			block: "nearest",
+		});
+	}, [activeRepository, listId, open]);
+
+	useEffect(() => {
+		if (!open) return;
+		function closeOnPointer(event: PointerEvent) {
+			let target = event.target;
+			if (!(target instanceof Node)) return;
+			if (trigger.current?.contains(target) || panel.current?.contains(target)) return;
+			setOpen(false);
+		}
+
+		function closeOnFocus(event: FocusEvent) {
+			let target = event.target;
+			if (!(target instanceof Node)) return;
+			if (trigger.current?.contains(target) || panel.current?.contains(target)) return;
+			setOpen(false);
+		}
+
+		function closeOnEscape(event: KeyboardEvent) {
+			if (event.key !== "Escape") return;
+			event.preventDefault();
+			setOpen(false);
+			trigger.current?.focus();
+		}
+
+		document.addEventListener("pointerdown", closeOnPointer);
+		document.addEventListener("focusin", closeOnFocus);
+		document.addEventListener("keydown", closeOnEscape);
+		return () => {
+			document.removeEventListener("pointerdown", closeOnPointer);
+			document.removeEventListener("focusin", closeOnFocus);
+			document.removeEventListener("keydown", closeOnEscape);
+		};
+	}, [open]);
+
+	function retry() {
+		request.current = undefined;
+		setError(undefined);
+		setAttempt(value => value + 1);
+	}
+
+	async function more() {
+		if (!page?.nextPage || loadingMore) return;
+		setLoadingMore(true);
+		setError(undefined);
+		try {
+			let next = await Api.repositories(page.nextPage);
+			if (!mounted.current) return;
+			setPage(current => {
+				let known = new Set(current?.repositories.map(repository => repository.id));
+				return {
+					repositories: [
+						...(current?.repositories ?? []),
+						...next.repositories.filter(repository => !known.has(repository.id)),
+					],
+					nextPage: next.nextPage,
+				};
+			});
+		} catch (reason) {
+			if (mounted.current && !reauthenticate(reason)) setError(reason);
+		} finally {
+			if (mounted.current) setLoadingMore(false);
+		}
+	}
+
+	function select(repository: Api.Repository) {
+		location.assign(repositoryHref(repository));
+	}
+
+	function searchKeyDown(event: ReactKeyboardEvent<HTMLInputElement>) {
+		if (event.key === "ArrowDown") {
+			setActive(value => matches.length === 0 ? 0 : (value + 1) % matches.length);
+		} else if (event.key === "ArrowUp") {
+			setActive(value => matches.length === 0 ? 0 : (value - 1 + matches.length) % matches.length);
+		} else if (event.key === "Enter" && activeRepository) {
+			select(activeRepository);
+		} else {
+			return;
+		}
+		event.preventDefault();
+	}
+
+	let popup = open && createPortal(
+		<div
+			className="fixed z-50 flex flex-col overflow-hidden rounded-lg bg-page ring-hairline shadow-overlay"
+			id={panelId}
+			ref={panel}
+			style={position}
+		>
+			<div className="p-2 hairline-b">
+				<label className="sr-only" htmlFor={`${listId}-search`}>Search repositories</label>
+				<input
+					aria-activedescendant={activeRepository ? optionId(listId, activeRepository) : undefined}
+					aria-autocomplete="list"
+					aria-controls={listId}
+					aria-expanded="true"
+					className="field h-8 w-full px-2 text-sm"
+					id={`${listId}-search`}
+					onChange={event => {
+						setQuery(event.target.value);
+						setActive(0);
+					}}
+					onKeyDown={searchKeyDown}
+					placeholder="Find a repository"
+					ref={search}
+					role="combobox"
+					value={query}
+				/>
+			</div>
+			<div className="min-h-0 flex-1 overflow-y-auto p-1" data-repository-scroll="">
+				{!page && !error && (
+					<p className="px-2 py-3 text-sm text-text-tertiary" role="status">
+						Loading repositories...
+					</p>
+				)}
+				{!page && error !== undefined && (
+					<div className="px-2 py-3">
+						<p className="text-sm text-destructive-ink" role="alert">
+							Could not load repositories.
+						</p>
+						<button className="btn btn-sm btn-secondary mt-2" onClick={retry} type="button">
+							Try again
+						</button>
+					</div>
+				)}
+				{page && repositories.length === 0 && (
+					<p className="px-2 py-3 text-sm text-text-tertiary" role="status">
+						No repositories available.
+					</p>
+				)}
+				{page && repositories.length > 0 && matches.length === 0 && (
+					<p className="px-2 py-3 text-sm text-text-tertiary" role="status">
+						{page.nextPage ? "No matches in loaded repositories." : "No matching repositories."}
+					</p>
+				)}
+				<div
+					aria-busy={!page && error === undefined}
+					aria-label="Repositories"
+					id={listId}
+					role="listbox"
+				>
+					{matches.map((repository, index) => {
+						let selected = sameRepository(current, repository);
+						return (
+							<button
+								aria-selected={selected}
+								className={`flex w-full items-center gap-2 rounded-sm px-2 py-2 text-left transition ${
+									index === activeIndex ? "bg-selected" : "hover:bg-hover"
+								}`}
+								id={optionId(listId, repository)}
+								key={repository.id}
+								onClick={() => select(repository)}
+								onMouseEnter={() => setActive(index)}
+								role="option"
+								tabIndex={-1}
+								type="button"
+							>
+								<span className="min-w-0 flex-1">
+									<span className="flex items-center gap-2">
+										<span className="truncate text-sm font-medium">{repository.fullName}</span>
+										{repository.private && (
+											<span className="shrink-0 rounded-sm bg-inset px-1.5 text-sm text-text-tertiary">
+												Private
+											</span>
+										)}
+									</span>
+									<span className="block text-sm text-text-tertiary">
+										{repository.permissions.push || repository.permissions.admin
+											? "Create and edit channels"
+											: "View channels"}
+									</span>
+								</span>
+								{selected && (
+									<CheckIcon aria-hidden="true" className="shrink-0 text-brand-ink" size={16} />
+								)}
+							</button>
+						);
+					})}
+				</div>
+			</div>
+			{page?.nextPage && (
+				<div className="p-1 hairline-t">
+					{error !== undefined && (
+						<p className="px-2 py-1 text-sm text-destructive-ink" role="alert">
+							Could not load more repositories.
+						</p>
+					)}
+					<button
+						className="btn btn-md btn-ghost w-full"
+						disabled={loadingMore}
+						onClick={() => void more()}
+						type="button"
+					>
+						{loadingMore ? "Loading..." : error ? "Try loading more again" : "More repositories"}
+					</button>
+				</div>
+			)}
+		</div>,
+		document.body,
+	);
+
+	return (
+		<>
+			<button
+				aria-controls={panelId}
+				aria-expanded={open}
+				aria-haspopup="listbox"
+				className="btn btn-sm btn-ghost min-w-0 max-w-40 shrink-0 gap-1.5 sm:max-w-64"
+				onClick={() => setOpen(value => !value)}
+				ref={trigger}
+				type="button"
+			>
+				<span className="truncate">{current?.fullName ?? "Choose repository"}</span>
+				<CaretDownIcon aria-hidden="true" className="shrink-0" size={14} />
+			</button>
+			{popup}
+		</>
+	);
+}

--- a/e2e/github.ts
+++ b/e2e/github.ts
@@ -4,16 +4,38 @@
  */
 let network = globalThis.fetch;
 
-const repository = {
-	node_id: "R_score",
-	owner: { login: "octo-org" },
-	name: "score",
-	full_name: "octo-org/score",
-	private: true,
-	html_url: "https://github.com/octo-org/score",
-	default_branch: "main",
-	permissions: { pull: true, push: true, admin: false },
-};
+const repositories = [
+	{
+		node_id: "R_score",
+		owner: { login: "octo-org" },
+		name: "score",
+		full_name: "octo-org/score",
+		private: true,
+		html_url: "https://github.com/octo-org/score",
+		default_branch: "main",
+		permissions: { pull: true, push: true, admin: false },
+	},
+	{
+		node_id: "R_notes",
+		owner: { login: "octocat" },
+		name: "notes",
+		full_name: "octocat/notes",
+		private: false,
+		html_url: "https://github.com/octocat/notes",
+		default_branch: "main",
+		permissions: { pull: true, push: false, admin: false },
+	},
+	...Array.from({ length: 12 }, (_, index) => ({
+		node_id: `R_archive_${index + 1}`,
+		owner: { login: "octo-org" },
+		name: `archive-${index + 1}`,
+		full_name: `octo-org/archive-${index + 1}`,
+		private: false,
+		html_url: `https://github.com/octo-org/archive-${index + 1}`,
+		default_branch: "main",
+		permissions: { pull: true, push: false, admin: false },
+	})),
+];
 
 function json(value: unknown, init: ResponseInit = {}): Response {
 	return Response.json(value, init);
@@ -35,8 +57,12 @@ let fake = async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof f
 				avatar_url: `https://example.invalid/${handle}.png`,
 			});
 		}
-		if (url.pathname === "/user/repos") return json([repository]);
-		if (url.pathname === "/repos/octo-org/score") return json(repository);
+		if (url.pathname === "/user/repos") {
+			if (handle === "expired") return json({ message: "Bad credentials" }, { status: 401 });
+			return json(repositories);
+		}
+		let repository = repositories.find(value => url.pathname === `/repos/${value.full_name}`);
+		if (repository) return json(repository);
 		return json({ message: "Not Found" }, { status: 404 });
 	}
 	return network(input, init);

--- a/e2e/hosted.e2e.ts
+++ b/e2e/hosted.e2e.ts
@@ -1,11 +1,34 @@
 import { authenticate, expect, test } from "./room";
 
+const score = {
+	id: "R_score",
+	owner: "octo-org",
+	name: "score",
+	fullName: "octo-org/score",
+	private: true,
+	url: "https://github.com/octo-org/score",
+	defaultBranch: "main",
+	permissions: { pull: true, push: true, admin: false },
+};
+
+const notes = {
+	id: "R_notes",
+	owner: "octocat",
+	name: "notes",
+	fullName: "octocat/notes",
+	private: false,
+	url: "https://github.com/octocat/notes",
+	defaultBranch: "main",
+	permissions: { pull: true, push: false, admin: false },
+};
+
 test("an authenticated repository creates a channel workspace", async ({ baseURL, page }) => {
 	await authenticate(page, "octocat", baseURL!);
 	await page.goto("/");
 
-	await expect(page.getByRole("heading", { name: "Where are you planning?" })).toBeVisible();
-	await page.getByRole("link", { name: /octo-org\/score/ }).click();
+	let search = page.getByRole("combobox", { name: "Search repositories" });
+	await expect(search).toBeFocused();
+	await page.getByRole("option", { name: /octo-org\/score/ }).click();
 	await expect(page.getByRole("heading", { name: "Planning channels" })).toBeVisible();
 	await page.getByLabel("Channel title").fill("Release readiness");
 	await page.getByRole("button", { name: "New channel" }).click();
@@ -14,5 +37,91 @@ test("an authenticated repository creates a channel workspace", async ({ baseURL
 	await expect(page.locator("#pane-chat")).toBeVisible();
 	await expect(page.getByRole("textbox", { name: "editable markdown" })).toBeVisible();
 	await expect(page.locator(".plan-decisions")).toBeAttached();
-	await expect(page.getByText("octo-org/score / Release readiness")).toBeVisible();
+	await expect(page.getByRole("button", { name: /octo-org\/score/ })).toBeVisible();
+	await expect(page.getByText("Release readiness", { exact: true })).toBeVisible();
+
+	await page.setViewportSize({ width: 320, height: 480 });
+	let workspacePicker = page.getByRole("button", { name: /octo-org\/score/ });
+	let pickerBounds = await workspacePicker.boundingBox();
+	expect(pickerBounds).toBeTruthy();
+	expect(pickerBounds!.width).toBeGreaterThan(80);
+	await expect(page.getByText("Release readiness", { exact: true })).toBeVisible();
+	await workspacePicker.click();
+	await expect(search).toBeFocused();
+	await search.fill("notes");
+	await search.press("Enter");
+	await expect(page).toHaveURL("/repositories/octocat/notes");
+	await expect(page.getByRole("heading", { name: "Planning channels" })).toBeVisible();
+	await expect(page.getByRole("button", { name: /octocat\/notes/ })).toBeVisible();
+	await expect(page.getByRole("button", { name: "New channel" })).toHaveCount(0);
+});
+
+test("the repository picker supports dismissal and keyboard selection", async ({ baseURL, page }) => {
+	await authenticate(page, "octocat", baseURL!);
+	await page.goto("/");
+
+	let trigger = page.getByRole("button", { name: "Choose repository" });
+	let search = page.getByRole("combobox", { name: "Search repositories" });
+	await expect(search).toBeFocused();
+	await search.press("Escape");
+	await expect(page.getByRole("listbox", { name: "Repositories" })).toBeHidden();
+	await expect(trigger).toBeFocused();
+
+	await trigger.click();
+	await expect(search).toBeFocused();
+	for (let index = 0; index < 12; index++) await search.press("ArrowDown");
+	await expect.poll(() => page.locator("[data-repository-scroll]").evaluate(node => node.scrollTop))
+		.toBeGreaterThan(0);
+	let activeId = await search.getAttribute("aria-activedescendant");
+	expect(activeId).toBeTruthy();
+	await expect(page.locator(`[id="${activeId}"]`)).toBeInViewport();
+	await search.fill("notes");
+	await search.press("Enter");
+	await expect(page).toHaveURL("/repositories/octocat/notes");
+});
+
+test("the repository picker stays inside a narrow viewport", async ({ baseURL, page }) => {
+	await page.setViewportSize({ width: 320, height: 200 });
+	await authenticate(page, "octocat", baseURL!);
+	await page.goto("/");
+
+	let trigger = page.getByRole("button", { name: "Choose repository" });
+	await expect(page.getByRole("combobox", { name: "Search repositories" })).toBeVisible();
+	let popupId = await trigger.getAttribute("aria-controls");
+	let bounds = await page.locator(`[id="${popupId}"]`).boundingBox();
+	expect(bounds).toBeTruthy();
+	expect(bounds!.x).toBeGreaterThanOrEqual(0);
+	expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(320);
+	expect(bounds!.y + bounds!.height).toBeLessThanOrEqual(200);
+});
+
+test("the repository picker retries and appends unique pages", async ({ baseURL, page }) => {
+	await authenticate(page, "octocat", baseURL!);
+	let fail = true;
+	await page.route("**/api/repositories?*", async route => {
+		let requested = new URL(route.request().url()).searchParams.get("page");
+		if (requested === "1" && fail) {
+			fail = false;
+			await route.fulfill({ status: 503, json: { error: "temporary failure" } });
+		} else if (requested === "1") {
+			await route.fulfill({ json: { repositories: [score], nextPage: 2 } });
+		} else {
+			await route.fulfill({ json: { repositories: [score, notes] } });
+		}
+	});
+	await page.goto("/");
+
+	await expect(page.getByRole("alert")).toHaveText("Could not load repositories.");
+	await page.getByRole("button", { name: "Try again" }).click();
+	await expect(page.getByRole("option", { name: /octo-org\/score/ })).toBeVisible();
+	await page.getByRole("button", { name: "More repositories" }).click();
+	await expect(page.getByRole("option", { name: /octocat\/notes/ })).toBeVisible();
+	await expect(page.getByRole("option", { name: /octo-org\/score/ })).toHaveCount(1);
+});
+
+test("expired GitHub authorization returns to sign in", async ({ baseURL, page }) => {
+	await authenticate(page, "expired", baseURL!);
+	await page.goto("/");
+
+	await expect(page.getByRole("link", { name: "Continue with GitHub" })).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- replace the full-page repository chooser with a searchable header dropdown shared across home, repository, and workspace screens
- auto-open the picker at `/` while preserving pagination, retry, expired-session recovery, and accessible keyboard/focus behavior
- keep repository and channel context usable on narrow screens and expand hosted E2E coverage

## Testing
- `bun run ci`
- `bun run types`
- `bun run build`
- `bun test` (657 passed, 2 skipped)
- `E2E_SKIP_BUILD=1 bun run e2e e2e/hosted.e2e.ts` (5 passed)