### PR TITLE
Contain Mermaid parse errors inside code fences

### DIFF
--- a/e2e/code.e2e.ts
+++ b/e2e/code.e2e.ts
@@ -79,6 +79,16 @@ test("a diagram is shown with its source hidden by default", async ({ join, seed
 	await expect(content(page).getByRole("button", { name: "Show source" })).toBeVisible();
 });
 
+test("an invalid diagram leaves its error inside the fence", async ({ join, seed }) => {
+	await seed("```mermaid\nflowchart LR\nA[raw MemEntry[]]\n```\n");
+	let page = await join("ana");
+
+	await expect(content(page).locator("[data-plan-error]")).toContainText("Parse error");
+	await expect(
+		page.locator("body > div").filter({ hasText: "Syntax error in text" }),
+	).toHaveCount(0);
+});
+
 test("naming a fence colours it, and the name reaches the file", async ({ join, room, seed }) => {
 	await seed("```\nlet total = 1;\n```\n");
 	let page = await join("ana");

--- a/packages/editor/src/widgets/render-blocks.tsx
+++ b/packages/editor/src/widgets/render-blocks.tsx
@@ -114,6 +114,10 @@ async function renderMermaid(key: string, source: string): Promise<string> {
 	let mermaid = await import("mermaid");
 	mermaid.default.initialize({
 		startOnLoad: false,
+		// Its own error drawing is a temporary full-page SVG appended to body,
+		// and a parse failure throws before Mermaid removes it. The preview below
+		// already presents the error beside the source that caused it.
+		suppressErrorRendering: true,
 		// Diagrams come from collaborators and agents, so scripts, click
 		// handlers and HTML labels stay off.
 		securityLevel: "strict",


### PR DESCRIPTION
## Summary
- suppress Mermaid's full-page fallback error rendering
- keep parse failures in Chopin's inline fence error UI
- cover invalid Mermaid without regressing valid diagrams

## Verification
- bun test (678 passed, 2 skipped)
- bun run types
- bun run ci
- focused valid and invalid Mermaid browser tests