### PR TITLE
Avoid apt when installing Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,13 +97,10 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
 
-      # Run unconditionally, cache hit or not: the browser is cached but the
-      # shared libraries it links against are installed by apt and are not.
-      # With the binary already present this only does the second half.
-      # A runner's apt mirror can stop responding; fail this prerequisite in
-      # minutes rather than leaving the E2E check alive until GitHub cancels it.
-      - timeout-minutes: 5
-        run: bun node_modules/@playwright/test/cli.js install --with-deps chromium
+      # Run unconditionally, cache hit or not: it makes the Playwright binary
+      # available when the cache is cold. GitHub's Ubuntu image already ships
+      # Chromium's shared libraries, so do not make E2E depend on its apt mirror.
+      - run: bun node_modules/@playwright/test/cli.js install chromium
 
       # Builds the client, then runs it. The build is deliberately here rather
       # than inside the Playwright config: web servers start before any global

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,10 @@ jobs:
       # Run unconditionally, cache hit or not: the browser is cached but the
       # shared libraries it links against are installed by apt and are not.
       # With the binary already present this only does the second half.
-      - run: bun node_modules/@playwright/test/cli.js install --with-deps chromium
+      # A runner's apt mirror can stop responding; fail this prerequisite in
+      # minutes rather than leaving the E2E check alive until GitHub cancels it.
+      - timeout-minutes: 5
+        run: bun node_modules/@playwright/test/cli.js install --with-deps chromium
 
       # Builds the client, then runs it. The build is deliberately here rather
       # than inside the Playwright config: web servers start before any global


### PR DESCRIPTION
## Summary
- install the exact Playwright Chromium binary without invoking apt
- rely on the GitHub-hosted Ubuntu image with preinstalled Chromium runtime libraries
- remove the runner apt-mirror dependency that caused E2E to stall

## Verification
- bun run ci
- GitHub Actions: static/unit and container jobs passed; E2E reached and is running after Playwright installation