### PR TITLE
Anchor compact comments to their passage

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -367,6 +367,7 @@ export function RoomWorkspace(
 			}
 			plan={
 				<PlanEditor
+					commentPresentation={mode === "split" ? "popover" : "sheet"}
 					connection={status}
 					onScrollTop={setPlanScrollTop}
 					questions={questions}

--- a/e2e/responsive-comments.e2e.ts
+++ b/e2e/responsive-comments.e2e.ts
@@ -1,0 +1,64 @@
+import { content, expect, test } from "./room";
+
+const TARGET = "Paragraph 30 contains enough text to receive a comment.";
+const PLAN = Array.from(
+	{ length: 40 },
+	(_, index) => `Paragraph ${index + 1} contains enough text to receive a comment.`,
+).join("\n\n");
+
+for (let viewport of [{ width: 390, height: 844 }, { width: 768, height: 1024 }]) {
+	test(`${viewport.width}px comments keep their passage above the sheet and restore the document`, async ({ join, seed }) => {
+		await seed(PLAN);
+		let page = await join("ana", { hasTouch: true, viewport });
+		let scroller = page.locator("[data-plan-scroll]");
+		let passage = content(page).getByText(TARGET, { exact: true });
+		await expect(page.getByRole("navigation", { name: "Workspace view" })).toBeVisible();
+		await expect(page.locator("[data-plan-comment-sheet]")).toHaveCount(1);
+
+		await passage.scrollIntoViewIfNeeded();
+		await passage.selectText();
+		await page.getByRole("button", { name: "Comment on this passage", exact: true }).click();
+		let draft = page.getByRole("dialog", { name: "New comment" });
+		await draft.getByPlaceholder("Comment on this passage…").fill("Keep this paragraph close.");
+		await draft.getByRole("button", { name: "Comment" }).click();
+		await expect(draft).toHaveCount(0);
+
+		await passage.evaluate(element => {
+			let scroller = element.closest("[data-plan-scroll]")!;
+			let passage = element.getBoundingClientRect();
+			let viewport = scroller.getBoundingClientRect();
+			scroller.scrollTop += passage.bottom - viewport.bottom + 64;
+			scroller.dispatchEvent(new Event("scroll"));
+		});
+		// Let the document host persist the reader's position before the sheet
+		// changes layout; the controlled scroll value is restored on re-render.
+		await page.evaluate(() =>
+			new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+		);
+		let originalScroll = await scroller.evaluate(element => element.scrollTop);
+		let marker = page.getByRole("button", {
+			name: /Comment on “Paragraph 30 contains enough text/,
+		});
+		await expect(marker).toBeInViewport();
+		let markerBox = await marker.boundingBox();
+		await page.touchscreen.tap(
+			markerBox!.x + markerBox!.width / 2,
+			markerBox!.y + markerBox!.height / 2,
+		);
+
+		let sheet = page.getByRole("dialog", { name: "Comment thread" });
+		await expect(sheet).toHaveAttribute("aria-modal", "true");
+		await expect.poll(async () => {
+			let sheetBox = await sheet.boundingBox();
+			let passageBox = await passage.boundingBox();
+			let gap = sheetBox!.y - (passageBox!.y + passageBox!.height);
+			return Math.abs(gap - 20) <= 1;
+		}).toBe(true);
+		await page.keyboard.press("Escape");
+		await expect(sheet).toHaveCount(0);
+		await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeCloseTo(
+			originalScroll,
+			0,
+		);
+	});
+}

--- a/packages/editor/src/comment-layer.tsx
+++ b/packages/editor/src/comment-layer.tsx
@@ -9,7 +9,7 @@ import { useCellValue } from "@mdxeditor/gurx";
 import { DraftCard, ThreadCard } from "./comments";
 import { markerPoints, popoverPoint } from "./comment-geometry";
 import { containsHit, passageHits } from "./comment-hits";
-import { commentRevealScroll } from "./comment-reveal";
+import { useCommentSheetReveal } from "./comment-sheet-reveal";
 import { $rangeOf } from "./marks";
 import { blockElement } from "./scroll";
 import { COARSE_POINTER_QUERY, hasCoarsePointer } from "./pointer";
@@ -39,11 +39,6 @@ function rect(value: DOMRect): Rect {
 		width: value.width,
 		height: value.height,
 	};
-}
-
-function commentScroller(host: HTMLElement): HTMLElement | undefined {
-	let child = host.firstElementChild;
-	return child instanceof HTMLElement ? child : undefined;
 }
 
 function Preview({
@@ -112,7 +107,6 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 	let failures = useRef(new Set<string>());
 	let origin = useRef<HTMLElement | undefined>(undefined);
 	let draftOpen = useRef(false);
-	let compactScroll = useRef<{ id: string; top: number; revealed: boolean } | undefined>(undefined);
 	let compact = useCellValue(widgets$).commentPresentation === "sheet";
 
 	useEffect(() => {
@@ -150,14 +144,6 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 		hoverOwner.current = undefined;
 		leave(id);
 	}, [leave]);
-	let rememberCompactScroll = useCallback((id: string) => {
-		if (!host || id === "orphans") return;
-		let scroller = commentScroller(host);
-		if (scroller) {
-			compactScroll.current = { id, top: scroller.scrollTop, revealed: false };
-		}
-	}, [host]);
-
 	let measure = () => {
 		if (!host) return;
 		let page = rect(host.getBoundingClientRect());
@@ -280,12 +266,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 				`[data-plan-comment-button="${pending.id}"]`,
 			) ?? undefined;
 			enter(pending.id);
-			if (pinned === pending.id) {
-				setPinned(undefined);
-			} else {
-				rememberCompactScroll(pending.id);
-				setPinned(pending.id);
-			}
+			setPinned(current => current === pending.id ? undefined : pending.id);
 		};
 		let out = () => {
 			if (hoverOwner.current) unhover(hoverOwner.current);
@@ -305,7 +286,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 			host.removeEventListener("pointerleave", out);
 			host.removeEventListener("pointercancel", cancel);
 		};
-	}, [editor, enter, host, hover, pinned, rememberCompactScroll, unhover]);
+	}, [editor, enter, host, hover, unhover]);
 
 	let restoreOrigin = useCallback(() => {
 		let target = origin.current;
@@ -348,39 +329,14 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 		restoreOrigin();
 	}, [editor, pinned, restoreOrigin, state.draft, state.threads, store]);
 
-	useLayoutEffect(() => {
-		if (pinned || !host) return;
-		let saved = compactScroll.current;
-		if (!saved) return;
-		compactScroll.current = undefined;
-		if (!saved.revealed) return;
-		let scroller = commentScroller(host);
-		if (scroller) scroller.scrollTop = saved.top;
-	}, [host, pinned]);
-
-	useLayoutEffect(() => {
-		if (!compact || !host || !pinned || pinned === "orphans") return;
-		let dialog = document.getElementById(`plan-comment-thread-${pinned}`);
-		let scroller = commentScroller(host);
-		let passages = placed.find(entry => entry.view.thread.id === pinned)?.passages;
-		if (!dialog || !scroller || !passages || passages.length === 0) return;
-		let passageTop = Math.min(...passages.map(passage => passage.top));
-		let passageBottom = Math.max(...passages.map(passage => passage.bottom));
-		let next = commentRevealScroll({
-			currentScroll: scroller.scrollTop,
-			gap: 20,
-			maxScroll: scroller.scrollHeight - scroller.clientHeight,
-			passageBottom,
-			passageTop,
-			sheetTop: dialog.getBoundingClientRect().top,
-			viewportTop: host.getBoundingClientRect().top,
-		});
-		if (Math.abs(next - scroller.scrollTop) >= 1) {
-			let saved = compactScroll.current;
-			if (saved?.id === pinned) saved.revealed = true;
-			scroller.scrollTop = next;
-		}
-	}, [cardHeights, compact, host, pinned, placed]);
+	let sheetId = compact && pinned !== "orphans" ? pinned : undefined;
+	let sheet = placed.find(entry => entry.view.thread.id === sheetId);
+	useCommentSheetReveal({
+		height: sheetId ? cardHeights[sheetId] : undefined,
+		host,
+		id: sheetId,
+		passages: sheet?.passages,
+	});
 
 	useEffect(() => {
 		if (!pinned && !preview) return;
@@ -521,10 +477,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 							onClick={event => {
 								origin.current = event.currentTarget;
 								if (shown) dismiss();
-								else {
-									rememberCompactScroll(view.thread.id);
-									setPinned(view.thread.id);
-								}
+								else setPinned(view.thread.id);
 							}}
 							onFocus={() => hover(view.thread.id)}
 							onMouseEnter={() => hover(view.thread.id)}

--- a/packages/editor/src/comment-layer.tsx
+++ b/packages/editor/src/comment-layer.tsx
@@ -4,21 +4,29 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import { createPortal } from "react-dom";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { ChatCircleIcon } from "@phosphor-icons/react";
+import { useCellValue } from "@mdxeditor/gurx";
 
 import { DraftCard, ThreadCard } from "./comments";
 import { markerPoints, popoverPoint } from "./comment-geometry";
 import { containsHit, passageHits } from "./comment-hits";
+import { commentRevealScroll } from "./comment-reveal";
 import { $rangeOf } from "./marks";
 import { blockElement } from "./scroll";
 import { COARSE_POINTER_QUERY, hasCoarsePointer } from "./pointer";
 import { useThreads } from "./threads";
+import { widgets$ } from "./widget-options";
 
 import type { CSSProperties } from "react";
 import type { Point, Rect } from "./comment-geometry";
 import type { PassageHit } from "./comment-hits";
 import type { ThreadStore, ThreadView } from "./threads";
 
-type PlacedThread = { view: ThreadView; button: Point; hits: PassageHit[] };
+type PlacedThread = {
+	view: ThreadView;
+	button: Point;
+	hits: PassageHit[];
+	passages: Rect[];
+};
 type MeasuredThread = { view: ThreadView; target: Rect; passages: Rect[]; hits: Rect[] };
 type PassagePress = { id: string; left: number; pointer: number; top: number; moved: boolean };
 
@@ -31,6 +39,11 @@ function rect(value: DOMRect): Rect {
 		width: value.width,
 		height: value.height,
 	};
+}
+
+function commentScroller(host: HTMLElement): HTMLElement | undefined {
+	let child = host.firstElementChild;
+	return child instanceof HTMLElement ? child : undefined;
 }
 
 function Preview({
@@ -89,7 +102,6 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 	let [placed, setPlaced] = useState<PlacedThread[]>([]);
 	let [preview, setPreview] = useState<string>();
 	let [pinned, setPinned] = useState<string>();
-	let [compact, setCompact] = useState(false);
 	let [coarse, setCoarse] = useState(false);
 	let [cardHeights, setCardHeights] = useState<{ [id: string]: number }>({});
 	let root = useRef<HTMLDivElement>(null);
@@ -100,6 +112,8 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 	let failures = useRef(new Set<string>());
 	let origin = useRef<HTMLElement | undefined>(undefined);
 	let draftOpen = useRef(false);
+	let compactScroll = useRef<{ id: string; top: number; revealed: boolean } | undefined>(undefined);
+	let compact = useCellValue(widgets$).commentPresentation === "sheet";
 
 	useEffect(() => {
 		setHost(document.querySelector<HTMLElement>(".plan-document") ?? undefined);
@@ -136,6 +150,13 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 		hoverOwner.current = undefined;
 		leave(id);
 	}, [leave]);
+	let rememberCompactScroll = useCallback((id: string) => {
+		if (!host || id === "orphans") return;
+		let scroller = commentScroller(host);
+		if (scroller) {
+			compactScroll.current = { id, top: scroller.scrollTop, revealed: false };
+		}
+	}, [host]);
 
 	let measure = () => {
 		if (!host) return;
@@ -180,6 +201,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 			view: entry.view,
 			button: buttons[index]!,
 			hits: passageHits(page, entry.hits),
+			passages: entry.passages,
 		}));
 
 		placedRef.current = next;
@@ -197,15 +219,10 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 		host.addEventListener("scroll", update, true);
 		let observer = new ResizeObserver(update);
 		observer.observe(host);
-		let compactUpdate = () => setCompact(host.clientWidth <= 640);
-		compactUpdate();
-		let compactObserver = new ResizeObserver(compactUpdate);
-		compactObserver.observe(host);
 		return () => {
 			off();
 			host.removeEventListener("scroll", update, true);
 			observer.disconnect();
-			compactObserver.disconnect();
 		};
 	}, [editor, host, state.threads, coarse]);
 
@@ -263,7 +280,12 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 				`[data-plan-comment-button="${pending.id}"]`,
 			) ?? undefined;
 			enter(pending.id);
-			setPinned(current => current === pending.id ? undefined : pending.id);
+			if (pinned === pending.id) {
+				setPinned(undefined);
+			} else {
+				rememberCompactScroll(pending.id);
+				setPinned(pending.id);
+			}
 		};
 		let out = () => {
 			if (hoverOwner.current) unhover(hoverOwner.current);
@@ -283,7 +305,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 			host.removeEventListener("pointerleave", out);
 			host.removeEventListener("pointercancel", cancel);
 		};
-	}, [editor, enter, host, hover, unhover]);
+	}, [editor, enter, host, hover, pinned, rememberCompactScroll, unhover]);
 
 	let restoreOrigin = useCallback(() => {
 		let target = origin.current;
@@ -325,6 +347,40 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 		store.focus(undefined);
 		restoreOrigin();
 	}, [editor, pinned, restoreOrigin, state.draft, state.threads, store]);
+
+	useLayoutEffect(() => {
+		if (pinned || !host) return;
+		let saved = compactScroll.current;
+		if (!saved) return;
+		compactScroll.current = undefined;
+		if (!saved.revealed) return;
+		let scroller = commentScroller(host);
+		if (scroller) scroller.scrollTop = saved.top;
+	}, [host, pinned]);
+
+	useLayoutEffect(() => {
+		if (!compact || !host || !pinned || pinned === "orphans") return;
+		let dialog = document.getElementById(`plan-comment-thread-${pinned}`);
+		let scroller = commentScroller(host);
+		let passages = placed.find(entry => entry.view.thread.id === pinned)?.passages;
+		if (!dialog || !scroller || !passages || passages.length === 0) return;
+		let passageTop = Math.min(...passages.map(passage => passage.top));
+		let passageBottom = Math.max(...passages.map(passage => passage.bottom));
+		let next = commentRevealScroll({
+			currentScroll: scroller.scrollTop,
+			gap: 20,
+			maxScroll: scroller.scrollHeight - scroller.clientHeight,
+			passageBottom,
+			passageTop,
+			sheetTop: dialog.getBoundingClientRect().top,
+			viewportTop: host.getBoundingClientRect().top,
+		});
+		if (Math.abs(next - scroller.scrollTop) >= 1) {
+			let saved = compactScroll.current;
+			if (saved?.id === pinned) saved.revealed = true;
+			scroller.scrollTop = next;
+		}
+	}, [cardHeights, compact, host, pinned, placed]);
 
 	useEffect(() => {
 		if (!pinned && !preview) return;
@@ -425,7 +481,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 	let previewWidth = Math.min(288, host.clientWidth * 0.8);
 
 	return createPortal(
-		<div className="plan-comment-layer" ref={root}>
+		<div className="plan-comment-layer" data-plan-comment-sheet={compact || undefined} ref={root}>
 			{placed.map(({ button, hits, view }) => {
 				let shown = pinned === view.thread.id;
 				let previewId = `plan-comment-preview-${view.thread.id}`;
@@ -465,7 +521,10 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 							onClick={event => {
 								origin.current = event.currentTarget;
 								if (shown) dismiss();
-								else setPinned(view.thread.id);
+								else {
+									rememberCompactScroll(view.thread.id);
+									setPinned(view.thread.id);
+								}
 							}}
 							onFocus={() => hover(view.thread.id)}
 							onMouseEnter={() => hover(view.thread.id)}

--- a/packages/editor/src/comment-reveal.test.ts
+++ b/packages/editor/src/comment-reveal.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+
+import { commentRevealScroll } from "./comment-reveal";
+
+test("comment reveal places short passages above the sheet and tall passages at the viewport top", () => {
+	expect(commentRevealScroll({
+		currentScroll: 400,
+		gap: 20,
+		maxScroll: 1_000,
+		passageBottom: 700,
+		passageTop: 650,
+		sheetTop: 500,
+		viewportTop: 80,
+	})).toBe(620);
+	expect(commentRevealScroll({
+		currentScroll: 400,
+		gap: 20,
+		maxScroll: 1_000,
+		passageBottom: 240,
+		passageTop: 200,
+		sheetTop: 500,
+		viewportTop: 80,
+	})).toBe(160);
+	expect(commentRevealScroll({
+		currentScroll: 400,
+		gap: 20,
+		maxScroll: 1_000,
+		passageBottom: 800,
+		passageTop: 200,
+		sheetTop: 500,
+		viewportTop: 80,
+	})).toBe(500);
+});
+
+test("comment reveal stays within the document scroll range", () => {
+	expect(commentRevealScroll({
+		currentScroll: 40,
+		gap: 20,
+		maxScroll: 1_000,
+		passageBottom: 100,
+		passageTop: 80,
+		sheetTop: 500,
+		viewportTop: 80,
+	})).toBe(0);
+	expect(commentRevealScroll({
+		currentScroll: 900,
+		gap: 20,
+		maxScroll: 1_000,
+		passageBottom: 800,
+		passageTop: 760,
+		sheetTop: 500,
+		viewportTop: 80,
+	})).toBe(1_000);
+});

--- a/packages/editor/src/comment-reveal.ts
+++ b/packages/editor/src/comment-reveal.ts
@@ -1,0 +1,20 @@
+export type CommentRevealLayout = {
+	currentScroll: number;
+	gap: number;
+	maxScroll: number;
+	passageBottom: number;
+	passageTop: number;
+	sheetTop: number;
+	viewportTop: number;
+};
+
+export function commentRevealScroll(layout: CommentRevealLayout): number {
+	let revealTop = layout.viewportTop + layout.gap;
+	let revealBottom = layout.sheetTop - layout.gap;
+	let passageHeight = layout.passageBottom - layout.passageTop;
+	let availableHeight = revealBottom - revealTop;
+	let delta = passageHeight <= availableHeight
+		? layout.passageBottom - revealBottom
+		: layout.passageTop - revealTop;
+	return Math.min(layout.maxScroll, Math.max(0, layout.currentScroll + delta));
+}

--- a/packages/editor/src/comment-sheet-reveal.ts
+++ b/packages/editor/src/comment-sheet-reveal.ts
@@ -1,0 +1,46 @@
+import { useLayoutEffect } from "react";
+
+import { commentRevealScroll } from "./comment-reveal";
+import { planScroller } from "./scroll";
+
+import type { Rect } from "./comment-geometry";
+
+/** Keep a compact comment beside its passage, then return the reader on close. */
+export function useCommentSheetReveal({
+	height,
+	host,
+	id,
+	passages,
+}: {
+	height: number | undefined;
+	host: HTMLElement | undefined;
+	id: string | undefined;
+	passages: Rect[] | undefined;
+}) {
+	useLayoutEffect(() => {
+		if (!host || !id) return;
+		let scroller = planScroller(host);
+		if (!scroller) return;
+		let top = scroller.scrollTop;
+		return () => {
+			if (scroller.isConnected) scroller.scrollTop = top;
+		};
+	}, [host, id]);
+
+	useLayoutEffect(() => {
+		if (!host || !id || !height || !passages || passages.length === 0) return;
+		let dialog = document.getElementById(`plan-comment-thread-${id}`);
+		let scroller = planScroller(host);
+		if (!dialog || !scroller) return;
+		let next = commentRevealScroll({
+			currentScroll: scroller.scrollTop,
+			gap: 20,
+			maxScroll: scroller.scrollHeight - scroller.clientHeight,
+			passageBottom: Math.max(...passages.map(passage => passage.bottom)),
+			passageTop: Math.min(...passages.map(passage => passage.top)),
+			sheetTop: dialog.getBoundingClientRect().top,
+			viewportTop: host.getBoundingClientRect().top,
+		});
+		if (Math.abs(next - scroller.scrollTop) >= 1) scroller.scrollTop = next;
+	}, [height, host, id, passages]);
+}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -26,4 +26,5 @@ export type { PlanStatusProps } from "./status";
 export { ThreadObserver, ThreadStore, useThreads } from "./threads";
 export type { Draft, ThreadState, ThreadView } from "./threads";
 export type { Connection, Transport, Unsubscribe } from "./transport";
+export type { CommentPresentation } from "./widget-options";
 export { QuestionnaireCard, register as registerPlanWidgets } from "./widgets";

--- a/packages/editor/src/plan-editor.tsx
+++ b/packages/editor/src/plan-editor.tsx
@@ -59,6 +59,8 @@ register();
 export type PlanEditorProps = {
 	wire: Transport | undefined;
 	connection?: Connection;
+	/** How comment threads are presented by the surrounding workspace. */
+	commentPresentation?: "popover" | "sheet";
 	/** Identity for this client's remote cursor. */
 	user: { name: string; color: string };
 	/** Read-only while an agent turn may be rewriting the plan. */
@@ -94,6 +96,7 @@ export function PlanEditor(
 	{
 		busy,
 		className,
+		commentPresentation = "popover",
 		connection,
 		onScrollTop,
 		questions,
@@ -243,6 +246,7 @@ export function PlanEditor(
 						onChanges,
 					}),
 					widgetsPlugin({
+						commentPresentation,
 						questions,
 						threads,
 						changes,
@@ -260,6 +264,7 @@ export function PlanEditor(
 			onAnchors,
 			onChanges,
 			questions,
+			commentPresentation,
 			threads,
 			changes,
 			offline,

--- a/packages/editor/src/plan-editor.tsx
+++ b/packages/editor/src/plan-editor.tsx
@@ -28,6 +28,7 @@ import type { PlanProvider } from "./provider";
 import type { QuestionnaireStore } from "./questionnaires";
 import type { ThreadStore } from "./threads";
 import type { Connection, Transport } from "./transport";
+import type { CommentPresentation } from "./widget-options";
 
 /**
  * Lexical paints remote cursors with inline styles unless the theme names a
@@ -60,7 +61,7 @@ export type PlanEditorProps = {
 	wire: Transport | undefined;
 	connection?: Connection;
 	/** How comment threads are presented by the surrounding workspace. */
-	commentPresentation?: "popover" | "sheet";
+	commentPresentation?: CommentPresentation;
 	/** Identity for this client's remote cursor. */
 	user: { name: string; color: string };
 	/** Read-only while an agent turn may be rewriting the plan. */

--- a/packages/editor/src/scroll.ts
+++ b/packages/editor/src/scroll.ts
@@ -20,6 +20,12 @@
 
 import type { LexicalEditor } from "lexical";
 
+/** The explicitly marked scroll owner for editor chrome anchored to the plan. */
+export function planScroller(element: Element | null | undefined): HTMLElement | undefined {
+	return element?.closest<HTMLElement>(".plan-document")
+		?.querySelector<HTMLElement>(":scope > [data-plan-scroll]") ?? undefined;
+}
+
 /**
  * The block element a node key sits in.
  *

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -158,17 +158,15 @@
 	right: 0;
 }
 
-@container (max-width: 40rem) {
-	.plan-comment-card {
-		top: auto !important;
-		right: 0;
-		bottom: 0;
-		left: 0 !important;
-		width: 100%;
-		max-height: calc(100% - 0.5rem);
-		padding-bottom: env(safe-area-inset-bottom, 0px);
-		border-radius: var(--radius-lg) var(--radius-lg) 0 0;
-	}
+.plan-comment-layer[data-plan-comment-sheet] .plan-comment-card {
+	top: auto !important;
+	right: 0;
+	bottom: 0;
+	left: 0 !important;
+	width: 100%;
+	max-height: calc(100% - 0.5rem);
+	padding-bottom: env(safe-area-inset-bottom, 0px);
+	border-radius: var(--radius-lg) var(--radius-lg) 0 0;
 }
 
 .plan-decisions {

--- a/packages/editor/src/table/touch-toolbar.tsx
+++ b/packages/editor/src/table/touch-toolbar.tsx
@@ -9,6 +9,7 @@ import {
 } from "@lexical/table";
 import { $getSelection, $isRangeSelection } from "lexical";
 
+import { planScroller } from "../scroll";
 import { placeSurface } from "../toolbar/placement";
 import { editorSurfaceViewport, listenToEditorGeometry } from "../toolbar/surface";
 import {
@@ -116,8 +117,7 @@ export function TableTouchToolbar(
 	useLayoutEffect(() => {
 		if (!selected) return;
 		let element = surface.current;
-		let scroller = editor.getRootElement()?.closest<HTMLElement>(".plan-document")
-			?.firstElementChild as HTMLElement | null;
+		let scroller = planScroller(editor.getRootElement());
 		if (!element || !scroller) return;
 		let previous = scroller.style.scrollPaddingBottom;
 		scroller.style.scrollPaddingBottom = `${element.offsetHeight + 16}px`;

--- a/packages/editor/src/toolbar/surface.ts
+++ b/packages/editor/src/toolbar/surface.ts
@@ -2,6 +2,7 @@
 
 import { currentViewport, listenToViewportChanges } from "@chopin/viewport";
 
+import { planScroller } from "../scroll";
 import { intersectViewport } from "./placement";
 
 import type { LexicalEditor } from "lexical";
@@ -24,8 +25,7 @@ export function editorSurfaceViewport(editor: LexicalEditor): ViewportBox {
 
 /** Keep fixed editor chrome attached through document and visual-viewport movement. */
 export function listenToEditorGeometry(editor: LexicalEditor, listener: () => void): () => void {
-	let scroller = editor.getRootElement()?.closest<HTMLElement>(".plan-document")
-		?.firstElementChild;
+	let scroller = planScroller(editor.getRootElement());
 	return listenToViewportChanges(listener, {
 		observeDocumentScroll: true,
 		scrollTargets: scroller ? [scroller] : [],

--- a/packages/editor/src/widget-options.ts
+++ b/packages/editor/src/widget-options.ts
@@ -6,6 +6,7 @@ import type { ThreadStore } from "./threads";
 import type { Transport } from "./transport";
 
 export type WidgetOptions = {
+	commentPresentation?: "popover" | "sheet";
 	questions?: QuestionnaireStore;
 	threads?: ThreadStore;
 	changes?: ChangeStore;

--- a/packages/editor/src/widget-options.ts
+++ b/packages/editor/src/widget-options.ts
@@ -5,8 +5,10 @@ import type { QuestionnaireStore } from "./questionnaires";
 import type { ThreadStore } from "./threads";
 import type { Transport } from "./transport";
 
+export type CommentPresentation = "popover" | "sheet";
+
 export type WidgetOptions = {
-	commentPresentation?: "popover" | "sheet";
+	commentPresentation?: CommentPresentation;
 	questions?: QuestionnaireStore;
 	threads?: ThreadStore;
 	changes?: ChangeStore;


### PR DESCRIPTION
## Summary

- keep the highlighted passage directly above an open comment sheet
- restore the readers prior document position when the sheet closes
- use the same comment-sheet behavior on phones and tablets
- retain desktop popovers at 1200px and wider

## Verification

- phone and tablet behavior test: 20/20 parallel stress runs
- browser suite excluding confirmed baseline failure: 157/157
- unit tests: 765 passed, 2 database-only skips
- types, formatting, lint, token checks, production build, and diff check passed
- visually inspected at 390x844 and 768x1024

## Baseline issue

The full suite also runs a callout keyboard test that currently fails identically on a clean origin/main worktree: `a callout type menu has one keyboard path`. No callout code is changed here.