### PR TITLE
Fix Coolify preview origins

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,7 @@ services:
       context: .
     environment:
       AGENT: ${AGENT:-on}
-      APP_ORIGIN: ${SERVICE_URL_APP_8787:-${APP_ORIGIN:-http://127.0.0.1:8787}}
+      APP_ORIGIN: ${SERVICE_URL_APP:-${APP_ORIGIN:-http://127.0.0.1:8787}}
       DATABASE_URL: postgresql://chopin:chopin@${SERVICE_NAME_DB:-db}:5432/chopin?sslmode=disable
       GITHUB_APP_SLUG: ${GITHUB_APP_SLUG:-}
       GITHUB_APP_CLIENT_ID: ${GITHUB_APP_CLIENT_ID:-}
@@ -12,6 +12,7 @@ services:
       GITHUB_ALLOWED_USERS: ${GITHUB_ALLOWED_USERS:-}
       GITHUB_ALLOWED_ORGANIZATIONS: ${GITHUB_ALLOWED_ORGANIZATIONS:-}
       MODEL: ${MODEL:-claude-sonnet-4.6}
+      SERVICE_URL_APP_8787:
       SESSION_ENCRYPTION_KEY: ${SESSION_ENCRYPTION_KEY:-}
       STORAGE_DRIVER: postgres
     depends_on:

--- a/readme.md
+++ b/readme.md
@@ -66,8 +66,9 @@ This builds the image, starts PostgreSQL, applies migrations, and listens on
 `bun run db:up` remains database-only for development with Vite HMR. The base
 `compose.yaml` publishes no host ports; these local commands merge the committed
 `compose.local.yaml` port mappings. Coolify can supply the optional
-`SERVICE_NAME_DB` and `SERVICE_URL_APP_8787` values for isolated previews;
-ordinary Compose deployments fall back to the `db` service and `APP_ORIGIN`.
+`SERVICE_NAME_DB` and `SERVICE_URL_APP` values for isolated previews; the empty
+`SERVICE_URL_APP_8787` entry marks the app's internal proxy port. Ordinary
+Compose deployments fall back to the `db` service and `APP_ORIGIN`.
 
 For a deployment using a managed database, build `Dockerfile`, provide
 `DATABASE_URL`, `APP_ORIGIN`, the GitHub App credentials and slug, and


### PR DESCRIPTION
## Summary
- derive `APP_ORIGIN` from Coolify's public service URL rather than its port-qualified routing URL
- retain `SERVICE_URL_APP_8787` as a separate marker for proxying to the app container
- document the distinction between preview origin discovery and internal port routing

## Testing
- `docker compose --env-file .env.example -f compose.yaml config --quiet`
- `docker compose --env-file .env.example -f compose.yaml -f compose.local.yaml config --quiet`
- simulated PR 74 resolves `APP_ORIGIN=https://74-chopin.githubnext.com`, `SERVICE_URL_APP_8787=https://74-chopin.githubnext.com:8787`, and database host `db-pr-74`
- `bun run ci`