### PR TITLE
Keep deployment origins explicit

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,7 @@ services:
       context: .
     environment:
       AGENT: ${AGENT:-on}
-      APP_ORIGIN: ${SERVICE_URL_APP:-${APP_ORIGIN:-http://127.0.0.1:8787}}
+      APP_ORIGIN: ${APP_ORIGIN:-http://127.0.0.1:8787}
       DATABASE_URL: postgresql://chopin:chopin@${SERVICE_NAME_DB:-db}:5432/chopin?sslmode=disable
       GITHUB_APP_SLUG: ${GITHUB_APP_SLUG:-}
       GITHUB_APP_CLIENT_ID: ${GITHUB_APP_CLIENT_ID:-}

--- a/readme.md
+++ b/readme.md
@@ -65,10 +65,11 @@ This builds the image, starts PostgreSQL, applies migrations, and listens on
 `http://127.0.0.1:8787`. `bun run docker:down` stops the stack. The ordinary
 `bun run db:up` remains database-only for development with Vite HMR. The base
 `compose.yaml` publishes no host ports; these local commands merge the committed
-`compose.local.yaml` port mappings. Coolify can supply the optional
-`SERVICE_NAME_DB` and `SERVICE_URL_APP` values for isolated previews; the empty
-`SERVICE_URL_APP_8787` entry marks the app's internal proxy port. Ordinary
-Compose deployments fall back to the `db` service and `APP_ORIGIN`.
+`compose.local.yaml` port mappings. Coolify can supply `SERVICE_NAME_DB` for an
+isolated preview database; the empty `SERVICE_URL_APP_8787` entry marks the
+app's internal proxy port. Set preview `APP_ORIGIN` to
+`https://${SERVICE_FQDN_APP}` when TLS terminates in front of Coolify. Ordinary
+Compose deployments fall back to the `db` service and local `APP_ORIGIN`.
 
 For a deployment using a managed database, build `Dockerfile`, provide
 `DATABASE_URL`, `APP_ORIGIN`, the GitHub App credentials and slug, and


### PR DESCRIPTION
## Summary
- stop deriving `APP_ORIGIN` from Coolify's internally generated HTTP service URL
- keep the port-qualified magic variable solely as the proxy routing marker
- document explicit production origins and the `https://${SERVICE_FQDN_APP}` Preview mapping for upstream TLS termination

## Testing
- `docker compose --env-file .env.example -f compose.yaml config --quiet`
- `docker compose --env-file .env.example -f compose.yaml -f compose.local.yaml config --quiet`
- production interpolation resolves `APP_ORIGIN=https://chopin.githubnext.com`
- Preview interpolation resolves `APP_ORIGIN=https://74-chopin.githubnext.com` and database host `db-pr-74`
- `bun run ci`