### PR TITLE
Install runtime CA certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,10 @@ RUN bun install --frozen-lockfile --production --filter '*'
 FROM oven/bun:${BUN_VERSION} AS runtime
 WORKDIR /app
 
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
+
 ENV NODE_ENV=production \
 	PORT=8787 \
 	SERVER_HOST=0.0.0.0


### PR DESCRIPTION
## Summary
- install Debian's `ca-certificates` bundle in the final Chopin image
- keep the package cache out of the resulting layer
- allow the native Copilot CLI to construct its outbound HTTPS client independently of inbound TLS termination

## Testing
- `bun run ci`
- `docker compose -f compose.yaml -f compose.local.yaml build app`
- verified `/etc/ssl/certs/ca-certificates.crt` exists and is non-empty in the production image
- started Copilot SDK `1.0.11` with native CLI `1.0.80`, `env: {}`, and an intentionally invalid `ghu_` token inside the image
- token validation now reaches GitHub and returns `401 Bad credentials` rather than `network fetch failed: builder error`