### PR TITLE
Fix local MCP GitHub token authorization

### DIFF
--- a/apps/server/src/auth/routes.test.ts
+++ b/apps/server/src/auth/routes.test.ts
@@ -12,6 +12,7 @@ import type {
 	GitHubTokenGrant,
 	GitHubUser,
 	InstallationPage,
+	Repository,
 	RepositoryPage,
 } from "../github/client";
 
@@ -102,6 +103,10 @@ class FakeGitHub implements GitHub {
 			}],
 			nextPage: page + 1,
 		};
+	}
+
+	async repository(): Promise<Repository> {
+		throw new Error("not used by auth route tests");
 	}
 
 	async repositoryAccess(token: string, owner: string, name: string) {

--- a/apps/server/src/github/client.test.ts
+++ b/apps/server/src/github/client.test.ts
@@ -298,6 +298,97 @@ describe("the GitHub client", () => {
 			.toBeUndefined();
 	});
 
+	it("keeps direct bearer permissions separate from GitHub App installation access", async () => {
+		let requests: Array<{ path: string; authorization: string | null }> = [];
+		let client = new GitHubClient({
+			fetch: async (input, init) => {
+				let url = new URL(String(input));
+				requests.push({
+					path: url.pathname,
+					authorization: new Headers(init?.headers).get("authorization"),
+				});
+				if (url.pathname === "/user") {
+					return Response.json({
+						node_id: "U_octocat",
+						login: "octocat",
+						avatar_url: "avatar",
+					});
+				}
+				if (url.pathname === "/user/installations") {
+					return Response.json({ message: "GitHub App token required" }, { status: 403 });
+				}
+				return Response.json(repository("R_score"));
+			},
+			endpoints: { api: "https://api.test" },
+		});
+
+		expect((await client.user("gho_cli")).login).toBe("octocat");
+		try {
+			await client.repositoryAccess("gho_cli", "octo-org", "score");
+			expect.unreachable();
+		} catch (err) {
+			expect(err).toBeInstanceOf(GitHubError);
+			expect((err as GitHubError).status).toBe(403);
+		}
+		expect(await client.repository("gho_cli", "octo-org", "score")).toMatchObject({
+			id: "R_score",
+			permissions: { pull: true, push: true, admin: false },
+		});
+		expect(requests.map(request => request.path)).toEqual([
+			"/user",
+			"/user/installations",
+			"/repos/octo-org/score",
+		]);
+		expect(requests.every(request => request.authorization === "Bearer gho_cli")).toBe(true);
+	});
+
+	it("preserves provider statuses for direct repository checks", async () => {
+		for (let [provider, expected] of [[401, 401], [403, 403], [404, 404], [429, 429], [500, 502]]) {
+			let client = new GitHubClient({
+				fetch: async () => Response.json({ message: "denied" }, { status: provider }),
+				endpoints: { api: "https://api.test" },
+			});
+			try {
+				await client.repository("token", "octo-org", "score");
+				expect.unreachable();
+			} catch (err) {
+				expect(err).toBeInstanceOf(GitHubError);
+				expect((err as GitHubError).status).toBe(expected);
+			}
+		}
+
+		let rateLimited = new GitHubClient({
+			fetch: async () =>
+				Response.json({ message: "rate limited" }, {
+					status: 403,
+					headers: { "x-ratelimit-remaining": "0" },
+				}),
+			endpoints: { api: "https://api.test" },
+		});
+		try {
+			await rateLimited.repository("token", "octo-org", "score");
+			expect.unreachable();
+		} catch (err) {
+			expect(err).toBeInstanceOf(GitHubError);
+			expect((err as GitHubError).status).toBe(429);
+		}
+
+		let secondaryRateLimit = new GitHubClient({
+			fetch: async () =>
+				Response.json({
+					message: "You have exceeded a secondary rate limit.",
+				}, { status: 403 }),
+			endpoints: { api: "https://api.test" },
+		});
+		try {
+			await secondaryRateLimit.repository("token", "octo-org", "score");
+			expect.unreachable();
+		} catch (err) {
+			expect(err).toBeInstanceOf(GitHubError);
+			expect((err as GitHubError).status).toBe(429);
+		}
+	});
+
 	it("rejects malformed or unsuccessful provider responses", async () => {
 		let client = new GitHubClient({
 			fetch: async () => Response.json({ login: "missing id" }),

--- a/apps/server/src/github/client.ts
+++ b/apps/server/src/github/client.ts
@@ -90,6 +90,9 @@ export interface GitHub {
 		installationId: string,
 		page: number,
 	): Promise<RepositoryPage>;
+	/** Resolve the repository role granted directly to a bearer token. */
+	repository(token: string, owner: string, name: string): Promise<Repository>;
+	/** Resolve the repository role within this GitHub App's active installations. */
 	repositoryAccess(token: string, owner: string, name: string): Promise<Repository | undefined>;
 	invalidate(token: string): void;
 }
@@ -260,6 +263,24 @@ async function body(response: Response): Promise<unknown> {
 		return await response.json();
 	} catch {
 		throw new GitHubError("GitHub returned an unreadable response");
+	}
+}
+
+async function isRateLimited(response: Response): Promise<boolean> {
+	if (response.status === 429) return true;
+	if (response.status !== 403) return false;
+	if (
+		response.headers.get("x-ratelimit-remaining") === "0"
+		|| response.headers.has("retry-after")
+	) return true;
+	try {
+		let value = record(await response.clone().json());
+		return (typeof value?.message === "string"
+			&& /(rate limit|abuse detection)/i.test(value.message))
+			|| (typeof value?.documentation_url === "string"
+				&& /(rate-limits|rate_limit)/i.test(value.documentation_url));
+	} catch {
+		return false;
 	}
 }
 
@@ -437,6 +458,11 @@ export class GitHubClient implements GitHub {
 		};
 	}
 
+	async repository(token: string, owner: string, name: string): Promise<Repository> {
+		let path = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
+		return repository(await this.#api(path, token));
+	}
+
 	async repositoryAccess(
 		token: string,
 		owner: string,
@@ -561,10 +587,12 @@ export class GitHubClient implements GitHub {
 			throw new GitHubError("GitHub API is unavailable");
 		}
 		if (!response.ok) {
-			let status = response.status === 401
-					|| response.status === 403
-					|| response.status === 404
-					|| response.status === 429
+			let rateLimited = await isRateLimited(response);
+			let status = rateLimited
+				? 429
+				: response.status === 401
+						|| response.status === 403
+						|| response.status === 404
 				? response.status
 				: 502;
 			throw new GitHubError("GitHub API rejected the request", status);

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -63,6 +63,7 @@ function createdDocument(id: string) {
 
 class GitHubBoundary implements GitHub {
 	readonly userTokens: string[] = [];
+	readonly repositoryCalls: Array<{ token: string; owner: string; name: string }> = [];
 	accessible = true;
 	repositoryValue: Repository = {
 		id: "R_score",
@@ -109,16 +110,14 @@ class GitHubBoundary implements GitHub {
 		return this.repositories();
 	}
 
-	async repository(_token: string, owner: string, name: string): Promise<Repository> {
+	async repository(token: string, owner: string, name: string): Promise<Repository> {
+		this.repositoryCalls.push({ token, owner, name });
+		if (!this.accessible) throw new GitHubError("repository not found", 404);
 		return this.value(owner, name);
 	}
 
-	async repositoryAccess(
-		_token: string,
-		owner: string,
-		name: string,
-	): Promise<Repository | undefined> {
-		return this.accessible ? this.value(owner, name) : undefined;
+	async repositoryAccess(): Promise<Repository | undefined> {
+		throw new Error("installation-gated access must not be used by MCP");
 	}
 
 	invalidate(): void {}
@@ -261,6 +260,11 @@ describe("the hosted MCP adapter", () => {
 		if (listed === "forbidden") throw new Error("readable repository was forbidden");
 		expect(listed).toHaveLength(101);
 		expect(listed.map(document => document.title)).not.toContain("Foreign title");
+		expect(github.repositoryCalls).toContainEqual({
+			token: "allowed",
+			owner: "octo-org",
+			name: "score",
+		});
 
 		github.repositoryValue = {
 			...github.repositoryValue,

--- a/apps/server/src/mcp/hosted.ts
+++ b/apps/server/src/mcp/hosted.ts
@@ -115,6 +115,17 @@ export function hosted(
 	auth: HostedAuth,
 	persistence?: ImplementationPersistence,
 ): McpOptions<HostedCaller> {
+	async function directRepository(caller: HostedCaller, owner: string, name: string) {
+		try {
+			return await auth.github.repository(caller.oauthToken, owner, name);
+		} catch (err) {
+			if (err instanceof GitHubError && (err.status === 403 || err.status === 404)) {
+				return undefined;
+			}
+			throw err;
+		}
+	}
+
 	function run(caller: HostedCaller, input: ImplementationInput): Run {
 		return {
 			id: crypto.randomUUID(),
@@ -147,11 +158,7 @@ export function hosted(
 			async list(caller, repository) {
 				let parts = repository.split("/");
 				if (parts.length !== 2 || !parts[0] || !parts[1]) return "forbidden";
-				let resolved = await auth.github.repositoryAccess(
-					caller.oauthToken,
-					parts[0],
-					parts[1],
-				);
+				let resolved = await directRepository(caller, parts[0], parts[1]);
 				if (!resolved?.permissions.pull) return "forbidden";
 
 				let documents = [];
@@ -169,8 +176,8 @@ export function hosted(
 			async read(caller, id) {
 				let channel = await auth.storage.channels.get(id);
 				if (!channel) return undefined;
-				let repository = await auth.github.repositoryAccess(
-					caller.oauthToken,
+				let repository = await directRepository(
+					caller,
 					channel.repositoryOwner,
 					channel.repositoryName,
 				);
@@ -220,11 +227,7 @@ export function hosted(
 			async create(caller, input) {
 				let parts = input.repository.split("/");
 				if (parts.length !== 2 || !parts[0] || !parts[1]) return { kind: "forbidden" };
-				let repository = await auth.github.repositoryAccess(
-					caller.oauthToken,
-					parts[0],
-					parts[1],
-				);
+				let repository = await directRepository(caller, parts[0], parts[1]);
 				if (!repository || (!repository.permissions.push && !repository.permissions.admin)) {
 					return { kind: "forbidden" };
 				}
@@ -292,8 +295,8 @@ export function hosted(
 					async readImplementation(caller: HostedCaller, id: string) {
 						let channel = await auth.storage.channels.get(id);
 						if (!channel) return undefined;
-						let repository = await auth.github.repositoryAccess(
-							caller.oauthToken,
+						let repository = await directRepository(
+							caller,
 							channel.repositoryOwner,
 							channel.repositoryName,
 						);
@@ -322,8 +325,8 @@ export function hosted(
 						) {
 							return { kind: "forbidden" as const };
 						}
-						let repository = await auth.github.repositoryAccess(
-							caller.oauthToken,
+						let repository = await directRepository(
+							caller,
 							channel.repositoryOwner,
 							channel.repositoryName,
 						);
@@ -375,8 +378,8 @@ export function hosted(
 					async reportLifecycle(caller: HostedCaller, input: LifecycleArguments) {
 						let channel = await auth.storage.channels.get(input.id);
 						if (!channel) return { kind: "forbidden" as const };
-						let repository = await auth.github.repositoryAccess(
-							caller.oauthToken,
+						let repository = await directRepository(
+							caller,
 							channel.repositoryOwner,
 							channel.repositoryName,
 						);

--- a/apps/server/src/mcp/routes.test.ts
+++ b/apps/server/src/mcp/routes.test.ts
@@ -21,6 +21,7 @@ class GitHubBoundary implements GitHub {
 	failure: Error | undefined;
 	membership: { state: "active" | "pending"; role: "member" } | undefined;
 	membershipFailure: GitHubError | undefined;
+	repositoryFailure: GitHubError | undefined;
 
 	authorize(): string {
 		return "";
@@ -56,12 +57,22 @@ class GitHubBoundary implements GitHub {
 		return this.repositories();
 	}
 
-	async repository(): Promise<Repository> {
-		throw new Error("not used by MCP route tests");
+	async repository(_token: string, owner: string, name: string): Promise<Repository> {
+		if (this.repositoryFailure) throw this.repositoryFailure;
+		return {
+			id: "R_score",
+			owner,
+			name,
+			fullName: `${owner}/${name}`,
+			private: true,
+			url: `https://github.test/${owner}/${name}`,
+			defaultBranch: "main",
+			permissions: { pull: true, push: true, admin: false },
+		};
 	}
 
 	async repositoryAccess(): Promise<Repository | undefined> {
-		throw new Error("not used by MCP route tests");
+		throw new Error("installation-gated access must not be used by MCP");
 	}
 
 	invalidate(): void {}
@@ -110,6 +121,18 @@ function request(method: string, init: RequestInit = {}): Request {
 function expectProtected(response: Response | undefined): void {
 	expect(response?.headers.get("cache-control")).toBe("no-store");
 	expect(response?.headers.get("x-content-type-options")).toBe("nosniff");
+}
+
+function listDocuments(): RequestInit {
+	return {
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({
+			jsonrpc: "2.0",
+			id: 2,
+			method: "tools/call",
+			params: { name: "list_documents", arguments: { repository: "octo-org/score" } },
+		}),
+	};
 }
 
 describe("the hosted MCP route", () => {
@@ -182,7 +205,7 @@ describe("the hosted MCP route", () => {
 			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
 		}));
 		expect(unavailableResponse?.status).toBe(503);
-		expect(await unavailableResponse?.text()).toBe("admission is temporarily unavailable");
+		expect(await unavailableResponse?.text()).toBe("GitHub access is temporarily unavailable");
 		expectProtected(unavailableResponse);
 
 		let member = setup({ allowedOrganizations: new Set(["githubnext"]) });
@@ -192,5 +215,45 @@ describe("the hosted MCP route", () => {
 			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
 		}));
 		expect(memberResponse?.status).toBe(200);
+	});
+
+	it("returns repository-forbidden for direct repository denials", async () => {
+		for (let status of [403, 404]) {
+			let { github, router } = setup();
+			github.repositoryFailure = new GitHubError("private repository title", status);
+			let response = await router.handle(request("POST", listDocuments()));
+			let body = await response?.json() as {
+				result: { structuredContent: { code: string }; isError: boolean };
+			};
+
+			expect(response?.status).toBe(200);
+			expectProtected(response);
+			expect(body.result).toMatchObject({
+				structuredContent: { code: "repository-forbidden" },
+				isError: true,
+			});
+			expect(JSON.stringify(body)).not.toContain("private repository title");
+		}
+	});
+
+	it("maps direct repository authentication and provider failures", async () => {
+		for (
+			let [provider, expected, message] of [
+				[401, 401, "unauthorized"],
+				[429, 503, "GitHub access is temporarily unavailable"],
+				[502, 503, "GitHub access is temporarily unavailable"],
+			] as const
+		) {
+			let { github, router } = setup();
+			github.repositoryFailure = new GitHubError("access-token private repository", provider);
+			let response = await router.handle(request("POST", listDocuments()));
+			let text = await response?.text();
+
+			expect(response?.status).toBe(expected);
+			expectProtected(response);
+			expect(text).toBe(message);
+			expect(text).not.toContain("access-token");
+			expect(text).not.toContain("private repository");
+		}
 	});
 });

--- a/apps/server/src/mcp/routes.ts
+++ b/apps/server/src/mcp/routes.ts
@@ -9,8 +9,11 @@ import type { ImplementationPersistence } from "./hosted";
 
 function failure(err: unknown): Response {
 	if (err instanceof AdmissionDenied) return new Response("forbidden", { status: 403 });
-	if (err instanceof GitHubError && err.status === 503) {
-		return new Response("admission is temporarily unavailable", { status: 503 });
+	if (err instanceof GitHubError) {
+		if (err.status === 401) return new Response("unauthorized", { status: 401 });
+		if (err.status === 429 || err.status >= 500) {
+			return new Response("GitHub access is temporarily unavailable", { status: 503 });
+		}
 	}
 	return new Response("MCP request failed", { status: 500 });
 }

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,10 +1,11 @@
 # Authentication
 
-Authentication covers the HTTP product, WebSocket admission, repository tools,
-and Copilot. A verified GitHub user supplies presence and attribution. Optional
-instance admission lists restrict who may use Chopin. The GitHub App
-installation then limits which repositories Chopin can see, and the user's own
-repository role limits what they can do inside Chopin.
+Authentication covers the HTTP product, WebSocket admission, local MCP,
+repository tools, and Copilot. A verified GitHub user supplies presence and
+attribution. Optional instance admission lists restrict who may use Chopin. The
+browser, WebSocket, and hosted Planner boundaries intersect the user's
+repository role with the GitHub App installation. Local MCP instead checks the
+repository role granted directly to its caller-supplied bearer token.
 
 ## GitHub App
 
@@ -97,8 +98,9 @@ Organization checks use the caller's token with
 has Members read access. Pending invitations and outside collaborators are not
 admitted, nor are billing managers who are not organization members.
 Public-membership lookup is not used. Organization admission does not restrict
-repository ownership; the existing App installation and repository role checks
-remain a separate boundary.
+repository ownership. Browser and hosted authorization retain separate App
+installation and repository role checks; local MCP checks the supplied token's
+repository role directly.
 
 Admission results are cached by a hash of the access token for 30 seconds.
 Browser requests, open-socket authorization, MCP requests, and agent permission
@@ -120,6 +122,12 @@ authorize the App without installing it. After sign-in, Chopin lists only the
 personal and organization installations that user can access and only the
 repositories selected for each installation. The repository picker links to
 the App installation page when access has not been installed or needs updating.
+
+Local MCP is an intentional exception to this installation boundary. Its bearer
+token is authenticated independently and authorized with a direct repository
+lookup. An MCP-created channel for a repository outside the App installation is
+not available through browser routes, WebSockets, or the hosted Planner until
+the installation includes that repository. See [Local agent MCP](local-agent-mcp.md).
 
 The authorization-code flow uses state, S256 PKCE, the exact configured callback,
 and the App client secret. It does not request OAuth scopes; permissions come

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,17 +1,22 @@
 # Repository channels
 
-Chopin keeps channel metadata in the selected storage adapter and uses
-GitHub as the current authorization source. An identity must first pass the
-instance's optional user or organization admission policy. A repository must
-then appear in the intersection of the authenticated user's access and a
-personal or organization GitHub App installation. The installation must include
-that repository. Merely being public is not enough to expose its Chopin
-channels.
+Chopin keeps channel metadata in the selected storage adapter and uses GitHub as
+the current authorization source. An identity must first pass the instance's
+optional user or organization admission policy. Browser routes, WebSockets, and
+the hosted Planner then require a repository to appear in the intersection of
+the authenticated user's access and a personal or organization GitHub App
+installation. The installation must include that repository. Merely being
+public is not enough to expose its Chopin channels through those surfaces.
 
 GitHub read access may list and open channels. Push or admin access may create a
 channel and mutate its plan, chat and decisions. The HTTP API and WebSocket
 upgrade both recheck those permissions; open sockets revalidate their
 session and repository access periodically.
+
+Local MCP checks the caller-supplied bearer token's repository permissions
+directly and does not require the Chopin App installation. A channel created
+through MCP remains unavailable to the browser, WebSockets, and hosted Planner
+until the installation includes its repository.
 
 ```text
 GET  /api/repositories/:owner/:repository/channels

--- a/docs/local-agent-mcp.md
+++ b/docs/local-agent-mcp.md
@@ -15,6 +15,13 @@ private organization membership. The normal `gh auth login` flow includes
 needs Members read access for an allowed organization and any required SSO
 authorization.
 
+The MCP bearer boundary is separate from Chopin's browser GitHub App session.
+Chopin authenticates the supplied token, applies the instance admission policy,
+and asks GitHub directly for that token's repository permissions. The Chopin App
+does not need to be installed on a repository for MCP access. Browser routes,
+WebSockets, and the hosted Planner still require an active App installation that
+includes the repository.
+
 ```bash
 export CHOPIN_URL="https://your-chopin-workspace.example"
 export GITHUB_TOKEN="$(gh auth token)"
@@ -71,16 +78,19 @@ instructions and current tool descriptions are authoritative.
 
 ## Access and troubleshooting
 
-HTTP `401` means bearer authentication failed: renew the GitHub CLI login with
+HTTP `401` means the bearer is invalid or expired: renew the GitHub CLI login with
 `gh auth login`, export `GITHUB_TOKEN` again, replace Claude's stored header if
 you use Claude Code, and reconnect the agent.
 
-HTTP `403` means the GitHub identity is not admitted by this Chopin instance.
-HTTP `503` means Chopin could not verify admission; check the token's `read:org`
-or Members access, SSO authorization, and GitHub availability.
+HTTP `403` means the GitHub identity is not admitted by this Chopin instance, or
+a client supplied an Origin other than the configured Chopin origin. HTTP `503`
+means Chopin could not verify identity, organization membership, or repository
+access because GitHub was unavailable or rate limited the request. Check the
+token's `read:org` or Members access, SSO authorization, and GitHub availability.
 
-`repository-forbidden` means the identity authenticated but lacks the
-operation's repository permission. Pull access is enough for
+`repository-forbidden` means the supplied token cannot expose the repository or
+lacks the operation's repository permission; it does not mean the Chopin App
+must be installed. Pull access is enough for
 `list_documents`, `read_document`, and `read_implementation`. Push or admin
 access is required for create, start, and report lifecycle operations. Use an
 account with the required access or ask a repository owner to grant it.


### PR DESCRIPTION
## Summary
- authorize hosted MCP repository operations from the caller bearer token so standard `gh auth token` credentials work
- keep browser, WebSocket, and hosted Planner authorization constrained by GitHub App installations
- distinguish repository denials, expired credentials, and GitHub availability or rate-limit failures, with regression coverage and updated documentation

## Testing
- `bun test apps/server/src/github/client.test.ts apps/server/src/mcp/hosted.test.ts apps/server/src/mcp/routes.test.ts apps/server/src/auth/routes.test.ts` (41 passed)
- `bun test` (833 passed, 2 skipped)
- `bun run types`
- `bun run ci`
- `git diff --check`
- local MCP route smoke test with the configured `GH_TOKEN` (`status=200 documents=0`)