### PR TITLE
Configure Chopin MCP for OpenCode

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -12,6 +12,16 @@
 				"--isolated"
 			],
 			"enabled": true
+		},
+		"chopin": {
+			"type": "remote",
+			"url": "https://chopin.githubnext.com/mcp",
+			"headers": {
+				"Authorization": "Bearer {env:GH_TOKEN}"
+			},
+			"oauth": false,
+			"timeout": 30000,
+			"enabled": true
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- add the hosted Chopin MCP endpoint to the project OpenCode configuration
- authenticate with the caller-provided `GH_TOKEN`, disable OAuth auto-detection, and allow a 30-second request timeout
- preserve the existing Playwright MCP configuration

## Testing
- `opencode mcp list` (Playwright and Chopin connected)
- parsed `opencode.json` and verified the complete Chopin MCP configuration
- `bun run ci`
- `git diff --check`

## Note
OpenCode loads configuration at startup, so restart OpenCode after pulling this change.