### PR TITLE
Load complete repository listings in background

### DIFF
--- a/apps/server/src/auth/routes.test.ts
+++ b/apps/server/src/auth/routes.test.ts
@@ -8,6 +8,8 @@ import { registerAuthRoutes } from "./routes";
 import type { AuthConfig } from "./config";
 import type {
 	GitHub,
+	GitHubCondition,
+	GitHubConditional,
 	GitHubOrganizationMembership,
 	GitHubTokenGrant,
 	GitHubUser,
@@ -60,9 +62,21 @@ class FakeGitHub implements GitHub {
 		return this.membership;
 	}
 
-	async installations(_token: string, page: number): Promise<InstallationPage> {
+	installations(_token: string, page: number): Promise<InstallationPage>;
+	installations(
+		_token: string,
+		page: number,
+		condition: GitHubCondition,
+	): Promise<GitHubConditional<InstallationPage>>;
+	async installations(
+		_token: string,
+		page: number,
+		condition?: GitHubCondition,
+	): Promise<GitHubConditional<InstallationPage>> {
 		if (this.denyRepositories) throw new GitHubError("GitHub API rejected the request", 401);
-		return {
+		let etag = 'W/"installations"';
+		if (condition?.ifNoneMatch === etag) return { notModified: true, etag };
+		let result: InstallationPage = {
 			installations: [{
 				id: "123",
 				account: {
@@ -82,15 +96,30 @@ class FakeGitHub implements GitHub {
 			}],
 			nextPage: page + 1,
 		};
+		return condition ? { ...result, etag } : result;
 	}
 
+	installationRepositories(
+		_token: string,
+		_installationId: string,
+		page: number,
+	): Promise<RepositoryPage>;
+	installationRepositories(
+		_token: string,
+		_installationId: string,
+		page: number,
+		condition: GitHubCondition,
+	): Promise<GitHubConditional<RepositoryPage>>;
 	async installationRepositories(
 		_token: string,
 		_installationId: string,
 		page: number,
-	): Promise<RepositoryPage> {
+		condition?: GitHubCondition,
+	): Promise<GitHubConditional<RepositoryPage>> {
 		if (this.denyRepositories) throw new GitHubError("GitHub API rejected the request", 401);
-		return {
+		let etag = '"repositories"';
+		if (condition?.ifNoneMatch === etag) return { notModified: true, etag };
+		let result: RepositoryPage = {
 			repositories: [{
 				id: "R_score",
 				owner: "octo-org",
@@ -103,6 +132,7 @@ class FakeGitHub implements GitHub {
 			}],
 			nextPage: page + 1,
 		};
+		return condition ? { ...result, etag } : result;
 	}
 
 	async repository(): Promise<Repository> {
@@ -214,13 +244,32 @@ describe("hosted authentication routes", () => {
 			}),
 		);
 		expect(installations!.status).toBe(200);
+		expect(installations!.headers.get("etag")).toBe('W/"installations"');
+		expect(installations!.headers.get("cache-control")).toBe("no-store");
 		expect((await installations!.json()).nextPage).toBe(4);
+		let unchangedInstallations = await router.handle(
+			new Request("https://chopin.test/api/github/installations?page=3", {
+				headers: { cookie: sessionCookie, "if-none-match": 'W/"installations"' },
+			}),
+		);
+		expect(unchangedInstallations!.status).toBe(304);
+		expect(unchangedInstallations!.headers.get("etag")).toBe('W/"installations"');
+		expect(unchangedInstallations!.headers.get("cache-control")).toBe("no-store");
+		expect(await unchangedInstallations!.text()).toBe("");
 		let repositories = await router.handle(
 			new Request("https://chopin.test/api/github/installations/123/repositories?page=3", {
 				headers: { cookie: sessionCookie },
 			}),
 		);
+		expect(repositories!.headers.get("etag")).toBe('"repositories"');
 		expect((await repositories!.json()).nextPage).toBe(4);
+		let unchangedRepositories = await router.handle(
+			new Request("https://chopin.test/api/github/installations/123/repositories?page=3", {
+				headers: { cookie: sessionCookie, "if-none-match": '"repositories"' },
+			}),
+		);
+		expect(unchangedRepositories!.status).toBe(304);
+		expect(unchangedRepositories!.headers.get("etag")).toBe('"repositories"');
 
 		let sessionId = sessionCookie.slice(sessionCookie.indexOf("=") + 1).split(".")[0]!;
 		let stored = await storage.sessions.get(sessionId, now);
@@ -236,7 +285,7 @@ describe("hosted authentication routes", () => {
 			}),
 		);
 		expect(setup!.status).toBe(303);
-		expect(setup!.headers.get("location")).toBe("/");
+		expect(setup!.headers.get("location")).toBe("/?repository_access=changed");
 		expect(github.invalidated).toEqual(["ghu_route_secret"]);
 
 		let refused = await router.handle(

--- a/apps/server/src/auth/routes.ts
+++ b/apps/server/src/auth/routes.ts
@@ -4,7 +4,7 @@ import { Admission, AdmissionDenied } from "./admission";
 import { OAuthAttempts, Sessions } from "./session";
 
 import type { AuthConfig } from "./config";
-import type { GitHub } from "../github/client";
+import type { GitHub, GitHubConditional } from "../github/client";
 import type { Router } from "../http/router";
 import type { StorageAdapter } from "../storage/port";
 
@@ -49,6 +49,17 @@ function empty(status: number, cookie?: string): Response {
 	responseHeaders.delete("content-type");
 	if (cookie) responseHeaders.append("set-cookie", cookie);
 	return new Response(null, { status, headers: responseHeaders });
+}
+
+function conditional<T extends object>(value: GitHubConditional<T>): Response {
+	let responseHeaders = headers();
+	if (value.etag) responseHeaders.set("etag", value.etag);
+	if ("notModified" in value) {
+		responseHeaders.delete("content-type");
+		return new Response(null, { status: 304, headers: responseHeaders });
+	}
+	let { etag: _etag, ...body } = value;
+	return Response.json(body, { headers: responseHeaders });
 }
 
 function redirected(location: string, status: 302 | 303, cookies: string[]): Response {
@@ -144,7 +155,7 @@ export function registerAuthRoutes(
 	router.on("GET", "/auth/github/setup", async request => {
 		let authenticated = await sessions.authenticate(request).catch(() => undefined);
 		if (authenticated) admission.invalidate(authenticated.access.token);
-		return redirected("/", 303, []);
+		return redirected("/?repository_access=changed", 303, []);
 	});
 
 	router.on("GET", "/auth/github/callback", async (request, url) => {
@@ -210,9 +221,12 @@ export function registerAuthRoutes(
 			try {
 				let result = await sessions.use(
 					authenticated,
-					token => github.installations(token, requestedPage),
+					token =>
+						github.installations(token, requestedPage, {
+							ifNoneMatch: request.headers.get("if-none-match") ?? undefined,
+						}),
 				);
-				return json(result.value);
+				return conditional(result.value);
 			} catch (err) {
 				if (err instanceof GitHubError && err.status === 401) {
 					return json({ error: "GitHub authorization expired" }, 401, sessions.clearCookie());
@@ -242,9 +256,12 @@ export function registerAuthRoutes(
 				try {
 					let result = await sessions.use(
 						authenticated,
-						token => github.installationRepositories(token, installationId, requestedPage),
+						token =>
+							github.installationRepositories(token, installationId, requestedPage, {
+								ifNoneMatch: request.headers.get("if-none-match") ?? undefined,
+							}),
 					);
-					return json(result.value);
+					return conditional(result.value);
 				} catch (err) {
 					if (err instanceof GitHubError && err.status === 401) {
 						return json(

--- a/apps/server/src/github/client.test.ts
+++ b/apps/server/src/github/client.test.ts
@@ -208,6 +208,54 @@ describe("the GitHub client", () => {
 		expect(requests.every(request => request.authorization === "Bearer ghu_user")).toBe(true);
 	});
 
+	it("passes conditional list validators through without caching response bodies", async () => {
+		let validators: Array<string | null> = [];
+		let client = new GitHubClient({
+			fetch: async (input, init) => {
+				let validator = new Headers(init?.headers).get("if-none-match");
+				validators.push(validator);
+				let url = new URL(String(input));
+				let etag = url.pathname === "/user/installations" ? 'W/"installations"' : '"repositories"';
+				if (validator === etag) return new Response(null, { status: 304, headers: { etag } });
+				return Response.json(
+					url.pathname === "/user/installations"
+						? { installations: [installation()] }
+						: { repositories: [repository("R_score")] },
+					{ headers: { etag } },
+				);
+			},
+			endpoints: { api: "https://api.test" },
+		});
+
+		let installations = await client.installations("ghu_user", 1, {});
+		expect("notModified" in installations).toBe(false);
+		expect(installations.etag).toBe('W/"installations"');
+		let unchangedInstallations = await client.installations("ghu_user", 1, {
+			ifNoneMatch: installations.etag,
+		});
+		expect(unchangedInstallations).toEqual({
+			notModified: true,
+			etag: 'W/"installations"',
+		});
+
+		let repositories = await client.installationRepositories("ghu_user", "123", 1, {});
+		expect("notModified" in repositories).toBe(false);
+		expect(repositories.etag).toBe('"repositories"');
+		let unchangedRepositories = await client.installationRepositories("ghu_user", "123", 1, {
+			ifNoneMatch: repositories.etag,
+		});
+		expect(unchangedRepositories).toEqual({
+			notModified: true,
+			etag: '"repositories"',
+		});
+		expect(validators).toEqual([
+			null,
+			'W/"installations"',
+			null,
+			'"repositories"',
+		]);
+	});
+
 	it("resolves active, pending, and absent organization membership", async () => {
 		let requested: string[] = [];
 		let client = new GitHubClient({

--- a/apps/server/src/github/client.ts
+++ b/apps/server/src/github/client.ts
@@ -53,6 +53,14 @@ export type InstallationPage = {
 	nextPage: number | undefined;
 };
 
+export type GitHubCondition = {
+	ifNoneMatch?: string;
+};
+
+export type GitHubConditional<T extends object> =
+	| (T & { etag?: string })
+	| { notModified: true; etag?: string };
+
 export type GitHubTokenGrant = {
 	accessToken: string;
 	accessExpiresIn: number;
@@ -85,11 +93,22 @@ export interface GitHub {
 		organization: string,
 	): Promise<GitHubOrganizationMembership | undefined>;
 	installations(token: string, page: number): Promise<InstallationPage>;
+	installations(
+		token: string,
+		page: number,
+		condition: GitHubCondition,
+	): Promise<GitHubConditional<InstallationPage>>;
 	installationRepositories(
 		token: string,
 		installationId: string,
 		page: number,
 	): Promise<RepositoryPage>;
+	installationRepositories(
+		token: string,
+		installationId: string,
+		page: number,
+		condition: GitHubCondition,
+	): Promise<GitHubConditional<RepositoryPage>>;
 	/** Resolve the repository role granted directly to a bearer token. */
 	repository(token: string, owner: string, name: string): Promise<Repository>;
 	/** Resolve the repository role within this GitHub App's active installations. */
@@ -421,41 +440,75 @@ export class GitHubClient implements GitHub {
 		}
 	}
 
-	async installations(token: string, page: number): Promise<InstallationPage> {
+	installations(token: string, page: number): Promise<InstallationPage>;
+	installations(
+		token: string,
+		page: number,
+		condition: GitHubCondition,
+	): Promise<GitHubConditional<InstallationPage>>;
+	async installations(
+		token: string,
+		page: number,
+		condition?: GitHubCondition,
+	): Promise<GitHubConditional<InstallationPage>> {
 		let path = "/user/installations";
 		let url = new URL(path, this.#endpoints.api);
 		url.searchParams.set("per_page", "100");
 		url.searchParams.set("page", String(page));
-		let response = await this.#request(url, token);
+		let response = await this.#request(url, token, condition?.ifNoneMatch);
+		if (response.status === 304) {
+			let etag = response.headers.get("etag") ?? condition?.ifNoneMatch;
+			return { notModified: true, ...(etag ? { etag } : {}) };
+		}
 		let value = record(await body(response));
 		if (!Array.isArray(value?.installations)) {
 			throw new GitHubError("GitHub returned an invalid installation list");
 		}
-		return {
+		let result: InstallationPage = {
 			installations: value.installations.map(installation),
 			nextPage: nextPage(response.headers.get("link"), this.#endpoints.api, path),
 		};
+		let etag = condition && response.headers.get("etag");
+		return etag ? { ...result, etag } : result;
 	}
 
+	installationRepositories(
+		token: string,
+		installationId: string,
+		page: number,
+	): Promise<RepositoryPage>;
+	installationRepositories(
+		token: string,
+		installationId: string,
+		page: number,
+		condition: GitHubCondition,
+	): Promise<GitHubConditional<RepositoryPage>>;
 	async installationRepositories(
 		token: string,
 		installationId: string,
 		page: number,
-	): Promise<RepositoryPage> {
+		condition?: GitHubCondition,
+	): Promise<GitHubConditional<RepositoryPage>> {
 		if (!/^\d+$/.test(installationId)) throw new GitHubError("installation not found", 404);
 		let path = `/user/installations/${installationId}/repositories`;
 		let url = new URL(path, this.#endpoints.api);
 		url.searchParams.set("per_page", "100");
 		url.searchParams.set("page", String(page));
-		let response = await this.#request(url, token);
+		let response = await this.#request(url, token, condition?.ifNoneMatch);
+		if (response.status === 304) {
+			let etag = response.headers.get("etag") ?? condition?.ifNoneMatch;
+			return { notModified: true, ...(etag ? { etag } : {}) };
+		}
 		let value = record(await body(response));
 		if (!Array.isArray(value?.repositories)) {
 			throw new GitHubError("GitHub returned an invalid repository list");
 		}
-		return {
+		let result: RepositoryPage = {
 			repositories: value.repositories.map(repository),
 			nextPage: nextPage(response.headers.get("link"), this.#endpoints.api, path),
 		};
+		let etag = condition && response.headers.get("etag");
+		return etag ? { ...result, etag } : result;
 	}
 
 	async repository(token: string, owner: string, name: string): Promise<Repository> {
@@ -570,22 +623,25 @@ export class GitHubClient implements GitHub {
 		return body(await this.#request(new URL(path, this.#endpoints.api), token));
 	}
 
-	async #request(url: URL, token: string): Promise<Response> {
+	async #request(url: URL, token: string, ifNoneMatch?: string): Promise<Response> {
 		let response: Response;
 		try {
+			let headers = new Headers({
+				accept: "application/vnd.github+json",
+				authorization: `Bearer ${token}`,
+				"user-agent": "chopin",
+				"x-github-api-version": "2022-11-28",
+			});
+			if (ifNoneMatch) headers.set("if-none-match", ifNoneMatch);
 			response = await this.#fetch(url, {
-				headers: {
-					accept: "application/vnd.github+json",
-					authorization: `Bearer ${token}`,
-					"user-agent": "chopin",
-					"x-github-api-version": "2022-11-28",
-				},
+				headers,
 				redirect: "error",
 				signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
 			});
 		} catch {
 			throw new GitHubError("GitHub API is unavailable");
 		}
+		if (response.status === 304 && ifNoneMatch) return response;
 		if (!response.ok) {
 			let rateLimited = await isRateLimited(response);
 			let status = rateLimited

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -63,6 +63,10 @@ export type InstallationPage = {
 	nextPage?: number;
 };
 
+export type ValidatedPage<T> =
+	| { page: T; etag?: string }
+	| { notModified: true; etag?: string };
+
 export type ChannelPage = {
 	repository: Repository;
 	canEdit: boolean;
@@ -86,8 +90,7 @@ export class ApiError extends Error {
 	}
 }
 
-async function response<T>(path: string, init?: RequestInit): Promise<T> {
-	let result = await fetch(path, init);
+async function decoded<T>(result: Response): Promise<T> {
 	let value: unknown;
 	try {
 		value = await result.json();
@@ -105,20 +108,38 @@ async function response<T>(path: string, init?: RequestInit): Promise<T> {
 	return value as T;
 }
 
+async function response<T>(path: string, init?: RequestInit): Promise<T> {
+	return decoded(await fetch(path, init));
+}
+
+async function validatedPage<T>(path: string, ifNoneMatch?: string): Promise<ValidatedPage<T>> {
+	let result = await fetch(path, {
+		headers: ifNoneMatch ? { "if-none-match": ifNoneMatch } : undefined,
+	});
+	let etag = result.headers.get("etag") ?? undefined;
+	if (result.status === 304) return { notModified: true, ...(etag ? { etag } : {}) };
+	return { page: await decoded<T>(result), ...(etag ? { etag } : {}) };
+}
+
 export function session(): Promise<Session> {
 	return response("/api/session");
 }
 
-export function installations(page = 1): Promise<InstallationPage> {
-	return response(`/api/github/installations?page=${page}`);
+export function installations(
+	page = 1,
+	ifNoneMatch?: string,
+): Promise<ValidatedPage<InstallationPage>> {
+	return validatedPage(`/api/github/installations?page=${page}`, ifNoneMatch);
 }
 
 export function installationRepositories(
 	installationId: string,
 	page = 1,
-): Promise<RepositoryPage> {
-	return response(
+	ifNoneMatch?: string,
+): Promise<ValidatedPage<RepositoryPage>> {
+	return validatedPage(
 		`/api/github/installations/${encodeURIComponent(installationId)}/repositories?page=${page}`,
+		ifNoneMatch,
 	);
 }
 

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -19,6 +19,7 @@ import { DocumentPicker } from "./document-picker";
 import * as Api from "./api";
 import { HostedApp, HostedFailure, HostedLoading, HostedLogin } from "./hosted";
 import { RepositoryPicker } from "./repository-picker";
+import { clearRepositoryCache } from "./repository-cache";
 import { Wire } from "./wire";
 import { useWorkspaceMode, useWorkspaceState, Workspace } from "./workspace";
 import { presentWorkspace } from "./workspace-model";
@@ -34,19 +35,21 @@ function Header(
 		label,
 		repository,
 		room,
+		userId,
 	}: {
 		canEdit: boolean;
 		members: Session.Member[];
 		label: string;
 		repository: Api.Repository;
 		room: string;
+		userId: string;
 	},
 ) {
 	return (
 		<header className="room-header hairline-b relative flex min-h-12 shrink-0 flex-nowrap items-center gap-2 px-2 py-2 sm:h-12 sm:gap-3 sm:px-4 sm:py-0">
 			<a className="hidden text-sm font-semibold sm:inline" href="/">chopin</a>
 			<span aria-hidden="true" className="hidden h-4 hairline-l sm:block" />
-			<RepositoryPicker compact current={repository} />
+			<RepositoryPicker compact current={repository} key={userId} userId={userId} />
 			<div className="flex min-w-0 flex-1 items-center gap-2">
 				<span aria-hidden="true" className="hidden text-sm text-text-tertiary sm:inline">/</span>
 				<DocumentPicker
@@ -86,6 +89,7 @@ export function RoomWorkspace(
 		label,
 		repository,
 		room,
+		userId,
 	}: {
 		agent?: boolean;
 		canEdit?: boolean;
@@ -93,6 +97,7 @@ export function RoomWorkspace(
 		label: string;
 		repository: Api.Repository;
 		room: string;
+		userId: string;
 	},
 ) {
 	let [wire, setWire] = useState<Wire>();
@@ -239,6 +244,7 @@ export function RoomWorkspace(
 					label={label}
 					repository={repository}
 					room={room}
+					userId={userId}
 				/>
 			}
 			controls={
@@ -285,6 +291,7 @@ export function RoomWorkspace(
 export function App() {
 	let [session, setSession] = useState<Api.Session>();
 	let [error, setError] = useState<unknown>();
+	let [repositoryCacheReady, setRepositoryCacheReady] = useState(false);
 
 	useEffect(() => {
 		let active = true;
@@ -298,8 +305,26 @@ export function App() {
 		};
 	}, []);
 
+	useEffect(() => {
+		if (!session) return;
+		let parameters = new URLSearchParams(location.search);
+		let accessChanged = parameters.get("repository_access") === "changed";
+		if (!session.user) clearRepositoryCache();
+		else if (accessChanged) clearRepositoryCache(session.user.id);
+		if (accessChanged) {
+			parameters.delete("repository_access");
+			let query = parameters.toString();
+			history.replaceState(
+				null,
+				"",
+				`${location.pathname}${query ? `?${query}` : ""}${location.hash}`,
+			);
+		}
+		setRepositoryCacheReady(true);
+	}, [session]);
+
 	if (error) return <HostedFailure error={error} />;
-	if (!session) return <HostedLoading />;
+	if (!session || !repositoryCacheReady) return <HostedLoading />;
 	if (!session.user) return <HostedLogin />;
 	return <HostedApp Workspace={RoomWorkspace} agent={session.agent} user={session.user} />;
 }

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import * as Api from "./api";
 import { RepositoryPicker } from "./repository-picker";
+import { clearRepositoryCache } from "./repository-cache";
 
 import type { ComponentType, FormEvent, ReactNode } from "react";
 
@@ -12,6 +13,7 @@ export type HostedWorkspaceProps = {
 	repository: Api.Repository;
 	canEdit: boolean;
 	agent?: boolean;
+	userId: string;
 };
 
 export type HostedRoute =
@@ -56,6 +58,7 @@ function Frame(
 ) {
 	async function signOut() {
 		await Api.logout();
+		clearRepositoryCache(user.id);
 		location.assign("/");
 	}
 
@@ -64,7 +67,12 @@ function Frame(
 			<header className="hosted-header hairline-b flex h-14 items-center bg-page px-3 sm:px-6">
 				<a className="text-sm font-semibold" href="/">chopin</a>
 				<span aria-hidden="true" className="mx-1 h-4 hairline-l sm:mx-2" />
-				<RepositoryPicker current={currentRepository} initialOpen={openRepositoryPicker} />
+				<RepositoryPicker
+					current={currentRepository}
+					initialOpen={openRepositoryPicker}
+					key={user.id}
+					userId={user.id}
+				/>
 				<div className="ml-auto flex items-center gap-3">
 					<span className="hidden text-sm text-text-secondary sm:inline">{user.login}</span>
 					<button className="btn btn-sm btn-ghost" onClick={() => void signOut()} type="button">
@@ -311,6 +319,7 @@ function ChannelWorkspace(
 			label={detail.channel.title}
 			repository={detail.repository}
 			room={detail.channel.id}
+			userId={user.id}
 		/>
 	);
 }

--- a/apps/web/src/repository-cache.test.ts
+++ b/apps/web/src/repository-cache.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import {
+	clearRepositoryCache,
+	installedRepositoryGroups,
+	loadRepositorySnapshot,
+	readRepositoryCache,
+	repositoryCacheIsStale,
+	writeRepositoryCache,
+} from "./repository-cache";
+
+import type { RepositorySnapshot } from "./repository-cache";
+
+class MemoryStorage implements Storage {
+	readonly #values = new Map<string, string>();
+
+	get length(): number {
+		return this.#values.size;
+	}
+
+	clear(): void {
+		this.#values.clear();
+	}
+
+	getItem(key: string): string | null {
+		return this.#values.get(key) ?? null;
+	}
+
+	key(index: number): string | null {
+		return [...this.#values.keys()][index] ?? null;
+	}
+
+	removeItem(key: string): void {
+		this.#values.delete(key);
+	}
+
+	setItem(key: string, value: string): void {
+		this.#values.set(key, value);
+	}
+}
+
+const originalStorage = Object.getOwnPropertyDescriptor(globalThis, "sessionStorage");
+const originalFetch = globalThis.fetch;
+
+function snapshot(userId = "U_octocat"): RepositorySnapshot {
+	let installation = {
+		id: "101",
+		account: { login: "octo-org", avatarUrl: "avatar", type: "organization" as const },
+		repositorySelection: "selected" as const,
+		configureUrl: "https://github.test/settings/installations/101",
+		suspended: false,
+		permissions: { contents: true, pullRequests: true, checks: true, statuses: true },
+	};
+	let score = {
+		id: "R_score",
+		owner: "octo-org",
+		name: "score",
+		fullName: "octo-org/score",
+		private: true,
+		url: "https://github.test/octo-org/score",
+		defaultBranch: "main",
+		permissions: { pull: true, push: true, admin: false },
+	};
+	return {
+		version: 1,
+		userId,
+		validatedAt: 10_000,
+		installationPages: [{
+			page: 1,
+			etag: '"installations"',
+			value: { installations: [installation] },
+		}],
+		repositoryPages: {
+			"101": [{
+				page: 1,
+				etag: '"repositories-1"',
+				value: { repositories: [score], nextPage: 2 },
+			}, {
+				page: 2,
+				etag: '"repositories-2"',
+				value: {
+					repositories: [score, {
+						...score,
+						id: "R_archive",
+						name: "archive",
+						fullName: "octo-org/archive",
+					}],
+				},
+			}],
+		},
+	};
+}
+
+beforeEach(() => {
+	Object.defineProperty(globalThis, "sessionStorage", {
+		configurable: true,
+		value: new MemoryStorage(),
+	});
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	if (originalStorage) Object.defineProperty(globalThis, "sessionStorage", originalStorage);
+	else delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+});
+
+describe("the repository tab cache", () => {
+	it("validates stored snapshots and removes the previous user's data", () => {
+		let stored = snapshot();
+		writeRepositoryCache(stored);
+		expect(readRepositoryCache(stored.userId)).toEqual(stored);
+		expect(installedRepositoryGroups(stored)[0]!.repositories.map(value => value.id)).toEqual([
+			"R_score",
+			"R_archive",
+		]);
+
+		expect(readRepositoryCache("U_other")).toBeUndefined();
+		expect(sessionStorage.getItem("chopin:repositories:U_octocat")).toBeNull();
+		sessionStorage.setItem("chopin:repositories:U_other", "not json");
+		expect(readRepositoryCache("U_other")).toBeUndefined();
+		expect(sessionStorage.getItem("chopin:repositories:U_other")).toBeNull();
+	});
+
+	it("clears the active user's snapshot and applies the freshness window", () => {
+		let stored = snapshot();
+		writeRepositoryCache(stored);
+		expect(repositoryCacheIsStale(stored, stored.validatedAt + 29_999)).toBe(false);
+		expect(repositoryCacheIsStale(stored, stored.validatedAt + 30_000)).toBe(true);
+		clearRepositoryCache(stored.userId);
+		expect(readRepositoryCache(stored.userId)).toBeUndefined();
+	});
+
+	it("rejects incomplete cached pagination chains", () => {
+		let stored = snapshot();
+		stored.repositoryPages["101"]!.pop();
+		writeRepositoryCache(stored);
+		expect(readRepositoryCache(stored.userId)).toBeUndefined();
+	});
+
+	it("revalidates every cached page with its own etag", async () => {
+		let previous = snapshot();
+		let requests: Array<{ path: string; etag: string | null }> = [];
+		globalThis.fetch = Object.assign(
+			async (input: string | URL | Request, init?: RequestInit) => {
+				let path = String(input);
+				let etag = new Headers(init?.headers).get("if-none-match");
+				requests.push({ path, etag });
+				return new Response(null, { status: 304, headers: etag ? { etag } : undefined });
+			},
+			{ preconnect: originalFetch.preconnect },
+		) as typeof fetch;
+
+		let refreshed = await loadRepositorySnapshot(previous.userId, previous);
+		expect(installedRepositoryGroups(refreshed)).toEqual(installedRepositoryGroups(previous));
+		expect(requests).toEqual([{
+			path: "/api/github/installations?page=1",
+			etag: '"installations"',
+		}, {
+			path: "/api/github/installations/101/repositories?page=1",
+			etag: '"repositories-1"',
+		}, {
+			path: "/api/github/installations/101/repositories?page=2",
+			etag: '"repositories-2"',
+		}]);
+		expect(refreshed.validatedAt).toBeGreaterThan(previous.validatedAt);
+	});
+
+	it("rebuilds pagination when a changed page shortens the chain", async () => {
+		let previous = snapshot();
+		let archive = installedRepositoryGroups(previous)[0]!.repositories[1]!;
+		let requests: string[] = [];
+		globalThis.fetch = Object.assign(
+			async (input: string | URL | Request) => {
+				let path = String(input);
+				requests.push(path);
+				if (path.includes("/repositories")) {
+					return Response.json({ repositories: [archive] }, { headers: { etag: '"changed"' } });
+				}
+				return new Response(null, { status: 304, headers: { etag: '"installations"' } });
+			},
+			{ preconnect: originalFetch.preconnect },
+		) as typeof fetch;
+
+		let refreshed = await loadRepositorySnapshot(previous.userId, previous);
+		expect(requests).toEqual([
+			"/api/github/installations?page=1",
+			"/api/github/installations/101/repositories?page=1",
+		]);
+		expect(installedRepositoryGroups(refreshed)[0]!.repositories).toEqual([archive]);
+		expect(refreshed.repositoryPages["101"]).toHaveLength(1);
+	});
+});

--- a/apps/web/src/repository-cache.ts
+++ b/apps/web/src/repository-cache.ts
@@ -1,0 +1,326 @@
+import * as Api from "./api";
+
+const ACTIVE_USER_KEY = "chopin:repositories:active-user";
+const CACHE_VERSION = 1;
+const FRESH_MS = 30_000;
+const MAX_LIST_PAGES = 100;
+
+type CachedPage<T> = {
+	page: number;
+	etag?: string;
+	value: T;
+};
+
+export type RepositorySnapshot = {
+	version: typeof CACHE_VERSION;
+	userId: string;
+	validatedAt: number;
+	installationPages: CachedPage<Api.InstallationPage>[];
+	repositoryPages: Record<string, CachedPage<Api.RepositoryPage>[]>;
+};
+
+export type InstalledRepositoryGroup = {
+	installation: Api.GitHubInstallation;
+	repositories: Api.Repository[];
+};
+
+function record(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? value as Record<string, unknown>
+		: undefined;
+}
+
+function nextPage(value: unknown): boolean {
+	return value === undefined || (Number.isSafeInteger(value) && Number(value) > 0);
+}
+
+function repository(value: unknown): value is Api.Repository {
+	let item = record(value);
+	let permissions = record(item?.permissions);
+	return !!item
+		&& typeof item.id === "string"
+		&& typeof item.owner === "string"
+		&& (item.ownerAvatarUrl === undefined || typeof item.ownerAvatarUrl === "string")
+		&& typeof item.name === "string"
+		&& typeof item.fullName === "string"
+		&& typeof item.private === "boolean"
+		&& typeof item.url === "string"
+		&& typeof item.defaultBranch === "string"
+		&& !!permissions
+		&& typeof permissions.pull === "boolean"
+		&& typeof permissions.push === "boolean"
+		&& typeof permissions.admin === "boolean";
+}
+
+function installation(value: unknown): value is Api.GitHubInstallation {
+	let item = record(value);
+	let account = record(item?.account);
+	let permissions = record(item?.permissions);
+	return !!item
+		&& typeof item.id === "string"
+		&& !!account
+		&& typeof account.login === "string"
+		&& typeof account.avatarUrl === "string"
+		&& (account.type === "user" || account.type === "organization")
+		&& (item.repositorySelection === "all" || item.repositorySelection === "selected")
+		&& typeof item.configureUrl === "string"
+		&& typeof item.suspended === "boolean"
+		&& !!permissions
+		&& typeof permissions.contents === "boolean"
+		&& typeof permissions.pullRequests === "boolean"
+		&& typeof permissions.checks === "boolean"
+		&& typeof permissions.statuses === "boolean";
+}
+
+function installationPage(value: unknown): value is Api.InstallationPage {
+	let item = record(value);
+	return !!item
+		&& Array.isArray(item.installations)
+		&& item.installations.every(installation)
+		&& nextPage(item.nextPage);
+}
+
+function repositoryPage(value: unknown): value is Api.RepositoryPage {
+	let item = record(value);
+	return !!item
+		&& Array.isArray(item.repositories)
+		&& item.repositories.every(repository)
+		&& nextPage(item.nextPage);
+}
+
+function cachedPages<T extends { nextPage?: number }>(
+	value: unknown,
+	valid: (value: unknown) => value is T,
+): CachedPage<T>[] | undefined {
+	if (!Array.isArray(value) || value.length === 0 || value.length > MAX_LIST_PAGES) {
+		return undefined;
+	}
+	let pages: CachedPage<T>[] = [];
+	for (let candidate of value) {
+		let item = record(candidate);
+		if (
+			!item
+			|| !Number.isSafeInteger(item.page)
+			|| Number(item.page) < 1
+			|| (item.etag !== undefined && typeof item.etag !== "string")
+			|| !valid(item.value)
+		) return undefined;
+		pages.push({
+			page: Number(item.page),
+			...(typeof item.etag === "string" ? { etag: item.etag } : {}),
+			value: item.value,
+		});
+	}
+	let expected = 1;
+	let visited = new Set<number>();
+	for (let [index, page] of pages.entries()) {
+		if (page.page !== expected || visited.has(page.page)) return undefined;
+		visited.add(page.page);
+		if (!page.value.nextPage) return index === pages.length - 1 ? pages : undefined;
+		expected = page.value.nextPage;
+	}
+	return undefined;
+}
+
+function cacheKey(userId: string): string {
+	return `chopin:repositories:${encodeURIComponent(userId)}`;
+}
+
+function storage(): Storage | undefined {
+	try {
+		return globalThis.sessionStorage;
+	} catch {
+		return undefined;
+	}
+}
+
+export function clearRepositoryCache(userId?: string): void {
+	let store = storage();
+	if (!store) return;
+	try {
+		let active = store.getItem(ACTIVE_USER_KEY) ?? undefined;
+		let target = userId ?? active;
+		if (target) store.removeItem(cacheKey(target));
+		if (!userId || active === userId) store.removeItem(ACTIVE_USER_KEY);
+	} catch {
+		// Storage may be disabled; repository loading still works in memory.
+	}
+}
+
+export function readRepositoryCache(userId: string): RepositorySnapshot | undefined {
+	let store = storage();
+	if (!store) return undefined;
+	let key = cacheKey(userId);
+	try {
+		let active = store.getItem(ACTIVE_USER_KEY);
+		if (active && active !== userId) store.removeItem(cacheKey(active));
+		store.setItem(ACTIVE_USER_KEY, userId);
+		let serialized = store.getItem(key);
+		if (!serialized) return undefined;
+		let item = record(JSON.parse(serialized));
+		let installations = cachedPages(item?.installationPages, installationPage);
+		let storedRepositories = record(item?.repositoryPages);
+		if (
+			!item
+			|| item.version !== CACHE_VERSION
+			|| item.userId !== userId
+			|| typeof item.validatedAt !== "number"
+			|| !Number.isFinite(item.validatedAt)
+			|| item.validatedAt < 0
+			|| !installations
+			|| !storedRepositories
+		) throw new Error("invalid repository cache");
+		let repositories: Record<string, CachedPage<Api.RepositoryPage>[]> = {};
+		for (let [installationId, value] of Object.entries(storedRepositories)) {
+			if (!/^\d+$/.test(installationId)) throw new Error("invalid repository cache");
+			let pages = cachedPages(value, repositoryPage);
+			if (!pages) throw new Error("invalid repository cache");
+			repositories[installationId] = pages;
+		}
+		let snapshot: RepositorySnapshot = {
+			version: CACHE_VERSION,
+			userId,
+			validatedAt: item.validatedAt,
+			installationPages: installations,
+			repositoryPages: repositories,
+		};
+		let expected = new Set(
+			installationsFor(snapshot)
+				.filter(value => !value.suspended && value.permissions.contents)
+				.map(value => value.id),
+		);
+		if (
+			[...expected].some(installationId => !Object.hasOwn(repositories, installationId))
+			|| Object.keys(repositories).some(installationId => !expected.has(installationId))
+		) throw new Error("invalid repository cache");
+		return snapshot;
+	} catch {
+		try {
+			store.removeItem(key);
+		} catch {
+			// Ignore storage failures and load from the network.
+		}
+		return undefined;
+	}
+}
+
+export function writeRepositoryCache(snapshot: RepositorySnapshot): void {
+	let store = storage();
+	if (!store) return;
+	try {
+		store.setItem(ACTIVE_USER_KEY, snapshot.userId);
+		store.setItem(cacheKey(snapshot.userId), JSON.stringify(snapshot));
+	} catch {
+		// Quota or privacy restrictions should not break repository selection.
+	}
+}
+
+export function repositoryCacheIsStale(snapshot: RepositorySnapshot, now = Date.now()): boolean {
+	return now - snapshot.validatedAt >= FRESH_MS;
+}
+
+async function pages<T extends { nextPage?: number }>(
+	previous: CachedPage<T>[] | undefined,
+	request: (page: number, etag?: string) => Promise<Api.ValidatedPage<T>>,
+	publish?: (pages: CachedPage<T>[]) => void,
+): Promise<CachedPage<T>[]> {
+	let result: CachedPage<T>[] = [];
+	let page = 1;
+	let visited = new Set<number>();
+	while (!visited.has(page)) {
+		if (visited.size >= MAX_LIST_PAGES) {
+			throw new Error("Repository listing exceeded its safety limit.");
+		}
+		visited.add(page);
+		let known = previous?.find(value => value.page === page);
+		let response = await request(page, known?.etag);
+		let loaded: CachedPage<T>;
+		if ("notModified" in response) {
+			if (!known) throw new Error("GitHub returned an unexpected not-modified response.");
+			loaded = { ...known, etag: response.etag ?? known.etag };
+		} else {
+			loaded = {
+				page,
+				...(response.etag ? { etag: response.etag } : {}),
+				value: response.page,
+			};
+		}
+		result.push(loaded);
+		publish?.([...result]);
+		if (!loaded.value.nextPage) return result;
+		page = loaded.value.nextPage;
+	}
+	throw new Error("Repository listing returned a pagination cycle.");
+}
+
+function installationsFor(snapshot: RepositorySnapshot): Api.GitHubInstallation[] {
+	let result: Api.GitHubInstallation[] = [];
+	let known = new Set<string>();
+	for (let installation of snapshot.installationPages.flatMap(page => page.value.installations)) {
+		if (known.has(installation.id)) continue;
+		known.add(installation.id);
+		result.push(installation);
+	}
+	return result;
+}
+
+export function installedRepositoryGroups(
+	snapshot: RepositorySnapshot,
+): InstalledRepositoryGroup[] {
+	return installationsFor(snapshot).map(installation => {
+		let repositories: Api.Repository[] = [];
+		let known = new Set<string>();
+		for (
+			let repository of (snapshot.repositoryPages[installation.id] ?? [])
+				.flatMap(page => page.value.repositories)
+		) {
+			if (known.has(repository.id)) continue;
+			known.add(repository.id);
+			repositories.push(repository);
+		}
+		return { installation, repositories };
+	});
+}
+
+export async function loadRepositorySnapshot(
+	userId: string,
+	previous?: RepositorySnapshot,
+	publish?: (snapshot: RepositorySnapshot) => void,
+): Promise<RepositorySnapshot> {
+	let installationPages = await pages(
+		previous?.installationPages,
+		(page, etag) => Api.installations(page, etag),
+	);
+	let repositoryPages: Record<string, CachedPage<Api.RepositoryPage>[]> = {};
+	let partial = (): RepositorySnapshot => ({
+		version: CACHE_VERSION,
+		userId,
+		validatedAt: 0,
+		installationPages,
+		repositoryPages,
+	});
+	publish?.(partial());
+	let failure: unknown;
+	for (let installed of installationsFor(partial())) {
+		if (installed.suspended || !installed.permissions.contents) continue;
+		try {
+			let loaded = await pages(
+				previous?.repositoryPages[installed.id],
+				(page, etag) => Api.installationRepositories(installed.id, page, etag),
+				value => {
+					repositoryPages[installed.id] = value;
+					publish?.(partial());
+				},
+			);
+			repositoryPages[installed.id] = loaded;
+		} catch (reason) {
+			if (reason instanceof Api.ApiError && (reason.status === 401 || reason.status === 429)) {
+				throw reason;
+			}
+			failure ??= reason ?? new Error("Could not load all repositories.");
+		}
+	}
+	// Never replace a complete cached snapshot with a partially refreshed one.
+	if (failure) throw failure;
+	return { ...partial(), validatedAt: Date.now() };
+}

--- a/apps/web/src/repository-picker.tsx
+++ b/apps/web/src/repository-picker.tsx
@@ -4,20 +4,22 @@ import { useEffect, useId, useMemo, useRef, useState } from "react";
 
 import { useAnchoredPicker } from "./anchored-picker";
 import * as Api from "./api";
+import {
+	clearRepositoryCache,
+	installedRepositoryGroups,
+	loadRepositorySnapshot,
+	readRepositoryCache,
+	repositoryCacheIsStale,
+	writeRepositoryCache,
+} from "./repository-cache";
 
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import type { InstalledRepositoryGroup, RepositorySnapshot } from "./repository-cache";
 
 export type RepositoryIdentity = Pick<
 	Api.Repository,
 	"owner" | "ownerAvatarUrl" | "name" | "fullName"
 >;
-
-type InstalledRepositories = {
-	installation: Api.GitHubInstallation;
-	page: Api.RepositoryPage;
-	error?: boolean;
-	loadingMore?: boolean;
-};
 
 function repositoryHref(repository: RepositoryIdentity): string {
 	return `/repositories/${encodeURIComponent(repository.owner)}/${
@@ -34,48 +36,11 @@ function optionId(list: string, repository: Api.Repository): string {
 	return `${list}-option-${repository.id}`;
 }
 
-function reauthenticate(reason: unknown): boolean {
+function reauthenticate(reason: unknown, userId: string): boolean {
 	if (!(reason instanceof Api.ApiError) || reason.status !== 401) return false;
+	clearRepositoryCache(userId);
 	location.assign("/");
 	return true;
-}
-
-async function installedRepositories(
-	publish: (installed: InstalledRepositories[], replace: boolean) => void,
-): Promise<InstalledRepositories[]> {
-	let installations: Api.GitHubInstallation[] = [];
-	let page = 1;
-	let visited = new Set<number>();
-	while (!visited.has(page)) {
-		visited.add(page);
-		let result = await Api.installations(page);
-		installations.push(...result.installations);
-		if (!result.nextPage) break;
-		page = result.nextPage;
-	}
-	let installed: InstalledRepositories[] = installations.map(installation => ({
-		installation,
-		page: { repositories: [] },
-		loadingMore: !installation.suspended && installation.permissions.contents,
-	}));
-	publish(installed, true);
-	for (let index = 0; index < installed.length; index++) {
-		let group = installed[index]!;
-		if (!group.loadingMore) continue;
-		try {
-			let page = await Api.installationRepositories(group.installation.id);
-			installed = installed.map((value, position) =>
-				position === index ? { installation: group.installation, page, loadingMore: false } : value
-			);
-		} catch (reason) {
-			if (reauthenticate(reason)) throw reason;
-			installed = installed.map((value, position) =>
-				position === index ? { ...group, error: true, loadingMore: false } : value
-			);
-		}
-		publish([installed[index]!], false);
-	}
-	return installed;
 }
 
 export function RepositoryPicker(
@@ -83,35 +48,43 @@ export function RepositoryPicker(
 		compact = false,
 		current,
 		initialOpen = false,
-	}: { compact?: boolean; current?: RepositoryIdentity; initialOpen?: boolean },
+		userId,
+	}: { compact?: boolean; current?: RepositoryIdentity; initialOpen?: boolean; userId: string },
 ) {
-	let request = useRef<Promise<InstalledRepositories[]> | undefined>(undefined);
+	let [initial] = useState(() => readRepositoryCache(userId));
+	let request = useRef<Promise<void> | undefined>(undefined);
+	let snapshot = useRef<RepositorySnapshot | undefined>(initial);
 	let mounted = useRef(true);
+	let previousQuery = useRef("");
 	let panelId = useId();
 	let listId = useId();
 	let [open, setOpen] = useState(initialOpen);
-	let [installed, setInstalled] = useState<InstalledRepositories[]>();
+	let [installed, setInstalled] = useState<InstalledRepositoryGroup[] | undefined>(() =>
+		initial ? installedRepositoryGroups(initial) : undefined
+	);
 	let [error, setError] = useState<unknown>();
-	let [attempt, setAttempt] = useState(0);
+	let [loading, setLoading] = useState(!initial);
+	let [refreshing, setRefreshing] = useState(false);
 	let [query, setQuery] = useState("");
 	let [active, setActive] = useState(0);
 	let [avatarFailed, setAvatarFailed] = useState(false);
 
 	let normalized = query.trim().toLowerCase();
-	let repositories = installed?.flatMap(group => group.page.repositories) ?? [];
+	let repositories = installed?.flatMap(group => group.repositories) ?? [];
 	let matches = normalized
 		? repositories.filter(repository => repository.fullName.toLowerCase().includes(normalized))
 		: repositories;
 	let activeIndex = matches.length === 0 ? -1 : Math.min(active, matches.length - 1);
 	let activeRepository = matches[activeIndex];
 	let pickerContent = useMemo(
-		() => ({ error, installed, matches: matches.length, normalized }),
-		[error, installed, matches.length, normalized],
+		() => ({ error, installed, loading, matches: matches.length, normalized, refreshing }),
+		[error, installed, loading, matches.length, normalized, refreshing],
 	);
 	let { panel, position, search, trigger } = useAnchoredPicker(open, setOpen, pickerContent);
 
 	useEffect(() => {
 		mounted.current = true;
+		if (!snapshot.current) void refresh();
 		return () => {
 			mounted.current = false;
 		};
@@ -120,28 +93,14 @@ export function RepositoryPicker(
 	useEffect(() => setAvatarFailed(false), [current?.ownerAvatarUrl]);
 
 	useEffect(() => {
-		if (!open) return;
-		let active = true;
-		let pending = request.current;
-		if (!pending) {
-			let created = installedRepositories((value, replace) => {
-				if (!mounted.current) return;
-				if (replace) return setInstalled(value);
-				let replacements = new Map(value.map(group => [group.installation.id, group]));
-				setInstalled(current =>
-					current?.map(group => replacements.get(group.installation.id) ?? group) ?? value
-				);
-			});
-			request.current = created;
-			pending = created;
+		if (!open) {
+			previousQuery.current = "";
+			return;
 		}
-		pending.then(() => {}, reason => {
-			if (active && !reauthenticate(reason)) setError(reason);
-		});
-		return () => {
-			active = false;
-		};
-	}, [attempt, open]);
+		let started = !previousQuery.current && !!normalized;
+		previousQuery.current = normalized;
+		if (started && snapshot.current && repositoryCacheIsStale(snapshot.current)) void refresh();
+	}, [normalized, open]);
 
 	useEffect(() => {
 		if (!open || !activeRepository) return;
@@ -160,86 +119,40 @@ export function RepositoryPicker(
 		return () => cancelAnimationFrame(frame);
 	}, [activeRepository, listId, open, position.height, position.top]);
 
-	function retry() {
-		request.current = undefined;
+	function refresh(): Promise<void> {
+		if (request.current) return request.current;
+		let previous = snapshot.current;
 		setError(undefined);
-		setInstalled(undefined);
-		setAttempt(value => value + 1);
-	}
-
-	async function more(installationId: string) {
-		let group = installed?.find(value => value.installation.id === installationId);
-		if (!group?.page.nextPage || group.loadingMore) return;
-		setInstalled(current =>
-			current?.map(value =>
-				value.installation.id === installationId ? { ...value, loadingMore: true } : value
-			)
-		);
-		setError(undefined);
-		try {
-			let next = await Api.installationRepositories(installationId, group.page.nextPage);
+		if (previous) setRefreshing(true);
+		else setLoading(true);
+		let pending = loadRepositorySnapshot(
+			userId,
+			previous,
+			previous
+				? undefined
+				: value => {
+					if (mounted.current) setInstalled(installedRepositoryGroups(value));
+				},
+		).then(value => {
 			if (!mounted.current) return;
-			setInstalled(current =>
-				current?.map(value => {
-					if (value.installation.id !== installationId) return value;
-					let known = new Set(value.page.repositories.map(repository => repository.id));
-					return {
-						...value,
-						loadingMore: false,
-						page: {
-							repositories: [
-								...value.page.repositories,
-								...next.repositories.filter(repository => !known.has(repository.id)),
-							],
-							nextPage: next.nextPage,
-						},
-					};
-				})
-			);
-		} catch (reason) {
-			if (mounted.current && !reauthenticate(reason)) setError(reason);
-		} finally {
+			snapshot.current = value;
+			writeRepositoryCache(value);
+			setInstalled(installedRepositoryGroups(value));
+		}, reason => {
+			if (mounted.current && !reauthenticate(reason, userId)) setError(reason);
+		}).finally(() => {
+			if (request.current === pending) request.current = undefined;
 			if (mounted.current) {
-				setInstalled(current =>
-					current?.map(value =>
-						value.installation.id === installationId
-							? { ...value, loadingMore: false }
-							: value
-					)
-				);
+				setLoading(false);
+				setRefreshing(false);
 			}
-		}
+		});
+		request.current = pending;
+		return pending;
 	}
 
-	async function retryInstallation(installationId: string) {
-		setInstalled(current =>
-			current?.map(value =>
-				value.installation.id === installationId
-					? { ...value, error: false, loadingMore: true }
-					: value
-			)
-		);
-		try {
-			let page = await Api.installationRepositories(installationId);
-			if (!mounted.current) return;
-			setInstalled(current =>
-				current?.map(value =>
-					value.installation.id === installationId
-						? { ...value, error: false, loadingMore: false, page }
-						: value
-				)
-			);
-		} catch (reason) {
-			if (mounted.current && !reauthenticate(reason)) {
-				setInstalled(current =>
-					current?.map(value =>
-						value.installation.id === installationId
-							? { ...value, error: true, loadingMore: false }
-							: value
-					)
-				);
-			}
-		}
+	function retry() {
+		void refresh();
 	}
 
 	function select(repository: Api.Repository) {
@@ -287,12 +200,12 @@ export function RepositoryPicker(
 				/>
 			</div>
 			<div className="min-h-0 flex-1 overflow-y-auto p-1" data-repository-scroll="">
-				{!installed && !error && (
+				{!installed && loading && (
 					<p className="px-2 py-3 text-sm text-text-tertiary" role="status">
 						Loading repositories...
 					</p>
 				)}
-				{!installed && error !== undefined && (
+				{!installed && !loading && error !== undefined && (
 					<div className="px-2 py-3">
 						<p className="text-sm text-destructive-ink" role="alert">
 							Could not load repositories.
@@ -302,7 +215,7 @@ export function RepositoryPicker(
 						</button>
 					</div>
 				)}
-				{installed?.length === 0 && (
+				{installed?.length === 0 && !loading && (
 					<div className="px-2 py-3">
 						<p className="text-sm font-medium">Install the GitHub App</p>
 						<p className="mt-1 text-sm text-text-tertiary">
@@ -313,15 +226,25 @@ export function RepositoryPicker(
 						</a>
 					</div>
 				)}
-				{installed?.some(group => group.loadingMore) && repositories.length === 0 && (
+				{installed && loading && repositories.length === 0 && installed.length > 0 && (
 					<p className="px-2 py-3 text-sm text-text-tertiary" role="status">
 						Loading installed repositories...
+					</p>
+				)}
+				{installed && loading && repositories.length > 0 && (
+					<p className="px-2 py-2 text-sm text-text-tertiary" role="status">
+						Loading remaining repositories...
+					</p>
+				)}
+				{installed && refreshing && (
+					<p className="px-2 py-2 text-sm text-text-tertiary" role="status">
+						Refreshing repositories...
 					</p>
 				)}
 				{installed
 					&& repositories.length === 0
 					&& installed.length > 0
-					&& !installed.some(group => group.loadingMore)
+					&& !loading
 					&& (
 						<p className="px-2 py-3 text-sm text-text-tertiary" role="status">
 							No installed repositories are available.
@@ -329,52 +252,35 @@ export function RepositoryPicker(
 					)}
 				{installed && repositories.length > 0 && matches.length === 0 && (
 					<p className="px-2 py-3 text-sm text-text-tertiary" role="status">
-						{installed.some(group =>
-								group.page.nextPage
-							)
-							? "No matches in loaded repositories."
+						{loading || refreshing
+							? "Checking for matching repositories..."
 							: "No matching repositories."}
 					</p>
 				)}
 				{installed?.filter(group =>
-					group.error || group.installation.suspended || !group.installation.permissions.contents
+					group.installation.suspended || !group.installation.permissions.contents
 				).map(group => (
 					<div className="flex items-center gap-2 px-2 py-2 text-sm" key={group.installation.id}>
 						<span className="min-w-0 flex-1 truncate text-text-tertiary">
 							{group.installation.account.login}
 						</span>
-						{group.error
-							? (
-								<button
-									className="text-brand-ink hover:underline"
-									disabled={group.loadingMore}
-									onClick={() => void retryInstallation(group.installation.id)}
-									type="button"
-								>
-									{group.loadingMore ? "Retrying..." : "Try again"}
-								</button>
-							)
-							: (
-								<a
-									className="text-brand-ink hover:underline"
-									href={group.installation.configureUrl}
-								>
-									Configure
-								</a>
-							)}
+						<a
+							className="text-brand-ink hover:underline"
+							href={group.installation.configureUrl}
+						>
+							Configure
+						</a>
 					</div>
 				))}
 				<div
-					aria-busy={(!installed && error === undefined)
-						|| installed?.some(group => group.loadingMore)}
+					aria-busy={loading || refreshing}
 					aria-label="Repositories"
 					id={listId}
 					role="listbox"
 				>
 					{installed?.map(group => {
-						let groupRepositories = matches.filter(repository =>
-							repository.owner.toLowerCase() === group.installation.account.login.toLowerCase()
-						);
+						let known = new Set(group.repositories.map(repository => repository.id));
+						let groupRepositories = matches.filter(repository => known.has(repository.id));
 						if (groupRepositories.length === 0) return null;
 						return (
 							<div
@@ -443,23 +349,17 @@ export function RepositoryPicker(
 			{installed && (
 				<div className="p-1 hairline-t">
 					{error !== undefined && (
-						<p className="px-2 py-1 text-sm text-destructive-ink" role="alert">
-							Could not load more repositories.
-						</p>
+						<div className="flex items-center gap-2 px-2 py-1 text-sm" role="alert">
+							<span className="min-w-0 flex-1 text-destructive-ink">
+								{snapshot.current
+									? "Could not refresh repositories."
+									: "Could not load all repositories."}
+							</span>
+							<button className="text-brand-ink hover:underline" onClick={retry} type="button">
+								Try again
+							</button>
+						</div>
 					)}
-					{installed.filter(group => group.page.nextPage).map(group => (
-						<button
-							className="btn btn-md btn-ghost w-full"
-							disabled={group.loadingMore}
-							key={group.installation.id}
-							onClick={() => void more(group.installation.id)}
-							type="button"
-						>
-							{group.loadingMore
-								? "Loading..."
-								: `More from ${group.installation.account.login}`}
-						</button>
-					))}
 					<a className="btn btn-md btn-ghost w-full" href="/auth/github/install">
 						Manage repository access
 					</a>

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -123,6 +123,13 @@ personal and organization installations that user can access and only the
 repositories selected for each installation. The repository picker links to
 the App installation page when access has not been installed or needs updating.
 
+The picker loads every repository page in the background and keeps a validated
+snapshot for the lifetime of the browser tab. Stale snapshots are revalidated
+page by page with GitHub ETags when search begins. The snapshot is scoped to the
+GitHub user and cleared on logout, account changes, and the installation setup
+callback. Listing responses remain `no-store`; the server forwards conditional
+requests but does not retain picker repository data.
+
 Local MCP is an intentional exception to this installation boundary. Its bearer
 token is authenticated independently and authorized with a direct repository
 lookup. An MCP-created channel for a repository outside the App installation is

--- a/e2e/github.ts
+++ b/e2e/github.ts
@@ -89,10 +89,19 @@ let fake = async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof f
 		});
 	}
 	if (url.origin === "https://api.github.com") {
-		let authorization = new Headers(init?.headers).get("authorization") ?? "";
+		let requestHeaders = new Headers(init?.headers);
+		let authorization = requestHeaders.get("authorization") ?? "";
 		let authorized = /^Bearer ghu_e2e_(.+)_\d+$/.exec(authorization);
 		if (!authorized) return json({ message: "Bad credentials" }, { status: 401 });
 		let handle = authorized[1]!;
+		let tagged = (value: unknown, etag: string, responseInit: ResponseInit = {}) => {
+			let headers = new Headers(responseInit.headers);
+			headers.set("etag", etag);
+			if (requestHeaders.get("if-none-match") === etag) {
+				return new Response(null, { status: 304, headers });
+			}
+			return json(value, { ...responseInit, headers });
+		};
 		if (url.pathname === "/user") {
 			return json({
 				node_id: `U_${handle}`,
@@ -109,7 +118,7 @@ let fake = async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof f
 		}
 		if (handle === "expired") return json({ message: "Bad credentials" }, { status: 401 });
 		if (url.pathname === "/user/installations") {
-			return json({ installations });
+			return tagged({ installations }, `"installations-${handle}"`);
 		}
 		if (url.pathname === "/user/installations/101/repositories") {
 			let available = repositories.filter(value => value.owner.login === "octo-org");
@@ -120,17 +129,27 @@ let fake = async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof f
 				}));
 			}
 			if (handle === "paged" && url.searchParams.get("page") !== "2") {
-				return json({ repositories: available.slice(0, 1) }, {
-					headers: {
-						link:
-							'<https://api.github.com/user/installations/101/repositories?per_page=100&page=2>; rel="next"',
+				return tagged(
+					{ repositories: available.slice(0, 1) },
+					`"repositories-${handle}-101-1"`,
+					{
+						headers: {
+							link:
+								'<https://api.github.com/user/installations/101/repositories?per_page=100&page=2>; rel="next"',
+						},
 					},
-				});
+				);
 			}
-			return json({ repositories: handle === "paged" ? available.slice(1) : available });
+			return tagged(
+				{ repositories: handle === "paged" ? available.slice(1) : available },
+				`"repositories-${handle}-101-${url.searchParams.get("page") ?? "1"}"`,
+			);
 		}
 		if (url.pathname === "/user/installations/102/repositories") {
-			return json({ repositories: repositories.filter(value => value.owner.login === "octocat") });
+			return tagged(
+				{ repositories: repositories.filter(value => value.owner.login === "octocat") },
+				`"repositories-${handle}-102-${url.searchParams.get("page") ?? "1"}"`,
+			);
 		}
 		let repository = repositories.find(value => url.pathname === `/repos/${value.full_name}`);
 		if (repository) return json(repository);

--- a/e2e/hosted.e2e.ts
+++ b/e2e/hosted.e2e.ts
@@ -186,7 +186,7 @@ test("the repository picker stays inside a narrow visual viewport", async ({ bas
 	).toBe(true);
 });
 
-test("the repository picker repositions as repository results and pagination errors arrive", async ({ baseURL, page }) => {
+test("the repository picker repositions as background results and errors arrive", async ({ baseURL, page }) => {
 	await page.setViewportSize({ width: 320, height: 568 });
 	await authenticate(page, "octocat", baseURL!);
 	let releaseInitial: (() => void) | undefined;
@@ -204,7 +204,17 @@ test("the repository picker repositions as repository results and pagination err
 				await route.fulfill({
 					json: installation === "101"
 						? { repositories: [score], nextPage: 2 }
-						: { repositories: [] },
+						: {
+							repositories: [{
+								...score,
+								id: "R_notes",
+								owner: "octocat",
+								name: "notes",
+								fullName: "octocat/notes",
+								private: false,
+								permissions: { pull: true, push: false, admin: false },
+							}],
+						},
 				});
 				return;
 			}
@@ -235,16 +245,15 @@ test("the repository picker repositions as repository results and pagination err
 	expect(loaded!.height).toBeGreaterThan(loading!.height + 40);
 	expect(loaded!.y).toBeLessThan(loading!.y - 40);
 
-	let more = page.getByRole("button", { name: "More from octo-org" });
-	await more.click();
-	await expect(page.getByRole("button", { name: "Loading..." })).toBeDisabled();
 	await expect.poll(() => releaseSecond !== undefined).toBe(true);
 	releaseSecond!();
-	await expect(page.getByRole("alert")).toHaveText("Could not load more repositories.");
+	await expect(page.getByRole("alert")).toContainText("Could not load all repositories.");
+	await expect(page.getByRole("option", { name: /octocat\/notes/ })).toBeVisible();
 	let failed = await popup.boundingBox();
 	expect(failed).toBeTruthy();
-	expect(failed!.height).toBeGreaterThan(loaded!.height);
-	expect(failed!.y).toBeLessThan(loaded!.y);
+	expect(failed!.height).toBeGreaterThan(0);
+	expect(failed!.y).toBeGreaterThanOrEqual(0);
+	expect(failed!.y + failed!.height).toBeLessThanOrEqual(568);
 });
 
 test("narrow coarse hosted controls and channel content remain reachable", async ({ baseURL, browser }) => {
@@ -370,16 +379,40 @@ test("an authorized user without an installation is sent to install the App", as
 	);
 });
 
-test("GitHub installation pagination reaches the repository picker", async ({ baseURL, page }) => {
+test("returning from GitHub App setup invalidates the tab cache", async ({ baseURL, page }) => {
+	await authenticate(page, "paged", baseURL!);
+	await page.goto("/");
+	await expect(page.getByRole("option", { name: /^octo-org\/archive-12\b/ })).toBeVisible();
+	await page.evaluate(() => {
+		let user = sessionStorage.getItem("chopin:repositories:active-user")!;
+		let key = `chopin:repositories:${encodeURIComponent(user)}`;
+		let snapshot = JSON.parse(sessionStorage.getItem(key)!) as {
+			validatedAt: number;
+			installationPages: Array<{ value: { installations: unknown[] } }>;
+			repositoryPages: Record<string, unknown>;
+		};
+		snapshot.validatedAt = Date.now();
+		snapshot.installationPages[0]!.value.installations = [];
+		snapshot.repositoryPages = {};
+		sessionStorage.setItem(key, JSON.stringify(snapshot));
+	});
+
+	await page.goto("/auth/github/setup?installation_id=101");
+	await expect(page).toHaveURL("/");
+	await expect(page.getByRole("option", { name: /^octo-org\/archive-12\b/ })).toBeVisible();
+});
+
+test("repository search includes pages loaded in the background", async ({ baseURL, page }) => {
 	await authenticate(page, "paged", baseURL!);
 	await page.goto("/");
 
-	await expect(page.getByRole("option", { name: /octo-org\/score/ })).toBeVisible();
-	await page.getByRole("button", { name: "More from octo-org" }).click();
-	await expect(page.getByRole("option", { name: /^octo-org\/archive-1\b/ })).toBeVisible();
+	let search = page.getByRole("combobox", { name: "Search repositories" });
+	await search.fill("archive-12");
+	await expect(page.getByRole("option", { name: /^octo-org\/archive-12\b/ })).toBeVisible();
+	await expect(page.getByRole("button", { name: /More from/ })).toHaveCount(0);
 });
 
-test("the repository picker retries and appends unique pages", async ({ baseURL, page }) => {
+test("the repository picker retries and appends unique background pages", async ({ baseURL, page }) => {
 	await authenticate(page, "octocat", baseURL!);
 	let fail = true;
 	await page.route(/\/api\/github\/installations\?page=\d+$/, async route => {
@@ -428,9 +461,37 @@ test("the repository picker retries and appends unique pages", async ({ baseURL,
 	await expect(page.getByRole("alert")).toHaveText("Could not load repositories.");
 	await page.getByRole("button", { name: "Try again" }).click();
 	await expect(page.getByRole("option", { name: /octo-org\/score/ })).toBeVisible();
-	await page.getByRole("button", { name: "More from octo-org" }).click();
 	await expect(page.getByRole("option", { name: /octo-org\/archive/ })).toBeVisible();
 	await expect(page.getByRole("option", { name: /octo-org\/score/ })).toHaveCount(1);
+});
+
+test("the tab cache revalidates stale repository pages with etags", async ({ baseURL, page }) => {
+	await authenticate(page, "paged", baseURL!);
+	await page.goto("/");
+	await expect(page.getByRole("option", { name: /^octo-org\/archive-12\b/ })).toBeVisible();
+
+	let cachedAt = await page.evaluate(() => {
+		let user = sessionStorage.getItem("chopin:repositories:active-user")!;
+		let key = `chopin:repositories:${encodeURIComponent(user)}`;
+		let snapshot = JSON.parse(sessionStorage.getItem(key)!) as { validatedAt: number };
+		snapshot.validatedAt = 0;
+		sessionStorage.setItem(key, JSON.stringify(snapshot));
+		return snapshot.validatedAt;
+	});
+	expect(cachedAt).toBe(0);
+
+	let validators: string[] = [];
+	page.on("request", async request => {
+		if (!request.url().includes("/api/github/installations")) return;
+		let validator = await request.headerValue("if-none-match");
+		if (validator) validators.push(validator);
+	});
+	await page.reload();
+	await expect(page.getByRole("option", { name: /^octo-org\/archive-12\b/ })).toBeVisible();
+	await page.getByRole("combobox", { name: "Search repositories" }).fill("archive-12");
+	await expect.poll(() => validators.length).toBeGreaterThanOrEqual(4);
+	await expect(page.getByText("Refreshing repositories...", { exact: true })).toHaveCount(0);
+	await expect(page.getByRole("option", { name: /^octo-org\/archive-12\b/ })).toBeVisible();
 });
 
 test("expired GitHub authorization returns to sign in", async ({ baseURL, page }) => {


### PR DESCRIPTION
## Summary

- load every accessible repository page in the background so picker search covers the complete installation set
- keep a user-scoped snapshot in `sessionStorage` and revalidate stale pages through stateless ETag pass-through while API responses remain `no-store`
- invalidate tab data on logout, account changes, and GitHub App setup, with retry and partial cold-load handling

## Testing

- `bun test` (839 passed, 2 skipped)
- `bun run types`
- `bun run ci`
- `bun run e2e -- hosted.e2e.ts` (12 passed)