### PR TITLE
Use UUIDv5 channel IDs

### DIFF
--- a/apps/server/src/channels/id.test.ts
+++ b/apps/server/src/channels/id.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+
+import { deterministicChannelId, isChannelId, newChannelId } from "./id";
+
+describe("channel ids", () => {
+	it("accepts canonical UUIDv5 and legacy UUIDv4 channel ids", () => {
+		expect(isChannelId("019c1234-1234-4123-8123-123456789abc")).toBe(true);
+		expect(isChannelId("019c1234-1234-5123-8123-123456789abc")).toBe(true);
+		expect(isChannelId("019c1234-1234-3123-8123-123456789abc")).toBe(false);
+		expect(isChannelId("019c1234-1234-5123-7123-123456789abc")).toBe(false);
+		expect(isChannelId("not-a-channel")).toBe(false);
+	});
+
+	it("mints fresh UUIDv5 channel ids", () => {
+		let first = newChannelId("R_score");
+		let second = newChannelId("R_score");
+		expect(first[14]).toBe("5");
+		expect(isChannelId(first)).toBe(true);
+		expect(second).not.toBe(first);
+	});
+
+	it("derives a stable repository-scoped idempotent creation id", () => {
+		let id = deterministicChannelId("R_score", "attempt-1");
+		expect(id).toBe("ba0d561e-c15d-522f-a4ea-e83f72584327");
+		expect(isChannelId(id)).toBe(true);
+		expect(deterministicChannelId("R_score", "attempt-1")).toBe(id);
+		expect(deterministicChannelId("R_other", "attempt-1")).not.toBe(id);
+		expect(deterministicChannelId("R_score", "attempt-2")).not.toBe(id);
+	});
+});

--- a/apps/server/src/channels/id.ts
+++ b/apps/server/src/channels/id.ts
@@ -1,0 +1,28 @@
+import { createHash } from "node:crypto";
+
+/** New channels are UUIDv5-shaped; UUIDv4 remains valid for existing channels. */
+const CHANNEL = /^[0-9a-f]{8}-[0-9a-f]{4}-[45][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+export function isChannelId(value: string): boolean {
+	return CHANNEL.test(value);
+}
+
+/** Stable identity for one repository-scoped name. */
+export function deterministicChannelId(repositoryId: string, name: string): string {
+	let bytes = createHash("sha256")
+		.update(repositoryId)
+		.update("\0")
+		.update(name)
+		.digest();
+	bytes[6] = (bytes[6]! & 0x0f) | 0x50;
+	bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+	let hex = bytes.toString("hex", 0, 16);
+	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${
+		hex.slice(20)
+	}`;
+}
+
+/** Mint a fresh canonical channel id in the same namespace as deterministic creation. */
+export function newChannelId(repositoryId: string): string {
+	return deterministicChannelId(repositoryId, crypto.randomUUID());
+}

--- a/apps/server/src/channels/routes.test.ts
+++ b/apps/server/src/channels/routes.test.ts
@@ -161,6 +161,7 @@ describe("channel routes", () => {
 		expect(created!.status).toBe(201);
 		let body = await created!.json();
 		expect(body.channel.title).toBe("Release readiness");
+		expect(body.channel.id[14]).toBe("5");
 		expect(body.channel.repositoryId).toBe("R_score");
 		expect(body.channel.createdBy).toBe("U_octocat");
 		expect(created!.headers.get("location")).toBe(`/channels/${body.channel.id}`);
@@ -180,6 +181,24 @@ describe("channel routes", () => {
 		expect((await storage.collaboration.load(body.channel.id, now))?.channel.id).toBe(
 			body.channel.id,
 		);
+	});
+
+	it("continues to open a legacy UUIDv4 channel", async () => {
+		let { router, storage, cookie, now } = await setup();
+		let id = "019c1234-1234-4123-8123-123456789abc";
+		await storage.channels.create({
+			id,
+			repositoryId: "R_score",
+			repositoryOwner: "octo-org",
+			repositoryName: "score",
+			title: "Legacy plan",
+			createdBy: "U_octocat",
+			now,
+		});
+
+		let response = await router.handle(request(`/api/channels/${id}`, cookie));
+		expect(response!.status).toBe(200);
+		expect((await response!.json()).channel.id).toBe(id);
 	});
 
 	it("lists matching documents with a query-bound cursor and repository avatar", async () => {
@@ -283,9 +302,14 @@ describe("channel routes", () => {
 
 	it("paginates opaquely and rejects malformed cursors", async () => {
 		let { router, storage, cookie, now } = await setup();
-		for (let index = 0; index < 2; index++) {
+		let ids = [
+			"019c1234-1234-5123-8123-123456789abc",
+			"119c1234-1234-4123-8123-123456789abc",
+			"219c1234-1234-5123-8123-123456789abc",
+		];
+		for (let [index, id] of ids.entries()) {
 			await storage.channels.create({
-				id: crypto.randomUUID(),
+				id,
 				repositoryId: "R_score",
 				repositoryOwner: "octo-org",
 				repositoryName: "score",
@@ -300,12 +324,20 @@ describe("channel routes", () => {
 		));
 		let page = await first!.json();
 		expect(page.channels).toHaveLength(1);
+		expect(page.channels[0].id).toBe(ids[0]);
 		expect(page.nextCursor).toBeString();
 		let second = await router.handle(request(
 			`/api/repositories/octo-org/score/channels?limit=1&cursor=${page.nextCursor}`,
 			cookie,
 		));
-		expect((await second!.json()).channels).toHaveLength(1);
+		let secondPage = await second!.json();
+		expect(secondPage.channels[0].id).toBe(ids[1]);
+		expect(secondPage.nextCursor).toBeString();
+		let third = await router.handle(request(
+			`/api/repositories/octo-org/score/channels?limit=1&cursor=${secondPage.nextCursor}`,
+			cookie,
+		));
+		expect((await third!.json()).channels[0].id).toBe(ids[2]);
 		let bad = await router.handle(request(
 			"/api/repositories/octo-org/score/channels?cursor=not-json",
 			cookie,

--- a/apps/server/src/channels/routes.ts
+++ b/apps/server/src/channels/routes.ts
@@ -2,6 +2,7 @@ import { GitHubError } from "../github/client";
 import { StorageError } from "../storage/errors";
 
 import { documentTitles } from "./document-title";
+import { isChannelId, newChannelId } from "./id";
 
 import type { HostedAuth } from "../auth/routes";
 import type { AuthenticatedSession } from "../auth/session";
@@ -11,7 +12,6 @@ import type { ChannelCursor, ChannelRecord } from "../storage/model";
 
 const OWNER = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
 const REPOSITORY = /^[A-Za-z0-9._-]{1,100}$/;
-const CHANNEL = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 function json(value: unknown, status = 200, cookie?: string, location?: string): Response {
 	let headers = new Headers({
@@ -79,7 +79,7 @@ function decoded(
 			return false;
 		}
 		let updatedAt = new Date(item.updatedAt);
-		if (Number.isNaN(updatedAt.getTime()) || !CHANNEL.test(item.id)) return false;
+		if (Number.isNaN(updatedAt.getTime()) || !isChannelId(item.id)) return false;
 		return { cursor: { updatedAt, id: item.id }, query: item.query };
 	} catch {
 		return false;
@@ -242,7 +242,7 @@ export function registerChannelRoutes(
 				for (let candidate of candidates) {
 					try {
 						channel = await auth.storage.channels.create({
-							id: crypto.randomUUID(),
+							id: newChannelId(repo.id),
 							repositoryId: repo.id,
 							repositoryOwner: repo.owner,
 							repositoryName: repo.name,
@@ -278,7 +278,7 @@ export function registerChannelRoutes(
 			let session = await auth.sessions.authenticate(request);
 			if (!session) return json({ error: "authentication required" }, 401);
 			let id = params.channelId!;
-			if (!CHANNEL.test(id)) return json({ error: "channel not found" }, 404);
+			if (!isChannelId(id)) return json({ error: "channel not found" }, 404);
 			let channel = await auth.storage.channels.get(id);
 			if (!channel) return json({ error: "channel not found" }, 404);
 			let repo = await authorizedRepository(

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -289,6 +289,7 @@ describe("the hosted MCP adapter", () => {
 		let result = await adapter.create.create(caller, creation);
 		expect(result.kind).toBe("created");
 		if (result.kind !== "created") return;
+		expect(result.document.id[14]).toBe("5");
 		let expected = createdDocument(result.document.id);
 		expect(result.document).toEqual({
 			...expected,

--- a/apps/server/src/mcp/hosted.ts
+++ b/apps/server/src/mcp/hosted.ts
@@ -1,5 +1,5 @@
+import { deterministicChannelId } from "../channels/id";
 import { GitHubError } from "../github/client";
-import { createHash } from "node:crypto";
 import * as Plan from "../plan/service";
 import * as Rooms from "../rooms";
 import { claimImplementation, reportImplementationLifecycle } from "../tasks/plan-graphs";
@@ -21,20 +21,6 @@ export type HostedCaller = {
 export type ImplementationPersistence = { lease(): Lease };
 
 const BEARER = new RegExp("^Bearer ([A-Za-z0-9._~+/-]+=*)$", "i");
-
-function channelId(repositoryId: string, idempotencyKey: string): string {
-	let bytes = createHash("sha256")
-		.update(repositoryId)
-		.update("\0")
-		.update(idempotencyKey)
-		.digest();
-	bytes[6] = (bytes[6]! & 0x0f) | 0x50;
-	bytes[8] = (bytes[8]! & 0x3f) | 0x80;
-	let hex = bytes.toString("hex", 0, 16);
-	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${
-		hex.slice(20)
-	}`;
-}
 
 type Document = {
 	id: string;
@@ -240,7 +226,7 @@ export function hosted(
 				let { brief, plan, ...origin } = input;
 				let creation: Plan.CreationMetadata = { brief, origin };
 				let initial = await Plan.initial(plan, creation);
-				let id = channelId(repository.id, input.idempotencyKey);
+				let id = deterministicChannelId(repository.id, input.idempotencyKey);
 				try {
 					await auth.storage.channels.create({
 						id,

--- a/apps/server/src/socket/admission.test.ts
+++ b/apps/server/src/socket/admission.test.ts
@@ -141,6 +141,22 @@ describe("socket admission", () => {
 		);
 		expect("data" in probe).toBe(true);
 
+		let deterministic = await storage.channels.create({
+			id: "019c1234-1234-5123-8123-123456789abc",
+			repositoryId: "R_score",
+			repositoryOwner: "octo-org",
+			repositoryName: "score",
+			title: "MCP plan",
+			createdBy: "U_octocat",
+			now,
+		});
+		let deterministicUrl = new URL(`https://chopin.test/ws?channel=${deterministic.id}`);
+		let deterministicRequest = new Request(deterministicUrl, {
+			headers: { cookie: pair(issued.cookie), origin: "https://chopin.test" },
+		});
+		let admitted = await admit(deterministicRequest, deterministicUrl, auth);
+		expect("data" in admitted && admitted.data.room).toBe(deterministic.id);
+
 		github.push = true;
 		let editor = await admit(request, url, auth);
 		expect("data" in editor && editor.data.canEdit).toBe(true);

--- a/apps/server/src/socket/admission.ts
+++ b/apps/server/src/socket/admission.ts
@@ -1,11 +1,10 @@
+import { isChannelId } from "../channels/id";
 import { GitHubError } from "../github/client";
 import { uid } from "../ids";
 import { StorageError } from "../storage/errors";
 
 import type { HostedAuth } from "../auth/routes";
 import type { SocketData } from "../wire";
-
-const CHANNEL = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 export type Admission = { data: SocketData } | { status: number; reason: string };
 
@@ -23,7 +22,7 @@ export async function admit(
 		let session = await auth.sessions.authenticate(request);
 		if (!session) return { status: 401, reason: "authentication required" };
 		let id = (url.searchParams.get("channel") || "").toLowerCase();
-		if (!CHANNEL.test(id)) return { status: 400, reason: "bad channel" };
+		if (!isChannelId(id)) return { status: 400, reason: "bad channel" };
 		let channel = await auth.storage.channels.get(id);
 		if (!channel) return { status: 404, reason: "channel not found" };
 		let access = await auth.sessions.use(

--- a/apps/web/src/hosted.test.ts
+++ b/apps/web/src/hosted.test.ts
@@ -19,6 +19,10 @@ describe("hosted routes", () => {
 			page: "channel",
 			id: "019c1234-1234-4123-8123-123456789abc",
 		});
+		expect(hostedRoute("/channels/019c1234-1234-5123-8123-123456789abc")).toEqual({
+			page: "channel",
+			id: "019c1234-1234-5123-8123-123456789abc",
+		});
 		expect(hostedRoute("/plans/main")).toEqual({ page: "missing" });
 	});
 });


### PR DESCRIPTION
## Summary
- centralize channel ID generation and validation
- mint UUIDv5-shaped IDs for web and idempotent MCP creation
- accept legacy UUIDv4 IDs across detail routes, pagination, sockets, and client routing

## Testing
- `bun test`
- `bun run types`
- `bun run ci`
- `bun run e2e` (169 passed)