### PR TITLE
Show unique people in room presence

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -18,6 +18,7 @@ import { decisionAttention, DecisionViewControl } from "./decision-view-control"
 import { DocumentPicker } from "./document-picker";
 import * as Api from "./api";
 import { HostedApp, HostedFailure, HostedLoading, HostedLogin } from "./hosted";
+import { peopleHere } from "./presence";
 import { RepositoryPicker } from "./repository-picker";
 import { clearRepositoryCache } from "./repository-cache";
 import { Wire } from "./wire";
@@ -45,6 +46,7 @@ function Header(
 		userId: string;
 	},
 ) {
+	let people = peopleHere(members);
 	return (
 		<header className="room-header hairline-b relative flex min-h-12 shrink-0 flex-nowrap items-center gap-2 px-2 py-2 sm:h-12 sm:gap-3 sm:px-4 sm:py-0">
 			<a className="hidden text-sm font-semibold sm:inline" href="/">chopin</a>
@@ -59,21 +61,21 @@ function Header(
 				/>
 			</div>
 			<div
-				aria-label={`People here: ${members.map(member => member.handle).join(", ")}`}
+				aria-label={`People here: ${people.map(member => member.handle).join(", ")}`}
 				className="room-members ml-auto flex shrink-0 items-center"
 				role="group"
 			>
-				{members.map(member => (
-					<span className="room-member-face -ml-1.5 first:ml-0" key={member.client}>
+				{people.map(member => (
+					<span className="room-member-face -ml-1.5 first:ml-0" key={member.handle.toLowerCase()}>
 						<Face handle={member.handle} ring size={24} />
 					</span>
 				))}
-				{members.length > 3 && (
+				{people.length > 3 && (
 					<span
 						aria-hidden="true"
 						className="room-member-overflow ml-1 hidden text-sm text-text-tertiary"
 					>
-						+{members.length - 3}
+						+{people.length - 3}
 					</span>
 				)}
 			</div>

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -61,13 +61,13 @@ function Header(
 				/>
 			</div>
 			<div
-				aria-label={`People here: ${people.map(member => member.handle).join(", ")}`}
+				aria-label={`People here: ${people.join(", ")}`}
 				className="room-members ml-auto flex shrink-0 items-center"
 				role="group"
 			>
-				{people.map(member => (
-					<span className="room-member-face -ml-1.5 first:ml-0" key={member.handle.toLowerCase()}>
-						<Face handle={member.handle} ring size={24} />
+				{people.map(handle => (
+					<span className="room-member-face -ml-1.5 first:ml-0" key={handle.toLowerCase()}>
+						<Face handle={handle} ring size={24} />
 					</span>
 				))}
 				{people.length > 3 && (

--- a/apps/web/src/presence.test.ts
+++ b/apps/web/src/presence.test.ts
@@ -8,23 +8,20 @@ describe("people here", () => {
 			{ handle: "e2e", client: "tab-1" },
 			{ handle: "e2e", client: "tab-2" },
 			{ handle: "E2E", client: "tab-3" },
-		])).toEqual([{ handle: "e2e", client: "tab-1" }]);
+		])).toEqual(["e2e"]);
 	});
 
 	it("keeps different verified GitHub accounts separate", () => {
 		expect(peopleHere([
 			{ handle: "ana", client: "ana-tab" },
 			{ handle: "bo", client: "bo-tab" },
-		])).toEqual([
-			{ handle: "ana", client: "ana-tab" },
-			{ handle: "bo", client: "bo-tab" },
-		]);
+		])).toEqual(["ana", "bo"]);
 	});
 
 	it("keeps a person while any of their connections remains", () => {
 		expect(peopleHere([
 			{ handle: "e2e", client: "tab-2" },
 			{ handle: "e2e", client: "tab-3" },
-		])).toEqual([{ handle: "e2e", client: "tab-2" }]);
+		])).toEqual(["e2e"]);
 	});
 });

--- a/apps/web/src/presence.test.ts
+++ b/apps/web/src/presence.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+
+import { peopleHere } from "./presence";
+
+describe("people here", () => {
+	it("represents one verified GitHub account once across its connections", () => {
+		expect(peopleHere([
+			{ handle: "e2e", client: "tab-1" },
+			{ handle: "e2e", client: "tab-2" },
+			{ handle: "E2E", client: "tab-3" },
+		])).toEqual([{ handle: "e2e", client: "tab-1" }]);
+	});
+
+	it("keeps different verified GitHub accounts separate", () => {
+		expect(peopleHere([
+			{ handle: "ana", client: "ana-tab" },
+			{ handle: "bo", client: "bo-tab" },
+		])).toEqual([
+			{ handle: "ana", client: "ana-tab" },
+			{ handle: "bo", client: "bo-tab" },
+		]);
+	});
+
+	it("keeps a person while any of their connections remains", () => {
+		expect(peopleHere([
+			{ handle: "e2e", client: "tab-2" },
+			{ handle: "e2e", client: "tab-3" },
+		])).toEqual([{ handle: "e2e", client: "tab-2" }]);
+	});
+});

--- a/apps/web/src/presence.ts
+++ b/apps/web/src/presence.ts
@@ -1,12 +1,14 @@
 import type { Session } from "@chopin/protocol";
 
 /** Derive people from a connection roster using GitHub's case-insensitive login identity. */
-export function peopleHere(members: readonly Session.Member[]): Session.Member[] {
+export function peopleHere(members: readonly Session.Member[]): string[] {
 	let seen = new Set<string>();
-	return members.filter(member => {
+	let people: string[] = [];
+	for (let member of members) {
 		let identity = member.handle.toLowerCase();
-		if (seen.has(identity)) return false;
+		if (seen.has(identity)) continue;
 		seen.add(identity);
-		return true;
-	});
+		people.push(member.handle);
+	}
+	return people;
 }

--- a/apps/web/src/presence.ts
+++ b/apps/web/src/presence.ts
@@ -1,0 +1,12 @@
+import type { Session } from "@chopin/protocol";
+
+/** Derive people from a connection roster using GitHub's case-insensitive login identity. */
+export function peopleHere(members: readonly Session.Member[]): Session.Member[] {
+	let seen = new Set<string>();
+	return members.filter(member => {
+		let identity = member.handle.toLowerCase();
+		if (seen.has(identity)) return false;
+		seen.add(identity);
+		return true;
+	});
+}

--- a/e2e/collab.e2e.ts
+++ b/e2e/collab.e2e.ts
@@ -11,7 +11,7 @@
  * login session cookie. They still meet in one repository-authorized channel.
  */
 
-import { content, expect, test } from "./room";
+import { content, expect, ready, test } from "./room";
 
 test("an edit by one appears for the other", async ({ join }) => {
 	let ana = await join("ana");
@@ -47,6 +47,27 @@ test("the header represents everyone here as faces", async ({ join }) => {
 	// A roster that keeps naming somebody who closed the tab is worse than no
 	// roster, because it is what you check before assuming you are alone.
 	await expect(ana.getByRole("img", { name: "bo" })).toHaveCount(0);
+});
+
+test("the header represents one account once across its open tabs", async ({ join }) => {
+	let first = await join("e2e");
+	let second = await first.context().newPage();
+	let third = await first.context().newPage();
+	await Promise.all([second.goto(first.url()), third.goto(first.url())]);
+	await Promise.all([ready(second), ready(third)]);
+
+	let people = first.getByRole("banner").getByRole("group", {
+		exact: true,
+		name: "People here: e2e",
+	});
+	await expect(people.getByRole("img", { name: "e2e" })).toHaveCount(1);
+
+	await first.close();
+	let remaining = third.getByRole("banner").getByRole("group", {
+		exact: true,
+		name: "People here: e2e",
+	});
+	await expect(remaining.getByRole("img", { name: "e2e" })).toHaveCount(1);
 });
 
 test("a peer's caret is drawn, and named", async ({ join }) => {


### PR DESCRIPTION
## Before

Opening one verified GitHub account in several tabs rendered and announced one header face per socket.

## After

The header derives one person per case-insensitive verified GitHub login. The server connection roster and cursor/session lifecycle remain per socket. Different accounts remain separate, and a person remains present until their final connection closes.

## Verification

- bun test — 846 passed, 2 PostgreSQL-only tests skipped
- bun run types
- bun run ci
- bun run build
- targeted Chromium presence E2E — 1 passed