### PR TITLE
Remove duplicate Decisions heading

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -21,7 +21,7 @@ import { HostedApp, HostedFailure, HostedLoading, HostedLogin } from "./hosted";
 import { RepositoryPicker } from "./repository-picker";
 import { clearRepositoryCache } from "./repository-cache";
 import { Wire } from "./wire";
-import { useWorkspaceMode, useWorkspaceState, Workspace } from "./workspace";
+import { HEADING, useWorkspaceMode, useWorkspaceState, Workspace } from "./workspace";
 import { presentWorkspace } from "./workspace-model";
 
 import type { Session } from "@chopin/protocol";
@@ -262,6 +262,7 @@ export function RoomWorkspace(
 			decisions={
 				<Decisions
 					connected={status === "connected" && effectiveCanEdit}
+					headingId={HEADING.decisions}
 					onShowPlan={showPlan}
 					reveal={reveal}
 					store={questions}

--- a/apps/web/src/workspace.tsx
+++ b/apps/web/src/workspace.tsx
@@ -217,7 +217,7 @@ function ConversationToggle(
 	);
 }
 
-const HEADING: Record<WorkspaceDestination, string> = {
+export const HEADING: Record<WorkspaceDestination, string> = {
 	plan: "workspace-plan-heading",
 	decisions: "workspace-decisions-heading",
 	conversation: "workspace-conversation-heading",
@@ -418,7 +418,6 @@ export function Workspace(
 							hidden={decisionsHidden}
 							inert={decisionsHidden}
 						>
-							<h2 className="sr-only" id={HEADING.decisions} tabIndex={-1}>Decisions</h2>
 							{decisions}
 						</section>
 					</div>

--- a/e2e/sidecar.e2e.ts
+++ b/e2e/sidecar.e2e.ts
@@ -86,10 +86,7 @@ test("the desktop document view is a centred segmented control", async ({ join, 
 	expect(planStyle).not.toBe(decisionsStyle);
 
 	await decisions.click();
-	let decisionsView = page.getByRole("region", { name: "Decisions" });
-	await expect(decisionsView).toBeVisible();
-	await expect(decisionsView.getByRole("heading", { level: 2, name: "Decisions" }))
-		.toHaveCount(1);
+	await expect(page.locator('[data-document-view="decisions"]')).toBeVisible();
 	await expect(decisions).toHaveAttribute("aria-pressed", "true");
 	await plan.click();
 	await expect(page.locator('[data-document-view="plan"]')).toBeVisible();

--- a/e2e/sidecar.e2e.ts
+++ b/e2e/sidecar.e2e.ts
@@ -86,7 +86,10 @@ test("the desktop document view is a centred segmented control", async ({ join, 
 	expect(planStyle).not.toBe(decisionsStyle);
 
 	await decisions.click();
-	await expect(page.locator('[data-document-view="decisions"]')).toBeVisible();
+	let decisionsView = page.getByRole("region", { name: "Decisions" });
+	await expect(decisionsView).toBeVisible();
+	await expect(decisionsView.getByRole("heading", { level: 2, name: "Decisions" }))
+		.toHaveCount(1);
 	await expect(decisions).toHaveAttribute("aria-pressed", "true");
 	await plan.click();
 	await expect(page.locator('[data-document-view="plan"]')).toBeVisible();

--- a/packages/editor/src/decisions.tsx
+++ b/packages/editor/src/decisions.tsx
@@ -20,6 +20,7 @@ export type DecisionsProps = {
 	store: QuestionnaireStore;
 	wire?: Transport;
 	connected?: boolean;
+	headingId?: string;
 	/** Reveal the plan before taking the reader to a questionnaire's result. */
 	onShowPlan?: (widget: string, question: string) => void;
 	/**
@@ -48,7 +49,9 @@ function useHistory() {
 	return [history, setHistory] as const;
 }
 
-export function Decisions({ connected, onShowPlan, reveal, store, wire }: DecisionsProps) {
+export function Decisions(
+	{ connected, headingId, onShowPlan, reveal, store, wire }: DecisionsProps,
+) {
 	let entries = useQuestionnaires(store);
 	let content = useRef<HTMLDivElement>(null);
 	let heading = useRef<HTMLHeadingElement>(null);
@@ -121,6 +124,7 @@ export function Decisions({ connected, onShowPlan, reveal, store, wire }: Decisi
 			<header className="flex shrink-0 items-center gap-2 px-3 py-2 hairline-b">
 				<h2
 					className="text-sm font-semibold tracking-wide text-text-tertiary uppercase"
+					id={headingId}
 					ref={heading}
 					tabIndex={-1}
 				>


### PR DESCRIPTION
## Summary
- reuse the visible Decisions heading as the workspace region label and focus target
- remove the duplicate screen-reader-only level-two heading without changing visual design or copy

## Verification
- `bun test` — 843 passed, 2 skipped
- `bun run types`
- `bun run ci`
- `bun run build`
- `E2E_SKIP_BUILD=1 bun scripts/e2e.ts e2e/sidecar.e2e.ts e2e/responsive-workspace.e2e.ts --grep "desktop document view|390px phone"` — 2 passed