### PR TITLE
Improve channel failure recovery

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -56,6 +56,7 @@ function Header(
 					canEdit={canEdit}
 					current={{ id: room, title: label }}
 					repository={repository}
+					userId={userId}
 				/>
 			</div>
 			<div

--- a/apps/web/src/channel-recovery.test.ts
+++ b/apps/web/src/channel-recovery.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+
+import { readChannelRecovery, rememberChannel } from "./channel-recovery";
+
+class MemoryStorage implements Storage {
+	readonly #values = new Map<string, string>();
+
+	get length(): number {
+		return this.#values.size;
+	}
+
+	clear(): void {
+		this.#values.clear();
+	}
+
+	getItem(key: string): string | null {
+		return this.#values.get(key) ?? null;
+	}
+
+	key(index: number): string | null {
+		return [...this.#values.keys()][index] ?? null;
+	}
+
+	removeItem(key: string): void {
+		this.#values.delete(key);
+	}
+
+	setItem(key: string, value: string): void {
+		this.#values.set(key, value);
+	}
+}
+
+const channel = {
+	id: "11111111-1111-4111-8111-111111111111",
+	title: "Release readiness",
+};
+
+const repository = {
+	owner: "octo-org",
+	name: "score",
+	fullName: "octo-org/score",
+};
+
+describe("channel recovery context", () => {
+	it("keeps known channel and repository context in this tab", () => {
+		let storage = new MemoryStorage();
+		rememberChannel("U_octocat", channel, repository, storage);
+
+		expect(readChannelRecovery("U_octocat", channel.id, storage)).toEqual({ channel, repository });
+	});
+
+	it("does not return another channel's context", () => {
+		let storage = new MemoryStorage();
+		rememberChannel("U_octocat", channel, repository, storage);
+
+		expect(readChannelRecovery(
+			"U_octocat",
+			"22222222-2222-4222-8222-222222222222",
+			storage,
+		))
+			.toBeUndefined();
+	});
+
+	it("does not return a previous user's context", () => {
+		let storage = new MemoryStorage();
+		rememberChannel("U_octocat", channel, repository, storage);
+
+		expect(readChannelRecovery("U_other", channel.id, storage)).toBeUndefined();
+	});
+
+	it("ignores malformed stored context", () => {
+		let storage = new MemoryStorage();
+		storage.setItem(`chopin:channel-recovery:U_octocat:${channel.id}`, "not json");
+
+		expect(readChannelRecovery("U_octocat", channel.id, storage)).toBeUndefined();
+	});
+});

--- a/apps/web/src/channel-recovery.ts
+++ b/apps/web/src/channel-recovery.ts
@@ -1,0 +1,63 @@
+import type * as Api from "./api";
+
+export type ChannelRecovery = {
+	channel: Pick<Api.Channel, "id" | "title">;
+	repository: Pick<Api.Repository, "owner" | "name" | "fullName">;
+};
+
+const KEY = "chopin:channel-recovery:";
+
+function record(value: unknown): Record<string, unknown> | undefined {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? value as Record<string, unknown>
+		: undefined;
+}
+
+function text(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0;
+}
+
+function recovery(value: unknown, id: string): value is ChannelRecovery {
+	let item = record(value);
+	let channel = record(item?.channel);
+	let repository = record(item?.repository);
+	return !!item
+		&& !!channel
+		&& channel.id === id
+		&& text(channel.title)
+		&& !!repository
+		&& text(repository.owner)
+		&& text(repository.name)
+		&& text(repository.fullName);
+}
+
+export function rememberChannel(
+	userId: string,
+	channel: ChannelRecovery["channel"],
+	repository: ChannelRecovery["repository"],
+	storage: Storage = sessionStorage,
+): void {
+	try {
+		storage.setItem(
+			`${KEY}${encodeURIComponent(userId)}:${channel.id}`,
+			JSON.stringify({ channel, repository }),
+		);
+	} catch {
+		// Recovery context must never prevent the navigation it is meant to help.
+	}
+}
+
+export function readChannelRecovery(
+	userId: string,
+	id: string,
+	storage: Storage = sessionStorage,
+): ChannelRecovery | undefined {
+	try {
+		let value: unknown = JSON.parse(
+			storage.getItem(`${KEY}${encodeURIComponent(userId)}:${id}`) ?? "null",
+		);
+		return recovery(value, id) ? value : undefined;
+	} catch {
+		return undefined;
+	}
+}

--- a/apps/web/src/document-picker.tsx
+++ b/apps/web/src/document-picker.tsx
@@ -4,6 +4,7 @@ import { useEffect, useId, useMemo, useRef, useState } from "react";
 
 import { useAnchoredPicker } from "./anchored-picker";
 import * as Api from "./api";
+import { rememberChannel } from "./channel-recovery";
 
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 
@@ -15,7 +16,12 @@ function message(error: unknown, fallback: string): string {
 	return error instanceof Error ? error.message : fallback;
 }
 
-function select(channel: Api.Channel) {
+function select(
+	userId: string,
+	channel: Api.Channel,
+	repository: Pick<Api.Repository, "owner" | "name" | "fullName">,
+) {
+	rememberChannel(userId, channel, repository);
 	location.assign(`/channels/${channel.id}`);
 }
 
@@ -25,10 +31,12 @@ export function DocumentPicker(
 		canEdit,
 		current,
 		repository,
+		userId,
 	}: {
 		canEdit: boolean;
 		current: Pick<Api.Channel, "id" | "title">;
-		repository: Pick<Api.Repository, "name" | "owner">;
+		repository: Pick<Api.Repository, "name" | "owner" | "fullName">;
+		userId: string;
 	},
 ) {
 	let request = useRef(0);
@@ -89,7 +97,7 @@ export function DocumentPicker(
 				channels.length === 0 ? 0 : (value - 1 + channels.length) % channels.length
 			);
 		} else if (event.key === "Enter" && activeChannel) {
-			select(activeChannel);
+			select(userId, activeChannel, repository);
 		} else return;
 		event.preventDefault();
 	}
@@ -125,6 +133,7 @@ export function DocumentPicker(
 		setCreateError(undefined);
 		try {
 			let created = await Api.createChannel(repository.owner, repository.name);
+			rememberChannel(userId, created.channel, created.repository);
 			location.assign(`/channels/${created.channel.id}`);
 		} catch (reason) {
 			setCreateError(reason);
@@ -207,7 +216,7 @@ export function DocumentPicker(
 								}`}
 								id={optionId(listId, channel)}
 								key={channel.id}
-								onClick={() => select(channel)}
+								onClick={() => select(userId, channel, repository)}
 								onMouseEnter={() => setActive(index)}
 								role="option"
 								tabIndex={-1}

--- a/apps/web/src/hosted.test.ts
+++ b/apps/web/src/hosted.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
-import { hostedRoute } from "./hosted";
+import { ApiError } from "./api";
+import { hostedRoute, retryableChannelFailure } from "./hosted";
 
 describe("hosted routes", () => {
 	it("recognizes repository and channel routes", () => {
@@ -24,5 +25,17 @@ describe("hosted routes", () => {
 			id: "019c1234-1234-5123-8123-123456789abc",
 		});
 		expect(hostedRoute("/plans/main")).toEqual({ page: "missing" });
+	});
+});
+
+describe("channel recovery", () => {
+	it("retries only failures a repeated channel read can recover from", () => {
+		expect(retryableChannelFailure(new Error("network unavailable"))).toBe(true);
+		expect(retryableChannelFailure(new ApiError("request timed out", 408))).toBe(true);
+		expect(retryableChannelFailure(new ApiError("too many requests", 429))).toBe(true);
+		expect(retryableChannelFailure(new ApiError("storage unavailable", 503))).toBe(true);
+		expect(retryableChannelFailure(new ApiError("channel not found", 404))).toBe(false);
+		expect(retryableChannelFailure(new ApiError("repository access is required", 403)))
+			.toBe(false);
 	});
 });

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import * as Api from "./api";
+import { readChannelRecovery, rememberChannel } from "./channel-recovery";
 import { RepositoryPicker } from "./repository-picker";
 import { clearRepositoryCache } from "./repository-cache";
 
@@ -41,6 +42,13 @@ export function hostedRoute(pathname: string): HostedRoute {
 	let channel = /^\/channels\/([0-9a-f-]{36})\/?$/i.exec(pathname);
 	if (channel) return { page: "channel", id: channel[1]!.toLowerCase() };
 	return { page: "missing" };
+}
+
+export function retryableChannelFailure(error: unknown): boolean {
+	return !(error instanceof Api.ApiError)
+		|| error.status === 408
+		|| error.status === 429
+		|| error.status >= 500;
 }
 
 function Frame(
@@ -96,14 +104,58 @@ function Loading({ label = "Loading" }: { label?: string }) {
 	);
 }
 
-function Failure({ error }: { error: unknown }) {
+function repositoryHref(repository: { owner: string; name: string }): string {
+	return `/repositories/${encodeURIComponent(repository.owner)}/${
+		encodeURIComponent(repository.name)
+	}`;
+}
+
+function Failure(
+	{
+		channel,
+		error,
+		onRetry,
+		repository,
+	}: {
+		channel?: { id: string; title?: string };
+		error: unknown;
+		onRetry?: () => void;
+		repository?: Pick<Api.Repository, "owner" | "name" | "fullName">;
+	},
+) {
 	let message = error instanceof Error ? error.message : "Something went wrong";
 	return (
 		<div className="flex h-full items-center justify-center bg-ground p-4 sm:p-6" data-hosted="">
 			<div className="ring-hairline max-w-md rounded-lg bg-page p-4 shadow-resting sm:p-6">
 				<h1 className="text-xl font-semibold">Cannot open Chopin</h1>
 				<p className="mt-2 text-sm text-text-secondary">{message}</p>
-				<a className="btn btn-md btn-secondary mt-5" href="/">Back to repositories</a>
+				{channel && (
+					<div className="mt-4 min-w-0">
+						{channel.title && <p className="break-words text-sm font-medium">{channel.title}</p>}
+						<p className="mt-1 break-all text-sm text-text-tertiary">{channel.id}</p>
+						{repository && (
+							<p className="mt-2 break-words text-sm text-text-secondary">
+								{repository.fullName}
+							</p>
+						)}
+					</div>
+				)}
+				<div className="mt-5 flex flex-wrap gap-2">
+					{onRetry && (
+						<button className="btn btn-md btn-primary" onClick={onRetry} type="button">
+							Try again
+						</button>
+					)}
+					{repository && (
+						<a
+							className={`btn btn-md ${onRetry ? "btn-secondary" : "btn-primary"}`}
+							href={repositoryHref(repository)}
+						>
+							View {repository.fullName} channels
+						</a>
+					)}
+					<a className="btn btn-md btn-secondary" href="/">Back to repositories</a>
+				</div>
 			</div>
 		</div>
 	);
@@ -178,6 +230,7 @@ function RepositoryChannels(
 		setCreating(true);
 		try {
 			let result = await Api.createChannel(owner, repository, title.trim());
+			rememberChannel(user.id, result.channel, result.repository);
 			location.assign(`/channels/${result.channel.id}`);
 		} catch (reason) {
 			setError(reason);
@@ -262,6 +315,7 @@ function RepositoryChannels(
 									}`}
 									href={`/channels/${channel.id}`}
 									key={channel.id}
+									onClick={() => rememberChannel(user.id, channel, page.repository)}
 								>
 									<span className="min-w-0 break-words text-sm font-medium">{channel.title}</span>
 									<span className="text-sm text-text-tertiary sm:shrink-0">
@@ -296,20 +350,39 @@ function ChannelWorkspace(
 ) {
 	let [detail, setDetail] = useState<Api.ChannelDetail>();
 	let [error, setError] = useState<unknown>();
+	let [retry, setRetry] = useState(0);
+	let recovery = readChannelRecovery(user.id, id);
 
 	useEffect(() => {
 		let active = true;
 		Api.channel(id).then(value => {
-			if (active) setDetail(value);
+			if (active) {
+				rememberChannel(user.id, value.channel, value.repository);
+				setDetail(value);
+			}
 		}, reason => {
 			if (active) setError(reason);
 		});
 		return () => {
 			active = false;
 		};
-	}, [id]);
+	}, [id, retry]);
 
-	if (error) return <Failure error={error} />;
+	if (error) {
+		return (
+			<Failure
+				channel={recovery?.channel ?? { id }}
+				error={error}
+				onRetry={retryableChannelFailure(error)
+					? () => {
+						setError(undefined);
+						setRetry(value => value + 1);
+					}
+					: undefined}
+				repository={recovery?.repository}
+			/>
+		);
+	}
 	if (!detail) return <Loading label="Opening channel..." />;
 	return (
 		<Workspace

--- a/e2e/hosted.e2e.ts
+++ b/e2e/hosted.e2e.ts
@@ -13,6 +13,31 @@ const score = {
 	permissions: { pull: true, push: true, admin: false },
 };
 
+const recoveryChannel = {
+	createdAt: "2026-08-14T12:00:00.000Z",
+	createdBy: "U_octocat",
+	id: "11111111-1111-4111-8111-111111111111",
+	repositoryId: score.id,
+	repositoryName: score.name,
+	repositoryOwner: score.owner,
+	revision: 1,
+	title: "Release readiness",
+	updatedAt: "2026-08-14T12:00:00.000Z",
+};
+
+async function showKnownChannel(page: Parameters<typeof authenticate>[0]) {
+	await page.route("**/api/repositories/octo-org/score/channels*", route =>
+		route.fulfill({
+			json: {
+				canEdit: true,
+				channels: [recoveryChannel],
+				repository: score,
+			},
+		}));
+	await page.goto("/repositories/octo-org/score");
+	await page.getByRole("link", { name: recoveryChannel.title }).click();
+}
+
 test("organization admission rejects outsiders and pending members", async ({ baseURL }) => {
 	for (let handle of ["outsider", "pending"]) {
 		let started = await fetch(`${baseURL}/auth/github`, { redirect: "manual" });
@@ -72,6 +97,71 @@ test("an authenticated repository creates a channel workspace", async ({ baseURL
 	await expect(page.getByRole("heading", { name: "Planning channels" })).toBeVisible();
 	await expect(page.getByRole("button", { name: /octocat\/notes/ })).toBeVisible();
 	await expect(page.getByRole("button", { name: "New channel" })).toHaveCount(0);
+});
+
+test("a known deleted channel keeps its context and routes back without retry", async ({ baseURL, page }) => {
+	await authenticate(page, "octocat", baseURL!);
+	await page.route(
+		new RegExp(`/api/channels/${recoveryChannel.id}$`),
+		route => route.fulfill({ status: 404, json: { error: "channel not found" } }),
+	);
+	await showKnownChannel(page);
+
+	await expect(page.getByRole("heading", { name: "Cannot open Chopin" })).toBeVisible();
+	await expect(page.getByText(recoveryChannel.title, { exact: true })).toBeVisible();
+	await expect(page.getByText(recoveryChannel.id, { exact: true })).toBeVisible();
+	await expect(page.getByText(score.fullName, { exact: true })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Try again" })).toHaveCount(0);
+	let channels = page.getByRole("link", { name: `View ${score.fullName} channels` });
+	await expect(channels).toHaveAttribute("href", "/repositories/octo-org/score");
+	await channels.click();
+	await expect(page).toHaveURL("/repositories/octo-org/score");
+	await expect(page.getByRole("heading", { name: "Planning channels" })).toBeVisible();
+});
+
+test("a transient channel failure retries the safe read", async ({ baseURL, page }) => {
+	await authenticate(page, "octocat", baseURL!);
+	let attempts = 0;
+	await page.route(new RegExp(`/api/channels/${recoveryChannel.id}$`), async route => {
+		attempts++;
+		if (attempts === 1) {
+			await route.fulfill({ status: 503, json: { error: "storage is unavailable" } });
+			return;
+		}
+		await route.fulfill({
+			json: { canEdit: true, channel: recoveryChannel, repository: score },
+		});
+	});
+	await showKnownChannel(page);
+
+	await expect(page.getByText(recoveryChannel.title, { exact: true })).toBeVisible();
+	await page.getByRole("button", { name: "Try again" }).click();
+	await expect(page.getByRole("button", { name: `Document: ${recoveryChannel.title}` }))
+		.toBeVisible();
+	expect(attempts).toBe(2);
+});
+
+test("an unknown direct channel link stays privacy-safe", async ({ baseURL, page }) => {
+	await authenticate(page, "octocat", baseURL!);
+	await page.route(
+		new RegExp(`/api/channels/${recoveryChannel.id}$`),
+		route => route.fulfill({ status: 404, json: { error: "channel not found" } }),
+	);
+	await showKnownChannel(page);
+	await expect(page.getByText(recoveryChannel.title, { exact: true })).toBeVisible();
+	let unknown = "22222222-2222-4222-8222-222222222222";
+	await page.route(
+		new RegExp(`/api/channels/${unknown}$`),
+		route => route.fulfill({ status: 404, json: { error: "channel not found" } }),
+	);
+	await page.goto(`/channels/${unknown}`);
+
+	await expect(page.getByText(unknown, { exact: true })).toBeVisible();
+	await expect(page.getByText(recoveryChannel.title, { exact: true })).toHaveCount(0);
+	await expect(page.getByText(score.fullName, { exact: true })).toHaveCount(0);
+	await expect(page.getByRole("link", { name: /channels$/ })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Try again" })).toHaveCount(0);
+	await expect(page.getByRole("link", { name: "Back to repositories" })).toBeVisible();
 });
 
 test("the repository picker supports dismissal and keyboard selection", async ({ baseURL, page }) => {


### PR DESCRIPTION
## Before

A failed channel-detail request discarded repository and channel context already visible in the tab. The failure card offered only Back to repositories, including for transient failures.

## After

- Retain known channel title, channel ID, and repository name in user-scoped per-tab recovery context.
- Show a direct route to the repository channel list when that context exists.
- Offer Try again only for the safe channel-detail read on network, timeout, rate-limit, or server failures.
- Keep missing 404 channels non-retryable.
- Keep unknown direct links privacy-safe: they show only the channel ID already present in the URL.
- Keep Back to repositories as the secondary escape.

## Evidence

Targeted hosted browser coverage verifies:

- a known deleted channel retains context, links back to its repository, and has no retry
- a transient failure retries the read and opens the channel
- an unknown direct link exposes no cached title or repository

## Verification

- bun test — 848 passed, 2 skipped
- bun run types
- bun run ci
- bun run build
- E2E_SKIP_BUILD=1 bun scripts/e2e.ts e2e/hosted.e2e.ts --grep recovery scenarios — 3 passed

The E2E harness stopped both servers and removed both disposable PostgreSQL services after the run.