### PR TITLE
Let callouts exit on double Enter

### DIFF
--- a/e2e/toolbar.e2e.ts
+++ b/e2e/toolbar.e2e.ts
@@ -119,6 +119,32 @@ test("a callout edits like prose and keeps its type controls out of the way", as
 	await written(page, room, /type="warning" title="Worth knowing"/);
 });
 
+test("enter twice leaves a callout at the end of the plan", async ({ join, room }) => {
+	let page = await join("ana");
+	let callout = await insertCallout(page);
+	let body = callout.locator("[data-plan-body]");
+	await expect(body.locator(":scope > p")).toHaveCount(1);
+
+	await page.keyboard.type("Keep this in the callout.");
+	await expect(body.locator(":scope > p")).toHaveText("Keep this in the callout.");
+	await page.keyboard.press("Enter");
+	await expect(body.locator(":scope > p")).toHaveCount(2);
+	await page.keyboard.type("Still in it.");
+	await page.keyboard.press("Enter");
+	await page.keyboard.press("Enter");
+	await page.keyboard.type("Outside the callout.");
+
+	await expect(body.locator(":scope > p")).toHaveCount(2);
+	await expect(callout).toContainText("Keep this in the callout.");
+	await expect(callout).toContainText("Still in it.");
+	await expect(callout).not.toContainText("Outside the callout.");
+	await written(
+		page,
+		room,
+		/Keep this in the callout\.[\s\S]*Still in it\.[\s\S]*<\/Callout>[\s\S]*Outside the callout\./,
+	);
+});
+
 test("escape closes the menu and leaves what was typed", async ({ join }) => {
 	let page = await join("ana");
 

--- a/packages/editor/src/toolbar/slash.tsx
+++ b/packages/editor/src/toolbar/slash.tsx
@@ -17,7 +17,7 @@ import {
 	useState,
 } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { $setBlocksType } from "@lexical/selection";
+import { $copyBlockFormatIndent, $setBlocksType } from "@lexical/selection";
 import {
 	$getSelection,
 	$isRangeSelection,
@@ -71,6 +71,32 @@ function replace(editor: LexicalEditor, build: () => ElementNode) {
 		let selection = $getSelection();
 		if (!$isRangeSelection(selection)) return;
 		$setBlocksType(selection, build);
+	});
+}
+
+/** Keep the replaced block as a block inside the new container. */
+function insertCallout(editor: LexicalEditor) {
+	editor.update(() => {
+		let selection = $getSelection();
+		if (!$isRangeSelection(selection)) return;
+		let body: ElementNode | undefined;
+
+		$setBlocksType(
+			selection,
+			() => $createCalloutNode(ulid()),
+			(previous, callout) => {
+				let paragraph = $createParagraphNode();
+				$copyBlockFormatIndent(previous, paragraph);
+				paragraph.append(...previous.getChildren());
+				callout.append(paragraph);
+				body = paragraph;
+			},
+		);
+
+		// An empty text child is normalised away after this update; anchor the
+		// caret to its paragraph so the next character does not become a direct
+		// child of the callout instead.
+		if (body?.getTextContentSize() === 0) body.selectEnd();
 	});
 }
 
@@ -132,12 +158,7 @@ const COMMANDS: SlashCommand[] = [
 		label: "Callout",
 		group: "Layout",
 		keywords: ["note", "warning", "aside", "admonition"],
-		run: editor =>
-			replace(editor, () => {
-				let callout = $createCalloutNode();
-				callout.setId(ulid());
-				return callout;
-			}),
+		run: insertCallout,
 	},
 	{
 		id: "table",

--- a/packages/editor/src/widgets/enter.tsx
+++ b/packages/editor/src/widgets/enter.tsx
@@ -1,5 +1,5 @@
 /**
- * Enter, in a block whose content is lines.
+ * Enter, in a block that otherwise has no way out.
  *
  * Lexical asks a block to make its own successor, and one that cannot returns
  * null — which is what a code block does, and why Enter inside one did nothing
@@ -7,9 +7,11 @@
  * common keystroke there is when writing code, and a block at the end of the
  * document with no way past it is a corner a reader can be typed into.
  *
- * So Enter is a line break here, and Enter on a line that is already empty
- * leaves instead. Pressing it twice is how every editor lets go of a fence,
- * and it is the only exit that has to be discovered rather than explained.
+ * So Enter is a line break in a fence, and Enter on a line that is already
+ * empty leaves instead. A callout already contains ordinary blocks, so its
+ * first Enter makes an empty paragraph normally and its second removes that
+ * paragraph and leaves the container. In either case, pressing Enter twice is
+ * the only exit that has to be discovered rather than explained.
  *
  * Registered on `INSERT_PARAGRAPH_COMMAND` rather than on the keystroke: that
  * is what rich text turns an unshifted Enter into, and it is also what
@@ -24,12 +26,13 @@ import {
 	$createParagraphNode,
 	$getSelection,
 	$isLineBreakNode,
+	$isParagraphNode,
 	$isRangeSelection,
 	$isTextNode,
 	COMMAND_PRIORITY_LOW,
 	INSERT_PARAGRAPH_COMMAND,
 } from "lexical";
-import { $isCodeBlockNode, $isMathNode } from "@chopin/dialect";
+import { $isCalloutNode, $isCodeBlockNode, $isMathNode } from "@chopin/dialect";
 
 import type { ElementNode, LexicalNode } from "lexical";
 
@@ -46,6 +49,25 @@ function lines(node: LexicalNode | null): ElementNode | undefined {
 		if ($isCodeBlockNode(cursor)) return cursor;
 		if ($isMathNode(cursor)) return cursor.isInlineMath() ? undefined : cursor;
 		cursor = cursor.getParent();
+	}
+	return undefined;
+}
+
+/** A blank final paragraph that a preceding Enter added to a callout. */
+function calloutExit(node: LexicalNode | null) {
+	let cursor = node;
+	while (cursor) {
+		let parent = cursor.getParent();
+		if ($isCalloutNode(parent)) {
+			if (
+				$isParagraphNode(cursor)
+				&& cursor.getTextContentSize() === 0
+				&& cursor.getPreviousSibling() !== null
+				&& cursor.getNextSibling() === null
+			) return { callout: parent, paragraph: cursor };
+			return undefined;
+		}
+		cursor = parent;
 	}
 	return undefined;
 }
@@ -86,6 +108,17 @@ export function EnterPlugin() {
 			() => {
 				let selection = $getSelection();
 				if (!$isRangeSelection(selection)) return false;
+
+				if (selection.isCollapsed()) {
+					let exit = calloutExit(selection.anchor.getNode());
+					if (exit) {
+						exit.paragraph.remove();
+						let paragraph = $createParagraphNode();
+						exit.callout.insertAfter(paragraph);
+						paragraph.select();
+						return true;
+					}
+				}
 
 				let block = lines(selection.anchor.getNode());
 				if (!block) return false;


### PR DESCRIPTION
## Summary

- leave a callout from its trailing empty paragraph on the second Enter
- keep slash-created callout contents in paragraph blocks and preserve the caret
- cover final-callout editing and persistence with a browser regression

## Testing

- `bun test`
- `bun run types`
- `bun run ci`
- `E2E_SKIP_BUILD=1 bun scripts/e2e.ts e2e/toolbar.e2e.ts`