### PR TITLE
Fix Mermaid diagram readability

### DIFF
--- a/e2e/code.e2e.ts
+++ b/e2e/code.e2e.ts
@@ -33,11 +33,43 @@ const PATCH = `\`\`\`diff
 \`\`\`
 `;
 
+const WIDE_MERMAID = `flowchart LR
+	A[Compact document measure that readers can track] --> B[Independent widget scrollers that preserve the document width]
+	B --> C[Keyboard-safe destination switching across responsive workspaces]
+	C --> D[Durable agent change chips and collaborator cursor labels]`;
+const TALL_MERMAID = WIDE_MERMAID.replace("flowchart LR", "flowchart TD");
+
 /** How many colours the highlighter ended up using. */
 async function colours(page: Page): Promise<number> {
 	return await page
 		.locator("[data-line] span[style*='color']")
 		.evaluateAll(nodes => new Set(nodes.map(node => (node as HTMLElement).style.color)).size);
+}
+
+async function diagramGeometry(page: Page) {
+	let region = content(page).getByRole("region", { name: "Diagram preview" });
+	return await region.evaluate(element => {
+		let svg = element.querySelector("svg")!;
+		let bounds = svg.getBoundingClientRect();
+		let labels = [...svg.querySelectorAll("text")];
+		let drawn = [...svg.querySelectorAll("text, rect, path[marker-end]")];
+		let scale = bounds.width / svg.viewBox.baseVal.width;
+		return {
+			edges: svg.querySelectorAll("path[marker-end]").length,
+			labels: labels.length,
+			minimumFontSize: Math.min(
+				...labels.map(label => Number.parseFloat(getComputedStyle(label).fontSize) * scale),
+			),
+			nodes: svg.querySelectorAll("rect").length,
+			region: { clientWidth: element.clientWidth, scrollWidth: element.scrollWidth },
+			regionHeight: element.getBoundingClientRect().height,
+			svg: { height: bounds.height, width: bounds.width },
+			verticallyContained: drawn.every(item => {
+				let rectangle = item.getBoundingClientRect();
+				return rectangle.top >= bounds.top - 1 && rectangle.bottom <= bounds.bottom + 1;
+			}),
+		};
+	});
 }
 
 test("a named fence is coloured with its source hidden by default", async ({ join, seed }) => {
@@ -67,6 +99,68 @@ test("a wide preview scrolls inside its code widget", async ({ join, seed }) => 
 	await expect(preview).toBeVisible();
 	expect(await rendered.evaluate(node => node.scrollWidth > node.clientWidth)).toBe(true);
 	expect(await rendered.evaluate(node => getComputedStyle(node).overflowX)).toBe("auto");
+	await expectNoHorizontalOverflow(page);
+});
+
+test("an inserted wide diagram stays readable in its own keyboard scroller", async ({ join }) => {
+	let page = await join("ana", { viewport: { width: 1440, height: 1000 } });
+	await content(page).click();
+	await page.keyboard.type("/diagram");
+	await page.getByRole("listbox", MENU).getByRole("option", { name: "Diagram" }).click();
+	await page.keyboard.insertText(WIDE_MERMAID);
+
+	let region = content(page).getByRole("region", { name: "Diagram preview" });
+	await expect(region).toBeVisible();
+
+	for (let viewport of [{ width: 1440, height: 1000 }, { width: 390, height: 844 }]) {
+		await page.setViewportSize(viewport);
+		let geometry = await diagramGeometry(page);
+		expect(geometry.labels).toBe(4);
+		expect(geometry.nodes).toBeGreaterThanOrEqual(4);
+		expect(geometry.edges).toBe(3);
+		expect(geometry.minimumFontSize, JSON.stringify(geometry)).toBeGreaterThanOrEqual(12);
+		expect(geometry.verticallyContained).toBe(true);
+		expect(geometry.region.scrollWidth).toBeGreaterThan(geometry.region.clientWidth);
+		await expectNoHorizontalOverflow(page);
+	}
+
+	await page.emulateMedia({ reducedMotion: "reduce" });
+	await expect(region).toHaveCSS("scroll-behavior", "auto");
+	await region.focus();
+	expect(await region.evaluate(node => node === document.activeElement)).toBe(true);
+	await page.keyboard.press("ArrowRight");
+	await expect.poll(() => region.evaluate(node => node.scrollLeft)).toBeGreaterThan(0);
+});
+
+test("a diagram recomputes its height after source and viewport changes", async ({ join, seed }) => {
+	await seed(`\`\`\`mermaid
+${WIDE_MERMAID}
+\`\`\`
+`);
+	let page = await join("ana", { viewport: { width: 1440, height: 1000 } });
+	let region = content(page).getByRole("region", { name: "Diagram preview" });
+	await expect(region).toBeVisible();
+	let wide = await diagramGeometry(page);
+
+	await content(page).getByRole("button", { name: "Show source" }).click();
+	let source = content(page).locator("[data-plan-source]");
+	await source.selectText();
+	await page.keyboard.insertText(TALL_MERMAID);
+
+	await expect.poll(async () => (await diagramGeometry(page)).svg.height).toBeGreaterThan(
+		wide.svg.height * 2,
+	);
+	let rerendered = await diagramGeometry(page);
+	expect(rerendered.regionHeight).toBeGreaterThanOrEqual(rerendered.svg.height);
+
+	await page.setViewportSize({ width: 390, height: 844 });
+	await expect.poll(async () => (await diagramGeometry(page)).region.clientWidth).toBeLessThan(
+		rerendered.region.clientWidth,
+	);
+	let resized = await diagramGeometry(page);
+	expect(resized.svg.height).toBeCloseTo(rerendered.svg.height, 0);
+	expect(resized.regionHeight).toBeGreaterThanOrEqual(resized.svg.height);
+	expect(resized.verticallyContained).toBe(true);
 	await expectNoHorizontalOverflow(page);
 });
 

--- a/e2e/responsive-content.e2e.ts
+++ b/e2e/responsive-content.e2e.ts
@@ -125,31 +125,39 @@ async function expectIntrinsicWidth(
 }
 
 async function expectVisibleMermaidSvg(page: Page): Promise<void> {
-	let result = await content(page).locator("[data-plan-language='mermaid'] svg").evaluateAll(
-		nodes => {
+	let result = await content(page).getByRole("region", { name: "Diagram preview" }).evaluateAll(
+		regions => {
 			let documentBox = globalThis.document.querySelector("[data-plan-scroll]")
 				?.getBoundingClientRect();
-			let visible = nodes.flatMap(node => {
-				let element = node as SVGSVGElement;
-				let style = getComputedStyle(element);
-				let rectangle = element.getBoundingClientRect();
+			let visible = regions.flatMap(region => {
+				let svg = region.querySelector("svg");
+				if (!svg) return [];
+				let style = getComputedStyle(svg);
+				let rectangle = svg.getBoundingClientRect();
+				let regionBox = region.getBoundingClientRect();
 				if (
 					style.display === "none" || style.visibility === "hidden" || rectangle.width === 0
 					|| rectangle.height === 0
 				) return [];
 				return [{
-					inside: !!documentBox && rectangle.left >= documentBox.left
-						&& rectangle.right <= documentBox.right,
-					intrinsicWidth: element.viewBox.baseVal.width || element.width.baseVal.value,
+					inside: !!documentBox && regionBox.left >= documentBox.left
+						&& regionBox.right <= documentBox.right,
+					intrinsicWidth: svg.viewBox.baseVal.width || svg.width.baseVal.value,
 					documentWidth: documentBox?.width ?? 0,
+					overflows: region.scrollWidth > region.clientWidth,
 				}];
 			});
-			return { all: nodes.length, visible };
+			return { all: regions.length, visible };
 		},
 	);
 	expect(result.all, "Mermaid must create SVG output").toBeGreaterThan(0);
 	expect(result.visible.length, "Mermaid must paint a visible SVG").toBeGreaterThan(0);
-	expect(result.visible.every(value => value.inside), "visible Mermaid SVGs must fit the document")
+	expect(result.visible.every(value => value.inside), "Mermaid scrollers must fit the document")
+		.toBe(true);
+	expect(
+		result.visible.every(value => value.overflows),
+		"wide Mermaid diagrams must scroll internally",
+	)
 		.toBe(true);
 	expect(
 		result.visible.some(value => value.intrinsicWidth > value.documentWidth),

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -992,6 +992,23 @@
 	height: auto;
 }
 
+.plan-content .plan-diagram {
+	max-inline-size: 100%;
+	overflow-x: auto;
+	overflow-y: hidden;
+	overscroll-behavior-inline: contain;
+}
+
+.plan-content .plan-diagram svg {
+	display: block;
+	max-width: none;
+}
+
+.plan-content .plan-diagram:focus-visible {
+	outline: 2px solid var(--color-brand);
+	outline-offset: 2px;
+}
+
 /* Tabs ------------------------------------------------------------------- */
 
 .plan-content [data-plan-chrome="tabs"] {

--- a/packages/editor/src/widgets/render-blocks.tsx
+++ b/packages/editor/src/widgets/render-blocks.tsx
@@ -125,7 +125,27 @@ async function renderMermaid(key: string, source: string): Promise<string> {
 		theme: "neutral",
 	});
 	let { svg } = await mermaid.default.render(`ace-mermaid-${key}`, source);
-	return svg;
+	let parsed = new DOMParser().parseFromString(svg, "image/svg+xml");
+	let root = parsed.documentElement;
+	let viewBox = root.getAttribute("viewBox")?.trim().split(/[\s,]+/).map(Number);
+	if (root.localName !== "svg" || viewBox?.length !== 4) return svg;
+	let width = viewBox[2]!;
+	let height = viewBox[3]!;
+	if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+		return svg;
+	}
+
+	/*
+	 * Mermaid writes `width="100%"` and an inline maximum from this viewBox.
+	 * In prose that makes a wide diagram shrink until its labels are unreadable.
+	 * Give the SVG its authored drawing size instead; the preview owns overflow
+	 * and normal document flow owns height after every render and resize.
+	 */
+	root.setAttribute("width", String(width));
+	root.setAttribute("height", String(height));
+	root.style.removeProperty("max-width");
+	if (!root.getAttribute("style")) root.removeAttribute("style");
+	return root.outerHTML;
 }
 
 /**
@@ -316,13 +336,25 @@ function Rendered(
 		);
 	}
 
-	// Produced by KaTeX or Mermaid from validated source under their strict
-	// modes, not by anything the author wrote.
+	if (!html) return null;
+	if (block.kind === "mermaid") {
+		return (
+			<div
+				aria-label="Diagram preview"
+				className="plan-diagram"
+				role="region"
+				tabIndex={0}
+				dangerouslySetInnerHTML={{ __html: html }}
+			/>
+		);
+	}
+
+	// Produced by KaTeX from validated source under its strict mode, not by
+	// anything the author wrote.
 	//
 	// Inline math is a span inside a sentence, so what wraps it has to be one
 	// too: a block element here would put a formula somebody wrote mid-clause
 	// on a line of its own, and the rest of the sentence after it.
-	if (!html) return null;
 	if (block.inline) return <span dangerouslySetInnerHTML={{ __html: html }} />;
 	return <div dangerouslySetInnerHTML={{ __html: html }} />;
 }


### PR DESCRIPTION
## Summary

- preserve Mermaid SVG viewBox dimensions so labels stay readable
- contain wide diagrams in a keyboard-focusable horizontal scroller while keeping their full natural height
- cover insertion, desktop and compact layouts, content rerenders, container resizes, keyboard scrolling, and reduced motion

## Before / after evidence

The design audit captures the original tiny-strip rendering: [desktop](https://github.com/githubnext/chopin/blob/maggie/design-audit/docs/design-audit/images/11-mermaid-preview-desktop.png) and [compact](https://github.com/githubnext/chopin/blob/maggie/design-audit/docs/design-audit/images/25-mermaid-preview-mobile.png).

| Width | Before | After |
| --- | --- | --- |
| 1440 viewport | 640 × 54.6 px SVG; effective labels 8.7 px; no internal overflow | 1173 × 100 px SVG at 16 px labels inside a 640 px scroller |
| 390 viewport | 350 × 29.9 px SVG; effective labels 4.8 px; no internal overflow | 1173 × 100 px SVG at 16 px labels inside a 350 px scroller |

The browser assertions also verify that every node, edge, and label remains vertically contained after Mermaid source changes and viewport resizing.

## Verification

- bun test — 853 passed, 2 expected database skips
- bun run types
- bun run ci — 0 warnings, 0 errors
- bun run build
- focused browser suites — 30 passed
- git diff --check