### PR TITLE
Make decision cards save independently

### DIFF
--- a/apps/server/src/questions/service.ts
+++ b/apps/server/src/questions/service.ts
@@ -25,7 +25,7 @@ import type { Server } from "bun";
 // `Plan` is the room's plan here; the protocol namespace of the same name is
 // aliased so the two cannot be confused at a glance.
 import type { Plan as Wired, Question as Wire, Request } from "@chopin/protocol";
-import type { Answer, Definition } from "@chopin/question";
+import type { Answer, DecisionDefinition, Definition } from "@chopin/question";
 import * as Service from "../plan/service";
 
 import type { Plan } from "../plan/service";
@@ -105,7 +105,7 @@ export async function ask(
 	}
 	let asked: Array<{
 		id: string;
-		single: Definition;
+		single: DecisionDefinition;
 		value: room.QuestionnaireInsertion["value"];
 		waiting: Promise<Ended>;
 		at: room.QuestionnaireInsertion["at"];
@@ -113,7 +113,7 @@ export async function ask(
 	await Service.exclusive(plan, async () => {
 		let anchors = placement ? validatePlacement(plan, definition, placement) : undefined;
 		asked = definition.questions.map((question, index) => {
-			let single = { questions: [question] };
+			let single = Question.decision({ questions: [question] });
 			// Widget and question identities are deliberately distinct.
 			let id = ulid();
 			let waiting = Store.ask(plan.questions, id, single, id);

--- a/apps/server/src/questions/store.ts
+++ b/apps/server/src/questions/store.ts
@@ -16,7 +16,7 @@
 
 import * as Question from "@chopin/question";
 
-import type { Answer, Definition, Drafts, Model } from "@chopin/question";
+import type { Answer, DecisionDefinition, Definition, Drafts, Model } from "@chopin/question";
 
 /** How long a resolved questionnaire is remembered, for late arrivals. */
 const CLOSED_TTL = 5 * 60 * 1_000;
@@ -34,7 +34,7 @@ export type Ended =
 
 type Open = {
 	id: string;
-	definition: Definition;
+	definition: DecisionDefinition;
 	/** The plan node this belongs to, when it has one. */
 	widget?: string;
 	model: Model;
@@ -68,7 +68,7 @@ export type Questions = {
 
 export type StoredOpen = {
 	id: string;
-	definition: Definition;
+	definition: DecisionDefinition;
 	widget?: string;
 	model: number[];
 	revision: number;
@@ -99,11 +99,12 @@ export function restore(entries: StoredOpen[]): Questions {
 			!Array.isArray(entry.model)
 			|| entry.model.some(value => !Number.isInteger(value) || value < 0 || value > 255)
 		) Question.reject("Questionnaire model is invalid");
+		let definition = Question.decision(entry.definition);
 		questions.open.set(entry.id, {
 			id: entry.id,
-			definition: entry.definition,
+			definition,
 			...(entry.widget ? { widget: entry.widget } : {}),
-			model: Question.restore(entry.model, entry.definition),
+			model: Question.restore(entry.model, definition),
 			revision: entry.revision,
 			presence: new Map(),
 		});
@@ -139,15 +140,16 @@ export function ask(
 	if (questions.open.has(id)) Question.reject("Questionnaire is already open");
 	questions.closed.delete(id);
 
-	let model = Question.create(definition);
+	let decision = Question.decision(definition);
+	let model = Question.create(decision);
 	// Proves the freshly built model reads back as the definition describes,
 	// rather than discovering it does not on the first patch.
-	Question.read(model, definition);
+	Question.read(model, decision);
 
 	return new Promise<Ended>(settle => {
 		questions.open.set(id, {
 			id,
-			definition,
+			definition: decision,
 			...(widget ? { widget } : {}),
 			model,
 			revision: 0,
@@ -164,7 +166,7 @@ export function get(questions: Questions, id: string): Open | undefined {
 /** Everything still open, for a client that has just joined. */
 export function outstanding(
 	questions: Questions,
-): Array<{ id: string; definition: Definition; widget?: string }> {
+): Array<{ id: string; definition: DecisionDefinition; widget?: string }> {
 	return [...questions.open.values()].map(entry => ({
 		id: entry.id,
 		definition: entry.definition,
@@ -175,7 +177,7 @@ export function outstanding(
 export type Opened =
 	| {
 		open: true;
-		definition: Definition;
+		definition: DecisionDefinition;
 		model: number[];
 		revision: number;
 		presence: Collaborator[];

--- a/e2e/responsive-decisions.e2e.ts
+++ b/e2e/responsive-decisions.e2e.ts
@@ -3,7 +3,6 @@ import { storedQuestion } from "../apps/server/src/testing/plan";
 import { expectInsideViewport, expectNoHorizontalOverflow } from "./responsive";
 import { installVisualViewport, setVisualViewport } from "./visual-viewport";
 
-const LONG_WIDGET = "01K0N500000000000000000001";
 const LONG_QUESTIONS = [
 	{
 		id: "01K0N500000000000000000002",
@@ -37,39 +36,42 @@ const LONG_QUESTIONS = [
 	})),
 ];
 
-const LONG_DEFINITION = { questions: LONG_QUESTIONS };
-const LONG_QUESTIONNAIRE = `<Questionnaire id="${LONG_WIDGET}" by="ana">
+const LONG_WIDGETS = LONG_QUESTIONS.map((_, index) =>
+	`01K0N4${String(index + 1).padStart(20, "0")}`
+);
+const LONG_QUESTIONNAIRES = LONG_QUESTIONS.map((question, index) =>
+	`<Questionnaire id="${LONG_WIDGETS[index]}" by="ana">
+<Question id="${question.id}" header="${question.header}" prompt="${question.question}" multiple="false">
 ${
-	LONG_QUESTIONS.map(question =>
-		`<Question id="${question.id}" header="${question.header}" prompt="${question.question}" multiple="false">
-${
-			question.options.map(option =>
-				`<Option id="${option.id}" label="${option.label}"${
-					option.description ? ` description="${option.description}"` : ""
-				} />`
-			).join("\n")
-		}
-</Question>`
-	).join("\n")
-}
-</Questionnaire>
-`;
+		question.options.map(option =>
+			`<Option id="${option.id}" label="${option.label}"${
+				option.description ? ` description="${option.description}"` : ""
+			} />`
+		).join("\n")
+	}
+</Question>
+</Questionnaire>`
+).join("\n");
 
 function questionnaire(page: import("@playwright/test").Page) {
 	return page.locator('[data-document-view="decisions"] article[data-plan-sidecar-questionnaire]');
 }
 
 for (let viewport of [{ width: 320, height: 568 }, { width: 390, height: 844 }]) {
-	test(`long coarse decisions preserve drafts and focus at ${viewport.width}x${viewport.height}`, async ({ baseURL, browser, room, seed }) => {
-		await seed(LONG_QUESTIONNAIRE, {
+	test(`long independent decisions preserve drafts and focus at ${viewport.width}x${viewport.height}`, async ({ baseURL, browser, room, seed }) => {
+		await seed(LONG_QUESTIONNAIRES, {
 			revision: 1,
-			openQuestions: [{
-				definition: LONG_DEFINITION,
-				id: LONG_WIDGET,
-				model: storedQuestion(LONG_DEFINITION),
-				revision: 0,
-				widget: LONG_WIDGET,
-			}],
+			openQuestions: LONG_QUESTIONS.map((question, index) => {
+				let definition = { questions: [question] };
+				let id = LONG_WIDGETS[index]!;
+				return {
+					definition,
+					id,
+					model: storedQuestion(definition),
+					revision: 0,
+					widget: id,
+				};
+			}),
 		});
 		let context = await browser.newContext({ baseURL, hasTouch: true, isMobile: true, viewport });
 		try {
@@ -102,57 +104,16 @@ for (let viewport of [{ width: 320, height: 568 }, { width: 390, height: 844 }])
 			expect(firstChoiceBox!.height).toBeGreaterThanOrEqual(18);
 			await firstLabel.click();
 			await expect(firstChoice).toBeChecked();
-			await expect(card.getByText("5 unanswered", { exact: false })).toBeVisible();
 
-			let tabs = card.getByRole("tablist", { name: "Questions" });
-			let tabTargets = tabs.getByRole("tab");
-			expect(await tabTargets.count()).toBe(LONG_QUESTIONS.length);
-			for (
-				let box of await tabTargets.evaluateAll(nodes =>
-					nodes.map(node => node.getBoundingClientRect().height)
-				)
-			) expect(box).toBeGreaterThanOrEqual(44);
-			expect(await tabs.evaluate(node => node.scrollWidth)).toBeGreaterThan(
-				await tabs.evaluate(node => node.clientWidth),
-			);
-
-			let next = card.getByRole("button", { name: "Next" });
-			let nextBox = await next.boundingBox();
-			expect(nextBox).toBeTruthy();
-			expect(nextBox!.height).toBeGreaterThanOrEqual(44);
-			await next.click();
-			await expect(tabTargets.nth(1)).toHaveAttribute("aria-selected", "true");
-			await expect(tabTargets.nth(1)).toBeFocused();
-			let secondChoice = card.getByRole("radio", { name: "Its current state" });
-			await card.getByText("Its current state", { exact: true }).click();
+			let second = questionnaire(page).filter({ hasText: LONG_QUESTIONS[1]!.header });
+			let secondChoice = second.getByRole("radio", { name: "Its current state" });
+			await second.getByText("Its current state", { exact: true }).click();
 			await expect(secondChoice).toBeChecked();
-			await expect(card.getByText("4 unanswered", { exact: false })).toBeVisible();
-
-			await card.getByRole("button", { name: "Back" }).click();
-			await expect(tabTargets.first()).toHaveAttribute("aria-selected", "true");
-			await expect(tabTargets.first()).toBeFocused();
 			await expect(firstChoice).toBeChecked();
 
-			await card.getByRole("button", { name: "Next" }).click();
-			await expect(tabTargets.nth(1)).toBeFocused();
-			await expect(secondChoice).toBeChecked();
-			for (let index = 2; index < LONG_QUESTIONS.length; index++) {
-				await card.getByRole("button", { name: "Next" }).click();
-				await expect(tabTargets.nth(index)).toHaveAttribute("aria-selected", "true");
-				await expect(tabTargets.nth(index)).toBeFocused();
-			}
-			await expect.poll(() =>
-				tabTargets.last().evaluate(node => {
-					let tab = node.getBoundingClientRect();
-					let list = node.parentElement!.getBoundingClientRect();
-					return tab.left >= list.left && tab.right <= list.right;
-				})
-			).toBe(true);
-
 			let actions = [
-				card.getByRole("button", { name: "Back" }),
 				card.getByRole("button", { name: "Cancel" }),
-				card.getByRole("button", { name: "Submit" }),
+				card.getByRole("button", { name: "Save answer" }),
 			];
 			for (let action of actions) {
 				await action.scrollIntoViewIfNeeded();
@@ -175,7 +136,6 @@ for (let viewport of [{ width: 320, height: 568 }, { width: 390, height: 844 }])
 					.getByRole("button", { name: /Decisions, 8 unanswered/ }),
 			).toBeVisible();
 
-			await tabTargets.first().click();
 			let customChoice = card.getByRole("radio", { name: "Write a custom answer" });
 			await customChoice.focus();
 			await page.keyboard.press("Space");

--- a/e2e/responsive-decisions.e2e.ts
+++ b/e2e/responsive-decisions.e2e.ts
@@ -87,6 +87,7 @@ for (let viewport of [{ width: 320, height: 568 }, { width: 390, height: 844 }])
 			await page.goto(`/channels/${room}`);
 			let card = questionnaire(page).filter({ hasText: LONG_QUESTIONS[0]!.header });
 			await expect(card).toBeVisible();
+			await expect(card.getByRole("textbox", { name: /Custom answer for/ })).toHaveCount(0);
 			await expectNoHorizontalOverflow(page);
 
 			let firstChoice = card.getByRole("radio", { name: "Use the compact layout" });
@@ -175,8 +176,11 @@ for (let viewport of [{ width: 320, height: 568 }, { width: 390, height: 844 }])
 			).toBeVisible();
 
 			await tabTargets.first().click();
+			let customChoice = card.getByRole("radio", { name: "Write a custom answer" });
+			await customChoice.focus();
+			await page.keyboard.press("Space");
 			let custom = card.getByRole("textbox", { name: /Custom answer for/ });
-			await custom.focus();
+			await expect(custom).toBeFocused();
 			await setVisualViewport(page, { event: "resize", height: 360 });
 			await expect.poll(() =>
 				custom.evaluate(node => {

--- a/e2e/sidecar.e2e.ts
+++ b/e2e/sidecar.e2e.ts
@@ -425,9 +425,9 @@ test("decision cards save independently with progressive custom answers", async 
 
 	await expect(storage.getByRole("textbox", { name: /Custom answer for/ })).toHaveCount(0);
 	await expect(scope.getByRole("textbox", { name: /Custom answer for/ })).toHaveCount(0);
-	await expect(saveStorage.locator("svg")).toHaveAttribute("aria-hidden", "true");
-	await expect(saveStorage.locator('svg path[d^="M232.49,80.49"]'))
-		.toHaveCount(1);
+	let check = saveStorage.locator('svg[data-plan-icon="check"]');
+	await expect(check).toHaveCount(1);
+	await expect(check).toHaveAttribute("aria-hidden", "true");
 
 	await storage.getByRole("radio", { name: /On disk as MDX/ }).check();
 	await saveStorage.click();

--- a/e2e/sidecar.e2e.ts
+++ b/e2e/sidecar.e2e.ts
@@ -415,38 +415,62 @@ test("an unanswered inline decision is also shown in Decisions and can be focuse
 	).toBeFocused();
 });
 
-test("saving one decision leaves another unanswered", async ({ join, seed }) => {
+test("decision cards save independently with progressive custom answers", async ({ join, seed }) => {
 	await seed(PROSE);
 	let page = await join("ana");
 	await page.getByRole("button", { name: /^Decisions/ }).click();
 	let storage = questionnaire(page).filter({ has: page.getByRole("heading", { name: "Storage" }) });
 	let scope = questionnaire(page).filter({ has: page.getByRole("heading", { name: "Scope" }) });
+	let saveStorage = storage.getByRole("button", { name: "Save answer" });
+
+	await expect(storage.getByRole("textbox", { name: /Custom answer for/ })).toHaveCount(0);
+	await expect(scope.getByRole("textbox", { name: /Custom answer for/ })).toHaveCount(0);
+	await expect(saveStorage.locator("svg")).toHaveAttribute("aria-hidden", "true");
+	await expect(saveStorage.locator('svg path[d^="M232.49,80.49"]'))
+		.toHaveCount(1);
 
 	await storage.getByRole("radio", { name: /On disk as MDX/ }).check();
-	await storage.getByRole("button", { name: "Save" }).click();
+	await saveStorage.click();
 	await expect(scope).toBeVisible();
 	await expect(scope).toBeFocused();
-	await expect(scope.getByRole("button", { name: "Save" })).toBeVisible();
+	await expect(scope.getByRole("button", { name: "Save answer" })).toBeVisible();
 	await expect(scope).not.toContainText("Answered by");
+	await expect(scope.getByRole("checkbox", { name: "Anchors" })).not.toBeChecked();
 
 	await page.getByRole("button", { name: "1 resolved" }).click();
 	let resolved = questionnaire(page).filter({ hasText: "Where should room state live?" });
 	await expect(resolved).toContainText("On disk as MDX");
 	await expect(resolved).toContainText("Answered by @ana");
-	await expect(resolved.getByRole("button", { name: "Save" })).toHaveCount(0);
+	await expect(resolved.getByRole("button", { name: "Save answer" })).toHaveCount(0);
+
+	let customChoice = scope.getByRole("checkbox", { name: "Write a custom answer" });
+	await customChoice.focus();
+	await page.keyboard.press("Space");
+	let custom = scope.getByRole("textbox", { name: "Custom answer for Scope" });
+	await expect(custom).toBeFocused();
+	await scope.getByRole("button", { name: "Save answer" }).click();
+	await expect(scope.getByRole("alert")).toHaveText("Scope requires a custom answer");
+	await custom.fill("Only collaborative anchors");
+	await scope.getByRole("checkbox", { name: "Anchors" }).check();
+	await expect(custom).toHaveCount(0);
+	await customChoice.check();
+	custom = scope.getByRole("textbox", { name: "Custom answer for Scope" });
+	await expect(custom).toHaveValue("Only collaborative anchors");
+	await expect(custom).toBeFocused();
+	await scope.getByRole("button", { name: "Save answer" }).click();
+	await expect(questionnaire(page).filter({ hasText: "Which of these belong in the first cut?" }))
+		.toContainText("Only collaborative anchors");
 });
 
-test("an unanswered question refuses to submit and says which", async ({ join, seed }) => {
+test("an unanswered decision reports its own validation error", async ({ join, seed }) => {
 	await seed(PROSE);
 	let page = await join("ana");
 	await page.getByRole("button", { name: /^Decisions/ }).click();
 	let card = questionnaire(page).filter({ has: page.getByRole("heading", { name: "Scope" }) });
 
-	await card.getByRole("button", { name: "Save" }).click();
+	await card.getByRole("button", { name: "Save answer" }).click();
 
-	await expect(card.getByRole("alert")).toHaveText(
-		"Every question needs an answer before submitting.",
-	);
+	await expect(card.getByRole("alert")).toHaveText("Scope requires an answer");
 	await expect(card).not.toContainText("Answered by");
 });
 
@@ -460,7 +484,7 @@ test("cancelling asks first", async ({ join, seed }) => {
 
 	await expect(card).toContainText("Cancel without answering?");
 	await card.getByRole("button", { name: "Keep it" }).click();
-	await expect(card.getByRole("button", { name: "Save" })).toBeVisible();
+	await expect(card.getByRole("button", { name: "Save answer" })).toBeVisible();
 });
 
 test("a marked passage has document chrome with a hover preview", async ({ join, seed }) => {

--- a/packages/editor/src/widgets/questionnaire.test.tsx
+++ b/packages/editor/src/widgets/questionnaire.test.tsx
@@ -3,6 +3,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { QuestionView } from "@chopin/question/react";
+import { QuestionnaireCard } from "./questionnaire";
 
 const SINGLE = {
 	questions: [{
@@ -24,7 +25,9 @@ test("a single decision renders as a saveable card without tabs", () => {
 	);
 
 	expect(markup).toContain("Decision");
-	expect(markup).toContain("Save");
+	expect(markup).toContain("Save answer");
+	expect(markup).toContain('data-plan-icon="check"');
+	expect(markup).toContain('aria-hidden="true"');
 	expect(markup).not.toContain('role="tablist"');
 });
 
@@ -50,4 +53,33 @@ test("a stored multi-question questionnaire keeps its tabbed compatibility view"
 
 	expect(markup).toContain('role="tablist"');
 	expect(markup).toContain("Scope");
+});
+
+test("a stored unanswered questionnaire keeps its compatibility view without a live record", () => {
+	let markup = renderToStaticMarkup(
+		createElement(QuestionnaireCard, {
+			value: {
+				id: "01K0N4TR8K7JGM4R1J7PW4R8YJ",
+				questions: [
+					{
+						id: "storage",
+						header: "Storage",
+						prompt: "Where should room state live?",
+						multiple: false,
+						options: [{ id: "mdx", label: "MDX on disk" }],
+					},
+					{
+						id: "scope",
+						header: "Scope",
+						prompt: "What belongs in the first cut?",
+						multiple: true,
+						options: [{ id: "anchors", label: "Anchors" }],
+					},
+				],
+			},
+		}),
+	);
+
+	expect(markup).toContain('role="tablist"');
+	expect(markup).not.toContain("Save answer");
 });

--- a/packages/protocol/question.d.ts
+++ b/packages/protocol/question.d.ts
@@ -49,6 +49,11 @@ export declare namespace Question {
 		questions: Item[];
 	};
 
+	/** One independently persisted decision card. */
+	export type DecisionDefinition = {
+		questions: [Item];
+	};
+
 	/**
 	 * One question's answer, as it exists while being decided.
 	 *
@@ -96,14 +101,14 @@ export declare namespace Question {
 	/** A new questionnaire, announced to the room. */
 	export type Asked = KIND<"question:asked"> & {
 		id: string;
-		definition: Definition;
+		definition: DecisionDefinition;
 		/** Present once the questionnaire has a node in the plan. */
 		widget?: string;
 	};
 
 	/** Every open questionnaire, sent when a client joins. */
 	export type Sync = KIND<"question:sync"> & {
-		open: Array<{ id: string; definition: Definition; widget?: string }>;
+		open: Array<{ id: string; definition: DecisionDefinition; widget?: string }>;
 	};
 
 	export namespace Open {
@@ -114,7 +119,7 @@ export declare namespace Question {
 			& (
 				| {
 					open: true;
-					definition: Definition;
+					definition: DecisionDefinition;
 					/** json-joy model, as bytes. */
 					model: number[];
 					revision: number;

--- a/packages/question/src/index.ts
+++ b/packages/question/src/index.ts
@@ -12,8 +12,8 @@
 
 export * as limits from "./limits";
 
-export { assertCallId, normalize, QuestionError, reject } from "./schema";
-export type { Answer, Definition, Item, Option } from "./schema";
+export { assertCallId, decision, normalize, QuestionError, reject } from "./schema";
+export type { Answer, DecisionDefinition, Definition, Item, Option } from "./schema";
 
 export { answered, apply, assertPatch, create, read, restore } from "./draft";
 export type { Applied, Draft, Drafts, Mode, Model } from "./draft";

--- a/packages/question/src/react/question-view.test.ts
+++ b/packages/question/src/react/question-view.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+
+import { currentQuestion } from "./question-view";
+
+test("a replacement definition falls back before rendering when its active question disappears", () => {
+	let storage = {
+		id: "storage",
+		header: "Storage",
+		question: "Where should room state live?",
+		multiple: false,
+		options: [],
+	};
+	let scope = {
+		id: "scope",
+		header: "Scope",
+		question: "What belongs in the first cut?",
+		multiple: false,
+		options: [],
+	};
+
+	expect(currentQuestion({ questions: [storage, scope] }, "removed")).toBe(storage);
+});

--- a/packages/question/src/react/question-view.tsx
+++ b/packages/question/src/react/question-view.tsx
@@ -57,6 +57,13 @@ export type QuestionViewProps = {
 	aside?: ReactNode;
 };
 
+export function currentQuestion(
+	definition: Definition,
+	active: string | undefined,
+): Item {
+	return definition.questions.find(question => question.id === active) ?? definition.questions[0]!;
+}
+
 function Badges({ people }: { people: Collaborator[] }) {
 	if (people.length === 0) return null;
 	return (
@@ -358,21 +365,14 @@ export function QuestionView(props: QuestionViewProps) {
 
 	let base = useId();
 	let single = definition.questions.length === 1;
-	let [active, setActive] = useState(() => definition.questions[0]?.id);
+	let [selected, setActive] = useState(() => definition.questions[0]?.id);
+	let current = currentQuestion(definition, selected);
+	let active = current.id;
+	if (active !== selected) setActive(active);
 	// Cancelling cannot be undone and the agent is waiting, so it takes a
 	// second, deliberate click rather than a modal nobody reads.
 	let [confirming, setConfirming] = useState(false);
 	let tabs = useRef<HTMLDivElement>(null);
-
-	// A question can disappear if the definition is replaced; fall back rather
-	// than rendering an empty panel.
-	useEffect(() => {
-		setActive(current =>
-			definition.questions.some(question => question.id === current)
-				? current
-				: definition.questions[0]?.id
-		);
-	}, [definition]);
 
 	useEffect(() => {
 		if (!active) return;
@@ -429,7 +429,6 @@ export function QuestionView(props: QuestionViewProps) {
 	}
 
 	let multiple = !single;
-	let current = definition.questions.find(question => question.id === active);
 	let index = definition.questions.findIndex(question => question.id === active);
 	let last = index === definition.questions.length - 1;
 	let unanswered = definition.questions.filter(question => !answered(question, drafts[question.id]))

--- a/packages/question/src/react/question-view.tsx
+++ b/packages/question/src/react/question-view.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useCallback, useEffect, useId, useRef, useState } from "react";
-import { FloppyDiskIcon, ShuffleSimpleIcon, XIcon } from "@phosphor-icons/react";
+import { CheckIcon, ShuffleSimpleIcon, XIcon } from "@phosphor-icons/react";
 
 import { answered } from "../draft";
 
@@ -151,6 +151,13 @@ function Custom(
 ) {
 	let active = draft?.mode === "custom";
 	let textarea = useRef<HTMLTextAreaElement>(null);
+	let focusOnReveal = useRef(false);
+
+	useEffect(() => {
+		if (!active || !focusOnReveal.current) return;
+		focusOnReveal.current = false;
+		textarea.current?.focus();
+	}, [active]);
 
 	useEffect(() => {
 		let viewport = window.visualViewport;
@@ -180,25 +187,28 @@ function Custom(
 					name={question.multiple ? undefined : name}
 					checked={active}
 					disabled={disabled}
-					onChange={event =>
-						onChange?.({ mode: event.currentTarget.checked ? "custom" : "choices" })}
+					onChange={event => {
+						focusOnReveal.current = event.currentTarget.checked;
+						onChange?.({ mode: event.currentTarget.checked ? "custom" : "choices" });
+					}}
 					className="mt-0.5 size-[18px] shrink-0 choice-control"
 				/>
 				<span className="font-medium">Write a custom answer</span>
 			</label>
 
-			<textarea
-				rows={2}
-				maxLength={4000}
-				value={draft?.custom ?? ""}
-				disabled={disabled}
-				aria-label={`Custom answer for ${question.header}`}
-				placeholder="Type another answer"
-				onFocus={() => onChange?.({ mode: "custom" })}
-				onChange={event => onChange?.({ mode: "custom", custom: event.currentTarget.value })}
-				className="question-custom-answer field mt-1.5 min-h-16 w-full resize-y px-2.5 py-2 text-sm transition placeholder:text-text-tertiary disabled:cursor-not-allowed"
-				ref={textarea}
-			/>
+			{active && (
+				<textarea
+					rows={2}
+					maxLength={4000}
+					value={draft?.custom ?? ""}
+					disabled={disabled}
+					aria-label={`Custom answer for ${question.header}`}
+					placeholder="Type another answer"
+					onChange={event => onChange?.({ custom: event.currentTarget.value })}
+					className="question-custom-answer field mt-1.5 min-h-16 w-full resize-y px-2.5 py-2 text-sm transition placeholder:text-text-tertiary disabled:cursor-not-allowed"
+					ref={textarea}
+				/>
+			)}
 		</div>
 	);
 }
@@ -621,8 +631,10 @@ export function QuestionView(props: QuestionViewProps) {
 							disabled={disabled || submitting}
 							className="btn btn-sm btn-primary"
 						>
-							<FloppyDiskIcon aria-hidden="true" size={16} weight="bold" />
-							{submitting ? (single ? "Saving…" : "Submitting…") : (single ? "Save" : "Submit")}
+							<CheckIcon aria-hidden="true" size={16} weight="bold" />
+							{submitting
+								? (single ? "Saving…" : "Submitting…")
+								: (single ? "Save answer" : "Submit")}
 						</button>
 					)}
 				</footer>

--- a/packages/question/src/react/question-view.tsx
+++ b/packages/question/src/react/question-view.tsx
@@ -631,7 +631,12 @@ export function QuestionView(props: QuestionViewProps) {
 							disabled={disabled || submitting}
 							className="btn btn-sm btn-primary"
 						>
-							<CheckIcon aria-hidden="true" size={16} weight="bold" />
+							<CheckIcon
+								aria-hidden="true"
+								data-plan-icon="check"
+								size={16}
+								weight="bold"
+							/>
 							{submitting
 								? (single ? "Saving…" : "Submitting…")
 								: (single ? "Save answer" : "Submit")}

--- a/packages/question/src/react/use-questionnaire.test.ts
+++ b/packages/question/src/react/use-questionnaire.test.ts
@@ -17,7 +17,24 @@ const DEFINITION = normalize({
 	}],
 });
 
-function transport() {
+const QUESTIONNAIRE = normalize({
+	questions: [
+		{
+			header: "Rollout",
+			question: "How should we deploy?",
+			multiple: false,
+			options: [{ label: "Canary", description: "Small percentage first." }],
+		},
+		{
+			header: "Timing",
+			question: "When should we deploy?",
+			multiple: false,
+			options: [{ label: "Tomorrow", description: "" }],
+		},
+	],
+});
+
+function transport(definition = DEFINITION) {
 	let opens = 0;
 	let edits = 0;
 	let submits = 0;
@@ -25,7 +42,7 @@ function transport() {
 	let submitRevisions: number[] = [];
 	let presence = 0;
 	let handlers = new Map<string, Set<(event: never) => void>>();
-	let model = create(DEFINITION);
+	let model = create(definition);
 
 	let value = {
 		async ask(kind: string, payload: Record<string, unknown>) {
@@ -33,7 +50,7 @@ function transport() {
 				opens++;
 				return {
 					open: true,
-					definition: DEFINITION,
+					definition,
 					model: [...model.toBinary()],
 					revision: 0,
 					presence: [],
@@ -74,6 +91,22 @@ function transport() {
 }
 
 describe("QuestionnaireController", () => {
+	it("rejects a questionnaire returned for an independent decision record", async () => {
+		let bridge = transport(QUESTIONNAIRE);
+		let controller = new QuestionnaireController(
+			bridge.value,
+			"question-1",
+			QUESTIONNAIRE,
+			true,
+		);
+		let off = controller.subscribe(() => {});
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		expect(controller.getSnapshot().error).toBe("Unable to sync shared answers.");
+		expect(bridge.submits()).toBe(0);
+		off();
+	});
+
 	it("gives two surfaces one model, one open and one presence lifecycle", async () => {
 		let bridge = transport();
 		let controller = new QuestionnaireController(bridge.value, "question-1", DEFINITION, true);

--- a/packages/question/src/react/use-questionnaire.test.ts
+++ b/packages/question/src/react/use-questionnaire.test.ts
@@ -21,6 +21,7 @@ function transport() {
 	let opens = 0;
 	let edits = 0;
 	let submits = 0;
+	let submitIds: string[] = [];
 	let submitRevisions: number[] = [];
 	let presence = 0;
 	let handlers = new Map<string, Set<(event: never) => void>>();
@@ -44,6 +45,7 @@ function transport() {
 			}
 			if (kind === "question:submit") {
 				submits++;
+				submitIds.push(payload.id as string);
 				submitRevisions.push(payload.revision as number);
 				return { ok: true };
 			}
@@ -65,6 +67,7 @@ function transport() {
 		opens: () => opens,
 		edits: () => edits,
 		submits: () => submits,
+		submitIds: () => submitIds,
 		submitRevisions: () => submitRevisions,
 		presence: () => presence,
 	};
@@ -125,6 +128,40 @@ describe("QuestionnaireController", () => {
 		expect(bridge.edits()).toBe(2);
 		expect(bridge.submitRevisions()).toEqual([2]);
 		off();
+	});
+
+	it("keeps validation inside the card being saved", async () => {
+		let bridge = transport();
+		let controller = new QuestionnaireController(bridge.value, "question-1", DEFINITION, true);
+		let off = controller.subscribe(() => {});
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		controller.submit();
+
+		expect(bridge.submits()).toBe(0);
+		expect(controller.getSnapshot().focus).toBe("q0");
+		expect(controller.getSnapshot().error).toBe("Rollout requires an answer");
+		off();
+	});
+
+	it("persists one card without changing its unanswered sibling", async () => {
+		let bridge = transport();
+		let first = new QuestionnaireController(bridge.value, "first", DEFINITION, true);
+		let sibling = new QuestionnaireController(bridge.value, "sibling", DEFINITION, true);
+		let offFirst = first.subscribe(() => {});
+		let offSibling = sibling.subscribe(() => {});
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		first.change("q0", { choice: "o0" });
+		first.submit();
+		await new Promise(resolve => setTimeout(resolve, 10));
+
+		expect(bridge.submitIds()).toEqual(["first"]);
+		expect(sibling.getSnapshot().drafts.q0?.choice).toBeNull();
+		expect(sibling.getSnapshot().error).toBeUndefined();
+		expect(sibling.getSnapshot().submitting).toBe(false);
+		offFirst();
+		offSibling();
 	});
 
 	it("does not restart transport during a Strict Mode subscribe cycle", async () => {

--- a/packages/question/src/react/use-questionnaire.ts
+++ b/packages/question/src/react/use-questionnaire.ts
@@ -12,9 +12,11 @@
 
 import { useEffect, useRef, useSyncExternalStore } from "react";
 
-import { answered, crdt } from "../draft";
+import { derive } from "../answer";
+import { crdt } from "../draft";
+import { decision } from "../schema";
 
-import type { Definition, Drafts } from "../index";
+import type { DecisionDefinition, Definition, Drafts } from "../index";
 import type { Collaborator } from "./question-view";
 
 type Unsubscribe = () => void;
@@ -71,6 +73,7 @@ export class QuestionnaireController {
 	#listeners = new Set<() => void>();
 	#teardown: Unsubscribe[] = [];
 	#model: Model | undefined;
+	#definition: DecisionDefinition | undefined;
 	#revision = 0;
 	#outbox: number[][] = [];
 	#pending = Promise.resolve();
@@ -160,26 +163,18 @@ export class QuestionnaireController {
 	};
 
 	submit = (): void => {
-		let definition = this.#snapshot.definition;
+		let definition = this.#definition;
 		let doc = this.#model;
 		if (
 			!this.bridge || !definition || !doc || this.#snapshot.closed || this.#terminal
 			|| this.#snapshot.submitting
 		) return;
 
-		// The server gives each durable decision its own controller and record.
-		// Validate that card only: unanswered sibling cards have independent
-		// controllers and must not block this save.
-		let question = definition.questions[0];
-		let draft = question ? (doc.view() as Drafts)[question.id] : undefined;
-		if (!question || !answered(question, draft)) {
+		let outcome = derive(definition, doc.view() as Drafts);
+		if (!outcome.ok) {
 			this.#set({
-				focus: question?.id,
-				error: question
-					? (draft?.mode === "custom"
-						? `${question.header} requires a custom answer`
-						: `${question.header} requires an answer`)
-					: "This decision requires an answer",
+				focus: outcome.question,
+				error: outcome.message,
 			});
 			return;
 		}
@@ -269,6 +264,7 @@ export class QuestionnaireController {
 		this.#generation++;
 		for (let off of this.#teardown.splice(0)) off();
 		this.#model = undefined;
+		this.#definition = undefined;
 		if (presence && this.bridge && this.#connected) {
 			this.bridge.send("question:presence", { id: this.id });
 		}
@@ -344,6 +340,13 @@ export class QuestionnaireController {
 
 		if (!this.#valid(generation)) return;
 		if (!reply.open) return this.#close();
+		let definition: DecisionDefinition;
+		try {
+			definition = decision(reply.definition!);
+		} catch {
+			this.#set({ syncing: false, error: "Unable to sync shared answers." });
+			return;
+		}
 
 		let doc = crdt.Model
 			.fromBinary<crdt.JsonNode<Drafts>>(new Uint8Array(reply.model!))
@@ -396,10 +399,11 @@ export class QuestionnaireController {
 
 		this.#teardown.push(offChanges);
 		this.#model = doc;
+		this.#definition = definition;
 		for (let patch of this.#outbox) send(patch);
 
 		this.#set({
-			definition: reply.definition,
+			definition,
 			drafts: doc.view() as Drafts,
 			collaborators: (reply.presence ?? []).map(normalize),
 			syncing: false,

--- a/packages/question/src/react/use-questionnaire.ts
+++ b/packages/question/src/react/use-questionnaire.ts
@@ -12,8 +12,7 @@
 
 import { useEffect, useRef, useSyncExternalStore } from "react";
 
-import { incomplete } from "../answer";
-import { crdt } from "../draft";
+import { answered, crdt } from "../draft";
 
 import type { Definition, Drafts } from "../index";
 import type { Collaborator } from "./question-view";
@@ -168,12 +167,19 @@ export class QuestionnaireController {
 			|| this.#snapshot.submitting
 		) return;
 
-		let drafts = doc.view() as Drafts;
-		let missing = incomplete(definition, drafts);
-		if (missing) {
+		// The server gives each durable decision its own controller and record.
+		// Validate that card only: unanswered sibling cards have independent
+		// controllers and must not block this save.
+		let question = definition.questions[0];
+		let draft = question ? (doc.view() as Drafts)[question.id] : undefined;
+		if (!question || !answered(question, draft)) {
 			this.#set({
-				focus: missing,
-				error: "Every question needs an answer before submitting.",
+				focus: question?.id,
+				error: question
+					? (draft?.mode === "custom"
+						? `${question.header} requires a custom answer`
+						: `${question.header} requires an answer`)
+					: "This decision requires an answer",
 			});
 			return;
 		}

--- a/packages/question/src/react/use-questionnaire.ts
+++ b/packages/question/src/react/use-questionnaire.ts
@@ -445,7 +445,6 @@ export type QuestionnaireOptions = {
 	bridge: Transport | undefined;
 	connected: boolean;
 	definition?: Definition;
-	onResolved?: () => void;
 };
 
 export function useQuestionnaire(options: QuestionnaireOptions): QuestionnaireState {
@@ -477,10 +476,6 @@ export function useQuestionnaire(options: QuestionnaireOptions): QuestionnaireSt
 	useEffect(() => {
 		controller.configure(options.definition, options.connected);
 	}, [controller, options.connected, options.definition]);
-
-	useEffect(() => {
-		if (snapshot.closed) options.onResolved?.();
-	}, [snapshot.closed, options.onResolved]);
 
 	return {
 		definition: snapshot.definition,

--- a/packages/question/src/schema.ts
+++ b/packages/question/src/schema.ts
@@ -14,6 +14,7 @@ import type { Question } from "@chopin/protocol";
 export type Option = Question.Option;
 export type Item = Question.Item;
 export type Definition = Question.Definition;
+export type DecisionDefinition = Question.DecisionDefinition;
 export type Answer = Question.Answer;
 
 /** Thrown for any malformed definition; the message reaches the agent. */
@@ -118,6 +119,14 @@ export function normalize(raw: unknown): Definition {
 	Object.freeze(questions);
 
 	return Object.freeze({ questions });
+}
+
+/** Narrow a questionnaire to the shape owned by one durable decision card. */
+export function decision(definition: Definition): DecisionDefinition {
+	if (definition.questions.length !== 1) {
+		fail("A decision record must contain exactly one question");
+	}
+	return definition as DecisionDefinition;
 }
 
 /** Reject a tool call id that could not have come from the SDK. */


### PR DESCRIPTION
## Summary

- validate and persist only the decision card being saved, leaving unanswered sibling cards untouched
- reveal and focus the custom-answer field only after explicit selection while preserving its local draft across mode changes
- replace the floppy affordance with the decorative Phosphor Check icon while retaining the accessible `Save answer` name

## Before / after

Before, a card-local Save could report `Every question needs an answer before submitting`, and every card exposed a custom textarea. The original contradiction is captured in the [design audit](https://github.com/githubnext/chopin/blob/maggie/design-audit/docs/design-audit/annotated/02-decision-workflow.png).

After, validation errors stay within and name the affected card; saving one card does not validate, submit, or visually change its sibling; and custom input appears only in custom mode with keyboard focus.

## Verification

- `bun test` — 855 passed, 2 database-dependent skips, 0 failed
- `bun run types`
- `bun run ci`
- `bun run build`
- focused decision-card browser coverage — 4 passed
- full browser suite — 174 passed
