### PR TITLE
Fix narrow rich-content containment

### DIFF
--- a/e2e/responsive-content.e2e.ts
+++ b/e2e/responsive-content.e2e.ts
@@ -161,11 +161,86 @@ async function expectOwnScroller(
 	name: string,
 	surface: ReturnType<Page["locator"]>,
 ): Promise<void> {
+	await expect(surface.first(), `${name} must be rendered`).toBeAttached();
 	expect(await surface.count(), `${name} must be rendered`).toBeGreaterThan(0);
 	expect(
 		await surface.evaluateAll(nodes => nodes.every(node => node.scrollWidth > node.clientWidth)),
 		`${name} must overflow internally`,
 	).toBe(true);
+}
+
+async function expectHorizontalScroll(
+	name: string,
+	surface: ReturnType<Page["locator"]>,
+): Promise<void> {
+	await surface.first().evaluate(node => {
+		node.scrollLeft = node.scrollWidth;
+	});
+	await expect.poll(
+		() => surface.first().evaluate(node => node.scrollLeft),
+		{ message: `${name} must allow its hidden content to be reached` },
+	).toBeGreaterThan(0);
+}
+
+async function expectPerceptibleHorizontalOverflow(
+	name: string,
+	surface: ReturnType<Page["locator"]>,
+): Promise<void> {
+	await expectOwnScroller(name, surface);
+	let geometry = await surface.evaluateAll(nodes =>
+		nodes.map(node => {
+			let style = getComputedStyle(node);
+			return {
+				overflow: style.overflowX,
+				thumb: getComputedStyle(node, "::-webkit-scrollbar-thumb").backgroundColor,
+				track: Number.parseFloat(getComputedStyle(node, "::-webkit-scrollbar").height),
+			};
+		})
+	);
+	expect(
+		geometry.every(value =>
+			value.overflow === "auto" && value.track >= 6
+			&& value.thumb !== "rgba(0, 0, 0, 0)" && value.thumb !== "transparent"
+		),
+		`${name} must expose a persistent horizontal overflow affordance (${JSON.stringify(geometry)})`,
+	).toBe(true);
+}
+
+async function expectWrapped(name: string, surface: ReturnType<Page["locator"]>): Promise<void> {
+	let geometry = await surface.evaluate(node => {
+		let style = getComputedStyle(node);
+		let line = Number.parseFloat(style.lineHeight);
+		let box = node.getBoundingClientRect();
+		let documentBox = node.closest("[data-plan-scroll]")!.getBoundingClientRect();
+		return {
+			height: box.height,
+			inside: box.left >= documentBox.left && box.right <= documentBox.right,
+			line,
+		};
+	});
+	expect(geometry.inside, `${name} must stay inside the document`).toBe(true);
+	expect(geometry.height, `${name} must wrap onto more than one line`).toBeGreaterThan(
+		geometry.line * 1.5,
+	);
+}
+
+async function expectTabInsideStrip(tab: ReturnType<Page["getByRole"]>) {
+	await expect.poll(() =>
+		tab.evaluate(node => {
+			let strip = node.closest('[role="tablist"]')!.getBoundingClientRect();
+			let box = node.getBoundingClientRect();
+			return box.left >= strip.left - 1 && box.right <= strip.right + 1;
+		})
+	).toBe(true);
+}
+
+async function selectLastTab(tabs: ReturnType<Page["getByRole"]>) {
+	await tabs.first().focus();
+	await tabs.first().press("End");
+	let last = tabs.last();
+	await expect(last).toHaveAttribute("aria-selected", "true");
+	await expect(last).toBeFocused();
+	await expectTabInsideStrip(last);
 }
 
 type Join = (handle: string) => Promise<Page>;
@@ -304,6 +379,82 @@ test("compact and desktop documents render the intended gutter and reading measu
 	expect(desktopGeometry.prose).toBeCloseTo(640, 0);
 	expect(desktopGeometry.content).toBeCloseTo(704, 0);
 	expect(desktopGeometry.documentLeft).toBeCloseTo(desktopGeometry.documentRight, 0);
+});
+
+for (let viewport of [{ width: 390, height: 844 }, { width: 1440, height: 900 }]) {
+	test(`${viewport.width}px keeps hostile rich content readable and navigable`, async ({ join, seed }) => {
+		await seed(RESPONSIVE_SOURCE);
+		let page = await join(`reader-${viewport.width}`, { viewport });
+		let document = content(page);
+		await expectWrapped(
+			"normal heading",
+			document.getByRole("heading", {
+				name:
+					"A deliberately detailed authored heading that must wrap at normal word boundaries inside a compact document",
+			}),
+		);
+		await expectWrapped(
+			"unbroken heading",
+			document.getByRole("heading", {
+				name:
+					"CompactDocumentMeasureMustRemainReadableWithoutForcingTheViewportWiderThanTheDocument",
+			}),
+		);
+		let code = document.locator("[data-plan-language='typescript'] [data-plan-preview] > div");
+		let table = document.locator("table");
+		if (viewport.width === 390) {
+			await expectPerceptibleHorizontalOverflow("long code line", code);
+			await expectPerceptibleHorizontalOverflow("wide table", table);
+			await expectHorizontalScroll("long code line", code);
+			await expectHorizontalScroll("wide table", table);
+		} else {
+			await expectInsideDocumentWidth("long code line", code);
+			await expectOwnScroller("wide table", table);
+		}
+
+		let strip = document.getByRole("tablist");
+		if (viewport.width === 390) await expectPerceptibleHorizontalOverflow("tab strip", strip);
+		else await expectOwnScroller("tab strip", strip);
+		await selectLastTab(strip.getByRole("tab"));
+
+		let callout = document.locator("[data-plan-type='warning']");
+		await expectInsideDocumentWidth("callout", callout);
+		await expectWrapped("callout title", callout.getByRole("textbox", { name: "Callout title" }));
+		await expectNoHorizontalOverflow(page);
+	});
+}
+
+test("reduced motion reveals a keyboard-selected tab immediately", async ({ join, seed }) => {
+	await seed(RESPONSIVE_SOURCE);
+	let page = await join("reduced-motion-reader", {
+		reducedMotion: "reduce",
+		viewport: { width: 390, height: 844 },
+	});
+	let tabs = content(page).getByRole("tablist").getByRole("tab");
+	await selectLastTab(tabs);
+});
+
+test("a selected tab follows strip layout changes without moving the document", async ({ join, seed }) => {
+	await seed(RESPONSIVE_SOURCE);
+	let page = await join("resized-tab-reader", { viewport: { width: 390, height: 844 } });
+	let scroller = page.locator("[data-plan-scroll]");
+	let tabs = content(page).getByRole("tablist").getByRole("tab");
+	await selectLastTab(tabs);
+	await scroller.evaluate(node => {
+		node.scrollTop = node.scrollHeight;
+	});
+	expect(
+		await scroller.evaluate(node => node.scrollHeight - node.clientHeight - node.scrollTop),
+	).toBeLessThanOrEqual(1);
+	await tabs.first().evaluate(node => {
+		node.textContent = "A preceding collaborative tab label that became dramatically wider";
+	});
+	await expectTabInsideStrip(tabs.last());
+	await page.setViewportSize({ width: 320, height: 844 });
+	await expectTabInsideStrip(tabs.last());
+	await expect.poll(() =>
+		scroller.evaluate(node => node.scrollHeight - node.clientHeight - node.scrollTop)
+	).toBeLessThanOrEqual(1);
 });
 
 test("narrow documents keep equal inline gutters", async ({ join, seed }) => {

--- a/e2e/responsive.ts
+++ b/e2e/responsive.ts
@@ -17,6 +17,8 @@ const TAB_FIRST = "01K0N4V4E7Y6P4MJ5WD8XZF3B2";
 const TAB_SECOND = "01K0N4W3B7P27CBAEC7A8C8WEA";
 const TAB_THIRD = "01K0N4X9ERK4P3R5AZBJ8Y0P6C";
 const TAB_FOURTH = "01K0N4Z7WH8C7H1P2Q9N4S6J3D";
+const TAB_FIFTH = "01K0N50CJW7B9ZQ4P6T8R2S5XM";
+const TAB_SIXTH = "01K0N51DNX8C0AR5Q7V9S3T6YP";
 const CALLOUT = "01K0N4Y9VG9DHBFZB6HC89E2AW";
 const LATEX_SLASH = "\\";
 
@@ -35,6 +37,10 @@ let paragraphs = Array.from(
 export const RESPONSIVE_SOURCE = `# Responsive architecture review
 
 This deliberately long opening paragraph gives the fixture comment injector enough ordinary prose to quote while a reader can still find its argument among the richer blocks below.
+
+## A deliberately detailed authored heading that must wrap at normal word boundaries inside a compact document
+
+## CompactDocumentMeasureMustRemainReadableWithoutForcingTheViewportWiderThanTheDocument
 
 The canonical reference is [TheCompleteArchitectureDecisionRecordForResponsiveWorkspaceContainmentMustWrapWithoutWideningTheDocument](https://example.com/architecture/decisions/responsive-workspace/viewport-safe-area-and-keyboard-avoidance-with-a-very-long-path-that-must-wrap-cleanly).
 
@@ -92,9 +98,19 @@ Temporary conversation still preserves the document's readable measure.
 Each wide widget owns its overflow without widening the collaborative source.
 
 </Tab>
+<Tab id="${TAB_FIFTH}" label="Focused authored destination remains visible">
+
+Keyboard focus follows the selected destination without losing the strip.
+
+</Tab>
+<Tab id="${TAB_SIXTH}" label="Reduced-motion native scrolling remains immediate">
+
+The final destination stays reachable without animated navigation.
+
+</Tab>
 </Tabs>
 
-<Callout id="${CALLOUT}" type="warning" title="EveryVisibleControlStaysInTheCompactViewportWhileItsOwnInputScrollsWithoutWideningTheDocument">
+<Callout id="${CALLOUT}" type="warning" title="Every visible control stays compact while authored content scrolls without widening the document">
 
 Every visible control and focused element stays inside the visual viewport.
 

--- a/e2e/table.e2e.ts
+++ b/e2e/table.e2e.ts
@@ -99,7 +99,7 @@ test("hovering a table raises rails on both axes", async ({ join, seed }) => {
 
 test("a wide table scrolls without losing its measured column rail", async ({ join, seed }) => {
 	await seed(WIDE_TABLE);
-	let page = await join("ana", { viewport: { width: 390, height: 844 } });
+	let page = await join("ana", { viewport: { width: 1440, height: 900 } });
 	let table = content(page).locator("table");
 
 	expect(await table.evaluate(node => node.scrollWidth > node.clientWidth)).toBe(true);
@@ -308,6 +308,62 @@ test("touch table action groups are labelled, reachable, and clear of the select
 	await openGroup(toolbar, "Remove");
 	await openGroup(toolbar, "Move");
 	await expect(page.locator("[data-plan-rail]")).not.toBeVisible();
+});
+
+test("a compact fine-pointer table keeps drag grips and actions reachable", async ({ join, seed }) => {
+	await seed(WIDE_TABLE);
+	let page = await join("ana", { viewport: { width: 390, height: 844 } });
+	let cell = content(page).locator("td").first();
+	await cell.click();
+
+	let toolbar = page.getByRole("toolbar", { name: "Table actions" });
+	await expect(toolbar).toBeVisible();
+	await expectInsideViewport(toolbar);
+	let rowRail = page.locator('[data-plan-rail="row"]');
+	let columnRail = page.locator('[data-plan-rail="column"]');
+	await expect(rowRail).toBeVisible();
+	await expect(columnRail).toBeVisible();
+	let rowGrip = grip(rowRail, "row", 2);
+	let columnGrip = grip(columnRail, "column", 1);
+	await expectInsideViewport(rowGrip);
+	await expectInsideViewport(columnGrip);
+	let rowRailBox = (await rowRail.boundingBox())!;
+	let rowGripBox = (await rowGrip.boundingBox())!;
+	let columnRailBox = (await columnRail.boundingBox())!;
+	let columnGripBox = (await columnGrip.boundingBox())!;
+	expect(rowRailBox.width).toBe(rowGripBox.width);
+	expect(columnRailBox.height).toBe(columnGripBox.height);
+	await expect(page.locator(".plan-grip-remove:visible, .plan-insert:visible, .plan-align:visible"))
+		.toHaveCount(0);
+	let controls = toolbar.getByRole("button");
+	let targets = await controls.evaluateAll(buttons =>
+		buttons.map(button => {
+			let box = button.getBoundingClientRect();
+			return { height: box.height, width: box.width };
+		})
+	);
+	expect(targets.every(target => target.height >= 44 && target.width >= 44)).toBe(true);
+	await controls.first().focus();
+	await expect(controls.first()).toBeFocused();
+	await expectInsideViewport(controls);
+	await expectNoHorizontalOverflow(page);
+});
+
+test("a compact fine-pointer grip still drags a row", async ({ join, seed }) => {
+	await seed(TABLE);
+	let page = await join("ana", { viewport: { width: 390, height: 844 } });
+	let rowRail = await rails(page);
+	let held = grip(rowRail, "row", 2);
+	let from = (await held.boundingBox())!;
+	let table = (await content(page).locator("table").boundingBox())!;
+
+	await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+	await page.mouse.down();
+	await page.mouse.move(from.x + from.width / 2, table.y + table.height + 8);
+	await page.mouse.up();
+
+	await expect(items(page)).toHaveText(["two", "three", "one"]);
+	await expectNoHorizontalOverflow(page);
 });
 
 test("a hybrid desktop exposes touch table actions and desktop rails", async ({ baseURL, browser, room, seed }) => {

--- a/packages/editor/src/callout.css
+++ b/packages/editor/src/callout.css
@@ -101,8 +101,9 @@
 }
 
 .plan-callout-title {
-	min-width: 2rem;
+	min-width: 0;
 	max-width: 100%;
+	flex: 1 1 auto;
 	border-radius: var(--radius-sm);
 	padding: 0.125rem 0.25rem;
 	margin-inline-start: -0.25rem;
@@ -110,6 +111,7 @@
 	font-weight: 600;
 	line-height: var(--text-sm--line-height);
 	color: var(--callout-ink);
+	overflow-wrap: anywhere;
 	text-wrap: pretty;
 	transition:
 		background var(--duration-fast) var(--ease-out),

--- a/packages/editor/src/pointer.ts
+++ b/packages/editor/src/pointer.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
 export const COARSE_POINTER_QUERY = "(any-pointer: coarse)";
-const PRIMARY_COARSE_POINTER_QUERY = "(pointer: coarse)";
+export const PRIMARY_COARSE_POINTER_QUERY = "(pointer: coarse)";
 
 export function hasCoarsePointer(
 	media: (query: string) => Pick<MediaQueryList, "matches"> = matchMedia,

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -54,6 +54,25 @@
 	.plan-content {
 		--plan-gutter: 1rem;
 	}
+
+	/* Wide authored surfaces keep their own visible, keyboard-operable lane. */
+	.plan-content :is(pre, table, .plan-code-view, [role="tablist"]) {
+		overscroll-behavior-inline: contain;
+	}
+
+	.plan-content :is(pre, table, .plan-code-view, [role="tablist"])::-webkit-scrollbar {
+		block-size: 8px;
+	}
+
+	.plan-content :is(pre, table, .plan-code-view, [role="tablist"])::-webkit-scrollbar-track {
+		background: var(--color-inset);
+	}
+
+	.plan-content :is(pre, table, .plan-code-view, [role="tablist"])::-webkit-scrollbar-thumb {
+		border: 2px solid var(--color-inset);
+		border-radius: var(--radius-lg);
+		background: var(--color-text-quaternary);
+	}
 }
 
 /* Reader-local comment chrome must not move collaborative line boxes. */
@@ -717,7 +736,7 @@
 	pointer-events: none;
 }
 
-.plan-table-touch-toolbar {
+.plan-table-action-toolbar {
 	position: fixed;
 	z-index: 50;
 	display: block;
@@ -728,20 +747,20 @@
 	box-shadow: var(--shadow-overlay);
 }
 
-.plan-table-touch-groups,
-.plan-table-touch-panel {
+.plan-table-action-groups,
+.plan-table-action-panel {
 	display: grid;
 	grid-template-columns: repeat(4, minmax(0, 1fr));
 	gap: 0.25rem;
 }
 
-.plan-table-touch-panel {
+.plan-table-action-panel {
 	grid-template-columns: repeat(2, minmax(0, 1fr));
 	padding-block-start: 0.25rem;
 	border-block-start: var(--edge-width) solid var(--color-edge);
 }
 
-.plan-table-touch-action {
+.plan-table-action {
 	width: 100%;
 	min-width: 0;
 	min-height: 44px;
@@ -752,32 +771,24 @@
 	line-height: 1.15;
 }
 
-.plan-table-touch-action[aria-expanded="true"] {
+.plan-table-action[aria-expanded="true"] {
 	background: var(--color-selected);
 	color: var(--color-text-primary);
 }
 
-.plan-table-touch-action:hover,
-.plan-table-touch-action:focus-visible {
+.plan-table-action:hover,
+.plan-table-action:focus-visible {
 	background: var(--color-hover);
 	color: var(--color-text-primary);
 }
 
-.plan-table-touch-action:focus-visible {
+.plan-table-action:focus-visible {
 	outline: 2px solid var(--color-brand);
 	outline-offset: -2px;
 }
 
-.plan-table-touch-action:disabled {
+.plan-table-action:disabled {
 	opacity: 0.45;
-}
-
-:root[data-plan-primary-coarse-pointer] .plan-rail {
-	display: none;
-}
-
-:root:not([data-plan-coarse-pointer]) .plan-table-touch-toolbar {
-	display: none;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/packages/editor/src/table/action-toolbar.tsx
+++ b/packages/editor/src/table/action-toolbar.tsx
@@ -1,4 +1,4 @@
-/** Coarse-pointer table actions over the same Lexical table the desktop rails edit. */
+/** Reachable table actions for compact and coarse-pointer layouts. */
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
@@ -23,7 +23,6 @@ import {
 	$setAlign,
 } from "./ops";
 import { alignmentLabel, nextAlign } from "./alignment";
-import { COARSE_POINTER_QUERY, hasCoarsePointer } from "../pointer";
 import { touchAvailability } from "./touch-actions";
 
 import type { LexicalEditor, NodeKey } from "lexical";
@@ -34,25 +33,16 @@ type SelectedCell = { cell: NodeKey; column: number; row: number; table: Table }
 type DockPlacement = SurfacePlacement & { width: number };
 type ActionGroup = "add" | "move" | "remove";
 
-export function TableTouchToolbar(
+export function TableActionToolbar(
 	{ editor, disabled }: { editor: LexicalEditor; disabled?: boolean },
 ) {
-	let [coarse, setCoarse] = useState(false);
 	let [selected, setSelected] = useState<SelectedCell>();
 	let [position, setPosition] = useState<DockPlacement>();
 	let [group, setGroup] = useState<ActionGroup>("add");
 	let surface = useRef<HTMLDivElement>(null);
 
-	useEffect(() => {
-		let query = matchMedia(COARSE_POINTER_QUERY);
-		let update = () => setCoarse(hasCoarsePointer());
-		update();
-		query.addEventListener("change", update);
-		return () => query.removeEventListener("change", update);
-	}, []);
-
 	let sync = useCallback(() => {
-		if (!coarse || disabled) return setSelected(undefined);
+		if (disabled) return setSelected(undefined);
 		editor.getEditorState().read(() => {
 			let selection = $getSelection();
 			if (!$isRangeSelection(selection)) return setSelected(undefined);
@@ -66,16 +56,21 @@ export function TableTouchToolbar(
 				table: $describe(table),
 			});
 		});
-	}, [coarse, disabled, editor]);
+	}, [disabled, editor]);
 
 	useEffect(() => {
 		sync();
 		let off = editor.registerUpdateListener(sync);
 		let root = editor.getRootElement();
-		let afterPointer = () => requestAnimationFrame(sync);
+		let frame = 0;
+		let afterPointer = () => {
+			cancelAnimationFrame(frame);
+			frame = requestAnimationFrame(sync);
+		};
 		root?.addEventListener("pointerup", afterPointer);
 		root?.addEventListener("focusin", afterPointer);
 		return () => {
+			cancelAnimationFrame(frame);
 			off();
 			root?.removeEventListener("pointerup", afterPointer);
 			root?.removeEventListener("focusin", afterPointer);
@@ -126,19 +121,19 @@ export function TableTouchToolbar(
 		};
 	}, [editor, group, selected]);
 
-	if (!coarse || disabled || !selected) return null;
+	if (disabled || !selected) return null;
 
 	let { column, row, table } = selected;
 	let act = (op: () => void) => editor.update(op);
 	let align = table.align[column] ?? null;
-	let button = "plan-table-touch-action";
+	let button = "plan-table-action";
 	let available = touchAvailability(table.shape, row, column);
 	let show = (next: ActionGroup) => setGroup(next);
 
 	return (
 		<div
 			aria-label="Table actions"
-			className="plan-table-touch-toolbar"
+			className="plan-table-action-toolbar"
 			contentEditable={false}
 			onMouseDown={event => event.preventDefault()}
 			ref={surface}
@@ -152,7 +147,7 @@ export function TableTouchToolbar(
 				}
 				: { left: 8, top: 8, visibility: "hidden" }}
 		>
-			<div className="plan-table-touch-groups">
+			<div className="plan-table-action-groups">
 				<button
 					aria-expanded={group === "add"}
 					className={button}
@@ -188,7 +183,7 @@ export function TableTouchToolbar(
 			</div>
 
 			{group === "add" && (
-				<div aria-label="Add table actions" className="plan-table-touch-panel" role="group">
+				<div aria-label="Add table actions" className="plan-table-action-panel" role="group">
 					<button
 						className={button}
 						disabled={!available.addRowBefore}
@@ -228,7 +223,7 @@ export function TableTouchToolbar(
 			)}
 
 			{group === "remove" && (
-				<div aria-label="Remove table actions" className="plan-table-touch-panel" role="group">
+				<div aria-label="Remove table actions" className="plan-table-action-panel" role="group">
 					<button
 						className={button}
 						disabled={!available.removeRow}
@@ -252,7 +247,7 @@ export function TableTouchToolbar(
 			)}
 
 			{group === "move" && (
-				<div aria-label="Move table actions" className="plan-table-touch-panel" role="group">
+				<div aria-label="Move table actions" className="plan-table-action-panel" role="group">
 					<button
 						className={button}
 						disabled={!available.moveRowUp}

--- a/packages/editor/src/table/chrome.tsx
+++ b/packages/editor/src/table/chrome.tsx
@@ -1,0 +1,69 @@
+/** One responsive policy for every piece of table editing chrome. */
+
+import { useEffect, useState } from "react";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { readOnly$ } from "@mdxeditor/editor";
+import { useCellValue } from "@mdxeditor/gurx";
+
+import { COARSE_POINTER_QUERY, PRIMARY_COARSE_POINTER_QUERY } from "../pointer";
+import { TableActionToolbar } from "./action-toolbar";
+import { TableRails } from "./rails";
+import { useTableSupport } from "./support";
+
+import type { RailMode } from "./rails";
+
+const COMPACT_VIEWPORT_QUERY = "(max-width: 40rem)";
+
+type TableChromeMode = "coarse" | "compact" | "full" | "hybrid";
+
+function readMode(
+	compact: Pick<MediaQueryList, "matches">,
+	coarse: Pick<MediaQueryList, "matches">,
+	primaryCoarse: Pick<MediaQueryList, "matches">,
+): TableChromeMode {
+	if (primaryCoarse.matches) return "coarse";
+	if (compact.matches) return "compact";
+	return coarse.matches ? "hybrid" : "full";
+}
+
+function railMode(mode: TableChromeMode): RailMode | undefined {
+	if (mode === "coarse") return undefined;
+	return mode === "compact" ? "grips" : "full";
+}
+
+export function TableChrome() {
+	let [editor] = useLexicalComposerContext();
+	let disabled = useCellValue(readOnly$);
+	let tables = useTableSupport(editor);
+	let [mode, setMode] = useState<TableChromeMode>(() =>
+		readMode(
+			matchMedia(COMPACT_VIEWPORT_QUERY),
+			matchMedia(COARSE_POINTER_QUERY),
+			matchMedia(PRIMARY_COARSE_POINTER_QUERY),
+		)
+	);
+
+	useEffect(() => {
+		let compact = matchMedia(COMPACT_VIEWPORT_QUERY);
+		let coarse = matchMedia(COARSE_POINTER_QUERY);
+		let primaryCoarse = matchMedia(PRIMARY_COARSE_POINTER_QUERY);
+		let update = () => setMode(readMode(compact, coarse, primaryCoarse));
+		compact.addEventListener("change", update);
+		coarse.addEventListener("change", update);
+		primaryCoarse.addEventListener("change", update);
+		update();
+		return () => {
+			compact.removeEventListener("change", update);
+			coarse.removeEventListener("change", update);
+			primaryCoarse.removeEventListener("change", update);
+		};
+	}, []);
+
+	let rails = railMode(mode);
+	return (
+		<>
+			{rails ? <TableRails disabled={disabled} mode={rails} tables={tables} /> : null}
+			{mode === "full" ? null : <TableActionToolbar disabled={disabled} editor={editor} />}
+		</>
+	);
+}

--- a/packages/editor/src/table/rails.tsx
+++ b/packages/editor/src/table/rails.tsx
@@ -24,23 +24,14 @@
 
 import { Fragment, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import {
-	$findTableNode,
-	$isTableNode,
-	registerTableCellUnmergeTransform,
-	registerTablePlugin,
-	registerTableSelectionObserver,
-} from "@lexical/table";
-import { readOnly$ } from "@mdxeditor/editor";
-import { useCellValue } from "@mdxeditor/gurx";
-import { $getRoot, $getSelection, $isElementNode, $isRangeSelection, mergeRegister } from "lexical";
+import { $findTableNode } from "@lexical/table";
+import { $getSelection, $isRangeSelection } from "lexical";
 
 import { alignmentLabel, nextAlign } from "./alignment";
 import { destination, dropSeam, gripBox, seamAt, seamBox, seams } from "./geometry";
 import {
 	$addColumn,
 	$addRow,
-	$describe,
 	$moveColumn,
 	$moveRow,
 	$removeColumn,
@@ -49,7 +40,7 @@ import {
 } from "./ops";
 import { canAddColumn, canAddRow, canRemoveColumn, canRemoveRow, HEADER } from "./shape";
 
-import type { ElementNode, LexicalEditor, NodeKey } from "lexical";
+import type { LexicalEditor, NodeKey } from "lexical";
 import type { Axis, Track } from "./geometry";
 import type { Table } from "./ops";
 
@@ -74,6 +65,8 @@ const SEAM = 16;
 const BUTTON = 15;
 const PAIR = 8;
 
+export type RailMode = "full" | "grips";
+
 /** Where a measured table is on the screen, and where its tracks are. */
 type Metrics = {
 	/**
@@ -95,24 +88,6 @@ type Metrics = {
 
 /** A drag in progress. */
 type Drag = { axis: Axis; from: number; seam: number };
-
-/** Read every table out of the document. */
-function collect(editor: LexicalEditor): Table[] {
-	let out: Table[] = [];
-	editor.getEditorState().read(() => {
-		let walk = (node: ElementNode) => {
-			for (let child of node.getChildren()) {
-				// A table cannot nest inside a table in this dialect, but a
-				// callout or a tab panel can hold one, so the walk cannot stop
-				// at the top level.
-				if ($isTableNode(child)) out.push($describe(child));
-				else if ($isElementNode(child)) walk(child);
-			}
-		};
-		walk($getRoot());
-	});
-	return out;
-}
 
 /**
  * Measure one table.
@@ -161,61 +136,18 @@ function measure(editor: LexicalEditor, table: Table): Metrics | undefined {
 	};
 }
 
-/**
- * Project each column's alignment onto its cells.
- *
- * The alignment is recorded on the header cell, because the `| :--- |` row is
- * the only place GFM has to put it, but it describes the whole column — and CSS
- * cannot cascade from one cell to the others beneath it. So it is written to
- * the elements rather than the document: the same arrangement as a tab panel's
- * visibility, for the same reason, which is that how a column is drawn should
- * not be an edit.
- *
- * Re-applied on every update, because Lexical rebuilds a block's element when
- * the block changes and a style set on the old one goes with it.
- */
-function paint(editor: LexicalEditor, tables: Table[]): void {
-	for (let table of tables) {
-		for (let row of table.cells) {
-			for (let column = 0; column < row.length; column++) {
-				let element = editor.getElementByKey(row[column]!);
-				if (!element) continue;
-				// Empty rather than "start", so clearing an alignment hands the
-				// column back to the stylesheet instead of pinning it to a
-				// value that would then win against any later change there.
-				element.style.textAlign = table.align[column] ?? "";
-			}
-		}
-	}
-}
-
-export function TableRails() {
+export function TableRails(
+	{ disabled, mode = "full", tables }: {
+		disabled?: boolean;
+		mode?: RailMode;
+		tables: Table[];
+	},
+) {
 	let [editor] = useLexicalComposerContext();
-	let disabled = useCellValue(readOnly$);
 
-	let [tables, setTables] = useState<Table[]>([]);
 	let [active, setActive] = useState<NodeKey>();
 	let [metrics, setMetrics] = useState<Metrics>();
 	let [drag, setDrag] = useState<Drag>();
-
-	/*
-	 * Everything `@lexical/table` assumes is installed, and was not.
-	 *
-	 * Without `registerTablePlugin` a table has no keyboard navigation and none
-	 * of the transforms that keep it rectangular. Without the unmerge transform
-	 * a table pasted from HTML keeps its spans, which the dialect has no way to
-	 * write — the export visitor ignores them, so the cells silently
-	 * redistribute themselves at the next save.
-	 */
-	useEffect(
-		() =>
-			mergeRegister(
-				registerTablePlugin(editor),
-				registerTableSelectionObserver(editor),
-				registerTableCellUnmergeTransform(editor),
-			),
-		[editor],
-	);
 
 	let table = tables.find(item => item.key === active);
 
@@ -236,53 +168,9 @@ export function TableRails() {
 
 	useEffect(() => () => cancelAnimationFrame(pending.current), []);
 
-	/*
-	 * Read the document, and only say so when it has actually changed shape.
-	 *
-	 * Every keystroke fires an update, and `collect` allocates as it walks — so
-	 * publishing unconditionally would re-render the rails and re-measure the
-	 * table once per character typed anywhere in the plan. The measurement
-	 * still has to happen on every update, because typing into a cell widens
-	 * its column, but that is a rectangle read behind a frame rather than a
-	 * pass over the whole tree.
-	 */
-	let last = useRef("");
 	useEffect(() => {
-		let refresh = () => {
-			// An update listener that throws takes every listener after it with
-			// it, including the one that syncs to Yjs. Losing the rails is the
-			// cheapest outcome available and the only acceptable one.
-			try {
-				let next = collect(editor);
-				let json = JSON.stringify(next);
-				if (json !== last.current) {
-					last.current = json;
-					setTables(next);
-					paint(editor, next);
-				}
-				schedule();
-			} catch (err) {
-				console.error("[plan] table rails could not read the document", err);
-			}
-		};
-		refresh();
-		return editor.registerUpdateListener(refresh);
+		return editor.registerUpdateListener(schedule);
 	}, [editor, schedule]);
-
-	/*
-	 * Repaint the alignment after any render that could have replaced an
-	 * element. Lexical rebuilds a block's element when the block changes, and
-	 * an inline style set on the old one goes with it — so this cannot be left
-	 * to the update above, which deliberately says nothing when the shape has
-	 * not moved.
-	 */
-	useEffect(() => {
-		try {
-			paint(editor, tables);
-		} catch (err) {
-			console.error("[plan] column alignment could not be painted", err);
-		}
-	}, [editor, tables]);
 
 	// Synchronously on a change of table, so switching between two never draws
 	// one frame of rails at the other's coordinates.
@@ -371,7 +259,7 @@ export function TableRails() {
 	 */
 	let caret = useRef<NodeKey | undefined>(undefined);
 	useEffect(() => {
-		return editor.registerUpdateListener(() => {
+		let sync = () => {
 			editor.getEditorState().read(() => {
 				let selection = $getSelection();
 				let found = $isRangeSelection(selection)
@@ -381,7 +269,9 @@ export function TableRails() {
 				caret.current = found;
 				if (found) setActive(found);
 			});
-		});
+		};
+		sync();
+		return editor.registerUpdateListener(sync);
 	}, [editor]);
 
 	let act = useCallback((op: () => void) => editor.update(op), [editor]);
@@ -389,6 +279,7 @@ export function TableRails() {
 	// Metrics lag the active table by a frame; drawing against the previous
 	// table's rectangles would put the rails somewhere they do not belong.
 	if (disabled || !table || !metrics || metrics.key !== table.key) return null;
+	let tools = mode === "full";
 
 	return (
 		<>
@@ -401,6 +292,7 @@ export function TableRails() {
 				onHover={hover}
 				table={table}
 				tracks={metrics.columns}
+				tools={tools}
 			/>
 			<Rail
 				axis="row"
@@ -411,6 +303,7 @@ export function TableRails() {
 				onHover={hover}
 				table={table}
 				tracks={metrics.rows}
+				tools={tools}
 			/>
 		</>
 	);
@@ -425,9 +318,10 @@ type RailProps = {
 	onHover: (key: NodeKey | undefined) => void;
 	table: Table;
 	tracks: Track[];
+	tools: boolean;
 };
 
-function Rail({ axis, drag, metrics, onAct, onDrag, onHover, table, tracks }: RailProps) {
+function Rail({ axis, drag, metrics, onAct, onDrag, onHover, table, tracks, tools }: RailProps) {
 	let column = axis === "column";
 	let key = table.key;
 	let count = tracks.length;
@@ -451,8 +345,8 @@ function Rail({ axis, drag, metrics, onAct, onDrag, onHover, table, tracks }: Ra
 	 *
 	 * `overflow: hidden` so a column scrolled out of the table's own scroller
 	 * takes its grip with it rather than leaving one floating past the edge.
-	 * The grips lie against the table and the buttons in a lane beyond them, so
-	 * the rail is as deep as the two together.
+	 * The grips lie against the table. A full rail adds the button lane beyond
+	 * them; a compact rail measures only the grips it actually draws.
 	 *
 	 * Half a seam of slack at each end, because the first and last seams sit
 	 * exactly on the table's edges and what is drawn on a seam straddles it:
@@ -461,17 +355,19 @@ function Rail({ axis, drag, metrics, onAct, onDrag, onHover, table, tracks }: Ra
 	 * be wanted.
 	 */
 	let pad = SEAM / 2;
+	let depth = tools ? DEPTH : GRIP;
+	let gripLane = tools ? TOOL : 0;
 	let frame = column
 		? {
 			left: metrics.left - pad,
-			top: metrics.top - DEPTH,
+			top: metrics.top - depth,
 			width: metrics.width + pad * 2,
-			height: DEPTH,
+			height: depth,
 		}
 		: {
-			left: metrics.left - DEPTH,
+			left: metrics.left - depth,
 			top: metrics.top - pad,
-			width: DEPTH,
+			width: depth,
 			height: metrics.height + pad * 2,
 		};
 
@@ -507,9 +403,7 @@ function Rail({ axis, drag, metrics, onAct, onDrag, onHover, table, tracks }: Ra
 			}}
 		>
 			{tracks.map((track, index) => {
-				// `TOOL` is the lane offset: the grips are the lane against the
-				// table, the buttons the one beyond it.
-				let box = gripBox(axis, track, origin, GRIP, TOOL);
+				let box = gripBox(axis, track, origin, GRIP, gripLane);
 				if (!holdable(index)) {
 					// The header still gets a bar, so the rail does not have a
 					// gap in it where the row everybody can see plainly is.
@@ -584,7 +478,7 @@ function Rail({ axis, drag, metrics, onAct, onDrag, onHover, table, tracks }: Ra
 				 * track it removes.
 				 */
 			}
-			{tracks.map((track, index) => {
+			{tools && tracks.map((track, index) => {
 				let middle = (track.start + track.end) / 2;
 				// A column carries two buttons, so they sit either side of the
 				// track's middle rather than both on it; a row has only the one.
@@ -632,7 +526,7 @@ function Rail({ axis, drag, metrics, onAct, onDrag, onHover, table, tracks }: Ra
 				);
 			})}
 
-			{addable
+			{tools && addable
 				&& lines.map((line, seam) => {
 					// Nothing may be inserted above the header row.
 					if (!column && seam <= HEADER) return null;
@@ -656,7 +550,7 @@ function Rail({ axis, drag, metrics, onAct, onDrag, onHover, table, tracks }: Ra
 					<div
 						aria-hidden="true"
 						className="plan-drop"
-						style={seamBox(axis, lines[at] ?? 0, origin, GRIP, 2, TOOL)}
+						style={seamBox(axis, lines[at] ?? 0, origin, GRIP, 2, gripLane)}
 					/>
 				)
 				: null}

--- a/packages/editor/src/table/support.ts
+++ b/packages/editor/src/table/support.ts
@@ -1,0 +1,94 @@
+/** Table behavior that exists independently of its responsive editing chrome. */
+
+import { useEffect, useRef, useState } from "react";
+import {
+	$isTableNode,
+	registerTableCellUnmergeTransform,
+	registerTablePlugin,
+	registerTableSelectionObserver,
+} from "@lexical/table";
+import { $getRoot, $isElementNode, mergeRegister } from "lexical";
+
+import { $describe } from "./ops";
+
+import type { ElementNode, LexicalEditor } from "lexical";
+import type { Table } from "./ops";
+
+/** Read every table out of the document. */
+function collect(editor: LexicalEditor): Table[] {
+	let out: Table[] = [];
+	editor.getEditorState().read(() => {
+		let walk = (node: ElementNode) => {
+			for (let child of node.getChildren()) {
+				// A table cannot nest inside a table in this dialect, but a
+				// callout or a tab panel can hold one, so the walk cannot stop
+				// at the top level.
+				if ($isTableNode(child)) out.push($describe(child));
+				else if ($isElementNode(child)) walk(child);
+			}
+		};
+		walk($getRoot());
+	});
+	return out;
+}
+
+/** Project each column's recorded alignment onto its rendered cells. */
+function paint(editor: LexicalEditor, tables: Table[]): void {
+	for (let table of tables) {
+		for (let row of table.cells) {
+			for (let column = 0; column < row.length; column++) {
+				let element = editor.getElementByKey(row[column]!);
+				if (!element) continue;
+				// Empty rather than "start", so clearing an alignment hands the
+				// column back to the stylesheet.
+				element.style.textAlign = table.align[column] ?? "";
+			}
+		}
+	}
+}
+
+/** Install Lexical's table behavior and expose the tables the chrome can use. */
+export function useTableSupport(editor: LexicalEditor): Table[] {
+	let [tables, setTables] = useState<Table[]>([]);
+
+	useEffect(
+		() =>
+			mergeRegister(
+				registerTablePlugin(editor),
+				registerTableSelectionObserver(editor),
+				registerTableCellUnmergeTransform(editor),
+			),
+		[editor],
+	);
+
+	let last = useRef("");
+	useEffect(() => {
+		let refresh = () => {
+			// An update listener that throws takes every listener after it with
+			// it, including the one that syncs to Yjs. Losing table decoration is
+			// the cheapest outcome available and the only acceptable one.
+			try {
+				let next = collect(editor);
+				let json = JSON.stringify(next);
+				if (json === last.current) return;
+				last.current = json;
+				setTables(next);
+				paint(editor, next);
+			} catch (err) {
+				console.error("[plan] table support could not read the document", err);
+			}
+		};
+		refresh();
+		return editor.registerUpdateListener(refresh);
+	}, [editor]);
+
+	useEffect(() => {
+		try {
+			paint(editor, tables);
+		} catch (err) {
+			console.error("[plan] column alignment could not be painted", err);
+		}
+	}, [editor, tables]);
+
+	return tables;
+}

--- a/packages/editor/src/widgets-plugin.tsx
+++ b/packages/editor/src/widgets-plugin.tsx
@@ -11,15 +11,12 @@
  * only way a later value arrives.
  */
 
-import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { addComposerChild$, readOnly$, realmPlugin } from "@mdxeditor/editor";
-import { useCellValue } from "@mdxeditor/gurx";
+import { addComposerChild$, realmPlugin } from "@mdxeditor/editor";
 
 import { ChangeObserver } from "./changes-observer";
 import { CommentLayer } from "./comment-layer";
 import { QuestionnaireObserver } from "./questionnaires";
-import { TableRails } from "./table/rails";
-import { TableTouchToolbar } from "./table/touch-toolbar";
+import { TableChrome } from "./table/chrome";
 import { ThreadObserver } from "./threads";
 import { Toolbar } from "./toolbar";
 import { CalloutPlugin, EnterPlugin, PreviewPlugin, TabsPlugin } from "./widgets";
@@ -29,12 +26,6 @@ import type { WidgetOptions } from "./widget-options";
 
 export { widgets$ } from "./widget-options";
 export type { WidgetOptions } from "./widget-options";
-
-function TableTouchToolbarPlugin() {
-	let [editor] = useLexicalComposerContext();
-	let disabled = useCellValue(readOnly$);
-	return <TableTouchToolbar disabled={disabled} editor={editor} />;
-}
 
 export const widgetsPlugin = realmPlugin<WidgetOptions>({
 	init(realm, params) {
@@ -60,8 +51,7 @@ export const widgetsPlugin = realmPlugin<WidgetOptions>({
 		realm.pub(addComposerChild$, EnterPlugin);
 		// Also where `@lexical/table`'s own plugins are registered, which the
 		// editor otherwise runs without.
-		realm.pub(addComposerChild$, TableRails);
-		realm.pub(addComposerChild$, TableTouchToolbarPlugin);
+		realm.pub(addComposerChild$, TableChrome);
 		realm.pub(addComposerChild$, Toolbar);
 	},
 	update(realm, params) {

--- a/packages/editor/src/widgets/tabs.tsx
+++ b/packages/editor/src/widgets/tabs.tsx
@@ -7,7 +7,7 @@
  * alongside the panels and toggles their DOM, leaving the model untouched.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $getRoot, $isElementNode } from "lexical";
@@ -20,6 +20,14 @@ type Group = {
 	key: string;
 	tabs: Array<{ id: string; key: string; label: string }>;
 };
+
+/** Reveal a tab without moving any scroll ancestor outside its own strip. */
+function revealInline(strip: HTMLElement, tab: HTMLElement): void {
+	let viewport = strip.getBoundingClientRect();
+	let item = tab.getBoundingClientRect();
+	if (item.left < viewport.left) strip.scrollLeft += item.left - viewport.left;
+	else if (item.right > viewport.right) strip.scrollLeft += item.right - viewport.right;
+}
 
 /** Read the tab structure out of the document. */
 function collect(editor: LexicalEditor): Group[] {
@@ -55,10 +63,32 @@ function Strip(
 		onSelect: (key: string) => void;
 	},
 ) {
-	let select = (index: number) => onSelect(group.tabs[index]!.key);
+	let strip = useRef<HTMLDivElement>(null);
+	let buttons = useRef<Array<HTMLButtonElement | null>>([]);
+	let activeIndex = group.tabs.findIndex(tab => tab.key === active);
+	let structure = group.tabs.map(tab => tab.key).join(" ");
+	let select = (index: number) => {
+		onSelect(group.tabs[index]!.key);
+		buttons.current[index]?.focus();
+	};
+
+	useLayoutEffect(() => {
+		let list = strip.current;
+		let activeButton = buttons.current[activeIndex];
+		if (!list || !activeButton) return;
+		let reveal = () => revealInline(list, activeButton);
+		reveal();
+		let observer = new ResizeObserver(reveal);
+		observer.observe(list);
+		for (let button of buttons.current) {
+			if (button) observer.observe(button);
+		}
+		return () => observer.disconnect();
+	}, [active, activeIndex, structure]);
 
 	return (
 		<div
+			ref={strip}
 			role="tablist"
 			// The strip is chrome, not content: keep it out of the editable tree.
 			contentEditable={false}
@@ -67,6 +97,9 @@ function Strip(
 			{group.tabs.map((tab, position) => (
 				<button
 					key={tab.key}
+					ref={element => {
+						buttons.current[position] = element;
+					}}
 					type="button"
 					role="tab"
 					id={`ace-tab-${tab.key}`}
@@ -83,7 +116,7 @@ function Strip(
 						else return;
 						event.preventDefault();
 					}}
-					className={`shrink-0 rounded-md px-2.5 py-1 text-sm font-medium transition ${
+					className={`max-w-full shrink-0 whitespace-normal break-words rounded-md px-2.5 py-1 text-left text-sm font-medium transition ${
 						tab.key === active
 							? "bg-selected text-text-primary"
 							: "text-text-quaternary hover:text-text-primary"


### PR DESCRIPTION
## Summary

- Contain long code, tables, and tab strips in native horizontal scrollers with a persistent compact-width affordance.
- Wrap authored headings, tab labels, and callout titles; keep the selected/focused tab revealed across keyboard selection and strip resizing.
- Keep compact table drag grips in the gutter and expose the existing 44px action toolbar without overlapping table content.
- Add one hostile-content fixture plus compact and desktop behavior coverage. Mermaid rendering remains unchanged and out of scope.

## 390×844 evidence

| Surface | Before on `main` | After |
| --- | --- | --- |
| Page | `390 / 390` client/scroll width | `390 / 390` |
| Code | `350 / 1378`; no perceptible scrollbar | `350 / 1378`; 8px scrollbar, 1028px reachable range |
| Table | `350 / 1979`; no perceptible scrollbar | `350 / 1979`; 8px scrollbar, compact grips/actions reachable |
| Tabs | `350 / 1817`; last tab at x=1470…1837 | `350 / 1800`; selected tab inside strip at scrollLeft=1450 |

## Verification

- `bun test` — 853 passed, 2 database-only skips
- `bun run types`
- `bun run ci`
- `bun run build`
- Responsive/table browser pass — 37/37
- Complete browser suite — 180/180
