### PR TITLE
Keep Coolify preview settings late-bound

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 STORAGE_DRIVER=postgres
 DATABASE_URL=postgresql://chopin:chopin@127.0.0.1:5432/chopin?sslmode=disable
 
+# Hosted planner defaults.
+AGENT=on
+MODEL=claude-sonnet-4.6
+
 # GitHub App sign-in.
 # Remote VM mode overrides this local origin in child processes; see docs/exe-dev.md.
 APP_ORIGIN=http://127.0.0.1:8787

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -464,6 +464,14 @@ whenever one paragraph is added at the top. What genuinely moved is knowable
 only from the operations that were asked for, which is why `edit.ts` derives
 what was written from object identity and what moved or went from the batch.
 
+**A Compose default becomes a production value in Coolify previews.** Coolify
+materialises `${NAME:-default}` while parsing the service and writes the
+production value into `environment`; that explicit value then wins over the
+preview `.env` file it attaches later. Settings that may differ in a preview
+stay as direct `${NAME}` references in `compose.yaml`, and `compose.test.ts`
+guards that late-binding contract. Application defaults and `.env.example`
+carry the defaults instead.
+
 **`bun run <script>` does not exit when what it started dies.** It sits there
 with no child. `scripts/dev.ts` spawns both processes directly for this reason,
 and gives each its own process group so the whole tree can be taken down.

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,17 +3,19 @@ services:
     build:
       context: .
     environment:
-      AGENT: ${AGENT:-on}
-      APP_ORIGIN: ${APP_ORIGIN:-http://127.0.0.1:8787}
+      # Coolify resolves default-bearing values from production before attaching
+      # the preview env file, so preview-overridable values stay late-bound.
+      AGENT: ${AGENT}
+      APP_ORIGIN: ${APP_ORIGIN}
       DATABASE_URL: postgresql://chopin:chopin@${SERVICE_NAME_DB:-db}:5432/chopin?sslmode=disable
-      GITHUB_APP_SLUG: ${GITHUB_APP_SLUG:-}
-      GITHUB_APP_CLIENT_ID: ${GITHUB_APP_CLIENT_ID:-}
-      GITHUB_APP_CLIENT_SECRET: ${GITHUB_APP_CLIENT_SECRET:-}
-      GITHUB_ALLOWED_USERS: ${GITHUB_ALLOWED_USERS:-}
-      GITHUB_ALLOWED_ORGANIZATIONS: ${GITHUB_ALLOWED_ORGANIZATIONS:-}
-      MODEL: ${MODEL:-claude-sonnet-4.6}
+      GITHUB_APP_SLUG: ${GITHUB_APP_SLUG}
+      GITHUB_APP_CLIENT_ID: ${GITHUB_APP_CLIENT_ID}
+      GITHUB_APP_CLIENT_SECRET: ${GITHUB_APP_CLIENT_SECRET}
+      GITHUB_ALLOWED_USERS: ${GITHUB_ALLOWED_USERS}
+      GITHUB_ALLOWED_ORGANIZATIONS: ${GITHUB_ALLOWED_ORGANIZATIONS}
+      MODEL: ${MODEL}
       SERVICE_URL_APP_8787:
-      SESSION_ENCRYPTION_KEY: ${SESSION_ENCRYPTION_KEY:-}
+      SESSION_ENCRYPTION_KEY: ${SESSION_ENCRYPTION_KEY}
       STORAGE_DRIVER: postgres
     depends_on:
       db:

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ This builds the image, starts PostgreSQL, applies migrations, and listens on
 isolated preview database; the empty `SERVICE_URL_APP_8787` entry marks the
 app's internal proxy port. Set preview `APP_ORIGIN` to
 `https://${SERVICE_FQDN_APP}` when TLS terminates in front of Coolify. Ordinary
-Compose deployments fall back to the `db` service and local `APP_ORIGIN`.
+Compose deployments use the `db` service and the local `APP_ORIGIN` from `.env`.
 
 For a deployment using a managed database, build `Dockerfile`, provide
 `DATABASE_URL`, `APP_ORIGIN`, the GitHub App credentials and slug, and

--- a/scripts/compose.test.ts
+++ b/scripts/compose.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+
+const PREVIEW_CONFIGURATION = [
+	"AGENT",
+	"APP_ORIGIN",
+	"GITHUB_APP_SLUG",
+	"GITHUB_APP_CLIENT_ID",
+	"GITHUB_APP_CLIENT_SECRET",
+	"GITHUB_ALLOWED_USERS",
+	"GITHUB_ALLOWED_ORGANIZATIONS",
+	"MODEL",
+	"SESSION_ENCRYPTION_KEY",
+] as const;
+
+describe("deployment compose", () => {
+	it("leaves preview configuration for Coolify's runtime environment", async () => {
+		let source = await Bun.file(new URL("../compose.yaml", import.meta.url)).text();
+		let compose = Bun.YAML.parse(source) as {
+			services?: { app?: { environment?: Record<string, unknown> } };
+		};
+		let environment = compose.services?.app?.environment;
+
+		expect(environment).toBeDefined();
+		for (let name of PREVIEW_CONFIGURATION) {
+			expect(environment?.[name]).toBe(`\${${name}}`);
+		}
+		expect(environment).toMatchObject({
+			DATABASE_URL: "postgresql://chopin:chopin@${SERVICE_NAME_DB:-db}:5432/chopin?sslmode=disable",
+			SERVICE_URL_APP_8787: null,
+			STORAGE_DRIVER: "postgres",
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- keep preview-overridable Compose values as direct references instead of eager `:-` defaults
- move local planner/model defaults into `.env.example`
- guard the Coolify late-binding contract with a focused YAML test and document the precedence rule

## Root cause
Coolify materializes default-bearing service environment entries from production before attaching the preview `.env`. The explicit production value then overrides the correct preview value.

## Verification
- `bun test`
- `bun run types`
- `bun run ci`
- `docker compose -f compose.yaml config --format json` with preview-specific values
- independent review: no remaining findings