### PR TITLE
Repair Enter handling for legacy callouts

### DIFF
--- a/packages/editor/src/widgets/enter.test.ts
+++ b/packages/editor/src/widgets/enter.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { createHeadlessEditor } from "@lexical/headless";
+import { $createTextNode, $getRoot, $isElementNode } from "lexical";
+
+import { $createCalloutNode, registry } from "@chopin/dialect";
+
+import { handleEnter } from "./enter";
+
+import type { LexicalEditor } from "lexical";
+
+const REGISTRY = registry();
+
+function enter(editor: LexicalEditor): boolean {
+	let handled = false;
+	editor.update(() => {
+		handled = handleEnter();
+	}, { discrete: true });
+	return handled;
+}
+
+function tree(editor: LexicalEditor) {
+	return editor.getEditorState().read(() =>
+		$getRoot().getChildren().map(node => ({
+			type: node.getType(),
+			children: $isElementNode(node)
+				? node.getChildren().map(child => ({ type: child.getType(), text: child.getTextContent() }))
+				: [],
+		}))
+	);
+}
+
+test("enter repairs and leaves a callout stored with direct text", () => {
+	let editor = createHeadlessEditor({
+		nodes: REGISTRY.nodes,
+		onError(error) {
+			throw error;
+		},
+	});
+
+	// This tree projects to valid source and survived in Yjs checkpoints created
+	// by the old slash command, even though current callouts contain paragraphs.
+	editor.update(() => {
+		let text = $createTextNode("Legacy body.");
+		$getRoot().append(
+			$createCalloutNode("01K0N4W3B7P27CBAEC7A8C8WEA").append(text),
+		);
+		text.selectEnd();
+	}, { discrete: true });
+
+	expect(enter(editor)).toBe(true);
+	expect(tree(editor)).toEqual([{
+		type: "plan-callout",
+		children: [
+			{ type: "paragraph", text: "Legacy body." },
+			{ type: "paragraph", text: "" },
+		],
+	}]);
+
+	expect(enter(editor)).toBe(true);
+	expect(tree(editor)).toEqual([
+		{
+			type: "plan-callout",
+			children: [{ type: "paragraph", text: "Legacy body." }],
+		},
+		{ type: "paragraph", children: [] },
+	]);
+});

--- a/packages/editor/src/widgets/enter.tsx
+++ b/packages/editor/src/widgets/enter.tsx
@@ -53,21 +53,15 @@ function lines(node: LexicalNode | null): ElementNode | undefined {
 	return undefined;
 }
 
-/** A blank final paragraph that a preceding Enter added to a callout. */
-function calloutExit(node: LexicalNode | null) {
-	let cursor = node;
-	while (cursor) {
-		let parent = cursor.getParent();
+/** The direct callout child that contains this node. */
+function calloutPosition(node: LexicalNode | null) {
+	let child = node;
+	while (child) {
+		let parent = child.getParent();
 		if ($isCalloutNode(parent)) {
-			if (
-				$isParagraphNode(cursor)
-				&& cursor.getTextContentSize() === 0
-				&& cursor.getPreviousSibling() !== null
-				&& cursor.getNextSibling() === null
-			) return { callout: parent, paragraph: cursor };
-			return undefined;
+			return { callout: parent, child };
 		}
-		cursor = parent;
+		child = parent;
 	}
 	return undefined;
 }
@@ -99,47 +93,85 @@ function done(block: ElementNode): boolean {
 	return $isTextNode(last) ? anchor.offset === last.getTextContentSize() : true;
 }
 
+export function handleEnter(): boolean {
+	let selection = $getSelection();
+	if (!$isRangeSelection(selection)) return false;
+
+	if (selection.isCollapsed()) {
+		let position = calloutPosition(selection.anchor.getNode());
+		if (position?.child.isInline()) {
+			/*
+			 * The old slash command stored callout prose as direct inline children.
+			 * Its canonical source is valid, so restoring the Yjs checkpoint keeps
+			 * that shape and Lexical asks the callout itself to handle Enter. Wrap
+			 * only the inline run at the caret before asking the paragraph instead.
+			 */
+			let first = position.child;
+			let previous = first.getPreviousSibling();
+			while (previous?.isInline()) {
+				first = previous;
+				previous = first.getPreviousSibling();
+			}
+
+			let inline: LexicalNode[] = [];
+			let cursor: LexicalNode | null = first;
+			while (cursor?.isInline()) {
+				inline.push(cursor);
+				cursor = cursor.getNextSibling();
+			}
+
+			let paragraph = $createParagraphNode()
+				.setFormat(position.callout.getFormatType())
+				.setIndent(position.callout.getIndent());
+			first.insertBefore(paragraph);
+			paragraph.append(...inline);
+			selection.insertParagraph();
+			return true;
+		}
+
+		if (
+			position
+			&& $isParagraphNode(position.child)
+			&& position.child.getTextContentSize() === 0
+			&& position.child.getPreviousSibling() !== null
+			&& position.child.getNextSibling() === null
+		) {
+			position.child.remove();
+			let paragraph = $createParagraphNode();
+			position.callout.insertAfter(paragraph);
+			paragraph.select();
+			return true;
+		}
+	}
+
+	let block = lines(selection.anchor.getNode());
+	if (!block) return false;
+
+	if (done(block)) {
+		// The blank line was the request to leave, not content, so
+		// it goes with it — otherwise every fence anybody escaped
+		// from would keep a trailing empty line nobody typed.
+		let last = block.getLastDescendant();
+		if ($isLineBreakNode(last)) last.remove();
+		else if ($isTextNode(last)) last.setTextContent(last.getTextContent().slice(0, -1));
+
+		let paragraph = $createParagraphNode();
+		block.insertAfter(paragraph);
+		paragraph.select();
+		return true;
+	}
+
+	selection.insertLineBreak();
+	return true;
+}
+
 export function EnterPlugin() {
 	let [editor] = useLexicalComposerContext();
 
 	useEffect(() => {
 		return editor.registerCommand(
 			INSERT_PARAGRAPH_COMMAND,
-			() => {
-				let selection = $getSelection();
-				if (!$isRangeSelection(selection)) return false;
-
-				if (selection.isCollapsed()) {
-					let exit = calloutExit(selection.anchor.getNode());
-					if (exit) {
-						exit.paragraph.remove();
-						let paragraph = $createParagraphNode();
-						exit.callout.insertAfter(paragraph);
-						paragraph.select();
-						return true;
-					}
-				}
-
-				let block = lines(selection.anchor.getNode());
-				if (!block) return false;
-
-				if (done(block)) {
-					// The blank line was the request to leave, not content, so
-					// it goes with it — otherwise every fence anybody escaped
-					// from would keep a trailing empty line nobody typed.
-					let last = block.getLastDescendant();
-					if ($isLineBreakNode(last)) last.remove();
-					else if ($isTextNode(last)) last.setTextContent(last.getTextContent().slice(0, -1));
-
-					let paragraph = $createParagraphNode();
-					block.insertAfter(paragraph);
-					paragraph.select();
-					return true;
-				}
-
-				selection.insertLineBreak();
-				return true;
-			},
+			handleEnter,
 			COMMAND_PRIORITY_LOW,
 		);
 	}, [editor]);


### PR DESCRIPTION
## Summary

- repair callouts whose legacy Yjs checkpoint stores prose as direct inline children
- preserve the caret while turning that inline run into paragraphs on the first Enter
- cover the persisted legacy shape through both Enter presses with a headless regression

## Testing

- `bun test`
- `bun run types`
- `bun run ci`
- `bun scripts/e2e.ts e2e/toolbar.e2e.ts --grep "enter twice leaves"`