### PR TITLE
Add document renaming

### DIFF
--- a/apps/server/src/channels/routes.test.ts
+++ b/apps/server/src/channels/routes.test.ts
@@ -110,13 +110,26 @@ async function setup(random?: () => number) {
 	};
 	let router = new Router();
 	let reset: string[] = [];
+	let renamed: string[] = [];
 	registerChannelRoutes(router, auth, {
 		onAgentReset: async id => {
 			reset.push(id);
 		},
+		onChannelRenamed: channel => {
+			renamed.push(channel.title);
+		},
 		random,
 	});
-	return { router, storage, github, cookie: pair(issued.cookie), sessionId: issued.id, reset, now };
+	return {
+		router,
+		storage,
+		github,
+		cookie: pair(issued.cookie),
+		sessionId: issued.id,
+		reset,
+		renamed,
+		now,
+	};
 }
 
 function request(path: string, cookie?: string, init: RequestInit = {}): Request {
@@ -199,6 +212,108 @@ describe("channel routes", () => {
 		let response = await router.handle(request(`/api/channels/${id}`, cookie));
 		expect(response!.status).toBe(200);
 		expect((await response!.json()).channel.id).toBe(id);
+	});
+
+	it("lets an editor rename a document without changing its plan revision", async () => {
+		let { router, storage, cookie, renamed, now } = await setup();
+		let channel = await storage.channels.create({
+			id: crypto.randomUUID(),
+			repositoryId: "R_score",
+			repositoryOwner: "octo-org",
+			repositoryName: "score",
+			title: "Release plan",
+			createdBy: "U_octocat",
+			now,
+		});
+		let response = await router.handle(request(`/api/channels/${channel.id}`, cookie, {
+			method: "PATCH",
+			headers: { "content-type": "application/json", origin: "https://chopin.test" },
+			body: JSON.stringify({ title: "  Launch plan  " }),
+		}));
+
+		expect(response!.status).toBe(200);
+		let body = await response!.json();
+		expect(body.channel).toMatchObject({
+			id: channel.id,
+			title: "Launch plan",
+			revision: channel.revision,
+		});
+		expect((await storage.channels.get(channel.id))!.title).toBe("Launch plan");
+		expect(renamed).toEqual(["Launch plan"]);
+
+		let repeated = await router.handle(request(`/api/channels/${channel.id}`, cookie, {
+			method: "PATCH",
+			headers: { origin: "https://chopin.test" },
+			body: JSON.stringify({ title: "Launch plan" }),
+		}));
+		expect(repeated!.status).toBe(200);
+		expect(renamed).toEqual(["Launch plan"]);
+	});
+
+	it("validates rename titles and preserves a document after a title conflict", async () => {
+		let { router, storage, cookie, now } = await setup();
+		let channel = await storage.channels.create({
+			id: crypto.randomUUID(),
+			repositoryId: "R_score",
+			repositoryOwner: "octo-org",
+			repositoryName: "score",
+			title: "Release plan",
+			createdBy: "U_octocat",
+			now,
+		});
+		await storage.channels.create({
+			id: crypto.randomUUID(),
+			repositoryId: "R_score",
+			repositoryOwner: "octo-org",
+			repositoryName: "score",
+			title: "Launch plan",
+			createdBy: "U_octocat",
+			now,
+		});
+		let patch = (body: unknown) =>
+			router.handle(request(`/api/channels/${channel.id}`, cookie, {
+				method: "PATCH",
+				headers: { origin: "https://chopin.test" },
+				body: JSON.stringify(body),
+			}));
+
+		expect((await patch({}))!.status).toBe(400);
+		expect((await patch({ title: " " }))!.status).toBe(400);
+		expect((await patch({ title: "x".repeat(121) }))!.status).toBe(400);
+		let conflict = await patch({ title: "launch PLAN" });
+		expect(conflict!.status).toBe(409);
+		expect(await conflict!.json()).toEqual({
+			error: "a document with this title already exists",
+		});
+		expect((await storage.channels.get(channel.id))!.title).toBe("Release plan");
+	});
+
+	it("requires current write access and the configured origin to rename", async () => {
+		let { router, storage, github, cookie, now } = await setup();
+		let channel = await storage.channels.create({
+			id: crypto.randomUUID(),
+			repositoryId: "R_score",
+			repositoryOwner: "octo-org",
+			repositoryName: "score",
+			title: "Release plan",
+			createdBy: "U_octocat",
+			now,
+		});
+		let body = JSON.stringify({ title: "Launch plan" });
+		let csrf = await router.handle(request(`/api/channels/${channel.id}`, cookie, {
+			method: "PATCH",
+			headers: { origin: "https://evil.test" },
+			body,
+		}));
+		expect(csrf!.status).toBe(403);
+
+		github.repo = { ...github.repo, permissions: { pull: true, push: false, admin: false } };
+		let viewer = await router.handle(request(`/api/channels/${channel.id}`, cookie, {
+			method: "PATCH",
+			headers: { origin: "https://chopin.test" },
+			body,
+		}));
+		expect(viewer!.status).toBe(403);
 	});
 
 	it("lists matching documents with a query-bound cursor and repository avatar", async () => {

--- a/apps/server/src/channels/routes.ts
+++ b/apps/server/src/channels/routes.ts
@@ -3,6 +3,7 @@ import { StorageError } from "../storage/errors";
 
 import { documentTitles } from "./document-title";
 import { isChannelId, newChannelId } from "./id";
+import { normalizedTitle } from "./title";
 
 import type { HostedAuth } from "../auth/routes";
 import type { AuthenticatedSession } from "../auth/session";
@@ -101,7 +102,10 @@ function limit(url: URL): number | undefined {
 	return Number.isSafeInteger(parsed) && parsed >= 1 && parsed <= 100 ? parsed : undefined;
 }
 
-async function requestedTitle(request: Request): Promise<{ title?: string; valid: boolean }> {
+async function requestedTitle(
+	request: Request,
+	optional: boolean,
+): Promise<{ title?: string; valid: boolean }> {
 	let length = Number(request.headers.get("content-length") || "0");
 	if (Number.isFinite(length) && length > 4_096) return { valid: false };
 	let source = await request.text();
@@ -110,12 +114,9 @@ async function requestedTitle(request: Request): Promise<{ title?: string; valid
 		let value = JSON.parse(source) as unknown;
 		if (!value || typeof value !== "object" || Array.isArray(value)) return { valid: false };
 		let raw = (value as Record<string, unknown>).title;
-		if (raw === undefined) return { valid: true };
-		if (typeof raw !== "string") return { valid: false };
-		let result = raw.trim();
-		return result.length >= 1 && result.length <= 120
-			? { valid: true, title: result }
-			: { valid: false };
+		if (raw === undefined) return { valid: optional };
+		let title = normalizedTitle(raw);
+		return title ? { valid: true, title } : { valid: false };
 	} catch {
 		return { valid: false };
 	}
@@ -166,7 +167,11 @@ async function authorizedRepository(
 export function registerChannelRoutes(
 	router: Router,
 	auth: HostedAuth,
-	options: { onAgentReset?: (channelId: string) => Promise<void>; random?: () => number } = {},
+	options: {
+		onAgentReset?: (channelId: string) => Promise<void>;
+		onChannelRenamed?: (channel: ChannelRecord) => void;
+		random?: () => number;
+	} = {},
 ): void {
 	router.on(
 		"GET",
@@ -231,7 +236,7 @@ export function registerChannelRoutes(
 				if (!repo.permissions.push && !repo.permissions.admin) {
 					return json({ error: "repository write access is required" }, 403);
 				}
-				let title = await requestedTitle(request);
+				let title = await requestedTitle(request, true);
 				if (!title.valid) {
 					return json({ error: "title must be between 1 and 120 characters" }, 400);
 				}
@@ -296,6 +301,52 @@ export function registerChannelRoutes(
 				channel: serialized(channel),
 			});
 		} catch (err) {
+			return failure(err, request, auth);
+		}
+	});
+
+	router.on("PATCH", "/api/channels/:channelId", async (request, _url, params) => {
+		if (request.headers.get("origin") !== auth.config.origin) {
+			return json({ error: "origin is not allowed" }, 403);
+		}
+		try {
+			let session = await auth.sessions.authenticate(request);
+			if (!session) return json({ error: "authentication required" }, 401);
+			let id = params.channelId!;
+			if (!isChannelId(id)) return json({ error: "channel not found" }, 404);
+			let channel = await auth.storage.channels.get(id);
+			if (!channel) return json({ error: "channel not found" }, 404);
+			let repo = await authorizedRepository(
+				auth,
+				session,
+				channel.repositoryOwner,
+				channel.repositoryName,
+			);
+			if (repo.id !== channel.repositoryId || !repo.permissions.pull) {
+				return json({ error: "channel not found" }, 404);
+			}
+			if (!repo.permissions.push && !repo.permissions.admin) {
+				return json({ error: "repository write access is required" }, 403);
+			}
+			let requested = await requestedTitle(request, false);
+			if (!requested.valid || !requested.title) {
+				return json({ error: "title must be between 1 and 120 characters" }, 400);
+			}
+			let renamed = await auth.storage.channels.rename({
+				id,
+				title: requested.title,
+				now: auth.clock(),
+			});
+			if (renamed.changed) options.onChannelRenamed?.(renamed.channel);
+			return json({
+				repository: repository(repo),
+				canEdit: true,
+				channel: serialized(renamed.channel),
+			});
+		} catch (err) {
+			if (err instanceof StorageError && err.failure === "conflict") {
+				return json({ error: "a document with this title already exists" }, 409);
+			}
 			return failure(err, request, auth);
 		}
 	});

--- a/apps/server/src/channels/title.ts
+++ b/apps/server/src/channels/title.ts
@@ -1,0 +1,9 @@
+export const MAX_TITLE_LENGTH = 120;
+
+/** Canonical browser and MCP rename title, after removing accidental edge whitespace. */
+export function normalizedTitle(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	let title = value.trim();
+	let length = Array.from(title).length;
+	return length >= 1 && length <= MAX_TITLE_LENGTH ? title : undefined;
+}

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -31,7 +31,7 @@ import { broadcast, fail, relay, tell, topic } from "./wire";
 
 import type { Server } from "bun";
 import type { Incoming } from "@chopin/protocol";
-import type { Lease } from "./storage/model";
+import type { ChannelRecord, Lease } from "./storage/model";
 import type { AuthorizationResult, Socket, SocketData } from "./wire";
 
 const config = load();
@@ -331,6 +331,23 @@ function scheduleAuthorization(ws: Socket): void {
 	}, ACCESS_RECHECK_MS);
 }
 
+async function refreshChannelMetadata(ws: Socket, room: Rooms.Room): Promise<void> {
+	try {
+		let channel = await storage.channels.get(room.id);
+		if (!channel || channel.updatedAt <= new Date(ws.data.channelUpdatedAt)) return;
+		if (ws.data.closed) return;
+		tell(ws, {
+			kind: "session:channel",
+			ts: 0,
+			channelId: channel.id,
+			title: channel.title,
+			updatedAt: channel.updatedAt.toISOString(),
+		});
+	} catch {
+		// Hello already carried the admission snapshot; a later rename event can supersede it.
+	}
+}
+
 function listen(): Server<SocketData> {
 	return Bun.serve<SocketData>({
 		hostname: config.host,
@@ -365,10 +382,13 @@ function listen(): Server<SocketData> {
 					kind: "session:hello",
 					ts: 0,
 					channelId: room.id,
+					title: ws.data.channelTitle,
+					updatedAt: ws.data.channelUpdatedAt,
 					you: { handle: ws.data.handle, client: ws.data.client },
 					members: Rooms.members(room),
 					canEdit: ws.data.canEdit,
 				});
+				void refreshChannelMetadata(ws, room);
 				relay(ws, { kind: "session:presence", ts: 0, members: Rooms.members(room) });
 				scheduleAuthorization(ws);
 			},
@@ -474,6 +494,16 @@ async function resetOpenAgents(
 	);
 }
 
+function announceChannelRename(channel: ChannelRecord): void {
+	broadcast(server, channel.id, {
+		kind: "session:channel",
+		ts: 0,
+		channelId: channel.id,
+		title: channel.title,
+		updatedAt: channel.updatedAt.toISOString(),
+	});
+}
+
 let hostedAuth = registerAuthRoutes(router, {
 	config: config.auth,
 	storage,
@@ -492,9 +522,12 @@ registerMcpRoutes(router, hostedAuth, {
 		if (!heldLease) throw new Error("storage writer lease is unavailable");
 		return heldLease;
 	},
+}, {
+	onChannelRenamed: announceChannelRename,
 });
 registerChannelRoutes(router, hostedAuth, {
 	onAgentReset: channelId => resetOpenAgents(room => room.id === channelId),
+	onChannelRenamed: announceChannelRename,
 });
 
 try {

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -14,6 +14,7 @@ import {
 	REPOSITORY_PATH_PATTERN,
 } from "./mcp/create";
 import { isLifecycleTool, LIFECYCLE_TOOLS, lifecycleCall } from "./mcp/lifecycle";
+import { normalizedTitle } from "./channels/title";
 
 import type { Brief, CreateDocumentInput } from "./mcp/create";
 import type { Run, Version } from "./tasks/graphs";
@@ -93,11 +94,27 @@ export type CreateDocument<Caller> = {
 	>;
 };
 
+export type RenameDocumentInput = {
+	id: string;
+	title: string;
+};
+
+export type RenameDocument<Caller> = {
+	rename(
+		caller: Caller,
+		input: RenameDocumentInput,
+	): Promise<
+		| { kind: "renamed" | "unchanged"; document: DocumentSummary }
+		| { kind: "conflict" | "forbidden" | "missing" }
+	>;
+};
+
 export type McpOptions<Caller> = {
 	/** The host owns authentication; MCP only receives its result. */
 	caller(request: Request): Promise<Caller | undefined> | Caller | undefined;
 	documents: DocumentReader<Caller>;
 	create?: CreateDocument<Caller>;
+	rename?: RenameDocument<Caller>;
 	implementations?: Implementations<Caller>;
 };
 
@@ -230,6 +247,40 @@ export const TOOLS: Tool[] = [
 		},
 	},
 	{
+		name: "rename_document",
+		description: "Rename a Chopin document without changing its canonical plan or revision.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				id: {
+					type: "string",
+					minLength: 1,
+					maxLength: MAX_DOCUMENT_ID_LENGTH,
+					pattern: "\\S",
+				},
+				title: { type: "string", minLength: 1, maxLength: MAX_TITLE_LENGTH },
+			},
+			required: ["id", "title"],
+			additionalProperties: false,
+		},
+		outputSchema: {
+			oneOf: [
+				DOCUMENT,
+				{
+					type: "object",
+					properties: {
+						code: {
+							type: "string",
+							enum: ["title-conflict", "repository-forbidden", "document-unavailable"],
+						},
+					},
+					required: ["code"],
+					additionalProperties: false,
+				},
+			],
+		},
+	},
+	{
 		name: "read_implementation",
 		description: "Read the approved implementation graph, plan and repository context.",
 		inputSchema: {
@@ -348,6 +399,17 @@ function isId(value: unknown): value is string {
 		&& value.trim().length > 0;
 }
 
+function renameArguments(value: Record<string, unknown>): RenameDocumentInput | undefined {
+	if (
+		Object.keys(value).length !== 2
+		|| !Object.hasOwn(value, "id")
+		|| !Object.hasOwn(value, "title")
+		|| !isId(value.id)
+	) return undefined;
+	let title = normalizedTitle(value.title);
+	return title ? { id: value.id, title } : undefined;
+}
+
 function isJsonRpcId(value: unknown): value is string | number | null {
 	return value === null || typeof value === "string" || typeof value === "number";
 }
@@ -386,7 +448,9 @@ function acceptsEvents(request: Request): boolean {
 }
 
 function serviceInstructions(tools: Tool[]): string | undefined {
-	let creation = tools.filter(tool => tool.name === "create_document");
+	let documentMutations = tools.filter(tool =>
+		tool.name === "create_document" || tool.name === "rename_document"
+	);
 	let implementation = tools
 		.filter(tool =>
 			tool.name === "read_implementation"
@@ -395,7 +459,7 @@ function serviceInstructions(tools: Tool[]): string | undefined {
 		);
 	return [
 		"Chopin's MCP contract and current tool descriptions are authoritative.",
-		...creation.map(tool => `${tool.name}: ${tool.description}`),
+		...documentMutations.map(tool => `${tool.name}: ${tool.description}`),
 		...(implementation.length > 0
 			? [
 				"Read the canonical implementation before every implementation or lifecycle action; copied plans and lifecycle instructions are not substitutes.",
@@ -445,9 +509,11 @@ export function handler<Caller>(
 	options: McpOptions<Caller>,
 ): (request: Request) => Promise<Response> {
 	let creation = options.create;
+	let renaming = options.rename;
 	let sessions = new Map<string, { name: string; version: string }>();
 	let tools = TOOLS.filter(tool =>
 		(tool.name !== "create_document" || creation)
+		&& (tool.name !== "rename_document" || renaming)
 		&& (!["read_implementation", "start_implementation"].includes(tool.name)
 			|| options.implementations)
 		&& (!isLifecycleTool(tool.name) || options.implementations?.reportLifecycle)
@@ -535,6 +601,24 @@ export function handler<Caller>(
 						return respond(text({ code: "idempotency-conflict" }, true));
 					}
 					return respond({ content: [], isError: true });
+				}
+				if (tool.name === "rename_document" && renaming) {
+					let input = renameArguments(tool.arguments);
+					if (!input) {
+						return notification
+							? undefined
+							: error(call.id, -32602, "rename_document requires an id and valid title");
+					}
+					let outcome = await renaming.rename(caller, input);
+					if (outcome.kind === "renamed" || outcome.kind === "unchanged") {
+						return respond(text(outcome.document));
+					}
+					let code = outcome.kind === "conflict"
+						? "title-conflict"
+						: outcome.kind === "forbidden"
+						? "repository-forbidden"
+						: "document-unavailable";
+					return respond(text({ code }, true));
 				}
 				if (tool.name === "read_implementation") {
 					if (Object.keys(tool.arguments).length !== 1 || !isId(tool.arguments.id)) {

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -309,6 +309,90 @@ describe("the hosted MCP adapter", () => {
 		expect(await adapter.documents.read(caller, result.document.id)).toEqual(expected);
 	});
 
+	it("renames document metadata with current write access and announces real changes", async () => {
+		let context = setup();
+		context.github.repositoryValue = {
+			...context.github.repositoryValue,
+			permissions: { pull: true, push: true, admin: false },
+		};
+		await context.storage.users.put({
+			id: "U_allowed",
+			login: "allowed",
+			avatarUrl: "",
+			now: context.now,
+		});
+		let channel = await context.storage.channels.create({
+			id: crypto.randomUUID(),
+			repositoryId: "R_score",
+			repositoryOwner: "octo-org",
+			repositoryName: "score",
+			title: "Release plan",
+			createdBy: "U_allowed",
+			now: context.now,
+		});
+		let announcements: string[] = [];
+		let adapter = hosted(context.auth, undefined, {
+			onChannelRenamed: renamed => announcements.push(renamed.title),
+		});
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller || !adapter.rename) throw new Error("hosted rename adapter is unavailable");
+
+		let renamed = await adapter.rename.rename(caller, { id: channel.id, title: "Launch plan" });
+		expect(renamed).toEqual({
+			kind: "renamed",
+			document: { id: channel.id, title: "Launch plan" },
+		});
+		expect((await context.storage.channels.get(channel.id))!.revision).toBe(channel.revision);
+		expect(announcements).toEqual(["Launch plan"]);
+
+		let repeated = await adapter.rename.rename(caller, { id: channel.id, title: "Launch plan" });
+		expect(repeated.kind).toBe("unchanged");
+		expect(announcements).toEqual(["Launch plan"]);
+	});
+
+	it("refuses MCP renames without write access or a unique repository title", async () => {
+		let context = setup();
+		await context.storage.users.put({
+			id: "U_allowed",
+			login: "allowed",
+			avatarUrl: "",
+			now: context.now,
+		});
+		let first = await context.storage.channels.create({
+			id: crypto.randomUUID(),
+			repositoryId: "R_score",
+			repositoryOwner: "octo-org",
+			repositoryName: "score",
+			title: "Release plan",
+			createdBy: "U_allowed",
+			now: context.now,
+		});
+		await context.storage.channels.create({
+			...first,
+			id: crypto.randomUUID(),
+			title: "Launch plan",
+			now: context.now,
+		});
+		let adapter = hosted(context.auth);
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller || !adapter.rename) throw new Error("hosted rename adapter is unavailable");
+
+		expect(await adapter.rename.rename(caller, { id: first.id, title: "Blocked" })).toEqual({
+			kind: "forbidden",
+		});
+		context.github.repositoryValue = {
+			...context.github.repositoryValue,
+			permissions: { pull: true, push: true, admin: false },
+		};
+		expect(await adapter.rename.rename(caller, { id: first.id, title: "launch PLAN" })).toEqual({
+			kind: "conflict",
+		});
+		context.github.accessible = false;
+		expect(await adapter.rename.rename(caller, { id: first.id, title: "Hidden" })).toEqual({
+			kind: "missing",
+		});
+	});
+
 	it("requires repository write access before creating a channel", async () => {
 		let context = setup();
 		let adapter = hosted(context.auth);

--- a/apps/server/src/mcp/hosted.ts
+++ b/apps/server/src/mcp/hosted.ts
@@ -8,7 +8,7 @@ import { implementationLifecycle } from "../tasks/lifecycle";
 
 import type { HostedAuth } from "../auth/routes";
 import type { GitHubUser } from "../github/client";
-import type { Implementation, ImplementationInput, McpOptions } from "../mcp";
+import type { Implementation, ImplementationInput, McpOptions, RenameDocumentInput } from "../mcp";
 import type { LifecycleArguments } from "./lifecycle";
 import type { ChannelRecord, Lease } from "../storage/model";
 import type { ClaimResult, Run } from "../tasks/graphs";
@@ -19,6 +19,7 @@ export type HostedCaller = {
 };
 
 export type ImplementationPersistence = { lease(): Lease };
+export type HostedCallbacks = { onChannelRenamed?: (channel: ChannelRecord) => void };
 
 const BEARER = new RegExp("^Bearer ([A-Za-z0-9._~+/-]+=*)$", "i");
 
@@ -100,6 +101,7 @@ function claimResult(value: ClaimResult) {
 export function hosted(
 	auth: HostedAuth,
 	persistence?: ImplementationPersistence,
+	callbacks: HostedCallbacks = {},
 ): McpOptions<HostedCaller> {
 	async function directRepository(caller: HostedCaller, owner: string, name: string) {
 		try {
@@ -206,6 +208,45 @@ export function hosted(
 					});
 				} catch {
 					return undefined;
+				}
+			},
+		},
+		rename: {
+			async rename(caller, input: RenameDocumentInput) {
+				let channel = await auth.storage.channels.get(input.id);
+				if (!channel) return { kind: "missing" as const };
+				let repository = await directRepository(
+					caller,
+					channel.repositoryOwner,
+					channel.repositoryName,
+				);
+				if (
+					!repository
+					|| repository.id !== channel.repositoryId
+					|| !repository.permissions.pull
+				) return { kind: "missing" as const };
+				if (!repository.permissions.push && !repository.permissions.admin) {
+					return { kind: "forbidden" as const };
+				}
+				try {
+					let result = await auth.storage.channels.rename({
+						id: channel.id,
+						title: input.title,
+						now: auth.clock(),
+					});
+					if (result.changed) callbacks.onChannelRenamed?.(result.channel);
+					return {
+						kind: result.changed ? "renamed" as const : "unchanged" as const,
+						document: { id: result.channel.id, title: result.channel.title },
+					};
+				} catch (err) {
+					if (err instanceof StorageError && err.failure === "conflict") {
+						return { kind: "conflict" as const };
+					}
+					if (err instanceof StorageError && err.failure === "missing") {
+						return { kind: "missing" as const };
+					}
+					throw err;
 				}
 			},
 		},

--- a/apps/server/src/mcp/rename.test.ts
+++ b/apps/server/src/mcp/rename.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "bun:test";
+
+import { handler, TOOLS } from "../mcp";
+
+import type { DocumentReader, RenameDocument } from "../mcp";
+
+const id = "f401c8d6-3717-4f1d-8473-cfdd0af894e4";
+
+function request(body: unknown): Request {
+	return new Request("https://chopin.test/mcp", {
+		method: "POST",
+		headers: {
+			authorization: "Bearer allowed",
+			"content-type": "application/json",
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+function reader(): DocumentReader<string> {
+	return {
+		async list() {
+			return [];
+		},
+		async read() {
+			return undefined;
+		},
+	};
+}
+
+function call(arguments_: Record<string, unknown>): Request {
+	return request({
+		jsonrpc: "2.0",
+		id: 1,
+		method: "tools/call",
+		params: { name: "rename_document", arguments: arguments_ },
+	});
+}
+
+async function json(response: Response): Promise<Record<string, unknown>> {
+	return await response.json() as Record<string, unknown>;
+}
+
+describe("the MCP rename protocol", () => {
+	it("canonicalizes and renames a document through the host adapter", async () => {
+		let received: unknown;
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			rename: {
+				async rename(caller, input) {
+					received = { caller, input };
+					return {
+						kind: "renamed" as const,
+						document: { id: input.id, title: input.title },
+					};
+				},
+			},
+		});
+		let tools = await json(await mcp(request({ jsonrpc: "2.0", id: 1, method: "tools/list" })));
+		expect((tools.result as { tools: Array<{ name: string }> }).tools.map(tool => tool.name))
+			.toContain("rename_document");
+
+		let response = await json(await mcp(call({ id, title: "  Launch plan  " })));
+
+		expect(received).toEqual({ caller: "octocat", input: { id, title: "Launch plan" } });
+		expect((response.result as { structuredContent: unknown }).structuredContent).toEqual({
+			id,
+			title: "Launch plan",
+		});
+	});
+
+	it("rejects malformed rename arguments before consulting the host", async () => {
+		let called = false;
+		let rename: RenameDocument<string> = {
+			async rename() {
+				called = true;
+				return { kind: "missing" };
+			},
+		};
+		let mcp = handler({ caller: () => "octocat", documents: reader(), rename });
+
+		for (
+			let arguments_ of [
+				{ id, title: " " },
+				{ id: " ", title: "Launch plan" },
+				{ id, title: "x".repeat(121) },
+				{ id, title: "Launch plan", extra: true },
+			]
+		) {
+			let response = await json(await mcp(call(arguments_)));
+			expect(response.error).toEqual({
+				code: -32602,
+				message: "rename_document requires an id and valid title",
+			});
+		}
+		expect(called).toBe(false);
+	});
+
+	it("returns stable tool errors for rename failures", async () => {
+		let tool = TOOLS.find(tool => tool.name === "rename_document")!;
+		expect(tool.outputSchema).toEqual(expect.objectContaining({
+			oneOf: expect.arrayContaining([
+				expect.objectContaining({
+					properties: { code: expect.objectContaining({ type: "string" }) },
+				}),
+			]),
+		}));
+		for (
+			let [kind, code] of [
+				["conflict", "title-conflict"],
+				["forbidden", "repository-forbidden"],
+				["missing", "document-unavailable"],
+			] as const
+		) {
+			let mcp = handler({
+				caller: () => "octocat",
+				documents: reader(),
+				rename: {
+					async rename() {
+						return { kind };
+					},
+				},
+			});
+			let response = await json(await mcp(call({ id, title: "Launch plan" })));
+			expect((response.result as { structuredContent: unknown }).structuredContent).toEqual({
+				code,
+			});
+			expect((response.result as { isError: boolean }).isError).toBe(true);
+		}
+	});
+});

--- a/apps/server/src/mcp/routes.ts
+++ b/apps/server/src/mcp/routes.ts
@@ -5,7 +5,7 @@ import { hosted } from "./hosted";
 
 import type { HostedAuth } from "../auth/routes";
 import type { Router } from "../http/router";
-import type { ImplementationPersistence } from "./hosted";
+import type { HostedCallbacks, ImplementationPersistence } from "./hosted";
 
 function failure(err: unknown): Response {
 	if (err instanceof AdmissionDenied) return new Response("forbidden", { status: 403 });
@@ -34,8 +34,9 @@ export function registerMcpRoutes(
 	router: Router,
 	auth: HostedAuth,
 	persistence?: ImplementationPersistence,
+	callbacks?: HostedCallbacks,
 ): void {
-	let endpoint = handler(hosted(auth, persistence));
+	let endpoint = handler(hosted(auth, persistence, callbacks));
 	let route = async (request: Request): Promise<Response> => {
 		if (request.headers.has("origin") && request.headers.get("origin") !== auth.config.origin) {
 			return protectedResponse(new Response("origin is not allowed", { status: 403 }));

--- a/apps/server/src/socket/admission.test.ts
+++ b/apps/server/src/socket/admission.test.ts
@@ -128,6 +128,8 @@ describe("socket admission", () => {
 		let viewer = await admit(request, url, auth);
 		expect("data" in viewer && viewer.data).toMatchObject({
 			room: channel.id,
+			channelTitle: "Plan",
+			channelUpdatedAt: now.toISOString(),
 			handle: "octocat",
 			principalId: "U_octocat",
 			canEdit: false,

--- a/apps/server/src/socket/admission.ts
+++ b/apps/server/src/socket/admission.ts
@@ -43,6 +43,8 @@ export async function admit(
 		return {
 			data: {
 				room: channel.id,
+				channelTitle: channel.title,
+				channelUpdatedAt: channel.updatedAt.toISOString(),
 				handle: session.user.login,
 				client: uid(),
 				canEdit: repository.permissions.push || repository.permissions.admin,

--- a/apps/server/src/storage/contract.ts
+++ b/apps/server/src/storage/contract.ts
@@ -153,6 +153,79 @@ export function storageContract(name: string, factory: Factory): void {
 			}
 		});
 
+		it("renames channel metadata without advancing its collaboration revision", async () => {
+			let storage = await opened(factory);
+			try {
+				let { channelId, lease, repositoryId } = await userAndChannel(storage);
+				let before = await storage.channels.get(channelId);
+				let now = new Date("2026-01-03T03:04:05.000Z");
+				let renamed = await storage.channels.rename({
+					id: channelId,
+					title: "Launch plan",
+					now,
+				});
+
+				expect(renamed).toMatchObject({ changed: true, channel: { title: "Launch plan" } });
+				expect(renamed.channel.updatedAt).toEqual(now);
+				expect(renamed.channel.revision).toBe(before!.revision);
+				expect((await storage.channels.list(repositoryId, 20, undefined, "launch")).channels)
+					.toHaveLength(1);
+				expect((await storage.channels.list(repositoryId, 20, undefined, "release")).channels)
+					.toEqual([]);
+				await storage.collaboration.commit({
+					channelId,
+					lease,
+					expectedRevision: 0,
+					operationId: id("operation"),
+					epoch: "epoch-1",
+					events: [],
+					now: new Date("2026-01-02T12:00:00.000Z"),
+				});
+				expect((await storage.channels.get(channelId))!.updatedAt).toEqual(now);
+
+				let repeated = await storage.channels.rename({
+					id: channelId,
+					title: "Launch plan",
+					now: new Date("2026-01-04T03:04:05.000Z"),
+				});
+				expect(repeated.changed).toBe(false);
+				expect(repeated.channel.updatedAt).toEqual(now);
+			} finally {
+				await storage.close();
+			}
+		});
+
+		it("keeps renamed document titles unique within their repository", async () => {
+			let storage = await opened(factory);
+			try {
+				let { userId, channelId, repositoryId } = await userAndChannel(storage);
+				let now = new Date("2026-01-03T03:04:05.000Z");
+				let other = await storage.channels.create({
+					id: id("channel"),
+					repositoryId,
+					repositoryOwner: "octo-org",
+					repositoryName: "score",
+					title: "Launch plan",
+					createdBy: userId,
+					now,
+				});
+
+				expect(storage.channels.rename({
+					id: channelId,
+					title: "launch PLAN",
+					now,
+				})).rejects.toBeInstanceOf(StorageError);
+				let recased = await storage.channels.rename({
+					id: other.id,
+					title: "LAUNCH PLAN",
+					now,
+				});
+				expect(recased.channel.title).toBe("LAUNCH PLAN");
+			} finally {
+				await storage.close();
+			}
+		});
+
 		it("keeps document titles unique within a repository without regard to case", async () => {
 			let storage = await opened(factory);
 			try {

--- a/apps/server/src/storage/memory/adapter.ts
+++ b/apps/server/src/storage/memory/adapter.ts
@@ -14,6 +14,8 @@ import type {
 	CreateChannel,
 	JsonValue,
 	Lease,
+	RenameChannel,
+	RenameResult,
 	ReplaceChannel,
 	SaveCheckpoint,
 	StoredChannel,
@@ -147,6 +149,7 @@ export class MemoryStorage implements StorageAdapter {
 	readonly channels: ChannelStore = {
 		create: input => this.#createChannel(input),
 		get: id => Promise.resolve(this.#channels.get(id)).then(value => value && channel(value)),
+		rename: input => this.#renameChannel(input),
 		list: (repositoryId, limit, after, query) =>
 			this.#listChannels(repositoryId, limit, after, query),
 		scan: (repositoryId, limit, after) => this.#scanChannels(repositoryId, limit, after),
@@ -221,6 +224,25 @@ export class MemoryStorage implements StorageAdapter {
 			});
 		}
 		return channel(saved);
+	}
+
+	async #renameChannel(input: RenameChannel): Promise<RenameResult> {
+		let found = this.#channels.get(input.id);
+		if (!found) throw missing(`channel ${input.id} does not exist`);
+		if (found.title === input.title) return { channel: channel(found), changed: false };
+		if (
+			[...this.#channels.values()].some(value =>
+				value.id !== found.id
+				&& value.repositoryId === found.repositoryId
+				&& value.title.toLowerCase() === input.title.toLowerCase()
+			)
+		) throw conflict(`channel title ${input.title} already exists in this repository`);
+		let updatedAt = input.now > found.updatedAt
+			? input.now
+			: new Date(found.updatedAt.getTime() + 1);
+		let saved = { ...found, title: input.title, updatedAt };
+		this.#channels.set(saved.id, saved);
+		return { channel: channel(saved), changed: true };
 	}
 
 	#listChannels(
@@ -421,7 +443,11 @@ export class MemoryStorage implements StorageAdapter {
 			})));
 			this.#events.set(input.channelId, existingEvents);
 		}
-		this.#channels.set(input.channelId, { ...found, revision, updatedAt: input.now });
+		this.#channels.set(input.channelId, {
+			...found,
+			revision,
+			updatedAt: new Date(Math.max(found.updatedAt.getTime(), input.now.getTime())),
+		});
 		this.#sequences.set(input.channelId, sequence + 1);
 		let result = { revision, sequence, repeated: false };
 		operations.set(input.operationId, result);
@@ -482,7 +508,11 @@ export class MemoryStorage implements StorageAdapter {
 			createdAt: input.now,
 		});
 		this.#updates.set(input.channelId, []);
-		this.#channels.set(input.channelId, { ...found, revision, updatedAt: input.now });
+		this.#channels.set(input.channelId, {
+			...found,
+			revision,
+			updatedAt: new Date(Math.max(found.updatedAt.getTime(), input.now.getTime())),
+		});
 		this.#sequences.set(input.channelId, sequence + 1);
 		let result = { revision, sequence, repeated: false };
 		operations.set(input.operationId, result);

--- a/apps/server/src/storage/model.ts
+++ b/apps/server/src/storage/model.ts
@@ -52,6 +52,17 @@ export type CreateChannel = Omit<ChannelRecord, "revision" | "createdAt" | "upda
 	initial?: InitialChannel;
 };
 
+export type RenameChannel = {
+	id: string;
+	title: string;
+	now: Date;
+};
+
+export type RenameResult = {
+	channel: ChannelRecord;
+	changed: boolean;
+};
+
 export type ChannelCursor = {
 	updatedAt: Date;
 	id: string;

--- a/apps/server/src/storage/port.ts
+++ b/apps/server/src/storage/port.ts
@@ -10,6 +10,8 @@ import type {
 	CreateWebSession,
 	Lease,
 	PutUser,
+	RenameChannel,
+	RenameResult,
 	ReplaceChannel,
 	SaveCheckpoint,
 	StoredChannel,
@@ -38,6 +40,7 @@ export interface SessionStore {
 export interface ChannelStore {
 	create(channel: CreateChannel): Promise<ChannelRecord>;
 	get(id: string): Promise<ChannelRecord | undefined>;
+	rename(channel: RenameChannel): Promise<RenameResult>;
 	list(repositoryId: string, limit: number, after?: {
 		updatedAt: Date;
 		id: string;

--- a/apps/server/src/storage/postgres/adapter.ts
+++ b/apps/server/src/storage/postgres/adapter.ts
@@ -18,6 +18,8 @@ import type {
 	CreateChannel,
 	JsonValue,
 	Lease,
+	RenameChannel,
+	RenameResult,
 	ReplaceChannel,
 	SaveCheckpoint,
 	StoredChannel,
@@ -442,6 +444,7 @@ export class PostgresStorage implements StorageAdapter {
 			`;
 				return found ? channel(found) : undefined;
 			}),
+		rename: input => this.#renameChannel(input),
 		list: (repositoryId, limit, after, query) =>
 			this.#listChannels(repositoryId, limit, after, query),
 		scan: (repositoryId, limit, after) => this.#scanChannels(repositoryId, limit, after),
@@ -531,6 +534,34 @@ export class PostgresStorage implements StorageAdapter {
 					`;
 				}
 				return channel(saved);
+			}));
+	}
+
+	#renameChannel(input: RenameChannel): Promise<RenameResult> {
+		return this.#run("rename channel", () =>
+			this.#sql.begin(async transaction => {
+				let [current] = await transaction<ChannelRow[]>`
+					SELECT ${transaction.unsafe(CHANNEL_COLUMNS)}
+					FROM channels
+					WHERE id = ${input.id}
+					FOR UPDATE
+				`;
+				if (!current) throw missing(`channel ${input.id} does not exist`);
+				let existing = channel(current);
+				if (existing.title === input.title) {
+					return { channel: existing, changed: false };
+				}
+				let updatedAt = input.now > existing.updatedAt
+					? input.now
+					: new Date(existing.updatedAt.getTime() + 1);
+				let [saved] = await transaction<ChannelRow[]>`
+					UPDATE channels
+					SET title = ${input.title}, updated_at = ${updatedAt}
+					WHERE id = ${input.id}
+					RETURNING ${transaction.unsafe(CHANNEL_COLUMNS)}
+				`;
+				if (!saved) throw corrupt("renaming a channel returned no record");
+				return { channel: channel(saved), changed: true };
 			}));
 	}
 
@@ -818,7 +849,8 @@ export class PostgresStorage implements StorageAdapter {
 				}
 				await transaction`
 				UPDATE channels
-				SET revision = ${revision}, next_sequence = ${sequence + 1}, updated_at = ${input.now}
+				SET revision = ${revision}, next_sequence = ${sequence + 1},
+					updated_at = GREATEST(updated_at, ${input.now})
 				WHERE id = ${input.channelId}
 			`;
 				return { revision, sequence, repeated: false };
@@ -946,7 +978,8 @@ export class PostgresStorage implements StorageAdapter {
 				`;
 				await transaction`
 					UPDATE channels
-					SET revision = ${revision}, next_sequence = ${sequence + 1}, updated_at = ${input.now}
+					SET revision = ${revision}, next_sequence = ${sequence + 1},
+						updated_at = GREATEST(updated_at, ${input.now})
 					WHERE id = ${input.channelId}
 				`;
 				return { revision, sequence, repeated: false };

--- a/apps/server/src/wire.ts
+++ b/apps/server/src/wire.ts
@@ -24,6 +24,8 @@ export type AuthorizationResult = "allowed" | "denied" | "unavailable";
 
 export type SocketData = Identity & {
 	room: string;
+	channelTitle: string;
+	channelUpdatedAt: string;
 	canEdit: boolean;
 	principalId: string;
 	sessionId: string;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -179,6 +179,14 @@ export function channel(id: string): Promise<ChannelDetail> {
 	return response(`/api/channels/${encodeURIComponent(id)}`);
 }
 
+export function renameChannel(id: string, title: string): Promise<ChannelDetail> {
+	return response(`/api/channels/${encodeURIComponent(id)}`, {
+		method: "PATCH",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({ title }),
+	});
+}
+
 export async function resetAgent(id: string): Promise<void> {
 	let result = await fetch(`/api/channels/${encodeURIComponent(id)}/agent/reset`, {
 		method: "POST",

--- a/apps/web/src/channel-recovery.test.ts
+++ b/apps/web/src/channel-recovery.test.ts
@@ -49,6 +49,16 @@ describe("channel recovery context", () => {
 		expect(readChannelRecovery("U_octocat", channel.id, storage)).toEqual({ channel, repository });
 	});
 
+	it("replaces the cached title after a document is renamed", () => {
+		let storage = new MemoryStorage();
+		rememberChannel("U_octocat", channel, repository, storage);
+		rememberChannel("U_octocat", { ...channel, title: "Launch plan" }, repository, storage);
+
+		expect(readChannelRecovery("U_octocat", channel.id, storage)?.channel.title).toBe(
+			"Launch plan",
+		);
+	});
+
 	it("does not return another channel's context", () => {
 		let storage = new MemoryStorage();
 		rememberChannel("U_octocat", channel, repository, storage);

--- a/apps/web/src/document-picker.tsx
+++ b/apps/web/src/document-picker.tsx
@@ -5,6 +5,7 @@ import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useAnchoredPicker } from "./anchored-picker";
 import * as Api from "./api";
 import { rememberChannel } from "./channel-recovery";
+import { DocumentRename } from "./document-rename";
 
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 
@@ -30,11 +31,13 @@ export function DocumentPicker(
 	{
 		canEdit,
 		current,
+		onRename,
 		repository,
 		userId,
 	}: {
 		canEdit: boolean;
 		current: Pick<Api.Channel, "id" | "title">;
+		onRename: (channel: Pick<Api.Channel, "title" | "updatedAt">) => void;
 		repository: Pick<Api.Repository, "name" | "owner" | "fullName">;
 		userId: string;
 	},
@@ -48,6 +51,9 @@ export function DocumentPicker(
 	let [listError, setListError] = useState<unknown>();
 	let [createError, setCreateError] = useState<unknown>();
 	let [creating, setCreating] = useState(false);
+	let [renaming, setRenaming] = useState(false);
+	let [renameError, setRenameError] = useState<unknown>();
+	let [renameSaving, setRenameSaving] = useState(false);
 	let [loadingMore, setLoadingMore] = useState(false);
 	let [active, setActive] = useState(0);
 	let [retry, setRetry] = useState(0);
@@ -56,10 +62,14 @@ export function DocumentPicker(
 	let activeIndex = channels.length === 0 ? -1 : Math.min(active, channels.length - 1);
 	let activeChannel = channels[activeIndex];
 	let pickerContent = useMemo(
-		() => ({ channels: channels.length, createError, listError }),
-		[channels.length, createError, listError],
+		() => ({ channels: channels.length, createError, listError, renameError, renaming }),
+		[channels.length, createError, listError, renameError, renaming],
 	);
-	let { panel, position, search, trigger } = useAnchoredPicker(open, setOpen, pickerContent);
+	let setPickerOpen = (next: boolean) => {
+		if (!next && renameSaving) return;
+		setOpen(next);
+	};
+	let { panel, position, search, trigger } = useAnchoredPicker(open, setPickerOpen, pickerContent);
 
 	useEffect(() => {
 		if (!open) return;
@@ -77,7 +87,7 @@ export function DocumentPicker(
 			});
 		}, normalized ? 160 : 0);
 		return () => window.clearTimeout(timer);
-	}, [normalized, open, repository.name, repository.owner, retry]);
+	}, [current.title, normalized, open, repository.name, repository.owner, retry]);
 
 	useEffect(() => {
 		if (!open || !activeChannel) return;
@@ -139,6 +149,22 @@ export function DocumentPicker(
 			setCreateError(reason);
 			setCreating(false);
 		}
+	}
+
+	function finishRename(detail: Api.ChannelDetail) {
+		onRename(detail.channel);
+		setRenaming(false);
+		setRenameError(undefined);
+		setRenameSaving(false);
+		setRetry(value => value + 1);
+		requestAnimationFrame(() => search.current?.focus());
+	}
+
+	function cancelRename() {
+		setRenaming(false);
+		setRenameError(undefined);
+		setRenameSaving(false);
+		requestAnimationFrame(() => search.current?.focus());
 	}
 
 	let popup = open && createPortal(
@@ -236,20 +262,45 @@ export function DocumentPicker(
 			</div>
 			{canEdit && (
 				<div className="p-1 hairline-t">
-					{createError !== undefined && (
-						<p className="px-2 py-2 text-sm text-destructive-ink" role="alert">
-							{message(createError, "Could not create document.")}
-						</p>
-					)}
-					<button
-						className="btn btn-md btn-ghost w-full justify-start"
-						disabled={creating}
-						onClick={() => void create()}
-						type="button"
-					>
-						<PlusIcon aria-hidden="true" size={16} />
-						<span className="ml-1">{creating ? "Creating..." : "Create new document"}</span>
-					</button>
+					{renaming
+						? (
+							<DocumentRename
+								channel={current}
+								className="p-2"
+								onCancel={cancelRename}
+								onErrorChange={setRenameError}
+								onRenamed={finishRename}
+								onSavingChange={setRenameSaving}
+							/>
+						)
+						: (
+							<>
+								{createError !== undefined && (
+									<p className="px-2 py-2 text-sm text-destructive-ink" role="alert">
+										{message(createError, "Could not create document.")}
+									</p>
+								)}
+								<button
+									className="btn btn-md btn-ghost w-full justify-start"
+									disabled={creating}
+									onClick={() => setRenaming(true)}
+									type="button"
+								>
+									Rename document
+								</button>
+								<button
+									className="btn btn-md btn-ghost w-full justify-start"
+									disabled={creating}
+									onClick={() => void create()}
+									type="button"
+								>
+									<PlusIcon aria-hidden="true" size={16} />
+									<span className="ml-1">
+										{creating ? "Creating..." : "Create new document"}
+									</span>
+								</button>
+							</>
+						)}
 				</div>
 			)}
 		</div>,
@@ -264,7 +315,7 @@ export function DocumentPicker(
 				aria-haspopup="listbox"
 				aria-label={`Document: ${current.title}`}
 				className="document-picker-trigger btn btn-sm btn-ghost min-w-0 max-w-64 justify-start gap-1 text-text-tertiary"
-				onClick={() => setOpen(value => !value)}
+				onClick={() => setPickerOpen(!open)}
 				ref={trigger}
 				title={current.title}
 				type="button"

--- a/apps/web/src/document-rename.tsx
+++ b/apps/web/src/document-rename.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useRef, useState } from "react";
+
+import * as Api from "./api";
+
+import type { FormEvent, KeyboardEvent } from "react";
+
+function message(error: unknown): string {
+	return error instanceof Error ? error.message : "Could not rename document.";
+}
+
+/** One server-backed title form shared by room navigation and repository rows. */
+export function DocumentRename(
+	{
+		channel,
+		className = "",
+		onCancel,
+		onErrorChange,
+		onRenamed,
+		onSavingChange,
+	}: {
+		channel: Pick<Api.Channel, "id" | "title">;
+		className?: string;
+		onCancel: () => void;
+		onErrorChange?: (error: unknown) => void;
+		onRenamed: (detail: Api.ChannelDetail) => void;
+		onSavingChange?: (saving: boolean) => void;
+	},
+) {
+	let input = useRef<HTMLInputElement>(null);
+	let [title, setTitle] = useState(channel.title);
+	let [error, setError] = useState<unknown>();
+	let [saving, setSaving] = useState(false);
+
+	useEffect(() => {
+		input.current?.focus();
+		input.current?.select();
+	}, []);
+
+	function report(next: unknown) {
+		setError(next);
+		onErrorChange?.(next);
+	}
+
+	async function submit(event: FormEvent) {
+		event.preventDefault();
+		let next = title.trim();
+		if (!next || saving) return;
+		setSaving(true);
+		onSavingChange?.(true);
+		report(undefined);
+		try {
+			onRenamed(await Api.renameChannel(channel.id, next));
+		} catch (reason) {
+			report(reason);
+			setSaving(false);
+			onSavingChange?.(false);
+		}
+	}
+
+	function keyDown(event: KeyboardEvent) {
+		if (event.key !== "Escape") return;
+		event.preventDefault();
+		event.stopPropagation();
+		if (saving) return;
+		onCancel();
+	}
+
+	return (
+		<form className={`flex min-w-0 flex-col gap-2 ${className}`} onSubmit={submit}>
+			<label className="sr-only" htmlFor={`document-title-${channel.id}`}>Document title</label>
+			<input
+				aria-invalid={error === undefined ? undefined : true}
+				className="field h-8 min-w-0 w-full px-2 text-sm"
+				id={`document-title-${channel.id}`}
+				maxLength={120}
+				onChange={event => {
+					setTitle(event.target.value);
+					if (error !== undefined) report(undefined);
+				}}
+				onKeyDown={keyDown}
+				ref={input}
+				required
+				value={title}
+			/>
+			{error !== undefined && (
+				<p className="text-sm text-destructive-ink" role="alert">{message(error)}</p>
+			)}
+			<div className="flex justify-end gap-2">
+				<button
+					className="btn btn-md btn-ghost"
+					disabled={saving}
+					onClick={onCancel}
+					type="button"
+				>
+					Cancel
+				</button>
+				<button
+					className="btn btn-md btn-primary"
+					disabled={!title.trim() || saving}
+					type="submit"
+				>
+					{saving ? "Saving..." : "Save"}
+				</button>
+			</div>
+		</form>
+	);
+}

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import * as Api from "./api";
 import { readChannelRecovery, rememberChannel } from "./channel-recovery";
+import { DocumentRename } from "./document-rename";
 import { RepositoryPicker } from "./repository-picker";
 import { clearRepositoryCache } from "./repository-cache";
 
@@ -11,6 +12,7 @@ export type HostedWorkspaceProps = {
 	room: string;
 	handle: string;
 	label: string;
+	updatedAt: string;
 	repository: Api.Repository;
 	canEdit: boolean;
 	agent?: boolean;
@@ -211,6 +213,7 @@ function RepositoryChannels(
 	let [title, setTitle] = useState("");
 	let [creating, setCreating] = useState(false);
 	let [loadingMore, setLoadingMore] = useState(false);
+	let [renaming, setRenaming] = useState<string>();
 
 	useEffect(() => {
 		let active = true;
@@ -239,16 +242,47 @@ function RepositoryChannels(
 	}
 
 	async function more() {
-		if (!page?.nextCursor || loadingMore) return;
+		let cursor = page?.nextCursor;
+		if (!cursor || loadingMore) return;
 		setLoadingMore(true);
 		try {
-			let next = await Api.channels(owner, repository, page.nextCursor);
-			setPage({ ...next, channels: [...page.channels, ...next.channels] });
+			let next = await Api.channels(owner, repository, cursor);
+			setPage(current =>
+				current && {
+					...next,
+					channels: [
+						...current.channels,
+						...next.channels.filter(channel =>
+							!current.channels.some(known => known.id === channel.id)
+						),
+					],
+				}
+			);
 		} catch (reason) {
 			setError(reason);
 		} finally {
 			setLoadingMore(false);
 		}
+	}
+
+	function stopRenaming(id: string) {
+		setRenaming(undefined);
+		requestAnimationFrame(() => document.getElementById(`rename-channel-${id}`)?.focus());
+	}
+
+	function renamed(detail: Api.ChannelDetail) {
+		rememberChannel(user.id, detail.channel, detail.repository);
+		setPage(current => {
+			if (!current) return current;
+			let channels = current.channels
+				.map(channel => channel.id === detail.channel.id ? detail.channel : channel)
+				.sort((left, right) =>
+					new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()
+					|| left.id.localeCompare(right.id)
+				);
+			return { ...current, channels };
+		});
+		stopRenaming(detail.channel.id);
 	}
 
 	if (error) return <Failure error={error} />;
@@ -309,19 +343,45 @@ function RepositoryChannels(
 					: (
 						<div className="ring-hairline mt-6 overflow-hidden rounded-lg bg-page">
 							{page.channels.map((channel, index) => (
-								<a
-									className={`flex min-w-0 flex-col items-start justify-between gap-1 px-4 py-4 hover:bg-hover sm:flex-row sm:items-center sm:gap-4 sm:px-5 ${
-										index ? "hairline-t" : ""
-									}`}
-									href={`/channels/${channel.id}`}
-									key={channel.id}
-									onClick={() => rememberChannel(user.id, channel, page.repository)}
-								>
-									<span className="min-w-0 break-words text-sm font-medium">{channel.title}</span>
-									<span className="text-sm text-text-tertiary sm:shrink-0">
-										{new Date(channel.updatedAt).toLocaleDateString()}
-									</span>
-								</a>
+								<div className={index ? "hairline-t" : ""} key={channel.id}>
+									{renaming === channel.id
+										? (
+											<DocumentRename
+												channel={channel}
+												className="px-4 py-4 sm:px-5"
+												onCancel={() => stopRenaming(channel.id)}
+												onRenamed={renamed}
+											/>
+										)
+										: (
+											<div className="flex min-w-0 items-center gap-2 pr-3 hover:bg-hover sm:pr-4">
+												<a
+													className="flex min-w-0 flex-1 flex-col items-start justify-between gap-1 px-4 py-4 sm:flex-row sm:items-center sm:gap-4 sm:px-5"
+													href={`/channels/${channel.id}`}
+													onClick={() => rememberChannel(user.id, channel, page.repository)}
+												>
+													<span className="min-w-0 break-words text-sm font-medium">
+														{channel.title}
+													</span>
+													<span className="text-sm text-text-tertiary sm:shrink-0">
+														{new Date(channel.updatedAt).toLocaleDateString()}
+													</span>
+												</a>
+												{page.canEdit && (
+													<button
+														aria-label={`Rename ${channel.title}`}
+														className="btn btn-sm btn-ghost shrink-0"
+														disabled={renaming !== undefined}
+														id={`rename-channel-${channel.id}`}
+														onClick={() => setRenaming(channel.id)}
+														type="button"
+													>
+														Rename
+													</button>
+												)}
+											</div>
+										)}
+								</div>
 							))}
 						</div>
 					)}
@@ -393,6 +453,7 @@ function ChannelWorkspace(
 			canEdit={detail.canEdit}
 			handle={user.login}
 			label={detail.channel.title}
+			updatedAt={detail.channel.updatedAt}
 			repository={detail.repository}
 			room={detail.channel.id}
 			userId={user.id}

--- a/apps/web/src/room-workspace.tsx
+++ b/apps/web/src/room-workspace.tsx
@@ -14,6 +14,7 @@ import {
 } from "@chopin/editor";
 
 import { Chat } from "./chat/chat";
+import { rememberChannel } from "./channel-recovery";
 import { decisionAttention, DecisionViewControl } from "./decision-view-control";
 import { DocumentPicker } from "./document-picker";
 import * as Api from "./api";
@@ -33,6 +34,7 @@ function Header(
 		canEdit,
 		members,
 		label,
+		onRename,
 		repository,
 		room,
 		userId,
@@ -40,6 +42,7 @@ function Header(
 		canEdit: boolean;
 		members: Session.Member[];
 		label: string;
+		onRename: (channel: Pick<Api.Channel, "title" | "updatedAt">) => void;
 		repository: Api.Repository;
 		room: string;
 		userId: string;
@@ -56,6 +59,7 @@ function Header(
 				<DocumentPicker
 					canEdit={canEdit}
 					current={{ id: room, title: label }}
+					onRename={onRename}
 					repository={repository}
 					userId={userId}
 				/>
@@ -91,6 +95,7 @@ export function RoomWorkspace(
 		label,
 		repository,
 		room,
+		updatedAt,
 		userId,
 	}: HostedWorkspaceProps,
 ) {
@@ -98,6 +103,8 @@ export function RoomWorkspace(
 	let [status, setStatus] = useState<Status>("connecting");
 	let [members, setMembers] = useState<Session.Member[]>([]);
 	let [effectiveCanEdit, setEffectiveCanEdit] = useState(canEdit);
+	let [metadata, setMetadata] = useState({ title: label, updatedAt });
+	let metadataRef = useRef(metadata);
 	let user = useMemo(() => cursor(handle), [handle]);
 	let mode = useWorkspaceMode();
 	let [workspace, dispatch] = useWorkspaceState();
@@ -132,6 +139,12 @@ export function RoomWorkspace(
 		},
 		[conversationActive],
 	);
+	let updateMetadata = useCallback((next: { title: string; updatedAt: string }) => {
+		if (Date.parse(next.updatedAt) <= Date.parse(metadataRef.current.updatedAt)) return;
+		metadataRef.current = next;
+		setMetadata(next);
+		rememberChannel(userId, { id: room, title: next.title }, repository);
+	}, [repository, room, userId]);
 
 	useEffect(() => {
 		setDecisionView(state => advanceDecisionView(state, hasPlanContent, unanswered));
@@ -192,6 +205,12 @@ export function RoomWorkspace(
 	}, [canEdit, room]);
 
 	useEffect(() => {
+		let next = { title: label, updatedAt };
+		metadataRef.current = next;
+		setMetadata(next);
+	}, [label, room, updatedAt]);
+
+	useEffect(() => {
 		let socket = new Wire({
 			channelId: room,
 			onAuthenticationRequired: () => location.assign("/"),
@@ -205,6 +224,10 @@ export function RoomWorkspace(
 			socket.on<Session.Hello>("session:hello", frame => {
 				setMembers(frame.members);
 				setEffectiveCanEdit(frame.canEdit);
+				updateMetadata(frame);
+			}),
+			socket.on<Session.Channel>("session:channel", frame => {
+				if (frame.channelId === room) updateMetadata(frame);
 			}),
 			socket.on<Session.Presence>("session:presence", frame => setMembers(frame.members)),
 			socket.on<Session.Access>("session:access", frame => setEffectiveCanEdit(frame.canEdit)),
@@ -216,7 +239,7 @@ export function RoomWorkspace(
 			socket.dispose();
 			setWire(undefined);
 		};
-	}, [room, handle, threads]);
+	}, [room, handle, threads, updateMetadata]);
 
 	return (
 		<Workspace
@@ -235,7 +258,8 @@ export function RoomWorkspace(
 				<Header
 					canEdit={effectiveCanEdit}
 					members={members}
-					label={label}
+					label={metadata.title}
+					onRename={updateMetadata}
 					repository={repository}
 					room={room}
 					userId={userId}

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -31,6 +31,7 @@ that repository to the installation.
 GET  /api/repositories/:owner/:repository/channels
 POST /api/repositories/:owner/:repository/channels
 GET  /api/channels/:channelId
+PATCH /api/channels/:channelId
 POST /api/channels/:channelId/agent/reset
 ```
 
@@ -42,6 +43,11 @@ original query and cannot be reused with another search.
 A title is optional during browser creation. Chopin generates one when omitted,
 or accepts a trimmed title from 1 through 120 characters. Titles are unique per
 repository without regard to case.
+
+`PATCH /api/channels/:channelId` accepts `{ "title": "..." }`. It updates only
+channel metadata, not the canonical MDX heading or plan revision. A changed
+title updates the channel activity time and is broadcast to clients in the open
+room; submitting the current title is a no-op.
 
 The reset endpoint releases Planner ownership and aborts its disposable runtime
 session. The current web application does not expose a control that calls it.

--- a/docs/local-agent-mcp.md
+++ b/docs/local-agent-mcp.md
@@ -108,6 +108,10 @@ Start the agent from the repository you want to inspect and ask:
 Use the Chopin list_documents tool to list the documents available for this repository. Return each document's id and title.
 ```
 
+`rename_document` accepts a document `id` and replacement `title`. It changes
+the catalog title only, leaving canonical plan source, plan revision, and
+creation provenance intact. Repeating the same title is safe and has no effect.
+
 `{"documents":[]}` is a successful response for a repository with no Chopin
 documents. After the connection is established, the MCP `initialize`
 instructions and current tool descriptions are authoritative.
@@ -128,8 +132,8 @@ token's `read:org` or Members access, SSO authorization, and GitHub availability
 lacks the operation's repository permission; it does not mean the GitHub App for
 Chopin must be installed. Pull access is enough for
 `list_documents`, `read_document`, and `read_implementation`. Push or admin
-access is required for create, start, and report lifecycle operations. Use an
-account with the required access or ask a repository owner to grant it.
+access is required for create, rename, start, and report lifecycle operations.
+Use an account with the required access or ask a repository owner to grant it.
 
 Use the optional
 [creating-chopin-plans skill](../skills/creating-chopin-plans/SKILL.md) to turn a

--- a/e2e/document-navigation.e2e.ts
+++ b/e2e/document-navigation.e2e.ts
@@ -93,6 +93,62 @@ test("the document picker searches beyond the first page in a capped result list
 	expect(requests.some(url => url.searchParams.get("query") === "needle")).toBe(true);
 });
 
+test("renaming the current document updates collaborators and survives reload", async ({ join, room }) => {
+	let ana = await join("ana");
+	let bo = await join("bo");
+	let title = `Launch plan ${room.slice(0, 8)}`;
+	let anaTrigger = ana.getByRole("banner").getByRole("button", { name: /^Document:/ });
+	let boTrigger = bo.getByRole("banner").getByRole("button", { name: /^Document:/ });
+
+	await ana.setViewportSize({ width: 320, height: 568 });
+	await anaTrigger.click();
+	await ana.getByRole("button", { name: "Rename document" }).click();
+	let input = ana.getByRole("textbox", { name: "Document title" });
+	await expect(input).toBeFocused();
+	await input.fill(title);
+	await ana.getByRole("button", { name: "Save" }).click();
+
+	await expect(anaTrigger).toHaveAccessibleName(`Document: ${title}`);
+	await expect(boTrigger).toHaveAccessibleName(`Document: ${title}`);
+	await ana.reload();
+	await expect(ana.getByRole("banner").getByRole("button", { name: `Document: ${title}` }))
+		.toBeVisible();
+});
+
+test("a delayed rename response cannot overwrite a newer collaborator rename", async ({ join, room }) => {
+	let ana = await join("ana");
+	let bo = await join("bo");
+	let release = Promise.withResolvers<void>();
+	let delay = true;
+	await ana.route(`**/api/channels/${room}`, async route => {
+		if (route.request().method() !== "PATCH" || !delay) return route.continue();
+		delay = false;
+		let response = await route.fetch();
+		await release.promise;
+		await route.fulfill({ response });
+	});
+	let first = `First rename ${room.slice(0, 8)}`;
+	let latest = `Latest rename ${room.slice(0, 8)}`;
+	let anaTrigger = ana.getByRole("banner").getByRole("button", { name: /^Document:/ });
+	let boTrigger = bo.getByRole("banner").getByRole("button", { name: /^Document:/ });
+
+	await anaTrigger.click();
+	await ana.getByRole("button", { name: "Rename document" }).click();
+	await ana.getByRole("textbox", { name: "Document title" }).fill(first);
+	await ana.getByRole("button", { name: "Save" }).click();
+	await expect(boTrigger).toHaveAccessibleName(`Document: ${first}`);
+
+	await boTrigger.click();
+	await bo.getByRole("button", { name: "Rename document" }).click();
+	await bo.getByRole("textbox", { name: "Document title" }).fill(latest);
+	await bo.getByRole("button", { name: "Save" }).click();
+	await expect(anaTrigger).toHaveAccessibleName(`Document: ${latest}`);
+
+	release.resolve();
+	await expect(ana.getByRole("button", { name: "Rename document" })).toBeVisible();
+	await expect(anaTrigger).toHaveAccessibleName(`Document: ${latest}`);
+});
+
 test("read-only visitors can browse documents without a creation action", async ({ baseURL, page, room }) => {
 	await authenticate(page, "readonly", baseURL!);
 	await page.goto(`/channels/${room}`);
@@ -104,6 +160,32 @@ test("read-only visitors can browse documents without a creation action", async 
 	await page.getByRole("banner").getByRole("button", { name: /^Document:/ }).click();
 	await expect(page.getByRole("combobox", { name: "Search documents" })).toBeFocused();
 	await expect(page.getByRole("button", { name: "Create new document" })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Rename document" })).toHaveCount(0);
+});
+
+test("document rename failures preserve the draft and can be retried", async ({ join, room }) => {
+	let page = await join("ana");
+	let failed = true;
+	await page.route("**/api/channels/*", async route => {
+		if (route.request().method() === "PATCH" && failed) {
+			failed = false;
+			await route.fulfill({ status: 503, json: { error: "rename is unavailable" } });
+			return;
+		}
+		await route.continue();
+	});
+	let title = `Retry rename ${room.slice(0, 8)}`;
+	let trigger = page.getByRole("banner").getByRole("button", { name: /^Document:/ });
+	await trigger.click();
+	await page.getByRole("button", { name: "Rename document" }).click();
+	let input = page.getByRole("textbox", { name: "Document title" });
+	await input.fill(title);
+	await page.getByRole("button", { name: "Save" }).click();
+	await expect(page.getByRole("alert")).toHaveText("rename is unavailable");
+	await expect(input).toHaveValue(title);
+
+	await page.getByRole("button", { name: "Save" }).click();
+	await expect(trigger).toHaveAccessibleName(`Document: ${title}`);
 });
 
 test("document picker keeps failures open and makes creation retryable", async ({ join }) => {

--- a/e2e/hosted.e2e.ts
+++ b/e2e/hosted.e2e.ts
@@ -99,6 +99,28 @@ test("an authenticated repository creates a channel workspace", async ({ baseURL
 	await expect(page.getByRole("button", { name: "New channel" })).toHaveCount(0);
 });
 
+test("an editor renames a channel from the repository list", async ({ join, room }) => {
+	let page = await join("ana");
+	let before = `Test ${room.slice(0, 8)}`;
+	let after = `Repository rename ${room.slice(0, 8)}`;
+	await page.goto("/repositories/octo-org/score");
+	await expect(page.getByRole("heading", { name: "Planning channels" })).toBeVisible();
+
+	await page.setViewportSize({ width: 320, height: 568 });
+	await page.getByRole("button", { name: `Rename ${before}` }).click();
+	let input = page.getByRole("textbox", { name: "Document title" });
+	await expect(input).toHaveValue(before);
+	await expectNoHorizontalOverflow(page);
+	await input.fill(after);
+	await page.getByRole("button", { name: "Save" }).click();
+	await expect(page.getByText(after, { exact: true })).toBeVisible();
+	await expect(page.getByText(before, { exact: true })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: `Rename ${after}` })).toBeFocused();
+
+	await page.reload();
+	await expect(page.getByText(after, { exact: true })).toBeVisible();
+});
+
 test("a known deleted channel keeps its context and routes back without retry", async ({ baseURL, page }) => {
 	await authenticate(page, "octocat", baseURL!);
 	await page.route(

--- a/packages/protocol/index.d.ts
+++ b/packages/protocol/index.d.ts
@@ -41,7 +41,7 @@ export type Request<T> = T & { rid: string };
 export declare namespace Session {
 	export type Incoming = Request<Ping>;
 
-	export type Outgoing = Hello | Presence | Access | Failure | Ping;
+	export type Outgoing = Hello | Presence | Access | Channel | Failure | Ping;
 
 	/** A member, as everyone else sees them. */
 	export type Member = {
@@ -54,10 +54,19 @@ export declare namespace Session {
 	/** Sent once, immediately, to the socket that just joined. */
 	export type Hello = KIND<"session:hello"> & {
 		channelId: string;
+		title: string;
+		updatedAt: string;
 		you: Member;
 		members: Member[];
 		/** Effective repository capability for this connection. */
 		canEdit: boolean;
+	};
+
+	/** Durable channel metadata changed while this room was open. */
+	export type Channel = KIND<"session:channel"> & {
+		channelId: string;
+		title: string;
+		updatedAt: string;
 	};
 
 	/** Repository permission changed while the socket was open. */


### PR DESCRIPTION
## Summary
- add atomic document title updates through the browser API and both storage adapters
- expose rename controls in the room picker and repository list with live, ordered collaborator updates
- add the `rename_document` MCP tool with repository authorization and structured errors

## Testing
- `bun test`
- `bun run types`
- `bun run ci`
- PostgreSQL storage contract: 20 passed
- `bun run e2e`: 180 passed
- `bun run build`