### PR TITLE
Add human-readable document URLs

### DIFF
--- a/apps/server/src/auth/routes.test.ts
+++ b/apps/server/src/auth/routes.test.ts
@@ -172,13 +172,22 @@ const CONFIG: AuthConfig = {
 
 async function callback(router: Router): Promise<Response> {
 	let start = await router.handle(new Request("https://chopin.test/auth/github"));
+	return complete(router, start!);
+}
+
+async function complete(
+	router: Router,
+	start: Response,
+	callbackReturnTo?: string,
+): Promise<Response> {
 	let state = new URL(start!.headers.get("location")!).searchParams.get("state");
 	let stateCookie = pair(cookies(start!)[0]!);
+	let callback = new URL("https://chopin.test/auth/github/callback");
+	callback.searchParams.set("code", "code");
+	callback.searchParams.set("state", state!);
+	if (callbackReturnTo !== undefined) callback.searchParams.set("return_to", callbackReturnTo);
 	return (await router.handle(
-		new Request(
-			`https://chopin.test/auth/github/callback?code=code&state=${state}`,
-			{ headers: { cookie: stateCookie } },
-		),
+		new Request(callback, { headers: { cookie: stateCookie } }),
 	))!;
 }
 
@@ -280,9 +289,12 @@ describe("hosted authentication routes", () => {
 			createdAt: now,
 		});
 		let setup = await router.handle(
-			new Request("https://chopin.test/auth/github/setup?installation_id=spoofed", {
-				headers: { cookie: sessionCookie },
-			}),
+			new Request(
+				"https://chopin.test/auth/github/setup?installation_id=spoofed&return_to=%2Fignored",
+				{
+					headers: { cookie: sessionCookie },
+				},
+			),
 		);
 		expect(setup!.status).toBe(303);
 		expect(setup!.headers.get("location")).toBe("/?repository_access=changed");
@@ -323,6 +335,90 @@ describe("hosted authentication routes", () => {
 		expect(response!.status).toBe(302);
 		expect(response!.headers.get("location"))
 			.toBe("https://github.com/apps/chopin-test/installations/new");
+	});
+
+	it("returns to the canonical product location stored with the OAuth attempt", async () => {
+		let github = new FakeGitHub();
+		let router = new Router();
+		registerAuthRoutes(router, {
+			config: CONFIG,
+			storage: new MemoryStorage(),
+			github,
+		});
+		let login = new URL("https://request-host.test/auth/github");
+		login.searchParams.set(
+			"return_to",
+			"/documents/octocat/temporary/../score?view=plan#decision-1",
+		);
+
+		let start = await router.handle(new Request(login));
+		let authorization = new URL(start!.headers.get("location")!);
+		expect(authorization.searchParams.has("return_to")).toBe(false);
+		expect(github.authorized?.redirectUri).toBe("https://chopin.test/auth/github/callback");
+		let response = await complete(router, start!, "/documents/callback-override");
+
+		expect(response.status).toBe(303);
+		expect(response.headers.get("location"))
+			.toBe("/documents/octocat/score?view=plan#decision-1");
+	});
+
+	it("falls back to the product root for unsafe, empty, or duplicate return paths", async () => {
+		let router = new Router();
+		registerAuthRoutes(router, {
+			config: CONFIG,
+			storage: new MemoryStorage(),
+			github: new FakeGitHub(),
+		});
+		let invalid = [
+			"",
+			"documents/octocat/score",
+			"//evil.test/documents/octocat/score",
+			"/%2e//evil.test/documents/octocat/score",
+			"/\\evil.test/documents/octocat/score",
+			"/documents/octocat/\u0000score",
+			"https://chopin.test/documents/octocat/score",
+			"https://evil.test/documents/octocat/score",
+			"/api",
+			"/api/session",
+			"/auth",
+			"/auth/github",
+			"/ws",
+			"/ws/connect",
+			"/mcp",
+			"/mcp/tools",
+			`/${"a".repeat(2_048)}`,
+		];
+
+		for (let value of invalid) {
+			let login = new URL("https://chopin.test/auth/github");
+			login.searchParams.set("return_to", value);
+			let start = await router.handle(new Request(login));
+			let response = await complete(router, start!);
+			expect(response.headers.get("location")).toBe("/");
+		}
+
+		let duplicate = new URL("https://chopin.test/auth/github");
+		duplicate.searchParams.append("return_to", "/documents/first");
+		duplicate.searchParams.append("return_to", "/documents/second");
+		let start = await router.handle(new Request(duplicate));
+		let response = await complete(router, start!);
+		expect(response.headers.get("location")).toBe("/");
+	});
+
+	it("accepts a return path at the 2048 character limit", async () => {
+		let router = new Router();
+		registerAuthRoutes(router, {
+			config: CONFIG,
+			storage: new MemoryStorage(),
+			github: new FakeGitHub(),
+		});
+		let returnPath = `/${"a".repeat(2_047)}`;
+		let login = new URL("https://chopin.test/auth/github");
+		login.searchParams.set("return_to", returnPath);
+
+		let start = await router.handle(new Request(login));
+		let response = await complete(router, start!);
+		expect(response.headers.get("location")).toBe(returnPath);
 	});
 
 	it("rejects missing or mismatched OAuth state", async () => {

--- a/apps/server/src/auth/routes.ts
+++ b/apps/server/src/auth/routes.ts
@@ -10,6 +10,9 @@ import type { StorageAdapter } from "../storage/port";
 
 type Clock = () => Date;
 
+const RETURN_PATH_MAX_LENGTH = 2_048;
+const RESERVED_RETURN_PATHS = ["/api", "/auth", "/ws", "/mcp"];
+
 type Dependencies = {
 	config: AuthConfig;
 	storage: StorageAdapter;
@@ -103,6 +106,39 @@ function parameter(url: URL, name: string): string | undefined {
 	return values.length === 1 && values[0] ? values[0] : undefined;
 }
 
+function returnPath(url: URL, origin: string): string {
+	let values = url.searchParams.getAll("return_to");
+	if (values.length !== 1) return "/";
+	let value = values[0]!;
+	if (
+		!value
+		|| value.length > RETURN_PATH_MAX_LENGTH
+		|| !value.startsWith("/")
+		|| value.startsWith("//")
+		|| value.includes("\\")
+	) return "/";
+	let hasControl = [...value].some(character => {
+		let code = character.charCodeAt(0);
+		return code <= 0x1f || (code >= 0x7f && code <= 0x9f);
+	});
+	if (hasControl) return "/";
+
+	let target: URL;
+	try {
+		target = new URL(value, origin);
+	} catch {
+		return "/";
+	}
+	if (target.origin !== origin || target.pathname.startsWith("//")) return "/";
+	if (
+		RESERVED_RETURN_PATHS.some(path =>
+			target.pathname === path || target.pathname.startsWith(`${path}/`)
+		)
+	) return "/";
+	let canonical = target.pathname + target.search + target.hash;
+	return canonical.length <= RETURN_PATH_MAX_LENGTH ? canonical : "/";
+}
+
 /** Register the GitHub OAuth and authenticated session surface. */
 export function registerAuthRoutes(
 	router: Router,
@@ -132,8 +168,8 @@ export function registerAuthRoutes(
 	let redirectUri = `${config.origin}/auth/github/callback`;
 	let context: HostedAuth = { config, storage, github, admission, sessions, clock };
 
-	router.on("GET", "/auth/github", async () => {
-		let issued = await attempts.issue();
+	router.on("GET", "/auth/github", async (_request, url) => {
+		let issued = await attempts.issue(returnPath(url, config.origin));
 		let location = github.authorize({
 			clientId: config.clientId,
 			redirectUri,
@@ -181,7 +217,7 @@ export function registerAuthRoutes(
 			let now = clock();
 			await storage.users.put({ ...profile, now });
 			let session = await sessions.issue(profile.id, grant);
-			return redirected("/", 303, [clear, session.cookie]);
+			return redirected(stored.returnPath ?? "/", 303, [clear, session.cookie]);
 		} catch (err) {
 			let response = failure(err);
 			response.headers.append("set-cookie", clear);

--- a/apps/server/src/auth/session.test.ts
+++ b/apps/server/src/auth/session.test.ts
@@ -349,11 +349,14 @@ describe("hosted login sessions", () => {
 });
 
 describe("OAuth attempts", () => {
-	it("carries state and the PKCE verifier in a short-lived encrypted cookie", async () => {
+	it("carries state, PKCE, and an optional return path in a short-lived encrypted cookie", async () => {
 		let now = new Date("2026-08-13T12:00:00.000Z");
 		let attempts = new OAuthAttempts(new Uint8Array(32).fill(8), true, () => now);
-		let issued = await attempts.issue();
+		let returnPath = "/documents/octocat/score?view=plan#decision";
+		let issued = await attempts.issue(returnPath);
 		let recovered = await attempts.read(request(pair(issued.cookie)));
+		let legacy = await attempts.issue();
+		let recoveredLegacy = await attempts.read(request(pair(legacy.cookie)));
 
 		expect(issued.state).toHaveLength(43);
 		expect(issued.verifier).toHaveLength(43);
@@ -363,8 +366,12 @@ describe("OAuth attempts", () => {
 		expect(issued.cookie).toContain("__Host-chopin_oauth_state=");
 		expect(issued.cookie).toContain("Path=/");
 		expect(issued.cookie).not.toContain(issued.state);
+		expect(issued.cookie).not.toContain(returnPath);
 		expect(recovered?.state).toBe(issued.state);
 		expect(recovered?.verifier).toBe(issued.verifier);
+		expect(recovered?.returnPath).toBe(returnPath);
+		expect(recoveredLegacy?.state).toBe(legacy.state);
+		expect(recoveredLegacy?.returnPath).toBeUndefined();
 
 		let cookie = pair(issued.cookie);
 		let tampered = `${cookie.slice(0, -1)}${cookie.endsWith("A") ? "B" : "A"}`;

--- a/apps/server/src/auth/session.ts
+++ b/apps/server/src/auth/session.ts
@@ -49,6 +49,7 @@ type StoredAttempt = {
 	state: string;
 	verifier: string;
 	expiresAt: string;
+	returnPath?: string;
 };
 
 type MemorySession = {
@@ -181,8 +182,16 @@ function attempt(value: unknown): StoredAttempt | undefined {
 		|| typeof record.state !== "string"
 		|| typeof record.verifier !== "string"
 		|| typeof record.expiresAt !== "string"
+		|| (record.returnPath !== undefined && typeof record.returnPath !== "string")
 	) return undefined;
-	return { v: 1, state: record.state, verifier: record.verifier, expiresAt: record.expiresAt };
+	let stored: StoredAttempt = {
+		v: 1,
+		state: record.state,
+		verifier: record.verifier,
+		expiresAt: record.expiresAt,
+	};
+	if (typeof record.returnPath === "string") stored.returnPath = record.returnPath;
+	return stored;
 }
 
 /** Process-local browser and GitHub credentials backed by a token-free ownership registry. */
@@ -603,7 +612,7 @@ export class Sessions {
 	}
 }
 
-/** Short-lived encrypted OAuth state and PKCE verifier carried only by the browser. */
+/** Short-lived encrypted OAuth attempt data carried only by the browser. */
 export class OAuthAttempts {
 	readonly #key: Promise<CryptoKey>;
 	readonly #secure: boolean;
@@ -617,20 +626,22 @@ export class OAuthAttempts {
 		this.cookieName = secure ? "__Host-chopin_oauth_state" : "chopin_oauth_state";
 	}
 
-	async issue(): Promise<OAuthAttempt> {
+	async issue(returnPath?: string): Promise<OAuthAttempt> {
 		let state = base64(random(SECRET_BYTES));
 		let verifier = base64(random(SECRET_BYTES));
 		let digest = new Uint8Array(await crypto.subtle.digest("SHA-256", encoder.encode(verifier)));
 		let expiresAt = new Date(this.#clock().getTime() + ATTEMPT_TTL_MS);
+		let stored: StoredAttempt = {
+			v: 1,
+			state,
+			verifier,
+			expiresAt: expiresAt.toISOString(),
+		};
+		if (returnPath !== undefined) stored.returnPath = returnPath;
 		let envelope = await encrypted(
 			await this.#key,
 			"chopin:oauth-state:v1",
-			{
-				v: 1,
-				state,
-				verifier,
-				expiresAt: expiresAt.toISOString(),
-			} satisfies StoredAttempt,
+			stored,
 		);
 		return {
 			state,

--- a/apps/server/src/channels/routes.test.ts
+++ b/apps/server/src/channels/routes.test.ts
@@ -174,10 +174,12 @@ describe("channel routes", () => {
 		expect(created!.status).toBe(201);
 		let body = await created!.json();
 		expect(body.channel.title).toBe("Release readiness");
+		expect(body.channel.slug).toBe("release-readiness");
 		expect(body.channel.id[14]).toBe("5");
 		expect(body.channel.repositoryId).toBe("R_score");
 		expect(body.channel.createdBy).toBe("U_octocat");
-		expect(created!.headers.get("location")).toBe(`/channels/${body.channel.id}`);
+		expect(created!.headers.get("location"))
+			.toBe("/documents/octo-org/score/release-readiness");
 		expect(await storage.channels.get(body.channel.id)).toMatchObject({
 			repositoryOwner: "octo-org",
 			repositoryName: "score",
@@ -194,6 +196,60 @@ describe("channel routes", () => {
 		expect((await storage.collaboration.load(body.channel.id, now))?.channel.id).toBe(
 			body.channel.id,
 		);
+	});
+
+	it("resolves canonical and historical document paths within the authorized repository", async () => {
+		let { router, storage, github, cookie, now } = await setup();
+		let channel = await storage.channels.create({
+			id: crypto.randomUUID(),
+			repositoryId: "R_score",
+			repositoryOwner: "octo-org",
+			repositoryName: "score",
+			title: "Release plan",
+			createdBy: "U_octocat",
+			now,
+		});
+		await storage.channels.rename({
+			id: channel.id,
+			title: "Résumé 計画",
+			now: new Date(now.getTime() + 1),
+		});
+
+		let canonical = await router.handle(request(
+			"/api/repositories/octo-org/score/documents/r%C3%A9sum%C3%A9-%E8%A8%88%E7%94%BB",
+			cookie,
+		));
+		expect(canonical!.status).toBe(200);
+		expect((await canonical!.json()).channel).toMatchObject({
+			id: channel.id,
+			title: "Résumé 計画",
+			slug: "résumé-計画",
+		});
+
+		let alias = await router.handle(request(
+			"/api/repositories/octo-org/score/documents/Release--Plan",
+			cookie,
+		));
+		expect(alias!.status).toBe(200);
+		expect((await alias!.json()).channel.slug).toBe("résumé-計画");
+
+		github.repo = { ...github.repo, permissions: { pull: false, push: false, admin: false } };
+		let denied = await router.handle(request(
+			"/api/repositories/octo-org/score/documents/release-plan",
+			cookie,
+		));
+		expect(denied!.status).toBe(404);
+
+		github.repo = {
+			...github.repo,
+			id: "R_recreated",
+			permissions: { pull: true, push: true, admin: false },
+		};
+		let recreated = await router.handle(request(
+			"/api/repositories/octo-org/score/documents/release-plan",
+			cookie,
+		));
+		expect(recreated!.status).toBe(404);
 	});
 
 	it("continues to open a legacy UUIDv4 channel", async () => {
@@ -236,6 +292,7 @@ describe("channel routes", () => {
 		expect(body.channel).toMatchObject({
 			id: channel.id,
 			title: "Launch plan",
+			slug: "launch-plan",
 			revision: channel.revision,
 		});
 		expect((await storage.channels.get(channel.id))!.title).toBe("Launch plan");

--- a/apps/server/src/channels/routes.ts
+++ b/apps/server/src/channels/routes.ts
@@ -1,8 +1,11 @@
+import { documentPath } from "@chopin/protocol/document-url";
+
 import { GitHubError } from "../github/client";
 import { StorageError } from "../storage/errors";
 
 import { documentTitles } from "./document-title";
 import { isChannelId, newChannelId } from "./id";
+import { documentSlug } from "./slug";
 import { normalizedTitle } from "./title";
 
 import type { HostedAuth } from "../auth/routes";
@@ -32,6 +35,7 @@ function serialized(channel: ChannelRecord) {
 		repositoryOwner: channel.repositoryOwner,
 		repositoryName: channel.repositoryName,
 		title: channel.title,
+		slug: channel.slug,
 		createdBy: channel.createdBy,
 		revision: channel.revision,
 		createdAt: channel.createdAt.toISOString(),
@@ -270,8 +274,35 @@ export function registerChannelRoutes(
 					{ repository: repository(repo), canEdit: true, channel: serialized(channel) },
 					201,
 					undefined,
-					`/channels/${channel.id}`,
+					documentPath(repo.owner, repo.name, channel.slug),
 				);
+			} catch (err) {
+				return failure(err, request, auth);
+			}
+		},
+	);
+
+	router.on(
+		"GET",
+		"/api/repositories/:owner/:repository/documents/:slug",
+		async (request, _url, params) => {
+			try {
+				let session = await auth.sessions.authenticate(request);
+				if (!session) return json({ error: "authentication required" }, 401);
+				let repo = await authorizedRepository(
+					auth,
+					session,
+					params.owner!,
+					params.repository!,
+				);
+				if (!repo.permissions.pull) return json({ error: "channel not found" }, 404);
+				let channel = await auth.storage.channels.resolve(repo.id, documentSlug(params.slug!));
+				if (!channel) return json({ error: "channel not found" }, 404);
+				return json({
+					repository: repository(repo),
+					canEdit: repo.permissions.push || repo.permissions.admin,
+					channel: serialized(channel),
+				});
 			} catch (err) {
 				return failure(err, request, auth);
 			}

--- a/apps/server/src/channels/slug.test.ts
+++ b/apps/server/src/channels/slug.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+
+import { documentSlug, documentSlugCandidate, MAX_DOCUMENT_SLUG_LENGTH } from "./slug";
+
+describe("document slugs", () => {
+	it("normalizes compatibility characters, case and accents", () => {
+		expect(documentSlug("  Café De\u0301jà Vu!  ")).toBe("café-déjà-vu");
+		expect(documentSlug("Ｆｕｌｌ　Ｗｉｄｔｈ")).toBe("full-width");
+	});
+
+	it("retains non-Latin letters, numbers and combining marks", () => {
+		expect(documentSlug("東京 計画 2026")).toBe("東京-計画-2026");
+		expect(documentSlug("किताब योजना")).toBe("किताब-योजना");
+	});
+
+	it("collapses punctuation and symbols into trimmed hyphens", () => {
+		expect(documentSlug("--- Release... readiness / phase #2 ---")).toBe(
+			"release-readiness-phase-2",
+		);
+	});
+
+	it("falls back for a title without letters, numbers or marks", () => {
+		expect(documentSlug("🚀 💥 !!!")).toBe("document");
+	});
+
+	it("caps slugs by Unicode code point without leaving a trailing hyphen", () => {
+		let letter = "𐐨";
+		expect(documentSlug("a".repeat(100))).toBe("a".repeat(100));
+		expect(documentSlug("a".repeat(101))).toBe("a".repeat(100));
+		expect(Array.from(documentSlug(letter.repeat(101)))).toHaveLength(
+			MAX_DOCUMENT_SLUG_LENGTH,
+		);
+		expect(documentSlug(`${"a".repeat(99)} b`)).toBe("a".repeat(99));
+	});
+});
+
+describe("document slug candidates", () => {
+	it("returns the base first and adds numbered suffixes", () => {
+		expect(documentSlugCandidate("release-plan", 1)).toBe("release-plan");
+		expect(documentSlugCandidate("release-plan", 2)).toBe("release-plan-2");
+		expect(documentSlugCandidate("release-plan", 12)).toBe("release-plan-12");
+	});
+
+	it("truncates the base to keep the suffix within the limit", () => {
+		let base = "𐐨".repeat(MAX_DOCUMENT_SLUG_LENGTH);
+		let candidate = documentSlugCandidate(base, 12);
+		expect(Array.from(candidate)).toHaveLength(MAX_DOCUMENT_SLUG_LENGTH);
+		expect(candidate).toBe(`${"𐐨".repeat(97)}-12`);
+
+		let hyphenBoundary = `${"a".repeat(97)}-bc`;
+		expect(documentSlugCandidate(hyphenBoundary, 2)).toBe(`${"a".repeat(97)}-2`);
+	});
+
+	it("rejects nonsensical candidate indexes", () => {
+		for (let index of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2 ** 53]) {
+			expect(() => documentSlugCandidate("release-plan", index)).toThrow(RangeError);
+		}
+	});
+});

--- a/apps/server/src/channels/slug.ts
+++ b/apps/server/src/channels/slug.ts
@@ -1,0 +1,26 @@
+export const MAX_DOCUMENT_SLUG_LENGTH = 100;
+
+function truncatedSlug(value: string, maximum: number): string {
+	return Array.from(value).slice(0, maximum).join("").replace(/-+$/u, "");
+}
+
+export function documentSlug(title: string): string {
+	let slug = title
+		.normalize("NFKC")
+		.toLowerCase()
+		.replace(/[^\p{L}\p{N}\p{M}]+/gu, "-")
+		.replace(/^-+|-+$/gu, "");
+	if (!slug) return "document";
+	return truncatedSlug(slug, MAX_DOCUMENT_SLUG_LENGTH);
+}
+
+/** Adds a collision suffix to a bounded base returned by documentSlug. */
+export function documentSlugCandidate(base: string, index: number): string {
+	if (!Number.isSafeInteger(index) || index < 1) {
+		throw new RangeError("document slug candidate index must be a positive safe integer");
+	}
+	if (index === 1) return base;
+	let suffix = `-${index}`;
+	let stem = truncatedSlug(base, MAX_DOCUMENT_SLUG_LENGTH - Array.from(suffix).length);
+	return `${stem}${suffix}`;
+}

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -341,6 +341,7 @@ async function refreshChannelMetadata(ws: Socket, room: Rooms.Room): Promise<voi
 			ts: 0,
 			channelId: channel.id,
 			title: channel.title,
+			slug: channel.slug,
 			updatedAt: channel.updatedAt.toISOString(),
 		});
 	} catch {
@@ -383,6 +384,7 @@ function listen(): Server<SocketData> {
 					ts: 0,
 					channelId: room.id,
 					title: ws.data.channelTitle,
+					slug: ws.data.channelSlug,
 					updatedAt: ws.data.channelUpdatedAt,
 					you: { handle: ws.data.handle, client: ws.data.client },
 					members: Rooms.members(room),
@@ -500,6 +502,7 @@ function announceChannelRename(channel: ChannelRecord): void {
 		ts: 0,
 		channelId: channel.id,
 		title: channel.title,
+		slug: channel.slug,
 		updatedAt: channel.updatedAt.toISOString(),
 	});
 }

--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -362,7 +362,7 @@ describe("the MCP read protocol", () => {
 		]));
 	});
 
-	it("advertises the canonical repository and non-blank channel constraints it enforces", () => {
+	it("advertises the canonical repository and non-blank document locator constraints", () => {
 		let list = TOOLS.find(tool => tool.name === "list_documents")!;
 		let read = TOOLS.find(tool => tool.name === "read_document")!;
 		expect((list.inputSchema.properties as Record<string, { pattern: string }>).repository.pattern)
@@ -373,7 +373,7 @@ describe("the MCP read protocol", () => {
 			"\\S",
 		);
 		expect((read.inputSchema.properties as Record<string, { maxLength: number }>).id.maxLength)
-			.toBe(128);
+			.toBe(2_048);
 	});
 
 	it("does not reveal documents to an unauthenticated caller", async () => {
@@ -469,8 +469,13 @@ describe("the MCP read protocol", () => {
 			let [id, name, arguments_, error] of [
 				[5, "list_documents", { repository: "./chopin" }, "list_documents requires a repository"],
 				[6, "list_documents", { repository: "owner/.." }, "list_documents requires a repository"],
-				[7, "read_document", { id: " \t" }, "read_document requires an id"],
-				[9, "read_document", { id: "x".repeat(129) }, "read_document requires an id"],
+				[7, "read_document", { id: " \t" }, "read_document requires an id or URL"],
+				[
+					9,
+					"read_document",
+					{ id: "x".repeat(2_049) },
+					"read_document requires an id or URL",
+				],
 			]
 		) {
 			let invalid = await json(
@@ -495,13 +500,13 @@ describe("the MCP read protocol", () => {
 		expect(unknown.error).toEqual({ code: -32601, message: "tool not found" });
 	});
 
-	it("counts read-document ids by JSON Schema characters", async () => {
+	it("counts read-document locators by JSON Schema characters", async () => {
 		let boundary = await json(
 			await endpoint()(request({
 				jsonrpc: "2.0",
 				id: 10,
 				method: "tools/call",
-				params: { name: "read_document", arguments: { id: "😀".repeat(128) } },
+				params: { name: "read_document", arguments: { id: "😀".repeat(2_048) } },
 			})),
 		);
 

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -126,6 +126,7 @@ type Tool = {
 };
 
 const MAX_DOCUMENT_ID_LENGTH = 128;
+const MAX_DOCUMENT_LOCATOR_LENGTH = 2_048;
 
 const DOCUMENT = {
 	type: "object",
@@ -182,14 +183,14 @@ export const TOOLS: Tool[] = [
 	},
 	{
 		name: "read_document",
-		description: "Read a Chopin channel's canonical source and revision.",
+		description: "Read a Chopin document by ID or canonical URL.",
 		inputSchema: {
 			type: "object",
 			properties: {
 				id: {
 					type: "string",
 					minLength: 1,
-					maxLength: MAX_DOCUMENT_ID_LENGTH,
+					maxLength: MAX_DOCUMENT_LOCATOR_LENGTH,
 					pattern: "\\S",
 				},
 			},
@@ -282,10 +283,13 @@ export const TOOLS: Tool[] = [
 	},
 	{
 		name: "read_implementation",
-		description: "Read the approved implementation graph, plan and repository context.",
+		description:
+			"Read the approved implementation graph, plan and repository context by document ID or canonical URL.",
 		inputSchema: {
 			type: "object",
-			properties: { id: { type: "string", minLength: 1, maxLength: MAX_DOCUMENT_ID_LENGTH } },
+			properties: {
+				id: { type: "string", minLength: 1, maxLength: MAX_DOCUMENT_LOCATOR_LENGTH },
+			},
 			required: ["id"],
 			additionalProperties: false,
 		},
@@ -396,6 +400,12 @@ function clientInfo(value: unknown): { name: string; version: string } {
 function isId(value: unknown): value is string {
 	return typeof value === "string"
 		&& Array.from(value).length <= MAX_DOCUMENT_ID_LENGTH
+		&& value.trim().length > 0;
+}
+
+function isLocator(value: unknown): value is string {
+	return typeof value === "string"
+		&& Array.from(value).length <= MAX_DOCUMENT_LOCATOR_LENGTH
 		&& value.trim().length > 0;
 }
 
@@ -577,10 +587,10 @@ export function handler<Caller>(
 						: respond(text({ documents }));
 				}
 				if (tool.name === "read_document") {
-					if (Object.keys(tool.arguments).length !== 1 || !isId(tool.arguments.id)) {
+					if (Object.keys(tool.arguments).length !== 1 || !isLocator(tool.arguments.id)) {
 						return notification
 							? undefined
-							: error(call.id, -32602, "read_document requires an id");
+							: error(call.id, -32602, "read_document requires an id or URL");
 					}
 					let document = await options.documents.read(caller, tool.arguments.id);
 					return document ? respond(text(document)) : respond({ content: [], isError: true });
@@ -621,10 +631,10 @@ export function handler<Caller>(
 					return respond(text({ code }, true));
 				}
 				if (tool.name === "read_implementation") {
-					if (Object.keys(tool.arguments).length !== 1 || !isId(tool.arguments.id)) {
+					if (Object.keys(tool.arguments).length !== 1 || !isLocator(tool.arguments.id)) {
 						return notification
 							? undefined
-							: error(call.id, -32602, "read_implementation requires an id");
+							: error(call.id, -32602, "read_implementation requires an id or URL");
 					}
 					if (!options.implementations) {
 						return respond(text({ code: "implementation-unavailable" }, true));

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -293,7 +293,7 @@ describe("the hosted MCP adapter", () => {
 		let expected = createdDocument(result.document.id);
 		expect(result.document).toEqual({
 			...expected,
-			url: `/channels/${result.document.id}`,
+			url: "/documents/octo-org/score/created-plan",
 		});
 		let stored = await context.storage.collaboration.load(result.document.id, context.now);
 		if (!stored) throw new Error("created channel was not stored");
@@ -307,6 +307,12 @@ describe("the hosted MCP adapter", () => {
 			},
 		});
 		expect(await adapter.documents.read(caller, result.document.id)).toEqual(expected);
+		expect(await adapter.documents.read(caller, result.document.url)).toEqual(expected);
+		expect(await adapter.documents.read(caller, `/channels/${result.document.id}`))
+			.toEqual(expected);
+		expect(
+			await adapter.documents.read(caller, `https://chopin.test/channels/${result.document.id}`),
+		).toEqual(expected);
 	});
 
 	it("renames document metadata with current write access and announces real changes", async () => {
@@ -422,7 +428,7 @@ describe("the hosted MCP adapter", () => {
 			kind: "replayed",
 			document: {
 				...createdDocument(first.document.id),
-				url: `/channels/${first.document.id}`,
+				url: "/documents/octo-org/score/created-plan",
 			},
 		});
 	});
@@ -743,6 +749,21 @@ describe("the hosted MCP adapter", () => {
 				graph: { state: "locked" },
 				execution: { state: "active", run: { session: "session-1" } },
 			});
+		expect(
+			await adapter.implementations.readImplementation(
+				caller,
+				"/documents/octo-org/score/release-readiness",
+			),
+		).toMatchObject({
+			graph: { state: "locked" },
+			execution: { state: "active", run: { session: "session-1" } },
+		});
+		expect(
+			await adapter.implementations.readImplementation(
+				caller,
+				`/channels/${opened.channel.id}`,
+			),
+		).toMatchObject({ graph: { state: "locked" } });
 		expect(await adapter.implementations.startImplementation(caller, input)).toMatchObject({
 			kind: "active",
 			run: { session: "session-1" },

--- a/apps/server/src/mcp/hosted.ts
+++ b/apps/server/src/mcp/hosted.ts
@@ -1,4 +1,7 @@
-import { deterministicChannelId } from "../channels/id";
+import { documentPath, parseDocumentPath } from "@chopin/protocol/document-url";
+
+import { deterministicChannelId, isChannelId } from "../channels/id";
+import { documentSlug } from "../channels/slug";
 import { GitHubError } from "../github/client";
 import * as Plan from "../plan/service";
 import * as Rooms from "../rooms";
@@ -114,6 +117,43 @@ export function hosted(
 		}
 	}
 
+	async function locatedChannel(caller: HostedCaller, locator: string) {
+		let path: URL | undefined;
+		try {
+			path = new URL(locator, auth.config.origin);
+		} catch {
+			path = undefined;
+		}
+		let parsed = path?.origin === auth.config.origin
+			? parseDocumentPath(path.pathname)
+			: undefined;
+		if (parsed?.slug) {
+			let repository = await directRepository(caller, parsed.owner, parsed.repository);
+			if (!repository?.permissions.pull) return "forbidden" as const;
+			let channel = await auth.storage.channels.resolve(
+				repository.id,
+				documentSlug(parsed.slug),
+			);
+			return channel ? { channel, repository } : undefined;
+		}
+
+		let legacy = path?.origin === auth.config.origin
+			? /^\/channels\/([0-9a-f-]{36})\/?$/i.exec(path.pathname)
+			: undefined;
+		let id = legacy?.[1]?.toLowerCase();
+		let channel = await auth.storage.channels.get(id && isChannelId(id) ? id : locator);
+		if (!channel) return undefined;
+		let repository = await directRepository(
+			caller,
+			channel.repositoryOwner,
+			channel.repositoryName,
+		);
+		if (!repository?.permissions.pull || repository.id !== channel.repositoryId) {
+			return "forbidden" as const;
+		}
+		return { channel, repository };
+	}
+
 	function run(caller: HostedCaller, input: ImplementationInput): Run {
 		return {
 			id: crypto.randomUUID(),
@@ -162,17 +202,9 @@ export function hosted(
 				return documents;
 			},
 			async read(caller, id) {
-				let channel = await auth.storage.channels.get(id);
-				if (!channel) return undefined;
-				let repository = await directRepository(
-					caller,
-					channel.repositoryOwner,
-					channel.repositoryName,
-				);
-				if (
-					!repository?.permissions.pull
-					|| repository.id !== channel.repositoryId
-				) return undefined;
+				let located = await locatedChannel(caller, id);
+				if (!located || located === "forbidden") return undefined;
+				let { channel } = located;
 
 				let live = Rooms.get(channel.id)?.plan;
 				if (live) {
@@ -268,8 +300,9 @@ export function hosted(
 				let creation: Plan.CreationMetadata = { brief, origin };
 				let initial = await Plan.initial(plan, creation);
 				let id = deterministicChannelId(repository.id, input.idempotencyKey);
+				let created: ChannelRecord;
 				try {
-					await auth.storage.channels.create({
+					created = await auth.storage.channels.create({
 						id,
 						repositoryId: repository.id,
 						repositoryOwner: repository.owner,
@@ -299,7 +332,11 @@ export function hosted(
 							creation: restored.creation,
 							source: restored.source,
 							revision: restored.revision,
-							url: `/channels/${id}`,
+							url: documentPath(
+								repository.owner,
+								repository.name,
+								stored.channel.slug,
+							),
 						}),
 					};
 				}
@@ -307,11 +344,11 @@ export function hosted(
 					kind: "created",
 					document: document({
 						id,
-						title: input.title,
+						title: created.title,
 						creation,
 						source: initial.source,
 						revision: 0,
-						url: `/channels/${id}`,
+						url: documentPath(repository.owner, repository.name, created.slug),
 					}),
 				};
 			},
@@ -320,17 +357,11 @@ export function hosted(
 			? {
 				implementations: {
 					async readImplementation(caller: HostedCaller, id: string) {
-						let channel = await auth.storage.channels.get(id);
-						if (!channel) return undefined;
-						let repository = await directRepository(
-							caller,
-							channel.repositoryOwner,
-							channel.repositoryName,
-						);
-						if (!repository?.permissions.pull || repository.id !== channel.repositoryId) {
-							return "forbidden" as const;
-						}
-						let live = Rooms.get(id)?.plan;
+						let located = await locatedChannel(caller, id);
+						if (located === "forbidden") return "forbidden" as const;
+						if (!located) return undefined;
+						let { channel } = located;
+						let live = Rooms.get(channel.id)?.plan;
 						if (live) {
 							return exposed(channel, {
 								source: Plan.source(live),
@@ -341,7 +372,7 @@ export function hosted(
 								lifecycle: live.lifecycle,
 							});
 						}
-						let stored = await auth.storage.collaboration.load(id, auth.clock());
+						let stored = await auth.storage.collaboration.load(channel.id, auth.clock());
 						return stored ? exposed(channel, await Plan.readStored(stored)) : undefined;
 					},
 					async startImplementation(caller: HostedCaller, input: ImplementationInput) {

--- a/apps/server/src/socket/admission.test.ts
+++ b/apps/server/src/socket/admission.test.ts
@@ -129,6 +129,7 @@ describe("socket admission", () => {
 		expect("data" in viewer && viewer.data).toMatchObject({
 			room: channel.id,
 			channelTitle: "Plan",
+			channelSlug: "plan",
 			channelUpdatedAt: now.toISOString(),
 			handle: "octocat",
 			principalId: "U_octocat",

--- a/apps/server/src/socket/admission.ts
+++ b/apps/server/src/socket/admission.ts
@@ -44,6 +44,7 @@ export async function admit(
 			data: {
 				room: channel.id,
 				channelTitle: channel.title,
+				channelSlug: channel.slug,
 				channelUpdatedAt: channel.updatedAt.toISOString(),
 				handle: session.user.login,
 				client: uid(),

--- a/apps/server/src/storage/contract.ts
+++ b/apps/server/src/storage/contract.ts
@@ -254,6 +254,87 @@ export function storageContract(name: string, factory: Factory): void {
 			}
 		});
 
+		it("resolves canonical and historical document slugs without rebinding aliases", async () => {
+			let storage = await opened(factory);
+			try {
+				let { userId, channelId, repositoryId } = await userAndChannel(storage);
+				let original = await storage.channels.get(channelId);
+				expect(original?.slug).toBe("release-plan");
+				expect((await storage.channels.resolve(repositoryId, "release-plan"))?.id)
+					.toBe(channelId);
+
+				let renamed = await storage.channels.rename({
+					id: channelId,
+					title: "Résumé 計画",
+					now: new Date("2026-01-03T03:04:05.000Z"),
+				});
+				expect(renamed.channel.slug).toBe("résumé-計画");
+				expect((await storage.channels.resolve(repositoryId, "release-plan"))?.id)
+					.toBe(channelId);
+				expect((await storage.channels.resolve(repositoryId, "résumé-計画"))?.id)
+					.toBe(channelId);
+
+				let restored = await storage.channels.rename({
+					id: channelId,
+					title: "Release plan",
+					now: new Date("2026-01-04T03:04:05.000Z"),
+				});
+				expect(restored.channel.slug).toBe("release-plan");
+				await storage.channels.rename({
+					id: channelId,
+					title: "Launch plan",
+					now: new Date("2026-01-05T03:04:05.000Z"),
+				});
+
+				let replacement = await storage.channels.create({
+					id: id("replacement-channel"),
+					repositoryId,
+					repositoryOwner: "octo-org",
+					repositoryName: "score",
+					title: "Release plan",
+					createdBy: userId,
+					now: new Date("2026-01-06T03:04:05.000Z"),
+				});
+				expect(replacement.slug).toBe("release-plan-2");
+				expect((await storage.channels.resolve(repositoryId, "release-plan"))?.id)
+					.toBe(channelId);
+				expect((await storage.channels.resolve(repositoryId, "release-plan-2"))?.id)
+					.toBe(replacement.id);
+				expect(await storage.channels.resolve(repositoryId, "missing"))
+					.toBeUndefined();
+			} finally {
+				await storage.close();
+			}
+		});
+
+		it("atomically disambiguates different titles with the same document slug", async () => {
+			let storage = await opened(factory);
+			try {
+				let { userId, repositoryId } = await userAndChannel(storage);
+				let now = new Date("2026-01-03T03:04:05.000Z");
+				let create = (channelId: string, title: string) =>
+					storage.channels.create({
+						id: channelId,
+						repositoryId,
+						repositoryOwner: "octo-org",
+						repositoryName: "score",
+						title,
+						createdBy: userId,
+						now,
+					});
+				let channels = await Promise.all([
+					create(id("channel"), "Bright road"),
+					create(id("channel"), "Bright-road!"),
+				]);
+				expect(channels.map(channel => channel.slug).sort()).toEqual([
+					"bright-road",
+					"bright-road-2",
+				]);
+			} finally {
+				await storage.close();
+			}
+		});
+
 		it("atomically reserves one title for concurrent creators", async () => {
 			let storage = await opened(factory);
 			try {

--- a/apps/server/src/storage/memory/adapter.ts
+++ b/apps/server/src/storage/memory/adapter.ts
@@ -1,4 +1,5 @@
 import { conflict, missing } from "../errors";
+import { documentSlug, documentSlugCandidate } from "../../channels/slug";
 
 import type {
 	AgentState,
@@ -83,6 +84,7 @@ export class MemoryStorage implements StorageAdapter {
 	#users = new Map<string, UserRecord>();
 	#sessions = new Map<string, WebSession>();
 	#channels = new Map<string, ChannelRecord>();
+	#channelSlugs = new Map<string, Map<string, string>>();
 	#snapshots = new Map<string, ChannelSnapshot>();
 	#sequences = new Map<string, number>();
 	#updates = new Map<string, ChannelUpdate[]>();
@@ -149,6 +151,11 @@ export class MemoryStorage implements StorageAdapter {
 	readonly channels: ChannelStore = {
 		create: input => this.#createChannel(input),
 		get: id => Promise.resolve(this.#channels.get(id)).then(value => value && channel(value)),
+		resolve: (repositoryId, slug) => {
+			let id = this.#channelSlugs.get(repositoryId)?.get(slug);
+			let found = id ? this.#channels.get(id) : undefined;
+			return Promise.resolve(found && channel(found));
+		},
 		rename: input => this.#renameChannel(input),
 		list: (repositoryId, limit, after, query) =>
 			this.#listChannels(repositoryId, limit, after, query),
@@ -203,8 +210,10 @@ export class MemoryStorage implements StorageAdapter {
 			)
 		) throw conflict(`channel title ${input.title} already exists in this repository`);
 		let { initial, now, ...record } = input;
+		let slug = this.#reserveSlug(input.repositoryId, input.id, input.title);
 		let saved: ChannelRecord = {
 			...record,
+			slug,
 			revision: 0,
 			createdAt: now,
 			updatedAt: now,
@@ -240,9 +249,26 @@ export class MemoryStorage implements StorageAdapter {
 		let updatedAt = input.now > found.updatedAt
 			? input.now
 			: new Date(found.updatedAt.getTime() + 1);
-		let saved = { ...found, title: input.title, updatedAt };
+		let slug = this.#reserveSlug(found.repositoryId, found.id, input.title);
+		let saved = { ...found, title: input.title, slug, updatedAt };
 		this.#channels.set(saved.id, saved);
 		return { channel: channel(saved), changed: true };
+	}
+
+	#reserveSlug(repositoryId: string, channelId: string, title: string): string {
+		let aliases = this.#channelSlugs.get(repositoryId);
+		if (!aliases) {
+			aliases = new Map();
+			this.#channelSlugs.set(repositoryId, aliases);
+		}
+		let base = documentSlug(title);
+		for (let index = 1;; index++) {
+			let candidate = documentSlugCandidate(base, index);
+			let owner = aliases.get(candidate);
+			if (owner && owner !== channelId) continue;
+			aliases.set(candidate, channelId);
+			return candidate;
+		}
 	}
 
 	#listChannels(

--- a/apps/server/src/storage/model.ts
+++ b/apps/server/src/storage/model.ts
@@ -35,6 +35,7 @@ export type ChannelRecord = {
 	repositoryOwner: string;
 	repositoryName: string;
 	title: string;
+	slug: string;
 	createdBy: string;
 	revision: number;
 	createdAt: Date;
@@ -46,11 +47,16 @@ export type InitialChannel = Omit<
 	"channelId" | "revision" | "throughSequence" | "createdAt"
 >;
 
-export type CreateChannel = Omit<ChannelRecord, "revision" | "createdAt" | "updatedAt"> & {
-	now: Date;
-	/** A complete revision-zero checkpoint published in the channel's creation transaction. */
-	initial?: InitialChannel;
-};
+export type CreateChannel =
+	& Omit<
+		ChannelRecord,
+		"slug" | "revision" | "createdAt" | "updatedAt"
+	>
+	& {
+		now: Date;
+		/** A complete revision-zero checkpoint published in the channel's creation transaction. */
+		initial?: InitialChannel;
+	};
 
 export type RenameChannel = {
 	id: string;

--- a/apps/server/src/storage/port.ts
+++ b/apps/server/src/storage/port.ts
@@ -40,6 +40,7 @@ export interface SessionStore {
 export interface ChannelStore {
 	create(channel: CreateChannel): Promise<ChannelRecord>;
 	get(id: string): Promise<ChannelRecord | undefined>;
+	resolve(repositoryId: string, slug: string): Promise<ChannelRecord | undefined>;
 	rename(channel: RenameChannel): Promise<RenameResult>;
 	list(repositoryId: string, limit: number, after?: {
 		updatedAt: Date;

--- a/apps/server/src/storage/postgres/adapter.test.ts
+++ b/apps/server/src/storage/postgres/adapter.test.ts
@@ -1,8 +1,12 @@
 import { SQL } from "bun";
 import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
 
+import { documentSlug } from "../../channels/slug";
 import { storageContract } from "../contract";
+import { StorageError } from "../errors";
 import { PostgresStorage } from "./adapter";
+import { backfillDocumentSlugs } from "./migrations/002_document_slugs";
 
 let url = process.env.TEST_DATABASE_URL;
 
@@ -28,6 +32,120 @@ if (url) {
 			]);
 		} finally {
 			await sql.close();
+		}
+	});
+
+	it("backfills unique readable slugs for channels created before the slug migration", async () => {
+		let sql = new SQL(url);
+		let schema = `slug_migration_${crypto.randomUUID().replaceAll("-", "")}`;
+		try {
+			await sql.unsafe(`CREATE SCHEMA "${schema}"`).simple();
+			let initial = await Bun.file(join(import.meta.dir, "migrations/001_initial.sql")).text();
+			let slugs = await Bun.file(join(import.meta.dir, "migrations/002_document_slugs.sql")).text();
+			await sql.begin(async transaction => {
+				await transaction.unsafe(`SET LOCAL search_path TO "${schema}"`).simple();
+				await transaction.unsafe(initial).simple();
+				await transaction`
+					INSERT INTO users (id, login, avatar_url, created_at, updated_at)
+					VALUES ('U_test', 'test', '', now(), now())
+				`;
+				let titles = [
+					"Release plan",
+					"Release-plan!",
+					"Résumé 計画",
+					"🚀",
+					"İstanbul",
+					"ΟΣ",
+					"\u0301",
+				];
+				for (let [index, title] of titles.entries()) {
+					await transaction`
+						INSERT INTO channels (
+							id, repository_id, repository_owner, repository_name, title,
+							created_by, created_at, updated_at
+						) VALUES (
+							${`channel-${index}`}, 'R_test', 'octo-org', 'score', ${title},
+							'U_test', ${new Date(1_700_000_000_000 + index)}, now()
+						)
+					`;
+				}
+				for (let index = 0; index < 505; index++) {
+					let punctuation = index.toString(2).replaceAll("0", "!").replaceAll("1", "?");
+					await transaction`
+						INSERT INTO channels (
+							id, repository_id, repository_owner, repository_name, title,
+							created_by, created_at, updated_at
+						) VALUES (
+							${`channel-batch-${String(index).padStart(3, "0")}`},
+							'R_test', 'octo-org', 'score', ${`Batch${punctuation}`},
+							'U_test', ${new Date(1_700_001_000_000 + index)}, now()
+						)
+					`;
+				}
+				await transaction.unsafe(slugs).simple();
+				await backfillDocumentSlugs(transaction);
+				let rows = await transaction<{ channelId: string; slug: string }[]>`
+					SELECT channel_id AS "channelId", slug
+					FROM channel_slugs
+					WHERE canonical
+					ORDER BY channel_id
+				`;
+				let byId = new Map(rows.map(row => [row.channelId, row.slug]));
+				expect(titles.map((_, index) => byId.get(`channel-${index}`))).toEqual([
+					documentSlug(titles[0]!),
+					`${documentSlug(titles[1]!)}-2`,
+					...titles.slice(2).map(documentSlug),
+				]);
+				let batch = rows.filter(row => row.channelId.startsWith("channel-batch-"));
+				expect(batch).toHaveLength(505);
+				expect(new Set(batch.map(row => row.slug)).size).toBe(505);
+				expect(byId.get("channel-batch-000")).toBe("batch");
+				expect(byId.get("channel-batch-504")).toBe("batch-505");
+			});
+		} finally {
+			await sql.unsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`).simple();
+			await sql.close();
+		}
+	});
+
+	it("orders concurrent create and rename slug reservations without deadlocking", async () => {
+		let storage = new PostgresStorage(url);
+		try {
+			await storage.migrate();
+			let suffix = crypto.randomUUID();
+			let now = new Date();
+			let userId = `user-${suffix}`;
+			let repositoryId = `repository-${suffix}`;
+			await storage.users.put({ id: userId, login: "slug-race", avatarUrl: "", now });
+			let existing = await storage.channels.create({
+				id: `existing-${suffix}`,
+				repositoryId,
+				repositoryOwner: "octo-org",
+				repositoryName: "score",
+				title: "Original title",
+				createdBy: userId,
+				now,
+			});
+			let results = await Promise.allSettled([
+				storage.channels.rename({ id: existing.id, title: "Shared title", now }),
+				storage.channels.create({
+					id: `created-${suffix}`,
+					repositoryId,
+					repositoryOwner: "octo-org",
+					repositoryName: "score",
+					title: "Shared title",
+					createdBy: userId,
+					now,
+				}),
+			]);
+			expect(results.filter(result => result.status === "fulfilled")).toHaveLength(1);
+			let rejected = results.find(result => result.status === "rejected");
+			expect(rejected?.status === "rejected" && rejected.reason).toBeInstanceOf(StorageError);
+			if (rejected?.status === "rejected" && rejected.reason instanceof StorageError) {
+				expect(rejected.reason.failure).toBe("conflict");
+			}
+		} finally {
+			await storage.close();
 		}
 	});
 } else {

--- a/apps/server/src/storage/postgres/adapter.ts
+++ b/apps/server/src/storage/postgres/adapter.ts
@@ -1,5 +1,6 @@
 import { SQL } from "bun";
 
+import { documentSlug, documentSlugCandidate } from "../../channels/slug";
 import { conflict, corrupt, missing, StorageError, unavailable } from "../errors";
 import { migrate, verifyMigrations } from "./migrations";
 
@@ -61,6 +62,7 @@ type ChannelRow = {
 	repositoryOwner: string;
 	repositoryName: string;
 	title: string;
+	slug?: string;
 	createdBy: string;
 	revision: Integer;
 	nextSequence?: Integer;
@@ -184,8 +186,10 @@ function session(row: SessionRow): WebSession {
 }
 
 function channel(row: ChannelRow): ChannelRecord {
+	if (!row.slug) throw corrupt(`channel ${row.id} has no canonical slug`);
 	return {
 		...row,
+		slug: row.slug,
 		revision: integer(row.revision, "channel revision"),
 		createdAt: date(row.createdAt, "channel creation time"),
 		updatedAt: date(row.updatedAt, "channel update time"),
@@ -270,6 +274,23 @@ const SESSION_COLUMNS = `
 `;
 
 const CHANNEL_COLUMNS = `
+	channels.id,
+	channels.repository_id AS "repositoryId",
+	channels.repository_owner AS "repositoryOwner",
+	channels.repository_name AS "repositoryName",
+	channels.title,
+	(
+		SELECT channel_slugs.slug
+		FROM channel_slugs
+		WHERE channel_slugs.channel_id = channels.id AND channel_slugs.canonical
+	) AS slug,
+	channels.created_by AS "createdBy",
+	channels.revision,
+	channels.created_at AS "createdAt",
+	channels.updated_at AS "updatedAt"
+`;
+
+const CHANNEL_RETURNING = `
 	id,
 	repository_id AS "repositoryId",
 	repository_owner AS "repositoryOwner",
@@ -444,6 +465,19 @@ export class PostgresStorage implements StorageAdapter {
 			`;
 				return found ? channel(found) : undefined;
 			}),
+		resolve: (repositoryId, slug) =>
+			this.#run("resolve channel slug", async () => {
+				let [found] = await this.#sql<ChannelRow[]>`
+					SELECT ${this.#sql.unsafe(CHANNEL_COLUMNS)}
+					FROM channel_slugs
+					JOIN channels
+						ON channels.id = channel_slugs.channel_id
+						AND channels.repository_id = channel_slugs.repository_id
+					WHERE channel_slugs.repository_id = ${repositoryId}
+						AND channel_slugs.slug = ${slug}
+				`;
+				return found ? channel(found) : undefined;
+			}),
 		rename: input => this.#renameChannel(input),
 		list: (repositoryId, limit, after, query) =>
 			this.#listChannels(repositoryId, limit, after, query),
@@ -510,9 +544,16 @@ export class PostgresStorage implements StorageAdapter {
 					${input.repositoryName}, ${input.title}, ${input.createdBy}, 0, 1,
 					${input.now}, ${input.now}
 				)
-				RETURNING ${transaction.unsafe(CHANNEL_COLUMNS)}
+				RETURNING ${transaction.unsafe(CHANNEL_RETURNING)}
 			`;
 				if (!saved) throw corrupt("creating a channel returned no record");
+				let slug = await this.#reserveSlug(
+					transaction,
+					input.repositoryId,
+					input.id,
+					input.title,
+					input.now,
+				);
 				await transaction`
 				INSERT INTO channel_state (channel_id, sidecar)
 				VALUES (
@@ -533,7 +574,7 @@ export class PostgresStorage implements StorageAdapter {
 						)
 					`;
 				}
-				return channel(saved);
+				return channel({ ...saved, slug });
 			}));
 	}
 
@@ -558,11 +599,60 @@ export class PostgresStorage implements StorageAdapter {
 					UPDATE channels
 					SET title = ${input.title}, updated_at = ${updatedAt}
 					WHERE id = ${input.id}
-					RETURNING ${transaction.unsafe(CHANNEL_COLUMNS)}
+					RETURNING ${transaction.unsafe(CHANNEL_RETURNING)}
 				`;
 				if (!saved) throw corrupt("renaming a channel returned no record");
-				return { channel: channel(saved), changed: true };
+				let slug = await this.#reserveSlug(
+					transaction,
+					existing.repositoryId,
+					existing.id,
+					input.title,
+					input.now,
+				);
+				return { channel: channel({ ...saved, slug }), changed: true };
 			}));
+	}
+
+	async #reserveSlug(
+		transaction: TransactionSQL,
+		repositoryId: string,
+		channelId: string,
+		title: string,
+		now: Date,
+	): Promise<string> {
+		let base = documentSlug(title);
+		for (let index = 1;; index++) {
+			let candidate = documentSlugCandidate(base, index);
+			let [inserted] = await transaction<{ channelId: string }[]>`
+				INSERT INTO channel_slugs (
+					repository_id, slug, channel_id, canonical, created_at
+				) VALUES (${repositoryId}, ${candidate}, ${channelId}, false, ${now})
+				ON CONFLICT DO NOTHING
+				RETURNING channel_id AS "channelId"
+			`;
+			if (!inserted) {
+				let [existing] = await transaction<{ channelId: string }[]>`
+					SELECT channel_id AS "channelId"
+					FROM channel_slugs
+					WHERE repository_id = ${repositoryId} AND slug = ${candidate}
+				`;
+				if (existing?.channelId !== channelId) continue;
+			}
+
+			await transaction`
+				UPDATE channel_slugs SET canonical = false
+				WHERE channel_id = ${channelId} AND canonical
+			`;
+			let [promoted] = await transaction<{ slug: string }[]>`
+				UPDATE channel_slugs SET canonical = true
+				WHERE repository_id = ${repositoryId}
+					AND slug = ${candidate}
+					AND channel_id = ${channelId}
+				RETURNING slug
+			`;
+			if (!promoted) throw corrupt(`could not reserve a slug for channel ${channelId}`);
+			return promoted.slug;
+		}
 	}
 
 	#listChannels(

--- a/apps/server/src/storage/postgres/migrations.ts
+++ b/apps/server/src/storage/postgres/migrations.ts
@@ -1,17 +1,33 @@
 import { join } from "node:path";
 
-import type { SQL } from "bun";
+import { backfillDocumentSlugs } from "./migrations/002_document_slugs";
+
+import type { SQL, TransactionSQL } from "bun";
+
+type Migration = {
+	id: string;
+	path: string;
+	applyPath?: string;
+	checksumTag?: string;
+	apply?: (sql: TransactionSQL) => Promise<void>;
+};
 
 const MIGRATIONS = [{
 	id: "001_initial",
 	path: join(import.meta.dir, "migrations/001_initial.sql"),
-}];
+}, {
+	id: "002_document_slugs",
+	path: join(import.meta.dir, "migrations/002_document_slugs.sql"),
+	applyPath: join(import.meta.dir, "migrations/002_document_slugs.ts"),
+	checksumTag: "apply:backfillDocumentSlugs:v1",
+	apply: backfillDocumentSlugs,
+}] satisfies Migration[];
 
 /** Stable across deployments; it serializes migrations, not ordinary writes. */
 const MIGRATION_LOCK = 2_043_237_431;
 
 type Applied = { id: string; checksum: string };
-type Expected = { id: string; source: string; checksum: string };
+type Expected = Migration & { source: string; checksum: string };
 
 function checksum(source: string): string {
 	return new Bun.CryptoHasher("sha256").update(source).digest("hex");
@@ -20,7 +36,11 @@ function checksum(source: string): string {
 async function expected(): Promise<Expected[]> {
 	return Promise.all(MIGRATIONS.map(async migration => {
 		let source = await Bun.file(migration.path).text();
-		return { id: migration.id, source, checksum: checksum(source) };
+		let applySource = migration.applyPath ? await Bun.file(migration.applyPath).text() : "";
+		let fingerprint = applySource || migration.checksumTag
+			? `${source}\n-- ${migration.checksumTag ?? "data migration"}\n${applySource}`
+			: source;
+		return { ...migration, source, checksum: checksum(fingerprint) };
 	}));
 }
 
@@ -60,6 +80,7 @@ export async function migrate(sql: SQL): Promise<void> {
 			let previous = applied.get(migration.id);
 			if (previous) continue;
 			await transaction.unsafe(migration.source).simple();
+			await migration.apply?.(transaction);
 			await transaction`
 				INSERT INTO chopin_migrations (id, checksum)
 				VALUES (${migration.id}, ${migration.checksum})

--- a/apps/server/src/storage/postgres/migrations/002_document_slugs.sql
+++ b/apps/server/src/storage/postgres/migrations/002_document_slugs.sql
@@ -1,0 +1,18 @@
+ALTER TABLE channels
+	ADD CONSTRAINT channels_repository_identity UNIQUE (repository_id, id);
+
+CREATE TABLE channel_slugs (
+	repository_id text NOT NULL,
+	slug text NOT NULL,
+	channel_id text NOT NULL,
+	canonical boolean NOT NULL,
+	created_at timestamptz NOT NULL,
+	PRIMARY KEY (repository_id, slug),
+	FOREIGN KEY (repository_id, channel_id)
+		REFERENCES channels(repository_id, id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX channel_slugs_canonical
+	ON channel_slugs (channel_id) WHERE canonical;
+
+CREATE INDEX channel_slugs_channel ON channel_slugs (channel_id);

--- a/apps/server/src/storage/postgres/migrations/002_document_slugs.ts
+++ b/apps/server/src/storage/postgres/migrations/002_document_slugs.ts
@@ -1,0 +1,107 @@
+import type { TransactionSQL } from "bun";
+
+const MAX_SLUG_LENGTH = 100;
+const BATCH_SIZE = 500;
+
+type Channel = {
+	id: string;
+	repositoryId: string;
+	title: string;
+	createdAt: Date | string;
+};
+
+function truncated(value: string, maximum: number): string {
+	return Array.from(value).slice(0, maximum).join("").replace(/-+$/u, "");
+}
+
+function slug(title: string): string {
+	let value = title
+		.normalize("NFKC")
+		.toLowerCase()
+		.replace(/[^\p{L}\p{N}\p{M}]+/gu, "-")
+		.replace(/^-+|-+$/gu, "");
+	return value ? truncated(value, MAX_SLUG_LENGTH) : "document";
+}
+
+function candidate(base: string, index: number): string {
+	if (index === 1) return base;
+	let suffix = `-${index}`;
+	return `${truncated(base, MAX_SLUG_LENGTH - Array.from(suffix).length)}${suffix}`;
+}
+
+async function page(sql: TransactionSQL, after?: Channel): Promise<Channel[]> {
+	let columns = sql.unsafe(`
+		channels.id,
+		channels.repository_id AS "repositoryId",
+		channels.title,
+		channels.created_at AS "createdAt"
+	`);
+	return after
+		? sql<Channel[]>`
+			SELECT ${columns}
+			FROM channels
+			WHERE (channels.repository_id, channels.created_at, channels.id) > (
+				${after.repositoryId}, ${after.createdAt}, ${after.id}
+			)
+				AND NOT EXISTS (
+					SELECT 1 FROM channel_slugs
+					WHERE channel_slugs.channel_id = channels.id AND channel_slugs.canonical
+				)
+			ORDER BY channels.repository_id, channels.created_at, channels.id
+			LIMIT ${BATCH_SIZE}
+			FOR UPDATE
+		`
+		: sql<Channel[]>`
+			SELECT ${columns}
+			FROM channels
+			WHERE NOT EXISTS (
+				SELECT 1 FROM channel_slugs
+				WHERE channel_slugs.channel_id = channels.id AND channel_slugs.canonical
+			)
+			ORDER BY channels.repository_id, channels.created_at, channels.id
+			LIMIT ${BATCH_SIZE}
+			FOR UPDATE
+		`;
+}
+
+/** Immutable data migration paired with 002_document_slugs.sql. */
+export async function backfillDocumentSlugs(sql: TransactionSQL): Promise<void> {
+	let occupied = new Set<string>();
+	let next = new Map<string, number>();
+	let repositoryId: string | undefined;
+	let after: Channel | undefined;
+	while (true) {
+		let channels = await page(sql, after);
+		if (channels.length === 0) return;
+		for (let channel of channels) {
+			if (channel.repositoryId !== repositoryId) {
+				repositoryId = channel.repositoryId;
+				occupied.clear();
+				next.clear();
+			}
+			let base = slug(channel.title);
+			let baseKey = `${channel.repositoryId}\0${base}`;
+			let index = next.get(baseKey) ?? 1;
+			while (true) {
+				let value = candidate(base, index);
+				let key = `${channel.repositoryId}\0${value}`;
+				index++;
+				if (occupied.has(key)) continue;
+				let [inserted] = await sql<{ slug: string }[]>`
+					INSERT INTO channel_slugs (
+						repository_id, slug, channel_id, canonical, created_at
+					) VALUES (
+						${channel.repositoryId}, ${value}, ${channel.id}, true, ${channel.createdAt}
+					)
+					ON CONFLICT DO NOTHING
+					RETURNING slug
+				`;
+				occupied.add(key);
+				if (!inserted) continue;
+				next.set(baseKey, index);
+				break;
+			}
+		}
+		after = channels.at(-1);
+	}
+}

--- a/apps/server/src/wire.ts
+++ b/apps/server/src/wire.ts
@@ -25,6 +25,7 @@ export type AuthorizationResult = "allowed" | "denied" | "unavailable";
 export type SocketData = Identity & {
 	room: string;
 	channelTitle: string;
+	channelSlug: string;
 	channelUpdatedAt: string;
 	canEdit: boolean;
 	principalId: string;

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -29,6 +29,7 @@ export type Channel = {
 	repositoryOwner: string;
 	repositoryName: string;
 	title: string;
+	slug: string;
 	createdBy: string;
 	revision: number;
 	createdAt: string;
@@ -98,7 +99,7 @@ async function decoded<T>(result: Response): Promise<T> {
 		value = undefined;
 	}
 	if (!result.ok) {
-		if (result.status === 401 && typeof location !== "undefined") location.assign("/");
+		if (result.status === 401 && typeof location !== "undefined") location.reload();
 		let message = value && typeof value === "object" && "error" in value
 				&& typeof value.error === "string"
 			? value.error
@@ -177,6 +178,18 @@ export function createChannel(
 
 export function channel(id: string): Promise<ChannelDetail> {
 	return response(`/api/channels/${encodeURIComponent(id)}`);
+}
+
+export function document(
+	owner: string,
+	repository: string,
+	slug: string,
+): Promise<ChannelDetail> {
+	return response(
+		`/api/repositories/${encodeURIComponent(owner)}/${encodeURIComponent(repository)}/documents/${
+			encodeURIComponent(slug)
+		}`,
+	);
 }
 
 export function renameChannel(id: string, title: string): Promise<ChannelDetail> {

--- a/apps/web/src/channel-recovery.test.ts
+++ b/apps/web/src/channel-recovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { readChannelRecovery, rememberChannel } from "./channel-recovery";
+import { readChannelRecovery, readDocumentRecovery, rememberChannel } from "./channel-recovery";
 
 class MemoryStorage implements Storage {
 	readonly #values = new Map<string, string>();
@@ -33,6 +33,7 @@ class MemoryStorage implements Storage {
 const channel = {
 	id: "11111111-1111-4111-8111-111111111111",
 	title: "Release readiness",
+	slug: "release-readiness",
 };
 
 const repository = {
@@ -47,6 +48,15 @@ describe("channel recovery context", () => {
 		rememberChannel("U_octocat", channel, repository, storage);
 
 		expect(readChannelRecovery("U_octocat", channel.id, storage)).toEqual({ channel, repository });
+		expect(
+			readDocumentRecovery(
+				"U_octocat",
+				repository.owner,
+				repository.name,
+				channel.slug,
+				storage,
+			),
+		).toEqual({ channel, repository });
 	});
 
 	it("replaces the cached title after a document is renamed", () => {
@@ -78,10 +88,37 @@ describe("channel recovery context", () => {
 		expect(readChannelRecovery("U_other", channel.id, storage)).toBeUndefined();
 	});
 
+	it("restores UUID recovery records written before slugs were introduced", () => {
+		let storage = new MemoryStorage();
+		storage.setItem(
+			`chopin:channel-recovery:${encodeURIComponent("U_octocat")}:${channel.id}`,
+			JSON.stringify({ channel: { id: channel.id, title: channel.title }, repository }),
+		);
+
+		expect(readChannelRecovery("U_octocat", channel.id, storage)).toEqual({
+			channel: { id: channel.id, title: channel.title },
+			repository,
+		});
+		expect(
+			readDocumentRecovery(
+				"U_octocat",
+				repository.owner,
+				repository.name,
+				channel.slug,
+				storage,
+			),
+		).toBeUndefined();
+	});
+
 	it("ignores malformed stored context", () => {
 		let storage = new MemoryStorage();
 		storage.setItem(`chopin:channel-recovery:U_octocat:${channel.id}`, "not json");
 
+		expect(readChannelRecovery("U_octocat", channel.id, storage)).toBeUndefined();
+		storage.setItem(
+			`chopin:channel-recovery:U_octocat:${channel.id}`,
+			JSON.stringify({ channel: { ...channel, slug: { invalid: true } }, repository }),
+		);
 		expect(readChannelRecovery("U_octocat", channel.id, storage)).toBeUndefined();
 	});
 });

--- a/apps/web/src/channel-recovery.ts
+++ b/apps/web/src/channel-recovery.ts
@@ -1,11 +1,14 @@
+import { documentPath } from "@chopin/protocol/document-url";
+
 import type * as Api from "./api";
 
 export type ChannelRecovery = {
-	channel: Pick<Api.Channel, "id" | "title">;
+	channel: Pick<Api.Channel, "id" | "title"> & Partial<Pick<Api.Channel, "slug">>;
 	repository: Pick<Api.Repository, "owner" | "name" | "fullName">;
 };
 
 const KEY = "chopin:channel-recovery:";
+const PATH_KEY = "chopin:document-recovery:";
 
 function record(value: unknown): Record<string, unknown> | undefined {
 	return value && typeof value === "object" && !Array.isArray(value)
@@ -25,6 +28,7 @@ function recovery(value: unknown, id: string): value is ChannelRecovery {
 		&& !!channel
 		&& channel.id === id
 		&& text(channel.title)
+		&& (channel.slug === undefined || text(channel.slug))
 		&& !!repository
 		&& text(repository.owner)
 		&& text(repository.name)
@@ -33,7 +37,7 @@ function recovery(value: unknown, id: string): value is ChannelRecovery {
 
 export function rememberChannel(
 	userId: string,
-	channel: ChannelRecovery["channel"],
+	channel: Pick<Api.Channel, "id" | "title" | "slug">,
 	repository: ChannelRecovery["repository"],
 	storage: Storage = sessionStorage,
 ): void {
@@ -42,8 +46,46 @@ export function rememberChannel(
 			`${KEY}${encodeURIComponent(userId)}:${channel.id}`,
 			JSON.stringify({ channel, repository }),
 		);
+		storage.setItem(
+			`${PATH_KEY}${encodeURIComponent(userId)}:${
+				documentPath(
+					repository.owner,
+					repository.name,
+					channel.slug,
+				)
+			}`,
+			JSON.stringify({ channel, repository }),
+		);
 	} catch {
 		// Recovery context must never prevent the navigation it is meant to help.
+	}
+}
+
+export function readDocumentRecovery(
+	userId: string,
+	owner: string,
+	repository: string,
+	slug: string,
+	storage: Storage = sessionStorage,
+): ChannelRecovery | undefined {
+	try {
+		let path = documentPath(owner, repository, slug);
+		let value: unknown = JSON.parse(
+			storage.getItem(`${PATH_KEY}${encodeURIComponent(userId)}:${path}`) ?? "null",
+		);
+		let item = record(value);
+		let storedChannel = record(item?.channel);
+		let storedRepository = record(item?.repository);
+		return text(storedChannel?.id)
+				&& text(storedChannel.slug)
+				&& storedChannel.slug === slug
+				&& storedRepository?.owner === owner
+				&& storedRepository.name === repository
+				&& recovery(value, storedChannel.id)
+			? value
+			: undefined;
+	} catch {
+		return undefined;
 	}
 }
 

--- a/apps/web/src/document-picker.tsx
+++ b/apps/web/src/document-picker.tsx
@@ -1,4 +1,5 @@
 import { CaretDownIcon, CheckIcon, PlusIcon } from "@phosphor-icons/react";
+import { documentPath } from "@chopin/protocol/document-url";
 import { createPortal } from "react-dom";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 
@@ -23,7 +24,7 @@ function select(
 	repository: Pick<Api.Repository, "owner" | "name" | "fullName">,
 ) {
 	rememberChannel(userId, channel, repository);
-	location.assign(`/channels/${channel.id}`);
+	location.assign(documentPath(repository.owner, repository.name, channel.slug));
 }
 
 /** Repository-scoped navigation and creation stay separate from repository selection. */
@@ -37,7 +38,7 @@ export function DocumentPicker(
 	}: {
 		canEdit: boolean;
 		current: Pick<Api.Channel, "id" | "title">;
-		onRename: (channel: Pick<Api.Channel, "title" | "updatedAt">) => void;
+		onRename: (channel: Pick<Api.Channel, "title" | "slug" | "updatedAt">) => void;
 		repository: Pick<Api.Repository, "name" | "owner" | "fullName">;
 		userId: string;
 	},
@@ -144,7 +145,11 @@ export function DocumentPicker(
 		try {
 			let created = await Api.createChannel(repository.owner, repository.name);
 			rememberChannel(userId, created.channel, created.repository);
-			location.assign(`/channels/${created.channel.id}`);
+			location.assign(documentPath(
+				created.repository.owner,
+				created.repository.name,
+				created.channel.slug,
+			));
 		} catch (reason) {
 			setCreateError(reason);
 			setCreating(false);

--- a/apps/web/src/hosted.test.ts
+++ b/apps/web/src/hosted.test.ts
@@ -1,11 +1,23 @@
 import { describe, expect, it } from "bun:test";
 
 import { ApiError } from "./api";
-import { hostedRoute, retryableChannelFailure } from "./hosted";
+import { githubLoginHref, hostedRoute, retryableChannelFailure } from "./hosted";
 
 describe("hosted routes", () => {
-	it("recognizes repository and channel routes", () => {
+	it("recognizes canonical document and legacy routes", () => {
 		expect(hostedRoute("/")).toEqual({ page: "repositories" });
+		expect(hostedRoute("/documents/octo-org/score")).toEqual({
+			page: "repository",
+			owner: "octo-org",
+			repository: "score",
+		});
+		expect(hostedRoute("/documents/octo-org/score/r%C3%A9sum%C3%A9-%E8%A8%88%E7%94%BB"))
+			.toEqual({
+				page: "document",
+				owner: "octo-org",
+				repository: "score",
+				slug: "résumé-計画",
+			});
 		expect(hostedRoute("/repositories/octo-org/score")).toEqual({
 			page: "repository",
 			owner: "octo-org",
@@ -25,6 +37,18 @@ describe("hosted routes", () => {
 			id: "019c1234-1234-5123-8123-123456789abc",
 		});
 		expect(hostedRoute("/plans/main")).toEqual({ page: "missing" });
+		expect(hostedRoute("/documents/octo-org/score/plan/extra"))
+			.toEqual({ page: "missing" });
+	});
+});
+
+describe("hosted login", () => {
+	it("binds the current product location to the OAuth attempt", () => {
+		expect(githubLoginHref("/documents/octo-org/score/release-plan", "?view=plan", "#item"))
+			.toBe(
+				"/auth/github?return_to=%2Fdocuments%2Focto-org%2Fscore%2Frelease-plan%3Fview%3Dplan%23item",
+			);
+		expect(githubLoginHref("/")).toBe("/auth/github?return_to=%2F");
 	});
 });
 

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
+import { documentPath, documentsPath, parseDocumentPath } from "@chopin/protocol/document-url";
 
 import * as Api from "./api";
-import { readChannelRecovery, rememberChannel } from "./channel-recovery";
+import { readChannelRecovery, readDocumentRecovery, rememberChannel } from "./channel-recovery";
 import { DocumentRename } from "./document-rename";
 import { RepositoryPicker } from "./repository-picker";
 import { clearRepositoryCache } from "./repository-cache";
@@ -12,6 +13,7 @@ export type HostedWorkspaceProps = {
 	room: string;
 	handle: string;
 	label: string;
+	slug: string;
 	updatedAt: string;
 	repository: Api.Repository;
 	canEdit: boolean;
@@ -22,6 +24,7 @@ export type HostedWorkspaceProps = {
 export type HostedRoute =
 	| { page: "repositories" }
 	| { page: "repository"; owner: string; repository: string }
+	| { page: "document"; owner: string; repository: string; slug: string }
 	| { page: "channel"; id: string }
 	| { page: "missing" };
 
@@ -35,6 +38,16 @@ function decoded(value: string): string | undefined {
 
 export function hostedRoute(pathname: string): HostedRoute {
 	if (pathname === "/" || pathname === "") return { page: "repositories" };
+	let document = parseDocumentPath(pathname);
+	if (document?.slug) {
+		return {
+			page: "document",
+			owner: document.owner,
+			repository: document.repository,
+			slug: document.slug,
+		};
+	}
+	if (document) return { page: "repository", ...document };
 	let repository = /^\/repositories\/([^/]+)\/([^/]+)\/?$/.exec(pathname);
 	if (repository) {
 		let owner = decoded(repository[1]!);
@@ -107,9 +120,12 @@ function Loading({ label = "Loading" }: { label?: string }) {
 }
 
 function repositoryHref(repository: { owner: string; name: string }): string {
-	return `/repositories/${encodeURIComponent(repository.owner)}/${
-		encodeURIComponent(repository.name)
-	}`;
+	return documentsPath(repository.owner, repository.name);
+}
+
+function canonicalize(pathname: string): void {
+	if (location.pathname === pathname) return;
+	history.replaceState(null, "", `${pathname}${location.search}${location.hash}`);
 }
 
 function Failure(
@@ -119,7 +135,7 @@ function Failure(
 		onRetry,
 		repository,
 	}: {
-		channel?: { id: string; title?: string };
+		channel?: { title?: string; slug?: string };
 		error: unknown;
 		onRetry?: () => void;
 		repository?: Pick<Api.Repository, "owner" | "name" | "fullName">;
@@ -134,7 +150,9 @@ function Failure(
 				{channel && (
 					<div className="mt-4 min-w-0">
 						{channel.title && <p className="break-words text-sm font-medium">{channel.title}</p>}
-						<p className="mt-1 break-all text-sm text-text-tertiary">{channel.id}</p>
+						{channel.slug && (
+							<p className="mt-1 break-all text-sm text-text-tertiary">{channel.slug}</p>
+						)}
 						{repository && (
 							<p className="mt-2 break-words text-sm text-text-secondary">
 								{repository.fullName}
@@ -164,6 +182,7 @@ function Failure(
 }
 
 export function HostedLogin() {
+	let href = githubLoginHref(location.pathname, location.search, location.hash);
 	return (
 		<div className="grid h-full bg-ground lg:grid-cols-[1.15fr_0.85fr]" data-hosted="">
 			<section className="flex items-end bg-text-primary p-6 text-page sm:p-10 lg:p-16">
@@ -184,13 +203,18 @@ export function HostedLogin() {
 					<p className="mt-2 text-sm text-text-secondary">
 						Sign in with GitHub to choose a repository and its planning channels.
 					</p>
-					<a className="btn btn-md btn-primary mt-6 w-full" href="/auth/github">
+					<a className="btn btn-md btn-primary mt-6 w-full" href={href}>
 						Continue with GitHub
 					</a>
 				</div>
 			</section>
 		</div>
 	);
+}
+
+export function githubLoginHref(pathname: string, search = "", hash = ""): string {
+	let parameters = new URLSearchParams({ return_to: `${pathname}${search}${hash}` });
+	return `/auth/github?${parameters}`;
 }
 
 function RepositoryHome({ user }: { user: Api.User }) {
@@ -216,9 +240,16 @@ function RepositoryChannels(
 	let [renaming, setRenaming] = useState<string>();
 
 	useEffect(() => {
+		canonicalize(documentsPath(owner, repository));
+	}, [owner, repository]);
+
+	useEffect(() => {
 		let active = true;
 		Api.channels(owner, repository).then(value => {
-			if (active) setPage(value);
+			if (active) {
+				canonicalize(documentsPath(value.repository.owner, value.repository.name));
+				setPage(value);
+			}
 		}, reason => {
 			if (active) setError(reason);
 		});
@@ -234,7 +265,11 @@ function RepositoryChannels(
 		try {
 			let result = await Api.createChannel(owner, repository, title.trim());
 			rememberChannel(user.id, result.channel, result.repository);
-			location.assign(`/channels/${result.channel.id}`);
+			location.assign(documentPath(
+				result.repository.owner,
+				result.repository.name,
+				result.channel.slug,
+			));
 		} catch (reason) {
 			setError(reason);
 			setCreating(false);
@@ -363,7 +398,11 @@ function RepositoryChannels(
 												>
 													<a
 														className="flex min-w-0 flex-1 flex-col items-start justify-between gap-1 px-4 py-4 sm:flex-row sm:items-center sm:gap-4 sm:px-5"
-														href={`/channels/${channel.id}`}
+														href={documentPath(
+															page.repository.owner,
+															page.repository.name,
+															channel.slug,
+														)}
 														onClick={() => rememberChannel(user.id, channel, page.repository)}
 													>
 														<span className="min-w-0 break-words text-sm font-medium">
@@ -408,9 +447,12 @@ function RepositoryChannels(
 }
 
 function ChannelWorkspace(
-	{ agent, id, user }: {
+	{ agent, id, owner, repository, slug, user }: {
 		agent: boolean;
-		id: string;
+		id?: string;
+		owner?: string;
+		repository?: string;
+		slug?: string;
 		user: Api.User;
 	},
 ) {
@@ -420,15 +462,29 @@ function ChannelWorkspace(
 	}>();
 	let [error, setError] = useState<unknown>();
 	let [retry, setRetry] = useState(0);
-	let recovery = readChannelRecovery(user.id, id);
+	let recovery = id
+		? readChannelRecovery(user.id, id)
+		: owner && repository && slug
+		? readDocumentRecovery(user.id, owner, repository, slug)
+		: undefined;
 
 	useEffect(() => {
 		let active = true;
-		let detail = Api.channel(id).then(value => {
-			if (active) rememberChannel(user.id, value.channel, value.repository);
+		let detail = id
+			? Api.channel(id)
+			: Api.document(owner!, repository!, slug!);
+		let prepared = detail.then(value => {
+			if (active) {
+				canonicalize(documentPath(
+					value.repository.owner,
+					value.repository.name,
+					value.channel.slug,
+				));
+				rememberChannel(user.id, value.channel, value.repository);
+			}
 			return value;
 		});
-		Promise.all([detail, import("./room-workspace")]).then(([detail, module]) => {
+		Promise.all([prepared, import("./room-workspace")]).then(([detail, module]) => {
 			if (active) setLoaded({ detail, Workspace: module.RoomWorkspace });
 		}, reason => {
 			if (active) setError(reason);
@@ -436,11 +492,14 @@ function ChannelWorkspace(
 		return () => {
 			active = false;
 		};
-	}, [id, retry]);
+	}, [id, owner, repository, retry, slug, user.id]);
 	if (error) {
+		let requestedRepository = owner && repository
+			? { owner, name: repository, fullName: `${owner}/${repository}` }
+			: undefined;
 		return (
 			<Failure
-				channel={recovery?.channel ?? { id }}
+				channel={recovery?.channel ?? (slug ? { slug } : undefined)}
 				error={error}
 				onRetry={retryableChannelFailure(error)
 					? () => {
@@ -448,7 +507,7 @@ function ChannelWorkspace(
 						setRetry(value => value + 1);
 					}
 					: undefined}
-				repository={recovery?.repository}
+				repository={recovery?.repository ?? requestedRepository}
 			/>
 		);
 	}
@@ -460,6 +519,7 @@ function ChannelWorkspace(
 			canEdit={detail.canEdit}
 			handle={user.login}
 			label={detail.channel.title}
+			slug={detail.channel.slug}
 			updatedAt={detail.channel.updatedAt}
 			repository={detail.repository}
 			room={detail.channel.id}
@@ -477,6 +537,16 @@ export function HostedApp(
 			return <RepositoryHome user={user} />;
 		case "repository":
 			return <RepositoryChannels owner={route.owner} repository={route.repository} user={user} />;
+		case "document":
+			return (
+				<ChannelWorkspace
+					agent={agent}
+					owner={route.owner}
+					repository={route.repository}
+					slug={route.slug}
+					user={user}
+				/>
+			);
 		case "channel":
 			return <ChannelWorkspace agent={agent} id={route.id} user={user} />;
 		case "missing":

--- a/apps/web/src/repository-picker.tsx
+++ b/apps/web/src/repository-picker.tsx
@@ -1,4 +1,5 @@
 import { CaretDownIcon, CheckIcon } from "@phosphor-icons/react";
+import { documentsPath } from "@chopin/protocol/document-url";
 import { createPortal } from "react-dom";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 
@@ -22,9 +23,7 @@ export type RepositoryIdentity = Pick<
 >;
 
 function repositoryHref(repository: RepositoryIdentity): string {
-	return `/repositories/${encodeURIComponent(repository.owner)}/${
-		encodeURIComponent(repository.name)
-	}`;
+	return documentsPath(repository.owner, repository.name);
 }
 
 function sameRepository(left: RepositoryIdentity | undefined, right: RepositoryIdentity): boolean {
@@ -39,7 +38,7 @@ function optionId(list: string, repository: Api.Repository): string {
 function reauthenticate(reason: unknown, userId: string): boolean {
 	if (!(reason instanceof Api.ApiError) || reason.status !== 401) return false;
 	clearRepositoryCache(userId);
-	location.assign("/");
+	location.reload();
 	return true;
 }
 

--- a/apps/web/src/room-workspace.tsx
+++ b/apps/web/src/room-workspace.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { documentPath } from "@chopin/protocol/document-url";
 import {
 	advanceDecisionView,
 	countUnanswered,
@@ -42,7 +43,7 @@ function Header(
 		canEdit: boolean;
 		members: Session.Member[];
 		label: string;
-		onRename: (channel: Pick<Api.Channel, "title" | "updatedAt">) => void;
+		onRename: (channel: Pick<Api.Channel, "title" | "slug" | "updatedAt">) => void;
 		repository: Api.Repository;
 		room: string;
 		userId: string;
@@ -95,6 +96,7 @@ export function RoomWorkspace(
 		label,
 		repository,
 		room,
+		slug,
 		updatedAt,
 		userId,
 	}: HostedWorkspaceProps,
@@ -103,7 +105,7 @@ export function RoomWorkspace(
 	let [status, setStatus] = useState<Status>("connecting");
 	let [members, setMembers] = useState<Session.Member[]>([]);
 	let [effectiveCanEdit, setEffectiveCanEdit] = useState(canEdit);
-	let [metadata, setMetadata] = useState({ title: label, updatedAt });
+	let [metadata, setMetadata] = useState({ title: label, slug, updatedAt });
 	let metadataRef = useRef(metadata);
 	let user = useMemo(() => cursor(handle), [handle]);
 	let mode = useWorkspaceMode();
@@ -139,11 +141,15 @@ export function RoomWorkspace(
 		},
 		[conversationActive],
 	);
-	let updateMetadata = useCallback((next: { title: string; updatedAt: string }) => {
+	let updateMetadata = useCallback((next: { title: string; slug: string; updatedAt: string }) => {
 		if (Date.parse(next.updatedAt) <= Date.parse(metadataRef.current.updatedAt)) return;
 		metadataRef.current = next;
 		setMetadata(next);
-		rememberChannel(userId, { id: room, title: next.title }, repository);
+		rememberChannel(userId, { id: room, title: next.title, slug: next.slug }, repository);
+		let path = documentPath(repository.owner, repository.name, next.slug);
+		if (location.pathname !== path) {
+			history.replaceState(null, "", `${path}${location.search}${location.hash}`);
+		}
 	}, [repository, room, userId]);
 
 	useEffect(() => {
@@ -205,15 +211,15 @@ export function RoomWorkspace(
 	}, [canEdit, room]);
 
 	useEffect(() => {
-		let next = { title: label, updatedAt };
+		let next = { title: label, slug, updatedAt };
 		metadataRef.current = next;
 		setMetadata(next);
-	}, [label, room, updatedAt]);
+	}, [label, room, slug, updatedAt]);
 
 	useEffect(() => {
 		let socket = new Wire({
 			channelId: room,
-			onAuthenticationRequired: () => location.assign("/"),
+			onAuthenticationRequired: () => location.reload(),
 			onStatus: next => {
 				setStatus(next);
 			},

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,6 +159,21 @@ keys solve separate identity problems. See [Repository channels](channels.md) fo
 channel ID construction and [Experimental implementation lifecycle](implementation-lifecycle.md)
 for graph counters.
 
+A channel UUID is the stable internal document identity used by storage, UUID
+API routes, WebSocket rooms, and MCP lifecycle mutations. The public browser
+identity is a repository-scoped, title-derived route:
+`/documents/:owner/:repository/:slug`. Slugs retain Unicode letters, numbers,
+and marks, add numeric suffixes for collisions, and keep every former canonical
+slug as an alias. Renaming changes the canonical route without changing the UUID
+or plan revision.
+
+Browser creation `Location` headers and MCP `create_document.url` expose the
+readable route. MCP `read_document` and `read_implementation` bridge the two
+identities by accepting either the canonical URL or UUID and returning the UUID;
+lifecycle calls continue to use that returned UUID. Legacy repository and UUID
+browser paths resolve through the existing internal routes before the browser
+replaces them with the canonical readable location.
+
 ## Collaborative document
 
 Chopin represents one document in three forms: Lexical for rich editing, Yjs for

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -73,7 +73,8 @@ SESSION_ENCRYPTION_KEY=<64 hex characters>
 ```
 
 The client ID is distinct from the numeric App ID. Generate the encryption key
-with `openssl rand -hex 32`; it protects only the OAuth state and PKCE cookie.
+with `openssl rand -hex 32`; it protects the short-lived OAuth attempt cookie,
+including state, the PKCE verifier, and an optional browser return path.
 
 `APP_ORIGIN` must be exactly one HTTP(S) origin: no credentials, path, query,
 fragment, or trailing slash. HTTPS is required except for loopback development,
@@ -131,7 +132,7 @@ requests but does not retain picker repository data.
 
 Local MCP is an intentional exception to this installation boundary. Its bearer
 token is authenticated independently and authorized with a direct repository
-lookup. An MCP-created channel for a repository outside the App installation is
+lookup. An MCP-created document for a repository outside the App installation is
 not available through browser routes, WebSockets, or the hosted agent until
 the installation includes that repository. See [Local agent MCP](local-agent-mcp.md).
 
@@ -142,6 +143,15 @@ callback ignores GitHub's untrusted `installation_id` query parameter, clears
 the browser's installation snapshot, and redirects into the product. The next
 picker or authorization request re-queries GitHub with the signed-in user's
 token.
+
+When a signed-out browser opens a document deep link, the sign-in request sends
+the current path, query, and fragment as `return_to`. Chopin accepts only one
+validated root-relative product path, stores it inside the encrypted OAuth
+attempt cookie, and redirects there after a successful callback. Absolute and
+protocol-relative URLs, control characters, backslashes, and API, auth,
+WebSocket, or MCP paths fall back to `/`; a callback query cannot override the
+stored value. GitHub App installation setup remains separate: its callback still
+ignores return paths and redirects to `/?repository_access=changed`.
 
 Organization members may need an owner to approve installation or new
 permissions. For an organization using SAML SSO, establish an active SAML
@@ -185,13 +195,14 @@ transcripts, reserved Planner context fields, and repository installations
 remain durable. Logout deletes the process-local session and registry row but
 does not revoke the GitHub App authorization.
 
-OAuth state and the PKCE verifier are held in a separate encrypted, ten-minute
-HttpOnly cookie. Browser state-changing routes and WebSocket upgrades require an
-Origin header exactly equal to `APP_ORIGIN`. The bearer-authenticated MCP route
-accepts a missing Origin, as non-browser clients normally omit it, but rejects a
-present mismatched Origin. Open sockets periodically recheck the process-local
-session, instance admission, and installation repository permission. A browser
-whose socket reconnects after a restart is returned to sign-in.
+OAuth state, the PKCE verifier, and the validated browser return path are held in
+a separate encrypted, ten-minute HttpOnly cookie. Browser state-changing routes
+and WebSocket upgrades require an Origin header exactly equal to `APP_ORIGIN`.
+The bearer-authenticated MCP route accepts a missing Origin, as non-browser
+clients normally omit it, but rejects a present mismatched Origin. Open sockets
+periodically recheck the process-local session, instance admission, and
+installation repository permission. A browser whose socket reconnects after a
+restart is returned to sign-in.
 
 When a credential rotates, any Planner SDK session holding the previous token
 is aborted and discarded before refresh. A later turn recreates it from the
@@ -210,10 +221,15 @@ GET  /api/github/installations?page=1
 GET  /api/github/installations/:installationId/repositories?page=1
 GET  /api/repositories/:owner/:repository/channels
 POST /api/repositories/:owner/:repository/channels
+GET  /api/repositories/:owner/:repository/documents/:slug
 GET  /api/channels/:channelId
+PATCH /api/channels/:channelId
 POST /api/channels/:channelId/agent/reset
 POST /auth/logout
 ```
+
+The repository-scoped document endpoint backs readable browser URLs. Existing
+UUID routes remain internal API and collaboration entry points.
 
 API and authentication paths are owned by the server in development and
 production.

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,6 +1,6 @@
 # Repository channels
 
-A channel is Chopin's durable collaboration container for one document, its
+A channel is Chopin's internal durable collaboration container for one document, its
 conversation, decisions, and one GitHub repository. Its metadata is stored
 locally; GitHub remains the current source of identity, installation access, and
 repository roles.
@@ -16,12 +16,12 @@ authorization then depends on the surface:
 | Hosted agent (Planner)     | The owning browser user's GitHub App token | The installation, ownership generation, session, credential revision, and role are rechecked before tools run. |
 | Local MCP                  | Caller-supplied GitHub bearer              | GitHub is queried directly; no App installation is required.                                                   |
 
-Pull access may list and open channels. Push or administration access may create
-a channel, edit its document, change decisions, invoke the hosted agent, and
+Pull access may list and open documents. Push or administration access may create
+a document, edit it, change decisions, invoke the hosted agent, and
 mutate an implementation lifecycle. A public repository is not sufficient to
-expose its channels through the browser.
+expose its documents through the browser.
 
-An MCP-created channel outside the App installation remains unavailable to
+An MCP-created document outside the App installation remains unavailable to
 browser routes, WebSockets, and the hosted agent until an account owner adds
 that repository to the installation.
 
@@ -30,10 +30,16 @@ that repository to the installation.
 ```text
 GET  /api/repositories/:owner/:repository/channels
 POST /api/repositories/:owner/:repository/channels
+GET  /api/repositories/:owner/:repository/documents/:slug
 GET  /api/channels/:channelId
 PATCH /api/channels/:channelId
 POST /api/channels/:channelId/agent/reset
 ```
+
+The `channels` and UUID paths are internal API names retained by the current
+implementation. The repository-scoped `documents/:slug` route resolves both the
+current document slug and its historical aliases. Browser creation returns the
+readable canonical document route in `Location`, not a UUID route.
 
 The listing route accepts a case-insensitive `query`, an opaque `cursor`, and a
 `limit` from 1 through 100. The default limit is 50. Results sort by most recent
@@ -44,15 +50,23 @@ A title is optional during browser creation. Chopin generates one when omitted,
 or accepts a trimmed title from 1 through 120 characters. Titles are unique per
 repository without regard to case.
 
-`PATCH /api/channels/:channelId` accepts `{ "title": "..." }`. It updates only
-channel metadata, not the canonical MDX heading or plan revision. A changed
-title updates the channel activity time and is broadcast to clients in the open
-room; submitting the current title is a no-op.
+`PATCH /api/channels/:channelId` accepts `{ "title": "..." }`. It updates the
+document title and canonical slug, but not the canonical MDX heading, UUID
+identity, or plan revision. A changed title updates the channel activity time
+and is broadcast to clients in the open room; submitting the current title is a
+no-op.
+
+Slugs are derived from Unicode-normalized, lowercased titles. Unicode letters,
+numbers, and combining marks remain readable while punctuation and spacing
+collapse to hyphens. Slugs are scoped to a repository and receive numbered
+suffixes such as `-2` when they collide. Every former canonical slug remains a
+permanent alias for the same document and cannot be rebound to another one, so a
+rename changes the canonical route without breaking an old link.
 
 The reset endpoint releases Planner ownership and aborts its disposable runtime
 session. The current web application does not expose a control that calls it.
 
-## Channel identity
+## Document URL and channel identity
 
 New channel IDs are lowercase, UUIDv5-shaped values derived with SHA-256. The
 server also accepts existing UUIDv4 IDs.
@@ -66,6 +80,19 @@ The stored GitHub repository node ID is authoritative. Owner and repository
 name are retained so GitHub can resolve the repository, but they are never
 trusted as a replacement for the node ID. This prevents a transferred or
 recreated repository name from inheriting another repository's channels.
+
+The UUID is the stable internal identity used by storage, UUID API routes,
+WebSocket rooms, and MCP lifecycle calls. Public browser locations use the
+repository and slug instead:
+
+```text
+/documents/:owner/:repository/:slug
+```
+
+Renaming a document promotes its new title-derived slug as canonical while
+retaining the same UUID and plan revision. Browser `Location` headers and the MCP
+`create_document` result expose the readable route rather than
+`/channels/:channelId`.
 
 ## Creation paths
 
@@ -86,10 +113,16 @@ differs.
 ## Browser routes
 
 ```text
-/                                      repository picker
-/repositories/:owner/:repository      channel list and creation
-/channels/:channelId                   conversation plus Plan or Decisions view
+/documents/:owner/:repository         document list and creation
+/documents/:owner/:repository/:slug   conversation plus Plan or Decisions view
+/                                     repository picker
 ```
+
+Historical slug URLs continue to open the document. The legacy
+`/repositories/:owner/:repository` and `/channels/:channelId` browser routes are
+also accepted. After resolving any historical or legacy link, the browser
+replaces its address with the current canonical `/documents/...` route while
+preserving the query and fragment.
 
 The application first authorizes metadata over HTTP, then opens one WebSocket
 for live channel traffic. Wide split mode shows Conversation beside either Plan,

--- a/docs/implementation-lifecycle.md
+++ b/docs/implementation-lifecycle.md
@@ -64,12 +64,14 @@ storage commit revision described in [Architecture](architecture.md).
 1. The team settles the plan and resolves its questions and comments.
 2. The hosted Planner reads the latest plan and drafts a dependency graph.
 3. A person reviews and approves that exact graph and plan revision.
-4. A coding agent calls `read_implementation` from the document's repository.
+4. A coding agent passes the canonical document URL, or its UUID, to
+   `read_implementation` from the document's repository.
 5. The agent verifies the repository, branch, and commit returned by Chopin
    against its checkout. The service does not inspect the checkout or resolve
    the original branch and commit against GitHub.
-6. `start_implementation` atomically claims the approved graph and creates one
-   run ID.
+6. The agent uses the returned document UUID and revisions with
+   `start_implementation`, which atomically claims the approved graph and creates
+   one run ID.
 7. The agent works only on dependency-ready tasks and reports their lifecycle.
 8. Every task receives one reported pull request and completion summary.
 9. An independent whole-graph review submits verification evidence for every
@@ -88,7 +90,7 @@ experimental.
 
 | Tool                   | Purpose                                                                                   |
 | ---------------------- | ----------------------------------------------------------------------------------------- |
-| `read_implementation`  | Read the approved graph, canonical plan, repository context, and current revisions.       |
+| `read_implementation`  | Read the approved graph, plan, and repository context by UUID or canonical URL.           |
 | `start_implementation` | Claim that exact graph while reporting the coding agent's repository, branch, and commit. |
 | `start_task`           | Move one dependency-ready task to in progress.                                            |
 | `block_task`           | Record a task blocker without releasing the graph lock.                                   |
@@ -100,6 +102,11 @@ experimental.
 Every post-claim lifecycle report carries a caller-generated idempotency key.
 `start_implementation` does not; the service creates a fresh run ID when it
 accepts the claim. Accepted transitions persist before publication.
+
+The readable URL is a locator for `read_implementation`; it is not a lifecycle
+identity. `read_implementation` returns the stable UUID as `document.id`, and
+`start_implementation` plus every task, pull-request, blocker, revision, and
+verification call continues using that UUID.
 
 ## Lock behavior
 

--- a/docs/local-agent-mcp.md
+++ b/docs/local-agent-mcp.md
@@ -65,6 +65,25 @@ graph, but the product has no user-facing way to approve the Planner's draft.
 See
 [Experimental implementation lifecycle](implementation-lifecycle.md).
 
+## Document URLs and IDs
+
+The `url` returned by `create_document` is the readable canonical route:
+
+```text
+/documents/:owner/:repository/:slug
+```
+
+`read_document` and `read_implementation` accept either a document UUID or that
+canonical URL in their `id` input. The URL may be passed back exactly as
+returned; an absolute URL must use the configured Chopin origin. Both reads
+return the stable UUID as the document `id`.
+
+The UUID remains the internal storage, API, WebSocket, and MCP identity. Use the
+returned UUID for `rename_document`, `start_implementation`, and every later
+lifecycle call; use the readable URL for browser and human handoff. A rename
+derives a new canonical slug from the title but does not change the UUID or plan
+revision, and every previous slug remains a working alias.
+
 ## Claude Code
 
 Install and sign in to Claude Code, then add Chopin to your user configuration:
@@ -108,9 +127,10 @@ Start the agent from the repository you want to inspect and ask:
 Use the Chopin list_documents tool to list the documents available for this repository. Return each document's id and title.
 ```
 
-`rename_document` accepts a document `id` and replacement `title`. It changes
-the catalog title only, leaving canonical plan source, plan revision, and
-creation provenance intact. Repeating the same title is safe and has no effect.
+`rename_document` accepts a document UUID and replacement `title`. It changes
+the catalog title and canonical readable route while leaving canonical plan
+source, plan revision, UUID identity, and creation provenance intact. Repeating
+the same title is safe and has no effect.
 
 `{"documents":[]}` is a successful response for a repository with no Chopin
 documents. After the connection is established, the MCP `initialize`

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -103,7 +103,7 @@ the image.
 | `GITHUB_APP_CLIENT_SECRET`     | required            | OAuth client secret used for user-token exchange and refresh.                                                                      |
 | `GITHUB_ALLOWED_USERS`         | empty               | Comma-separated admitted GitHub logins.                                                                                            |
 | `GITHUB_ALLOWED_ORGANIZATIONS` | empty               | Comma-separated organizations whose active members are admitted.                                                                   |
-| `SESSION_ENCRYPTION_KEY`       | required            | Exactly 64 hexadecimal characters used for the short-lived OAuth state and PKCE cookie.                                            |
+| `SESSION_ENCRYPTION_KEY`       | required            | Exactly 64 hexadecimal characters used for the encrypted OAuth attempt cookie, including its validated return path.                |
 | `SERVER_HOST`                  | `127.0.0.1`         | Source-process bind address. The image sets `0.0.0.0`.                                                                             |
 | `PORT`                         | `8787`              | Source-process HTTP and WebSocket port. The supplied image and health check expect internal port 8787.                             |
 | `MODEL`                        | `claude-sonnet-4.6` | Model requested for hosted agent sessions.                                                                                         |

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -8,10 +8,10 @@ runtime `STORAGE_DRIVER`.
 
 ## State model
 
-The database stores channel metadata, collaboration recovery state, domain
-sidecars, token-free ownership references, and the writer lease. GitHub tokens,
-browser-cookie verifiers, open rooms, Awareness presence, and Copilot SDK
-sessions never cross the storage boundary.
+The database stores channel metadata, repository-scoped document slug aliases,
+collaboration recovery state, domain sidecars, token-free ownership references,
+and the writer lease. GitHub tokens, browser-cookie verifiers, open rooms,
+Awareness presence, and Copilot SDK sessions never cross the storage boundary.
 
 The versioned sidecar is the atomic domain snapshot associated with a channel.
 It includes document sequence and plan revision counters, question and comment
@@ -34,6 +34,8 @@ Every adapter must provide:
 - monotonic storage sequences across checkpoints;
 - atomic checkpoint and epoch replacement;
 - atomic first-Planner ownership with a generation token;
+- repository-scoped canonical and historical slug resolution without rebinding
+  aliases;
 - expiring, token-free process-session registry rows;
 - startup removal of every registry row and Planner owner reference;
 - renewable leases whose fencing token protects commits, epoch replacements,
@@ -65,13 +67,14 @@ recovery or acknowledgement behavior.
 ## PostgreSQL schema
 
 The migration runner owns `chopin_migrations`, including a checksum for each
-applied migration. The initial application schema contains:
+applied migration. The application schema contains:
 
 | Table                | Purpose                                                                                                          |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `users`              | GitHub identity and attribution records.                                                                         |
 | `web_sessions`       | Token-free process-session IDs, user IDs, and expiry timestamps used by Planner ownership.                       |
 | `channels`           | Repository identity, title, creator, storage revision, next sequence, and timestamps.                            |
+| `channel_slugs`      | One canonical title-derived slug per channel plus permanent repository-scoped historical aliases.                |
 | `channel_state`      | Current sidecar JSON for a channel.                                                                              |
 | `channel_snapshots`  | Complete Yjs checkpoint, canonical source, source hash, epoch, counters, and checkpoint sidecar.                 |
 | `channel_operations` | Per-channel operation idempotency and the revision and sequence assigned to each operation.                      |
@@ -81,8 +84,11 @@ applied migration. The initial application schema contains:
 | `storage_leases`     | Renewable named leases and fencing tokens.                                                                       |
 
 Channel titles have a case-insensitive unique constraint within each repository.
-Foreign keys remove dependent collaboration state when a channel is deleted,
-although the current product has no channel-deletion route.
+Slug values are also unique per repository, with one canonical slug per channel.
+A rename promotes a new collision-suffixed slug but retains all former slugs as
+aliases that cannot be assigned to another channel. Foreign keys remove slug
+aliases and dependent collaboration state when a channel is deleted, although
+the current product has no channel-deletion route.
 
 ## Commit and acknowledgement
 

--- a/e2e/database.ts
+++ b/e2e/database.ts
@@ -9,6 +9,14 @@ const DEFAULT_DATABASES: Record<number, string> = {
 	8789: "postgresql://chopin:chopin@127.0.0.1:5434/chopin?sslmode=disable",
 };
 
+export function testChannelSlug(id: string): string {
+	return `test-${id.slice(0, 8)}`;
+}
+
+export function testChannelPath(id: string): string {
+	return `/documents/octo-org/score/${testChannelSlug(id)}`;
+}
+
 function url(port: number): string {
 	let index = port === 8789 ? 1 : 0;
 	return process.env[`E2E_DATABASE_URL_${index}`] || DEFAULT_DATABASES[port]!;
@@ -26,6 +34,7 @@ async function sql<T>(port: number, action: (database: SQL) => Promise<T>): Prom
 export async function createChannel(port: number, id: string): Promise<void> {
 	await sql(port, async database => {
 		let now = new Date();
+		let slug = testChannelSlug(id);
 		await database.begin(async transaction => {
 			await transaction`
 				INSERT INTO users (id, login, avatar_url, created_at, updated_at)
@@ -40,6 +49,11 @@ export async function createChannel(port: number, id: string): Promise<void> {
 					${id}, 'R_score', 'octo-org', 'score', ${`Test ${id.slice(0, 8)}`},
 					'U_e2e', 0, 1, ${now}, ${now}
 				)
+			`;
+			await transaction`
+				INSERT INTO channel_slugs (
+					repository_id, slug, channel_id, canonical, created_at
+				) VALUES ('R_score', ${slug}, ${id}, true, ${now})
 			`;
 			await transaction`
 				INSERT INTO channel_state (channel_id, sidecar) VALUES (${id}, 'null'::jsonb)

--- a/e2e/document-navigation.e2e.ts
+++ b/e2e/document-navigation.e2e.ts
@@ -1,4 +1,4 @@
-import { authenticate, expect, test } from "./room";
+import { authenticate, expect, roomPath, test } from "./room";
 
 function channel(id: string, title: string) {
 	return {
@@ -9,6 +9,7 @@ function channel(id: string, title: string) {
 		repositoryName: "score",
 		repositoryOwner: "octo-org",
 		revision: 0,
+		slug: title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, ""),
 		title,
 		updatedAt: "2026-08-19T12:00:00.000Z",
 	};
@@ -45,7 +46,7 @@ test("the room header switches documents with keyboard focus and creates one imm
 
 	await trigger.click();
 	await page.getByRole("button", { name: "Create new document" }).click();
-	await expect(page).toHaveURL(/\/channels\/[0-9a-f-]{36}$/);
+	await expect(page).toHaveURL(/\/documents\/octo-org\/score\/[a-z]+-[a-z]+$/);
 	await expect(header.getByRole("button", { name: /^Document: [a-z]+-[a-z]+$/ })).toBeVisible();
 });
 
@@ -97,6 +98,8 @@ test("renaming the current document updates collaborators and survives reload", 
 	let ana = await join("ana");
 	let bo = await join("bo");
 	let title = `Launch plan ${room.slice(0, 8)}`;
+	let previousPath = roomPath(room);
+	let renamedPath = `/documents/octo-org/score/${title.toLowerCase().replaceAll(" ", "-")}`;
 	let anaTrigger = ana.getByRole("banner").getByRole("button", { name: /^Document:/ });
 	let boTrigger = bo.getByRole("banner").getByRole("button", { name: /^Document:/ });
 
@@ -110,9 +113,13 @@ test("renaming the current document updates collaborators and survives reload", 
 
 	await expect(anaTrigger).toHaveAccessibleName(`Document: ${title}`);
 	await expect(boTrigger).toHaveAccessibleName(`Document: ${title}`);
+	await expect(ana).toHaveURL(renamedPath);
+	await expect(bo).toHaveURL(renamedPath);
 	await ana.reload();
 	await expect(ana.getByRole("banner").getByRole("button", { name: `Document: ${title}` }))
 		.toBeVisible();
+	await ana.goto(previousPath);
+	await expect(ana).toHaveURL(renamedPath);
 });
 
 test("a delayed rename response cannot overwrite a newer collaborator rename", async ({ join, room }) => {
@@ -151,7 +158,7 @@ test("a delayed rename response cannot overwrite a newer collaborator rename", a
 
 test("read-only visitors can browse documents without a creation action", async ({ baseURL, page, room }) => {
 	await authenticate(page, "readonly", baseURL!);
-	await page.goto(`/channels/${room}`);
+	await page.goto(roomPath(room));
 	await expect(page.getByRole("banner")).toBeVisible();
 	await expect(page.getByRole("textbox", { name: "editable markdown" })).toHaveAttribute(
 		"contenteditable",
@@ -216,5 +223,5 @@ test("document picker keeps failures open and makes creation retryable", async (
 	await expect(page.getByRole("alert")).toHaveText("creation is unavailable");
 	await expect(create).toBeEnabled();
 	await create.click();
-	await expect(page).toHaveURL(/\/channels\/[0-9a-f-]{36}$/);
+	await expect(page).toHaveURL(/\/documents\/octo-org\/score\/[a-z]+-[a-z]+$/);
 });

--- a/e2e/hosted.e2e.ts
+++ b/e2e/hosted.e2e.ts
@@ -1,4 +1,4 @@
-import { authenticate, expect, test } from "./room";
+import { authenticate, expect, roomPath, test } from "./room";
 import { expectInsideViewport, expectNoHorizontalOverflow } from "./responsive";
 import { installVisualViewport } from "./visual-viewport";
 
@@ -21,6 +21,7 @@ const recoveryChannel = {
 	repositoryName: score.name,
 	repositoryOwner: score.owner,
 	revision: 1,
+	slug: "release-readiness",
 	title: "Release readiness",
 	updatedAt: "2026-08-14T12:00:00.000Z",
 };
@@ -34,7 +35,7 @@ async function showKnownChannel(page: Parameters<typeof authenticate>[0]) {
 				repository: score,
 			},
 		}));
-	await page.goto("/repositories/octo-org/score");
+	await page.goto("/documents/octo-org/score");
 	await page.getByRole("link", { name: recoveryChannel.title }).click();
 }
 
@@ -75,7 +76,9 @@ test("an authenticated repository creates a channel workspace", async ({ baseURL
 	await channelTitle.fill(title);
 	await page.getByRole("button", { name: "New channel" }).click();
 
-	await expect(page).toHaveURL(/\/channels\/[0-9a-f-]{36}$/);
+	await expect(page).toHaveURL(
+		`/documents/octo-org/score/${title.toLowerCase().replaceAll(" ", "-")}`,
+	);
 	await expect(page.locator("#pane-chat")).toBeVisible();
 	await expect(page.getByRole("textbox", { name: "editable markdown" })).toBeVisible();
 	await expect(page.locator(".plan-decisions")).toBeAttached();
@@ -93,17 +96,33 @@ test("an authenticated repository creates a channel workspace", async ({ baseURL
 	await search.fill("notes");
 	await expect(page.getByRole("option", { name: /octocat\/notes/ })).toBeVisible();
 	await search.press("Enter");
-	await expect(page).toHaveURL("/repositories/octocat/notes");
+	await expect(page).toHaveURL("/documents/octocat/notes");
 	await expect(page.getByRole("heading", { name: "Planning channels" })).toBeVisible();
 	await expect(page.getByRole("button", { name: /octocat\/notes/ })).toBeVisible();
 	await expect(page.getByRole("button", { name: "New channel" })).toHaveCount(0);
+});
+
+test("a signed-out document link returns to the document after OAuth", async ({ baseURL, page, room }) => {
+	let path = roomPath(room);
+	await page.goto(path);
+	await expect(page).toHaveURL(path);
+	let login = page.getByRole("link", { name: "Continue with GitHub" });
+	let href = await login.getAttribute("href");
+	let returnTo = new URL(href!, baseURL).searchParams.get("return_to");
+	expect(returnTo).toBe(path);
+
+	let destination = await authenticate(page, "octocat", baseURL!, returnTo!);
+	expect(destination).toBe(path);
+	await page.goto(destination);
+	await expect(page).toHaveURL(path);
+	await expect(page.getByRole("banner")).toBeVisible();
 });
 
 test("an editor renames a channel from the repository list", async ({ join, room }) => {
 	let page = await join("ana");
 	let before = `Test ${room.slice(0, 8)}`;
 	let after = `Repository rename ${room.slice(0, 8)}`;
-	await page.goto("/repositories/octo-org/score");
+	await page.goto("/documents/octo-org/score");
 	await expect(page.getByRole("heading", { name: "Planning channels" })).toBeVisible();
 
 	await page.setViewportSize({ width: 320, height: 568 });
@@ -121,39 +140,55 @@ test("an editor renames a channel from the repository list", async ({ join, room
 	await expect(page.getByText(after, { exact: true })).toBeVisible();
 });
 
+test("a legacy repository path adopts the resolved repository casing", async ({ baseURL, page }) => {
+	await authenticate(page, "octocat", baseURL!);
+	await page.route(
+		"**/api/repositories/OCTO-ORG/SCORE/channels*",
+		route => route.fulfill({ json: { canEdit: true, channels: [], repository: score } }),
+	);
+	await page.goto("/repositories/OCTO-ORG/SCORE?view=list#documents");
+
+	await expect(page).toHaveURL("/documents/octo-org/score?view=list#documents");
+	await expect(page.getByText("No planning channels yet")).toBeVisible();
+});
+
 test("a known deleted channel keeps its context and routes back without retry", async ({ baseURL, page }) => {
 	await authenticate(page, "octocat", baseURL!);
 	await page.route(
-		new RegExp(`/api/channels/${recoveryChannel.id}$`),
+		"**/api/repositories/octo-org/score/documents/release-readiness",
 		route => route.fulfill({ status: 404, json: { error: "channel not found" } }),
 	);
 	await showKnownChannel(page);
 
 	await expect(page.getByRole("heading", { name: "Cannot open Chopin" })).toBeVisible();
 	await expect(page.getByText(recoveryChannel.title, { exact: true })).toBeVisible();
-	await expect(page.getByText(recoveryChannel.id, { exact: true })).toBeVisible();
+	await expect(page.getByText(recoveryChannel.id, { exact: true })).toHaveCount(0);
+	await expect(page.getByText(recoveryChannel.slug, { exact: true })).toBeVisible();
 	await expect(page.getByText(score.fullName, { exact: true })).toBeVisible();
 	await expect(page.getByRole("button", { name: "Try again" })).toHaveCount(0);
 	let channels = page.getByRole("link", { name: `View ${score.fullName} channels` });
-	await expect(channels).toHaveAttribute("href", "/repositories/octo-org/score");
+	await expect(channels).toHaveAttribute("href", "/documents/octo-org/score");
 	await channels.click();
-	await expect(page).toHaveURL("/repositories/octo-org/score");
+	await expect(page).toHaveURL("/documents/octo-org/score");
 	await expect(page.getByRole("heading", { name: "Planning channels" })).toBeVisible();
 });
 
 test("a transient channel failure retries the safe read", async ({ baseURL, page }) => {
 	await authenticate(page, "octocat", baseURL!);
 	let attempts = 0;
-	await page.route(new RegExp(`/api/channels/${recoveryChannel.id}$`), async route => {
-		attempts++;
-		if (attempts === 1) {
-			await route.fulfill({ status: 503, json: { error: "storage is unavailable" } });
-			return;
-		}
-		await route.fulfill({
-			json: { canEdit: true, channel: recoveryChannel, repository: score },
-		});
-	});
+	await page.route(
+		"**/api/repositories/octo-org/score/documents/release-readiness",
+		async route => {
+			attempts++;
+			if (attempts === 1) {
+				await route.fulfill({ status: 503, json: { error: "storage is unavailable" } });
+				return;
+			}
+			await route.fulfill({
+				json: { canEdit: true, channel: recoveryChannel, repository: score },
+			});
+		},
+	);
 	await showKnownChannel(page);
 
 	await expect(page.getByText(recoveryChannel.title, { exact: true })).toBeVisible();
@@ -166,7 +201,7 @@ test("a transient channel failure retries the safe read", async ({ baseURL, page
 test("an unknown direct channel link stays privacy-safe", async ({ baseURL, page }) => {
 	await authenticate(page, "octocat", baseURL!);
 	await page.route(
-		new RegExp(`/api/channels/${recoveryChannel.id}$`),
+		"**/api/repositories/octo-org/score/documents/release-readiness",
 		route => route.fulfill({ status: 404, json: { error: "channel not found" } }),
 	);
 	await showKnownChannel(page);
@@ -178,7 +213,7 @@ test("an unknown direct channel link stays privacy-safe", async ({ baseURL, page
 	);
 	await page.goto(`/channels/${unknown}`);
 
-	await expect(page.getByText(unknown, { exact: true })).toBeVisible();
+	await expect(page.getByText(unknown, { exact: true })).toHaveCount(0);
 	await expect(page.getByText(recoveryChannel.title, { exact: true })).toHaveCount(0);
 	await expect(page.getByText(score.fullName, { exact: true })).toHaveCount(0);
 	await expect(page.getByRole("link", { name: /channels$/ })).toHaveCount(0);
@@ -231,7 +266,7 @@ test("the repository picker supports dismissal and keyboard selection", async ({
 	await search.fill("notes");
 	await expect(page.getByRole("option", { name: /octocat\/notes/ })).toBeVisible();
 	await search.press("Enter");
-	await expect(page).toHaveURL("/repositories/octocat/notes");
+	await expect(page).toHaveURL("/documents/octocat/notes");
 });
 
 test("the repository picker stays inside a narrow visual viewport", async ({ baseURL, page }) => {
@@ -403,6 +438,7 @@ test("narrow coarse hosted controls and channel content remain reachable", async
 						repositoryName: score.name,
 						repositoryOwner: score.owner,
 						revision: 1,
+						slug: "a-planning-channel-title-long-enough-to-wrap-beside-a-deliberately-visible-date",
 						title:
 							"A planning channel title long enough to wrap beside a deliberately visible date",
 						updatedAt: "2026-08-14T12:00:00.000Z",
@@ -411,7 +447,7 @@ test("narrow coarse hosted controls and channel content remain reachable", async
 				},
 			});
 		});
-		await page.goto("/repositories/octo-org/score");
+		await page.goto("/documents/octo-org/score");
 		await expect(page.getByText("Loading channels...")).toBeVisible();
 
 		for (
@@ -606,9 +642,11 @@ test("the tab cache revalidates stale repository pages with etags", async ({ bas
 	await expect(page.getByRole("option", { name: /^octo-org\/archive-12\b/ })).toBeVisible();
 });
 
-test("expired GitHub authorization returns to sign in", async ({ baseURL, page }) => {
+test("expired GitHub authorization returns to sign in without losing the document", async ({ baseURL, page, room }) => {
+	let path = roomPath(room);
 	await authenticate(page, "expired", baseURL!);
-	await page.goto("/");
+	await page.goto(path);
 
 	await expect(page.getByRole("link", { name: "Continue with GitHub" })).toBeVisible();
+	await expect(page).toHaveURL(path);
 });

--- a/e2e/responsive-activity.e2e.ts
+++ b/e2e/responsive-activity.e2e.ts
@@ -38,7 +38,7 @@ test("the compact room header preserves long identity and secondary actions", as
 		let session = await response.json() as Record<string, unknown>;
 		await route.fulfill({ response, json: { ...session, agent: true } });
 	});
-	await page.route("**/api/channels/**", async route => {
+	await page.route("**/api/repositories/octo-org/score/documents/**", async route => {
 		let response = await route.fetch();
 		let detail = await response.json() as {
 			channel: Record<string, unknown>;

--- a/e2e/room.ts
+++ b/e2e/room.ts
@@ -2,7 +2,13 @@
 
 import { expect, test as base } from "@playwright/test";
 
-import { createChannel, readSource, seedChannel, seedLegacyCalloutChannel } from "./database";
+import {
+	createChannel,
+	readSource,
+	seedChannel,
+	seedLegacyCalloutChannel,
+	testChannelPath,
+} from "./database";
 
 import type { SeedState } from "../apps/server/src/testing/plan";
 import type { Browser, BrowserContext, BrowserContextOptions, Page } from "@playwright/test";
@@ -11,8 +17,15 @@ function port(url: string): number {
 	return Number(new URL(url).port);
 }
 
-export async function authenticate(page: Page, handle: string, baseURL: string): Promise<void> {
-	let started = await fetch(`${baseURL}/auth/github`, { redirect: "manual" });
+export async function authenticate(
+	page: Page,
+	handle: string,
+	baseURL: string,
+	returnTo?: string,
+): Promise<string> {
+	let login = new URL("/auth/github", baseURL);
+	if (returnTo) login.searchParams.set("return_to", returnTo);
+	let started = await fetch(login, { redirect: "manual" });
 	expect(started.status).toBe(302);
 	let authorization = new URL(started.headers.get("location")!);
 	let state = authorization.searchParams.get("state");
@@ -31,6 +44,7 @@ export async function authenticate(page: Page, handle: string, baseURL: string):
 	expect(session).toBeTruthy();
 	let [name, value] = session!.split(";", 1)[0]!.split("=", 2);
 	await page.context().addCookies([{ name: name!, value: value!, url: baseURL }]);
+	return callback.headers.get("location")!;
 }
 
 /** Open a room in a context that needs setup before navigation. */
@@ -47,7 +61,7 @@ export async function openIsolatedRoom(
 		await beforeNavigation?.(context);
 		let page = await context.newPage();
 		await authenticate(page, handle, baseURL);
-		await page.goto(`/channels/${room}`);
+		await page.goto(testChannelPath(room));
 		await ready(page);
 		return { close: () => context.close(), context, page };
 	} catch (error) {
@@ -89,7 +103,7 @@ export const test = base.extend<Fixtures>({
 				target = await isolated.newPage();
 			}
 			await authenticate(target, handle, baseURL!);
-			await target.goto(`/channels/${room}`);
+			await target.goto(testChannelPath(room));
 			await ready(target);
 			return target;
 		});
@@ -107,6 +121,7 @@ export const test = base.extend<Fixtures>({
 });
 
 export { expect };
+export { testChannelPath as roomPath } from "./database";
 
 /** The editable surface. */
 export function content(page: Page) {

--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -7,7 +7,7 @@
  * is worth one file that fails in one.
  */
 
-import { content, expect, ready, test } from "./room";
+import { content, expect, ready, roomPath, test } from "./room";
 
 import type { Chat } from "../packages/protocol/index";
 import type { Page, WebSocketRoute } from "@playwright/test";
@@ -193,7 +193,7 @@ test("a GitHub session joins its authorized channel", async ({ join, room }) => 
 		name: "Repository: octo-org/score",
 	});
 
-	await expect(page).toHaveURL(`/channels/${room}`);
+	await expect(page).toHaveURL(roomPath(room));
 	await expect(repository).toContainText("score");
 	await expect(repository).toHaveAttribute("title", "octo-org/score");
 	await expect(page.locator("header").first().getByRole("img", { name: "ana" })).toHaveCount(1);

--- a/packages/protocol/document-url.test.ts
+++ b/packages/protocol/document-url.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+
+import { documentPath, documentsPath, parseDocumentPath } from "@chopin/protocol/document-url";
+
+describe("document paths", () => {
+	it("builds and parses canonical collection and document paths", () => {
+		expect(documentsPath("octo-org", "score")).toBe("/documents/octo-org/score");
+		expect(documentPath("octo-org", "score", "release-plan")).toBe(
+			"/documents/octo-org/score/release-plan",
+		);
+		expect(parseDocumentPath("/documents/octo-org/score")).toEqual({
+			owner: "octo-org",
+			repository: "score",
+		});
+		expect(parseDocumentPath("/documents/octo-org/score/release-plan")).toEqual({
+			owner: "octo-org",
+			repository: "score",
+			slug: "release-plan",
+		});
+	});
+
+	it("encodes and decodes each Unicode and reserved-character segment", () => {
+		let path = documentPath("München org", "計画/roadmap", "café?#100%");
+		expect(path).toBe(
+			"/documents/M%C3%BCnchen%20org/%E8%A8%88%E7%94%BB%2Froadmap/caf%C3%A9%3F%23100%25",
+		);
+		expect(parseDocumentPath(path)).toEqual({
+			owner: "München org",
+			repository: "計画/roadmap",
+			slug: "café?#100%",
+		});
+	});
+
+	it("accepts one optional trailing slash", () => {
+		expect(parseDocumentPath("/documents/octo-org/score/")).toEqual({
+			owner: "octo-org",
+			repository: "score",
+		});
+		expect(parseDocumentPath("/documents/octo-org/score/release-plan/")).toEqual({
+			owner: "octo-org",
+			repository: "score",
+			slug: "release-plan",
+		});
+	});
+
+	it("rejects malformed percent encoding", () => {
+		for (
+			let path of [
+				"/documents/%/score",
+				"/documents/octo-org/%E0%A4%A",
+				"/documents/octo-org/score/%C0%AF",
+			]
+		) {
+			expect(parseDocumentPath(path)).toBeUndefined();
+		}
+	});
+
+	it("rejects missing, empty and extra segments", () => {
+		for (
+			let path of [
+				"/documents",
+				"/documents/octo-org",
+				"/documents//score",
+				"/documents/octo-org//release-plan",
+				"/documents/octo-org/score/release-plan/extra",
+				"/documents/octo-org/score//",
+			]
+		) {
+			expect(parseDocumentPath(path)).toBeUndefined();
+		}
+		expect(() => documentsPath("", "score")).toThrow(TypeError);
+		expect(() => documentPath("octo-org", "score", "")).toThrow(TypeError);
+	});
+
+	it("does not parse legacy routes", () => {
+		expect(parseDocumentPath("/repositories/octo-org/score")).toBeUndefined();
+		expect(parseDocumentPath("/channels/019c1234-1234-5123-8123-123456789abc"))
+			.toBeUndefined();
+	});
+});

--- a/packages/protocol/document-url.ts
+++ b/packages/protocol/document-url.ts
@@ -1,0 +1,35 @@
+export type ParsedDocumentPath = {
+	owner: string;
+	repository: string;
+	slug?: string;
+};
+
+const DOCUMENT_PATH = /^\/documents\/([^/]+)\/([^/]+)(?:\/([^/]+))?\/?$/;
+
+function encodedSegment(value: string): string {
+	if (!value) throw new TypeError("document path segments must not be empty");
+	return encodeURIComponent(value);
+}
+
+export function documentsPath(owner: string, repository: string): string {
+	return `/documents/${encodedSegment(owner)}/${encodedSegment(repository)}`;
+}
+
+export function documentPath(owner: string, repository: string, slug: string): string {
+	return `${documentsPath(owner, repository)}/${encodedSegment(slug)}`;
+}
+
+export function parseDocumentPath(pathname: string): ParsedDocumentPath | undefined {
+	let match = DOCUMENT_PATH.exec(pathname);
+	if (!match) return undefined;
+	try {
+		let owner = decodeURIComponent(match[1]!);
+		let repository = decodeURIComponent(match[2]!);
+		if (!owner || !repository) return undefined;
+		if (match[3] === undefined) return { owner, repository };
+		let slug = decodeURIComponent(match[3]);
+		return slug ? { owner, repository, slug } : undefined;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/protocol/index.d.ts
+++ b/packages/protocol/index.d.ts
@@ -55,6 +55,7 @@ export declare namespace Session {
 	export type Hello = KIND<"session:hello"> & {
 		channelId: string;
 		title: string;
+		slug: string;
 		updatedAt: string;
 		you: Member;
 		members: Member[];
@@ -66,6 +67,7 @@ export declare namespace Session {
 	export type Channel = KIND<"session:channel"> & {
 		channelId: string;
 		title: string;
+		slug: string;
 		updatedAt: string;
 	};
 

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -13,6 +13,10 @@
 		"./address": {
 			"types": "./address.ts",
 			"default": "./address.ts"
+		},
+		"./document-url": {
+			"types": "./document-url.ts",
+			"default": "./document-url.ts"
 		}
 	}
 }

--- a/skills/creating-chopin-plans/SKILL.md
+++ b/skills/creating-chopin-plans/SKILL.md
@@ -32,8 +32,10 @@ same key. Once creation succeeds, do not call `create_document` again.
 
 ## Hand off
 
-Return the created document's `url` as the canonical handoff, with its title
-and identifier. Do not open it automatically.
+Return the created document's human-readable `url` as the canonical handoff,
+with its title. Treat the returned `id` as an internal MCP identifier: include it
+separately when useful, but never replace the `/documents/...` URL with a
+`/channels/<id>` link. Do not open it automatically.
 
 Use [prompt.md](prompt.md) as a starter when handing an already-settled
 conversation to an agent with this skill installed.

--- a/skills/implementing-chopin-plans/SKILL.md
+++ b/skills/implementing-chopin-plans/SKILL.md
@@ -9,15 +9,15 @@ Chopin's MCP initialize instructions and current tool descriptions are authorita
 
 ## Claim the canonical graph
 
-1. Resolve the supplied canonical document URL through Chopin MCP and call `read_implementation`.
-2. Read the returned graph, acceptance criteria, dependencies, repository context, revisions, lifecycle state, MCP initialize instructions, and current tool descriptions. Copied plans and remembered command sequences are not substitutes.
+1. Pass the supplied canonical document URL directly as the `id` input to `read_implementation`; the read tool accepts either that URL or a document UUID.
+2. Read the returned document UUID, graph, acceptance criteria, dependencies, repository context, revisions, lifecycle state, MCP initialize instructions, and current tool descriptions. Copied plans and remembered command sequences are not substitutes.
 3. Compare the graph's repository, base branch, and base commit with the local checkout. Inspect repository identity, branch, remotes, commit, and working tree before claiming or editing.
 4. If the checkout does not match, surface the mismatch and stop.
-5. Call `start_implementation` with the returned revisions and current checkout context. Begin only when the claim succeeds, and retain the returned run identity for later calls.
+5. Call `start_implementation` with the returned document UUID, revisions, and current checkout context. Begin only when the claim succeeds, and retain the returned run identity for later calls.
 
 ## Execute ready work
 
-Re-read the implementation before every lifecycle action, then follow the service instructions for the current state.
+Re-read the implementation before every lifecycle action, then follow the service instructions for the current state. Reads may use the canonical URL or UUID, but `start_implementation` and every later lifecycle call must use the UUID returned as `document.id`.
 
 - Work only on tasks whose dependencies are complete. Independent ready roots may be delegated when the runtime supports it; the owning agent remains responsible for MCP reporting, review, verification evidence, and one pull request per task.
 - Make only the required changes. Do not edit Chopin plan or graph content or start another top-level agent CLI session.

--- a/skills/implementing-chopin-plans/contract.test.ts
+++ b/skills/implementing-chopin-plans/contract.test.ts
@@ -55,7 +55,7 @@ test("the MCP service publishes its complete implementation contract", async () 
 		[
 			"Chopin's MCP contract and current tool descriptions are authoritative.",
 			"Read the canonical implementation before every implementation or lifecycle action; copied plans and lifecycle instructions are not substitutes.",
-			"read_implementation: Read the approved implementation graph, plan and repository context.",
+			"read_implementation: Read the approved implementation graph, plan and repository context by document ID or canonical URL.",
 			"start_implementation: Atomically claim the current approved implementation graph.",
 			"start_task: Mark one dependency-ready task as in progress for the active implementation run.",
 			"block_task: Record a task-level blocker while keeping the active implementation run and graph lock.",


### PR DESCRIPTION
## Summary
- add repository-scoped Unicode document slugs with permanent rename aliases and migration backfill
- make `/documents/:owner/:repository[/:slug]` canonical across browser navigation, live renames, and MCP handoffs while retaining UUID compatibility
- preserve shared document destinations through GitHub OAuth and session reauthentication

## Testing
- `bun test`
- `bun run types`
- `bun run ci`
- PostgreSQL storage suite against a clean disposable database
- `bun run build`
- `bun run e2e` (182 passed)
- focused hosted and document-navigation E2E after final migration review (25 passed)