### PR TITLE
Persist user navigation

### DIFF
--- a/apps/server/src/channels/routes.test.ts
+++ b/apps/server/src/channels/routes.test.ts
@@ -232,6 +232,20 @@ describe("channel routes", () => {
 		));
 		expect(alias!.status).toBe(200);
 		expect((await alias!.json()).channel.slug).toBe("résumé-計画");
+		expect(await storage.navigation.projects("U_octocat")).toMatchObject([
+			{ repositoryId: "R_score", repositoryOwner: "octo-org", repositoryName: "score" },
+		]);
+		expect((await storage.navigation.get("U_octocat"))!.lastDocumentId).toBe(channel.id);
+		let remembered = await storage.channels.create({
+			id: crypto.randomUUID(),
+			repositoryId: "R_score",
+			repositoryOwner: "octo-org",
+			repositoryName: "score",
+			title: "Remembered document",
+			createdBy: "U_octocat",
+			now,
+		});
+		await storage.navigation.setLastDocument("U_octocat", remembered.id, now);
 
 		github.repo = { ...github.repo, permissions: { pull: false, push: false, admin: false } };
 		let denied = await router.handle(request(
@@ -239,6 +253,7 @@ describe("channel routes", () => {
 			cookie,
 		));
 		expect(denied!.status).toBe(404);
+		expect((await storage.navigation.get("U_octocat"))!.lastDocumentId).toBe(remembered.id);
 
 		github.repo = {
 			...github.repo,
@@ -250,6 +265,7 @@ describe("channel routes", () => {
 			cookie,
 		));
 		expect(recreated!.status).toBe(404);
+		expect((await storage.navigation.get("U_octocat"))!.lastDocumentId).toBe(remembered.id);
 	});
 
 	it("continues to open a legacy UUIDv4 channel", async () => {
@@ -268,6 +284,40 @@ describe("channel routes", () => {
 		let response = await router.handle(request(`/api/channels/${id}`, cookie));
 		expect(response!.status).toBe(200);
 		expect((await response!.json()).channel.id).toBe(id);
+	});
+
+	it("adds an authorized deep-linked document's repository to navigation", async () => {
+		let { router, storage, cookie, now } = await setup();
+		let channel = await storage.channels.create({
+			id: crypto.randomUUID(),
+			repositoryId: "R_score",
+			repositoryOwner: "octo-org",
+			repositoryName: "score",
+			title: "Deep link",
+			createdBy: "U_octocat",
+			now,
+		});
+		let recorded: Parameters<typeof storage.navigation.recordVisit>[0][] = [];
+		let recordVisit = storage.navigation.recordVisit;
+		storage.navigation.recordVisit = async input => {
+			recorded.push(input);
+			return recordVisit(input);
+		};
+
+		let response = await router.handle(request(`/api/channels/${channel.id}`, cookie));
+		expect(response!.status).toBe(200);
+		expect(recorded).toEqual([{
+			userId: "U_octocat",
+			repositoryId: "R_score",
+			repositoryOwner: "octo-org",
+			repositoryName: "score",
+			documentId: channel.id,
+			now,
+		}]);
+		expect(await storage.navigation.projects("U_octocat")).toMatchObject([
+			{ repositoryId: "R_score", repositoryOwner: "octo-org", repositoryName: "score" },
+		]);
+		expect((await storage.navigation.get("U_octocat"))!.lastDocumentId).toBe(channel.id);
 	});
 
 	it("lets an editor rename a document without changing its plan revision", async () => {

--- a/apps/server/src/channels/routes.ts
+++ b/apps/server/src/channels/routes.ts
@@ -167,6 +167,29 @@ async function authorizedRepository(
 	return repository;
 }
 
+/** Opens a document only after its current repository identity has been revalidated. */
+async function openedDocument(
+	auth: HostedAuth,
+	session: AuthenticatedSession,
+	repo: Repository,
+	channel: ChannelRecord,
+) {
+	if (repo.id !== channel.repositoryId || !repo.permissions.pull) return undefined;
+	await auth.storage.navigation.recordVisit({
+		userId: session.user.id,
+		repositoryId: repo.id,
+		repositoryOwner: repo.owner,
+		repositoryName: repo.name,
+		documentId: channel.id,
+		now: auth.clock(),
+	});
+	return {
+		repository: repository(repo),
+		canEdit: repo.permissions.push || repo.permissions.admin,
+		channel: serialized(channel),
+	};
+}
+
 /** Authenticated metadata routes; live collaboration is still the following stage. */
 export function registerChannelRoutes(
 	router: Router,
@@ -298,11 +321,8 @@ export function registerChannelRoutes(
 				if (!repo.permissions.pull) return json({ error: "channel not found" }, 404);
 				let channel = await auth.storage.channels.resolve(repo.id, documentSlug(params.slug!));
 				if (!channel) return json({ error: "channel not found" }, 404);
-				return json({
-					repository: repository(repo),
-					canEdit: repo.permissions.push || repo.permissions.admin,
-					channel: serialized(channel),
-				});
+				let opened = await openedDocument(auth, session, repo, channel);
+				return opened ? json(opened) : json({ error: "channel not found" }, 404);
 			} catch (err) {
 				return failure(err, request, auth);
 			}
@@ -323,14 +343,8 @@ export function registerChannelRoutes(
 				channel.repositoryOwner,
 				channel.repositoryName,
 			);
-			if (repo.id !== channel.repositoryId || !repo.permissions.pull) {
-				return json({ error: "channel not found" }, 404);
-			}
-			return json({
-				repository: repository(repo),
-				canEdit: repo.permissions.push || repo.permissions.admin,
-				channel: serialized(channel),
-			});
+			let opened = await openedDocument(auth, session, repo, channel);
+			return opened ? json(opened) : json({ error: "channel not found" }, 404);
 		} catch (err) {
 			return failure(err, request, auth);
 		}

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -19,6 +19,7 @@ import { describe, load } from "./config";
 import { GitHubError } from "./github/client";
 import { Router } from "./http/router";
 import { registerMcpRoutes } from "./mcp/routes";
+import { registerNavigationRoutes } from "./navigation/routes";
 import * as Service from "./plan/service";
 import * as Inject from "./questions/inject";
 import * as Marks from "./comments/inject";
@@ -532,6 +533,7 @@ registerChannelRoutes(router, hostedAuth, {
 	onAgentReset: channelId => resetOpenAgents(room => room.id === channelId),
 	onChannelRenamed: announceChannelRename,
 });
+registerNavigationRoutes(router, hostedAuth, { storage });
 
 try {
 	await storage.health();

--- a/apps/server/src/navigation/routes.test.ts
+++ b/apps/server/src/navigation/routes.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it } from "bun:test";
+
+import { Admission } from "../auth/admission";
+import { Sessions } from "../auth/session";
+import { Router } from "../http/router";
+import { MemoryStorage } from "../storage/memory/adapter";
+import { registerNavigationRoutes } from "./routes";
+
+import type { HostedAuth } from "../auth/routes";
+import type {
+	GitHub,
+	GitHubTokenGrant,
+	GitHubUser,
+	InstallationPage,
+	Repository,
+	RepositoryPage,
+} from "../github/client";
+
+class FakeGitHub implements GitHub {
+	repositories = new Map<string, Repository>();
+	accesses: string[] = [];
+	accessGate: ((owner: string, name: string) => Promise<void>) | undefined;
+
+	authorize(): string {
+		return "https://github.test/authorize";
+	}
+
+	async exchange(): Promise<GitHubTokenGrant> {
+		return grant("ghu_user");
+	}
+
+	async refresh(): Promise<GitHubTokenGrant> {
+		return grant("ghu_refreshed");
+	}
+
+	async user(): Promise<GitHubUser> {
+		return { id: "U_octocat", login: "octocat", avatarUrl: "avatar" };
+	}
+
+	async organizationMembership() {
+		return undefined;
+	}
+
+	async installations(): Promise<InstallationPage> {
+		return { installations: [], nextPage: undefined };
+	}
+
+	async installationRepositories(): Promise<RepositoryPage> {
+		return { repositories: [...this.repositories.values()], nextPage: undefined };
+	}
+
+	async repository(_token: string, owner: string, name: string): Promise<Repository> {
+		let found = this.repositories.get(`${owner}/${name}`);
+		if (!found) throw new Error("repository not found");
+		return found;
+	}
+
+	async repositoryAccess(
+		_token: string,
+		owner: string,
+		name: string,
+	): Promise<Repository | undefined> {
+		this.accesses.push(`${owner}/${name}`);
+		await this.accessGate?.(owner, name);
+		return this.repositories.get(`${owner}/${name}`);
+	}
+
+	invalidate(): void {}
+}
+
+function grant(accessToken: string): GitHubTokenGrant {
+	return {
+		accessToken,
+		accessExpiresIn: 28_800,
+		refreshToken: "ghr_user",
+		refreshExpiresIn: 15_897_600,
+	};
+}
+
+function repository(
+	id: string,
+	owner: string,
+	name: string,
+	pull = true,
+): Repository {
+	return {
+		id,
+		owner,
+		ownerAvatarUrl: `https://avatars.test/${owner}.png`,
+		name,
+		fullName: `${owner}/${name}`,
+		private: true,
+		url: `https://github.test/${owner}/${name}`,
+		defaultBranch: "main",
+		permissions: { pull, push: pull, admin: false },
+	};
+}
+
+function pair(cookie: string): string {
+	return cookie.split(";", 1)[0]!;
+}
+
+async function setup() {
+	let now = new Date("2026-08-21T12:00:00.000Z");
+	let storage = new MemoryStorage();
+	await storage.users.put({ id: "U_octocat", login: "octocat", avatarUrl: "avatar", now });
+	let sessions = new Sessions(storage, true, () => now);
+	let issued = await sessions.issue("U_octocat", grant("ghu_user"));
+	let github = new FakeGitHub();
+	let config = {
+		origin: "https://chopin.test",
+		appSlug: "chopin-test",
+		clientId: "client-id",
+		clientSecret: "client-secret",
+		encryptionKey: new Uint8Array(32).fill(4),
+	};
+	let auth: HostedAuth = {
+		config,
+		storage,
+		github,
+		admission: new Admission(config, github, () => now.getTime()),
+		sessions,
+		clock: () => now,
+	};
+	let router = new Router();
+	registerNavigationRoutes(router, auth, { storage });
+	return { router, storage, github, cookie: pair(issued.cookie), now };
+}
+
+function request(path: string, cookie?: string, init: RequestInit = {}): Request {
+	let headers = new Headers(init.headers);
+	if (cookie) headers.set("cookie", cookie);
+	return new Request(`https://chopin.test${path}`, { ...init, headers });
+}
+
+describe("navigation routes", () => {
+	it("requires authentication", async () => {
+		let { router } = await setup();
+		let response = await router.handle(request("/api/navigation"));
+		expect(response!.status).toBe(401);
+	});
+
+	it("lists ordered available and unavailable projects", async () => {
+		let { router, storage, github, cookie, now } = await setup();
+		await storage.navigation.addProject({
+			userId: "U_octocat",
+			repositoryId: "R_available",
+			repositoryOwner: "octo-org",
+			repositoryName: "available",
+			now,
+		});
+		await storage.navigation.addProject({
+			userId: "U_octocat",
+			repositoryId: "R_unavailable",
+			repositoryOwner: "octo-org",
+			repositoryName: "unavailable",
+			now,
+		});
+		github.repositories.set(
+			"octo-org/available",
+			repository("R_available", "octo-org", "available"),
+		);
+		github.repositories.set(
+			"octo-org/unavailable",
+			repository("R_replaced", "octo-org", "unavailable"),
+		);
+
+		let response = await router.handle(request("/api/navigation", cookie));
+		expect(response!.status).toBe(200);
+		expect(await response!.json()).toMatchObject({
+			projects: [
+				{ repositoryId: "R_available", position: 0, available: true },
+				{ repositoryId: "R_unavailable", position: 1, available: false },
+			],
+		});
+	});
+
+	it("checks stored projects concurrently without changing their order", async () => {
+		let { router, storage, github, cookie, now } = await setup();
+		for (let name of ["first", "second"]) {
+			await storage.navigation.addProject({
+				userId: "U_octocat",
+				repositoryId: `R_${name}`,
+				repositoryOwner: "octo-org",
+				repositoryName: name,
+				now,
+			});
+			github.repositories.set(`octo-org/${name}`, repository(`R_${name}`, "octo-org", name));
+		}
+		let release: (() => void) | undefined;
+		let gate = new Promise<void>(resolve => {
+			release = resolve;
+		});
+		let firstAccessed: (() => void) | undefined;
+		let first = new Promise<void>(resolve => {
+			firstAccessed = resolve;
+		});
+		github.accessGate = async () => {
+			firstAccessed?.();
+			await gate;
+		};
+
+		let pending = router.handle(request("/api/navigation", cookie));
+		await first;
+		await Promise.resolve();
+		expect(github.accesses).toEqual(["octo-org/first", "octo-org/second"]);
+		release!();
+		expect((await pending)!.status).toBe(200);
+	});
+
+	it("rejects inaccessible projects and returns an existing project when repeated", async () => {
+		let { router, github, cookie } = await setup();
+		github.repositories.set("octo-org/score", repository("R_score", "octo-org", "score", false));
+		let denied = await router.handle(request("/api/navigation/projects", cookie, {
+			method: "POST",
+			headers: { "content-type": "application/json", origin: "https://chopin.test" },
+			body: JSON.stringify({ owner: "octo-org", repository: "score" }),
+		}));
+		expect(denied!.status).toBe(403);
+
+		github.repositories.set("octo-org/score", repository("R_score", "octo-org", "score"));
+		let added = await router.handle(request("/api/navigation/projects", cookie, {
+			method: "POST",
+			headers: { "content-type": "application/json", origin: "https://chopin.test" },
+			body: JSON.stringify({ owner: "octo-org", repository: "score" }),
+		}));
+		let repeated = await router.handle(request("/api/navigation/projects", cookie, {
+			method: "POST",
+			headers: { "content-type": "application/json", origin: "https://chopin.test" },
+			body: JSON.stringify({ owner: "octo-org", repository: "score" }),
+		}));
+		expect(added!.status).toBe(201);
+		expect(repeated!.status).toBe(200);
+		expect(await repeated!.json()).toEqual(await added!.json());
+	});
+
+	it("rejects cross-origin navigation mutations", async () => {
+		let { router, cookie } = await setup();
+		let headers = { "content-type": "application/json", origin: "https://elsewhere.test" };
+		let project = await router.handle(request("/api/navigation/projects", cookie, {
+			method: "POST",
+			headers,
+			body: JSON.stringify({ owner: "octo-org", repository: "score" }),
+		}));
+		let document = await router.handle(request("/api/navigation", cookie, {
+			method: "PATCH",
+			headers,
+			body: JSON.stringify({ documentId: "document" }),
+		}));
+		expect(project!.status).toBe(403);
+		expect(document!.status).toBe(403);
+	});
+
+	it("rejects recording a document outside the user's projects", async () => {
+		let { router, storage, github, cookie, now } = await setup();
+		github.repositories.set("octo-org/other", repository("R_other", "octo-org", "other"));
+		await storage.channels.create({
+			id: crypto.randomUUID(),
+			repositoryId: "R_other",
+			repositoryOwner: "octo-org",
+			repositoryName: "other",
+			title: "Other document",
+			createdBy: "U_octocat",
+			now,
+		}).then(async channel => {
+			let response = await router.handle(request("/api/navigation", cookie, {
+				method: "PATCH",
+				headers: { "content-type": "application/json", origin: "https://chopin.test" },
+				body: JSON.stringify({ documentId: channel.id }),
+			}));
+			expect(response!.status).toBe(404);
+		});
+	});
+
+	it("falls back to the first accessible document by project and channel order", async () => {
+		let { router, storage, github, cookie, now } = await setup();
+		await storage.navigation.addProject({
+			userId: "U_octocat",
+			repositoryId: "R_unavailable",
+			repositoryOwner: "octo-org",
+			repositoryName: "unavailable",
+			now,
+		});
+		await storage.navigation.addProject({
+			userId: "U_octocat",
+			repositoryId: "R_available",
+			repositoryOwner: "octo-org",
+			repositoryName: "available",
+			now,
+		});
+		github.repositories.set(
+			"octo-org/unavailable",
+			repository("R_unavailable", "octo-org", "unavailable", false),
+		);
+		github.repositories.set(
+			"octo-org/available",
+			repository("R_available", "octo-org", "available"),
+		);
+		let inaccessible = await storage.channels.create({
+			id: crypto.randomUUID(),
+			repositoryId: "R_unavailable",
+			repositoryOwner: "octo-org",
+			repositoryName: "unavailable",
+			title: "Unavailable document",
+			createdBy: "U_octocat",
+			now,
+		});
+		let fallback = await storage.channels.create({
+			id: crypto.randomUUID(),
+			repositoryId: "R_available",
+			repositoryOwner: "octo-org",
+			repositoryName: "available",
+			title: "Available document",
+			createdBy: "U_octocat",
+			now: new Date(now.getTime() + 1),
+		});
+		await storage.navigation.setLastDocument("U_octocat", inaccessible.id, now);
+
+		let response = await router.handle(request("/api/navigation", cookie));
+		expect(response!.status).toBe(200);
+		expect((await response!.json()).lastDocumentId).toBe(fallback.id);
+		expect((await storage.navigation.get("U_octocat"))!.lastDocumentId).toBe(fallback.id);
+	});
+});

--- a/apps/server/src/navigation/routes.ts
+++ b/apps/server/src/navigation/routes.ts
@@ -1,0 +1,245 @@
+import { GitHubError } from "../github/client";
+import { StorageError } from "../storage/errors";
+
+import type { HostedAuth } from "../auth/routes";
+import type { AuthenticatedSession } from "../auth/session";
+import type { Repository } from "../github/client";
+import type { Router } from "../http/router";
+import type { UserProject } from "../storage/model";
+import type { StorageAdapter } from "../storage/port";
+
+const OWNER = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
+const REPOSITORY = /^[A-Za-z0-9._-]{1,100}$/;
+const BODY_LIMIT = 4_096;
+
+export type NavigationProject = {
+	repositoryId: string;
+	repositoryOwner: string;
+	repositoryName: string;
+	position: number;
+	available: boolean;
+	repository?: {
+		id: string;
+		owner: string;
+		name: string;
+		fullName: string;
+		ownerAvatarUrl?: string;
+		permissions: { pull: boolean; push: boolean; admin: boolean };
+	};
+};
+
+export type NavigationResponse = {
+	projects: NavigationProject[];
+	lastDocumentId?: string;
+};
+
+function json(value: unknown, status = 200): Response {
+	return Response.json(value, {
+		status,
+		headers: {
+			"cache-control": "no-store",
+			"content-type": "application/json; charset=utf-8",
+			"x-content-type-options": "nosniff",
+		},
+	});
+}
+
+function empty(status: number): Response {
+	return new Response(null, { status, headers: { "cache-control": "no-store" } });
+}
+
+function failure(err: unknown): Response {
+	if (err instanceof GitHubError) {
+		if (err.status === 401) {
+			return json({ error: "GitHub authorization expired" }, 401);
+		}
+		return json({ error: err.message }, err.status);
+	}
+	if (err instanceof StorageError) {
+		let status = err.failure === "missing"
+			? 404
+			: err.failure === "conflict"
+			? 409
+			: err.failure === "unavailable"
+			? 503
+			: 500;
+		return json(
+			{ error: status === 503 ? "storage is unavailable" : "navigation storage failed" },
+			status,
+		);
+	}
+	return json({ error: "request failed" }, 500);
+}
+
+function serialized(project: UserProject, repository?: Repository): NavigationProject {
+	return {
+		repositoryId: project.repositoryId,
+		repositoryOwner: project.repositoryOwner,
+		repositoryName: project.repositoryName,
+		position: project.position,
+		available: Boolean(repository),
+		...(repository
+			? {
+				repository: {
+					id: repository.id,
+					owner: repository.owner,
+					name: repository.name,
+					fullName: repository.fullName,
+					...(repository.ownerAvatarUrl
+						? { ownerAvatarUrl: repository.ownerAvatarUrl }
+						: {}),
+					permissions: repository.permissions,
+				},
+			}
+			: {}),
+	};
+}
+
+async function body(request: Request): Promise<Record<string, unknown> | undefined> {
+	let length = Number(request.headers.get("content-length") || "0");
+	if (Number.isFinite(length) && length > BODY_LIMIT) return undefined;
+	let source = await request.text();
+	if (new TextEncoder().encode(source).length > BODY_LIMIT) return undefined;
+	try {
+		let value = JSON.parse(source) as unknown;
+		return value && typeof value === "object" && !Array.isArray(value)
+			? value as Record<string, unknown>
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+async function accessible(
+	auth: HostedAuth,
+	session: AuthenticatedSession,
+	project: UserProject,
+): Promise<Repository | undefined> {
+	let result = await auth.sessions.use(
+		session,
+		token => auth.github.repositoryAccess(token, project.repositoryOwner, project.repositoryName),
+	);
+	let repository = result.value;
+	return repository && repository.id === project.repositoryId && repository.permissions.pull
+		? repository
+		: undefined;
+}
+
+async function response(
+	auth: HostedAuth,
+	storage: StorageAdapter,
+	session: AuthenticatedSession,
+): Promise<NavigationResponse> {
+	let stored = await storage.navigation.projects(session.user.id);
+	let available = new Map<string, Repository>();
+	let resolved = await Promise.all(stored.map(async project => ({
+		project,
+		repository: await accessible(auth, session, project),
+	})));
+	let projects = resolved.map(({ project, repository }) => {
+		if (repository) available.set(project.repositoryId, repository);
+		return serialized(project, repository);
+	});
+
+	let navigation = await storage.navigation.get(session.user.id);
+	let selected = navigation?.lastDocumentId;
+	if (selected) {
+		let channel = await storage.channels.get(selected);
+		if (!channel || !available.has(channel.repositoryId)) selected = undefined;
+	}
+	if (!selected) {
+		for (let project of stored) {
+			if (!available.has(project.repositoryId)) continue;
+			let first = await storage.channels.list(project.repositoryId, 1);
+			if (first.channels[0]) {
+				selected = first.channels[0].id;
+				break;
+			}
+		}
+	}
+	if (selected !== navigation?.lastDocumentId) {
+		await storage.navigation.setLastDocument(session.user.id, selected, auth.clock());
+	}
+	return { projects, ...(selected ? { lastDocumentId: selected } : {}) };
+}
+
+/** Persistent user navigation, revalidated against GitHub on every read. */
+export function registerNavigationRoutes(
+	router: Router,
+	auth: HostedAuth,
+	options: { storage?: StorageAdapter } = {},
+): void {
+	let storage = options.storage ?? auth.storage;
+
+	router.on("GET", "/api/navigation", async request => {
+		try {
+			let session = await auth.sessions.authenticate(request);
+			if (!session) return json({ error: "authentication required" }, 401);
+			return json(await response(auth, storage, session));
+		} catch (err) {
+			return failure(err);
+		}
+	});
+
+	router.on("POST", "/api/navigation/projects", async request => {
+		if (request.headers.get("origin") !== auth.config.origin) {
+			return json({ error: "origin is not allowed" }, 403);
+		}
+		try {
+			let session = await auth.sessions.authenticate(request);
+			if (!session) return json({ error: "authentication required" }, 401);
+			let input = await body(request);
+			let owner = input?.owner;
+			let name = input?.repository;
+			if (
+				typeof owner !== "string" || typeof name !== "string" || !OWNER.test(owner)
+				|| !REPOSITORY.test(name)
+			) return json({ error: "owner and repository are required" }, 400);
+			let result = await auth.sessions.use(
+				session,
+				token => auth.github.repositoryAccess(token, owner, name),
+			);
+			let repository = result.value;
+			if (!repository) return json({ error: "repository not found" }, 404);
+			if (!repository.permissions.pull) {
+				return json({ error: "repository read access is required" }, 403);
+			}
+			let added = await storage.navigation.addProject({
+				userId: session.user.id,
+				repositoryId: repository.id,
+				repositoryOwner: repository.owner,
+				repositoryName: repository.name,
+				now: auth.clock(),
+			});
+			return json(serialized(added.project, repository), added.added ? 201 : 200);
+		} catch (err) {
+			return failure(err);
+		}
+	});
+
+	router.on("PATCH", "/api/navigation", async request => {
+		if (request.headers.get("origin") !== auth.config.origin) {
+			return json({ error: "origin is not allowed" }, 403);
+		}
+		try {
+			let session = await auth.sessions.authenticate(request);
+			if (!session) return json({ error: "authentication required" }, 401);
+			let input = await body(request);
+			let documentId = input?.documentId;
+			if (typeof documentId !== "string" || documentId.length === 0) {
+				return json({ error: "documentId is required" }, 400);
+			}
+			let channel = await storage.channels.get(documentId);
+			if (!channel) return json({ error: "document not found" }, 404);
+			let project = (await storage.navigation.projects(session.user.id))
+				.find(value => value.repositoryId === channel.repositoryId);
+			if (!project) return json({ error: "document not found" }, 404);
+			let repository = await accessible(auth, session, project);
+			if (!repository) return json({ error: "document not found" }, 404);
+			await storage.navigation.setLastDocument(session.user.id, channel.id, auth.clock());
+			return empty(204);
+		} catch (err) {
+			return failure(err);
+		}
+	});
+}

--- a/apps/server/src/storage/contract.ts
+++ b/apps/server/src/storage/contract.ts
@@ -129,6 +129,136 @@ export function storageContract(name: string, factory: Factory): void {
 			}
 		});
 
+		it("reports whether adding a project changed navigation and keeps its original order", async () => {
+			let storage = await opened(factory);
+			try {
+				let now = new Date("2026-01-02T03:04:05.000Z");
+				let userId = id("user");
+				await storage.users.put({
+					id: userId,
+					login: "mona",
+					avatarUrl: "https://example.test/mona",
+					now,
+				});
+				let first = await storage.navigation.addProject({
+					userId,
+					repositoryId: "R_first",
+					repositoryOwner: "githubnext",
+					repositoryName: "chopin",
+					now,
+				});
+				let second = await storage.navigation.addProject({
+					userId,
+					repositoryId: "R_second",
+					repositoryOwner: "githubnext",
+					repositoryName: "second",
+					now: new Date(now.getTime() + 1),
+				});
+				let repeated = await storage.navigation.addProject({
+					userId,
+					repositoryId: "R_first",
+					repositoryOwner: "githubnext",
+					repositoryName: "chopin",
+					now: new Date(now.getTime() + 2),
+				});
+
+				expect(first.added).toBe(true);
+				expect(second.added).toBe(true);
+				expect(repeated).toEqual({ project: first.project, added: false });
+				expect((await storage.navigation.projects(userId)).map(project => project.repositoryId))
+					.toEqual(["R_first", "R_second"]);
+			} finally {
+				await storage.close();
+			}
+		});
+
+		it("stores the last document idempotently", async () => {
+			let storage = await opened(factory);
+			try {
+				let now = new Date("2026-01-02T03:04:05.000Z");
+				let { userId, channelId } = await userAndChannel(storage);
+				let first = await storage.navigation.setLastDocument(userId, channelId, now);
+				let repeated = await storage.navigation.setLastDocument(userId, channelId, now);
+
+				expect(repeated).toEqual(first);
+				expect(await storage.navigation.get(userId)).toEqual(first);
+			} finally {
+				await storage.close();
+			}
+		});
+
+		it("rejects a last document that does not exist", async () => {
+			let storage = await opened(factory);
+			try {
+				let { userId } = await userAndChannel(storage);
+				await expect(storage.navigation.setLastDocument(
+					userId,
+					id("missing-channel"),
+					new Date("2026-01-02T03:04:05.000Z"),
+				)).rejects.toMatchObject({ failure: "missing" });
+				expect(await storage.navigation.get(userId)).toBeUndefined();
+			} finally {
+				await storage.close();
+			}
+		});
+
+		it("records a deep-link visit without adding a project when its document is missing", async () => {
+			let storage = await opened(factory);
+			try {
+				let { userId } = await userAndChannel(storage);
+				await expect(storage.navigation.recordVisit({
+					userId,
+					repositoryId: "R_missing",
+					repositoryOwner: "githubnext",
+					repositoryName: "missing",
+					documentId: id("missing-channel"),
+					now: new Date("2026-01-02T03:04:05.000Z"),
+				})).rejects.toMatchObject({ failure: "missing" });
+				expect(await storage.navigation.projects(userId)).toEqual([]);
+				expect(await storage.navigation.get(userId)).toBeUndefined();
+			} finally {
+				await storage.close();
+			}
+		});
+
+		it("rejects a deep-link visit whose document belongs to another repository", async () => {
+			let storage = await opened(factory);
+			try {
+				let { userId, channelId } = await userAndChannel(storage);
+				await expect(storage.navigation.recordVisit({
+					userId,
+					repositoryId: id("other-repository"),
+					repositoryOwner: "githubnext",
+					repositoryName: "other",
+					documentId: channelId,
+					now: new Date("2026-01-02T03:04:05.000Z"),
+				})).rejects.toMatchObject({ failure: "missing" });
+				expect(await storage.navigation.projects(userId)).toEqual([]);
+				expect(await storage.navigation.get(userId)).toBeUndefined();
+			} finally {
+				await storage.close();
+			}
+		});
+
+		it("adds a project and records a deep-link visit together", async () => {
+			let storage = await opened(factory);
+			try {
+				let { userId, channelId, repositoryId } = await userAndChannel(storage);
+				let saved = await storage.navigation.recordVisit({
+					userId,
+					repositoryId,
+					repositoryOwner: "octo-org",
+					repositoryName: "score",
+					documentId: channelId,
+					now: new Date("2026-01-02T03:04:05.000Z"),
+				});
+				expect(saved.lastDocumentId).toBe(channelId);
+				expect(await storage.navigation.projects(userId)).toMatchObject([{ repositoryId }]);
+			} finally {
+				await storage.close();
+			}
+		});
+
 		it("lists only a repository's channels in stable order", async () => {
 			let storage = await opened(factory);
 			try {

--- a/apps/server/src/storage/memory/adapter.ts
+++ b/apps/server/src/storage/memory/adapter.ts
@@ -2,6 +2,8 @@ import { conflict, missing } from "../errors";
 import { documentSlug, documentSlugCandidate } from "../../channels/slug";
 
 import type {
+	AddUserProject,
+	AddUserProjectResult,
 	AgentState,
 	ChannelCursor,
 	ChannelPage,
@@ -15,6 +17,7 @@ import type {
 	CreateChannel,
 	JsonValue,
 	Lease,
+	RecordNavigationVisit,
 	RenameChannel,
 	RenameResult,
 	ReplaceChannel,
@@ -22,6 +25,8 @@ import type {
 	StoredChannel,
 	StoredEvent,
 	UpdateAgentContext,
+	UserNavigation,
+	UserProject,
 	UserRecord,
 	WebSession,
 } from "../model";
@@ -29,6 +34,7 @@ import type {
 	ChannelStore,
 	CollaborationStore,
 	LeaseStore,
+	NavigationStore,
 	SessionStore,
 	StorageAdapter,
 	UserStore,
@@ -52,6 +58,14 @@ function session(value: WebSession): WebSession {
 		expiresAt: new Date(value.expiresAt),
 		createdAt: new Date(value.createdAt),
 	};
+}
+
+function project(value: UserProject): UserProject {
+	return { ...value, addedAt: new Date(value.addedAt) };
+}
+
+function navigation(value: UserNavigation): UserNavigation {
+	return { ...value, updatedAt: new Date(value.updatedAt) };
 }
 
 function channel(value: ChannelRecord): ChannelRecord {
@@ -83,6 +97,8 @@ export class MemoryStorage implements StorageAdapter {
 
 	#users = new Map<string, UserRecord>();
 	#sessions = new Map<string, WebSession>();
+	#projects = new Map<string, UserProject[]>();
+	#navigation = new Map<string, UserNavigation>();
 	#channels = new Map<string, ChannelRecord>();
 	#channelSlugs = new Map<string, Map<string, string>>();
 	#snapshots = new Map<string, ChannelSnapshot>();
@@ -148,6 +164,21 @@ export class MemoryStorage implements StorageAdapter {
 		},
 	};
 
+	readonly navigation: NavigationStore = {
+		projects: userId => {
+			this.#requireUser(userId);
+			return Promise.resolve((this.#projects.get(userId) ?? []).map(project));
+		},
+		addProject: input => this.#addProject(input),
+		get: userId => {
+			this.#requireUser(userId);
+			let found = this.#navigation.get(userId);
+			return Promise.resolve(found && navigation(found));
+		},
+		setLastDocument: (userId, documentId, now) => this.#setLastDocument(userId, documentId, now),
+		recordVisit: input => this.#recordVisit(input),
+	};
+
 	readonly channels: ChannelStore = {
 		create: input => this.#createChannel(input),
 		get: id => Promise.resolve(this.#channels.get(id)).then(value => value && channel(value)),
@@ -198,6 +229,53 @@ export class MemoryStorage implements StorageAdapter {
 				});
 			}
 		}
+	}
+
+	#requireUser(userId: string): void {
+		if (!this.#users.has(userId)) throw missing(`user ${userId} does not exist`);
+	}
+
+	#addProject(input: AddUserProject): Promise<AddUserProjectResult> {
+		this.#requireUser(input.userId);
+		let projects = this.#projects.get(input.userId) ?? [];
+		let existing = projects.find(project => project.repositoryId === input.repositoryId);
+		if (existing) return Promise.resolve({ project: project(existing), added: false });
+		let saved: UserProject = {
+			userId: input.userId,
+			repositoryId: input.repositoryId,
+			repositoryOwner: input.repositoryOwner,
+			repositoryName: input.repositoryName,
+			position: Math.max(-1, ...projects.map(project => project.position)) + 1,
+			addedAt: input.now,
+		};
+		this.#projects.set(input.userId, [...projects, saved]);
+		return Promise.resolve({ project: project(saved), added: true });
+	}
+
+	async #setLastDocument(
+		userId: string,
+		documentId: string | undefined,
+		now: Date,
+	): Promise<UserNavigation> {
+		this.#requireUser(userId);
+		if (documentId && !this.#channels.has(documentId)) {
+			throw missing(`channel ${documentId} does not exist`);
+		}
+		let saved: UserNavigation = { userId, lastDocumentId: documentId, updatedAt: now };
+		this.#navigation.set(userId, saved);
+		return navigation(saved);
+	}
+
+	async #recordVisit(input: RecordNavigationVisit): Promise<UserNavigation> {
+		this.#requireUser(input.userId);
+		let document = this.#channels.get(input.documentId);
+		if (!document || document.repositoryId !== input.repositoryId) {
+			throw missing(
+				`channel ${input.documentId} does not exist in repository ${input.repositoryId}`,
+			);
+		}
+		await this.#addProject(input);
+		return this.#setLastDocument(input.userId, input.documentId, input.now);
 	}
 
 	async #createChannel(input: CreateChannel): Promise<ChannelRecord> {

--- a/apps/server/src/storage/model.ts
+++ b/apps/server/src/storage/model.ts
@@ -19,6 +19,32 @@ export type PutUser = Omit<UserRecord, "createdAt" | "updatedAt"> & {
 	now: Date;
 };
 
+export type UserProject = {
+	userId: string;
+	repositoryId: string;
+	repositoryOwner: string;
+	repositoryName: string;
+	position: number;
+	addedAt: Date;
+};
+
+export type AddUserProject = Omit<UserProject, "position" | "addedAt"> & { now: Date };
+
+export type AddUserProjectResult = {
+	project: UserProject;
+	added: boolean;
+};
+
+export type RecordNavigationVisit = AddUserProject & {
+	documentId: string;
+};
+
+export type UserNavigation = {
+	userId: string;
+	lastDocumentId: string | undefined;
+	updatedAt: Date;
+};
+
 /** Process-lifetime registry row used only by durable agent ownership. */
 export type WebSession = {
 	id: string;

--- a/apps/server/src/storage/port.ts
+++ b/apps/server/src/storage/port.ts
@@ -1,4 +1,6 @@
 import type {
+	AddUserProject,
+	AddUserProjectResult,
 	AgentState,
 	ChannelPage,
 	ChannelRecord,
@@ -10,12 +12,15 @@ import type {
 	CreateWebSession,
 	Lease,
 	PutUser,
+	RecordNavigationVisit,
 	RenameChannel,
 	RenameResult,
 	ReplaceChannel,
 	SaveCheckpoint,
 	StoredChannel,
 	UpdateAgentContext,
+	UserNavigation,
+	UserProject,
 	UserRecord,
 	WebSession,
 } from "./model";
@@ -35,6 +40,18 @@ export interface SessionStore {
 		lease: Lease,
 		leaseTtlMs: number,
 	): Promise<{ deleted: number; lease: Lease }>;
+}
+
+export interface NavigationStore {
+	projects(userId: string): Promise<UserProject[]>;
+	addProject(input: AddUserProject): Promise<AddUserProjectResult>;
+	get(userId: string): Promise<UserNavigation | undefined>;
+	setLastDocument(
+		userId: string,
+		documentId: string | undefined,
+		now: Date,
+	): Promise<UserNavigation>;
+	recordVisit(input: RecordNavigationVisit): Promise<UserNavigation>;
 }
 
 export interface ChannelStore {
@@ -75,6 +92,7 @@ export interface StorageAdapter {
 	readonly driver: string;
 	readonly users: UserStore;
 	readonly sessions: SessionStore;
+	readonly navigation: NavigationStore;
 	readonly channels: ChannelStore;
 	readonly collaboration: CollaborationStore;
 	readonly leases: LeaseStore;

--- a/apps/server/src/storage/postgres/adapter.test.ts
+++ b/apps/server/src/storage/postgres/adapter.test.ts
@@ -6,9 +6,14 @@ import { documentSlug } from "../../channels/slug";
 import { storageContract } from "../contract";
 import { StorageError } from "../errors";
 import { PostgresStorage } from "./adapter";
+import { migrate, verifyMigrations } from "./migrations";
 import { backfillDocumentSlugs } from "./migrations/002_document_slugs";
 
 let url = process.env.TEST_DATABASE_URL;
+
+function digest(source: string): string {
+	return new Bun.CryptoHasher("sha256").update(source).digest("hex");
+}
 
 if (url) {
 	storageContract("postgres", () => new PostgresStorage(url));
@@ -102,6 +107,56 @@ if (url) {
 				expect(byId.get("channel-batch-000")).toBe("batch");
 				expect(byId.get("channel-batch-504")).toBe("batch-505");
 			});
+		} finally {
+			await sql.unsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`).simple();
+			await sql.close();
+		}
+	});
+
+	it("upgrades a database that recorded user navigation as migration 002 without rewriting history", async () => {
+		let sql = new SQL(url, { max: 1 });
+		let schema = `legacy_navigation_${crypto.randomUUID().replaceAll("-", "")}`;
+		try {
+			await sql.unsafe(`CREATE SCHEMA "${schema}"`).simple();
+			await sql.unsafe(`SET search_path TO "${schema}"`).simple();
+			let initial = await Bun.file(join(import.meta.dir, "migrations/001_initial.sql")).text();
+			let navigation = await Bun.file(
+				join(import.meta.dir, "migrations/003_user_navigation.sql"),
+			).text();
+			await sql.unsafe(initial).simple();
+			await sql.unsafe(navigation).simple();
+			await sql`
+				CREATE TABLE chopin_migrations (
+					id text PRIMARY KEY,
+					checksum text NOT NULL,
+					applied_at timestamptz NOT NULL DEFAULT now()
+				)
+			`;
+			await sql`
+				INSERT INTO chopin_migrations (id, checksum)
+				VALUES
+					('001_initial', ${digest(initial)}),
+					('002_user_navigation', ${digest(navigation)})
+			`;
+
+			await migrate(sql);
+			await verifyMigrations(sql);
+			let rows = await sql<{ id: string }[]>`
+				SELECT id FROM chopin_migrations ORDER BY id
+			`;
+			expect(rows.map(row => row.id)).toEqual([
+				"001_initial",
+				"002_document_slugs",
+				"002_user_navigation",
+			]);
+			expect(await sql<{ table: string | null }[]>`SELECT to_regclass('channel_slugs') AS table`)
+				.toEqual([
+					{ table: "channel_slugs" },
+				]);
+			expect(await sql<{ table: string | null }[]>`SELECT to_regclass('user_navigation') AS table`)
+				.toEqual([
+					{ table: "user_navigation" },
+				]);
 		} finally {
 			await sql.unsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`).simple();
 			await sql.close();

--- a/apps/server/src/storage/postgres/adapter.ts
+++ b/apps/server/src/storage/postgres/adapter.ts
@@ -3,6 +3,7 @@ import { SQL } from "bun";
 import { documentSlug, documentSlugCandidate } from "../../channels/slug";
 import { conflict, corrupt, missing, StorageError, unavailable } from "../errors";
 import { migrate, verifyMigrations } from "./migrations";
+import { PostgresNavigationStore } from "./navigation";
 
 import type { TransactionSQL } from "bun";
 import type {
@@ -33,6 +34,7 @@ import type {
 	ChannelStore,
 	CollaborationStore,
 	LeaseStore,
+	NavigationStore,
 	SessionStore,
 	StorageAdapter,
 	UserStore,
@@ -357,6 +359,10 @@ export class PostgresStorage implements StorageAdapter {
 
 	constructor(url: string) {
 		this.#sql = new SQL(url, { connectionTimeout: 10, idleTimeout: 30, max: 10 });
+		this.navigation = new PostgresNavigationStore(
+			this.#sql,
+			(action, execute) => this.#run(action, execute),
+		);
 	}
 
 	readonly users: UserStore = {
@@ -455,6 +461,8 @@ export class PostgresStorage implements StorageAdapter {
 					return { deleted: deleted.length, lease: lease(renewed) };
 				})),
 	};
+
+	readonly navigation: NavigationStore;
 
 	readonly channels: ChannelStore = {
 		create: input => this.#createChannel(input),

--- a/apps/server/src/storage/postgres/migrations.ts
+++ b/apps/server/src/storage/postgres/migrations.ts
@@ -21,7 +21,13 @@ const MIGRATIONS = [{
 	applyPath: join(import.meta.dir, "migrations/002_document_slugs.ts"),
 	checksumTag: "apply:backfillDocumentSlugs:v1",
 	apply: backfillDocumentSlugs,
+}, {
+	id: "003_user_navigation",
+	path: join(import.meta.dir, "migrations/003_user_navigation.sql"),
 }] satisfies Migration[];
+
+/** Navigation shipped as 002 before document slugs claimed that number on main. */
+const LEGACY_MIGRATION_IDS = new Map([["002_user_navigation", "003_user_navigation"]]);
 
 /** Stable across deployments; it serializes migrations, not ordinary writes. */
 const MIGRATION_LOCK = 2_043_237_431;
@@ -48,12 +54,14 @@ function checked(rows: Applied[], migrations: Expected[], complete: boolean): Ma
 	let known = new Map(migrations.map(migration => [migration.id, migration.checksum]));
 	let applied = new Map<string, string>();
 	for (let row of rows) {
-		let digest = known.get(row.id);
+		let id = LEGACY_MIGRATION_IDS.get(row.id) ?? row.id;
+		let digest = known.get(id);
 		if (!digest) throw new Error(`database has unknown migration ${row.id}`);
 		if (digest !== row.checksum) {
 			throw new Error(`migration ${row.id} changed after it was applied`);
 		}
-		applied.set(row.id, row.checksum);
+		if (applied.has(id)) throw new Error(`database has duplicate migration ${id}`);
+		applied.set(id, row.checksum);
 	}
 	if (complete) {
 		let missing = migrations.find(migration => !applied.has(migration.id));

--- a/apps/server/src/storage/postgres/migrations/003_user_navigation.sql
+++ b/apps/server/src/storage/postgres/migrations/003_user_navigation.sql
@@ -1,0 +1,16 @@
+CREATE TABLE user_projects (
+	user_id text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+	repository_id text NOT NULL,
+	repository_owner text NOT NULL,
+	repository_name text NOT NULL,
+	position integer NOT NULL CHECK (position >= 0),
+	added_at timestamptz NOT NULL,
+	PRIMARY KEY (user_id, repository_id),
+	UNIQUE (user_id, position)
+);
+
+CREATE TABLE user_navigation (
+	user_id text PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+	last_document_id text REFERENCES channels(id) ON DELETE SET NULL,
+	updated_at timestamptz NOT NULL
+);

--- a/apps/server/src/storage/postgres/navigation.ts
+++ b/apps/server/src/storage/postgres/navigation.ts
@@ -1,0 +1,201 @@
+import { corrupt, missing } from "../errors";
+
+import type { SQL, TransactionSQL } from "bun";
+import type {
+	AddUserProject,
+	AddUserProjectResult,
+	RecordNavigationVisit,
+	UserNavigation,
+	UserProject,
+} from "../model";
+import type { NavigationStore } from "../port";
+
+type Timestamp = Date | string;
+type Integer = bigint | number | string;
+
+type ProjectRow = {
+	userId: string;
+	repositoryId: string;
+	repositoryOwner: string;
+	repositoryName: string;
+	position: Integer;
+	addedAt: Timestamp;
+};
+
+type NavigationRow = {
+	userId: string;
+	lastDocumentId: string | null;
+	updatedAt: Timestamp;
+};
+
+type Run = <T>(action: string, execute: () => Promise<T>) => Promise<T>;
+
+const PROJECT_COLUMNS = `
+	user_id AS "userId",
+	repository_id AS "repositoryId",
+	repository_owner AS "repositoryOwner",
+	repository_name AS "repositoryName",
+	position,
+	added_at AS "addedAt"
+`;
+
+const NAVIGATION_COLUMNS = `
+	user_id AS "userId",
+	last_document_id AS "lastDocumentId",
+	updated_at AS "updatedAt"
+`;
+
+function date(value: Timestamp, field: string): Date {
+	let parsed = value instanceof Date ? new Date(value) : new Date(value);
+	if (Number.isNaN(parsed.getTime())) throw corrupt(`storage returned an invalid ${field}`);
+	return parsed;
+}
+
+function integer(value: Integer, field: string): number {
+	let parsed = typeof value === "number" ? value : Number(value);
+	if (!Number.isSafeInteger(parsed) || parsed < 0) {
+		throw corrupt(`storage returned an invalid ${field}`);
+	}
+	return parsed;
+}
+
+function project(row: ProjectRow): UserProject {
+	return {
+		...row,
+		position: integer(row.position, "project position"),
+		addedAt: date(row.addedAt, "project added time"),
+	};
+}
+
+function navigation(row: NavigationRow): UserNavigation {
+	return {
+		...row,
+		lastDocumentId: row.lastDocumentId ?? undefined,
+		updatedAt: date(row.updatedAt, "navigation update time"),
+	};
+}
+
+/** Per-user navigation queries, kept apart from the channel persistence engine. */
+export class PostgresNavigationStore implements NavigationStore {
+	readonly #sql: SQL;
+	readonly #run: Run;
+
+	constructor(sql: SQL, run: Run) {
+		this.#sql = sql;
+		this.#run = run;
+	}
+
+	readonly projects = (userId: string): Promise<UserProject[]> =>
+		this.#run("list projects", async () => {
+			await this.#requireUser(userId);
+			let rows = await this.#sql<ProjectRow[]>`
+				SELECT ${this.#sql.unsafe(PROJECT_COLUMNS)}
+				FROM user_projects
+				WHERE user_id = ${userId}
+				ORDER BY position ASC
+			`;
+			return rows.map(project);
+		});
+
+	readonly addProject = (input: AddUserProject): Promise<AddUserProjectResult> =>
+		this.#run(
+			"add project",
+			() => this.#sql.begin(transaction => this.#addProject(transaction, input)),
+		);
+
+	readonly get = (userId: string): Promise<UserNavigation | undefined> =>
+		this.#run("read navigation", async () => {
+			await this.#requireUser(userId);
+			let [found] = await this.#sql<NavigationRow[]>`
+				SELECT ${this.#sql.unsafe(NAVIGATION_COLUMNS)}
+				FROM user_navigation WHERE user_id = ${userId}
+			`;
+			return found ? navigation(found) : undefined;
+		});
+
+	readonly setLastDocument = (
+		userId: string,
+		documentId: string | undefined,
+		now: Date,
+	): Promise<UserNavigation> =>
+		this.#run("save navigation", () => this.#saveNavigation(this.#sql, userId, documentId, now));
+
+	readonly recordVisit = (input: RecordNavigationVisit): Promise<UserNavigation> =>
+		this.#run("record navigation visit", () =>
+			this.#sql.begin(async transaction => {
+				await this.#requireDocument(transaction, input.documentId, input.repositoryId);
+				await this.#addProject(transaction, input);
+				return this.#saveNavigation(transaction, input.userId, input.documentId, input.now);
+			}));
+
+	async #addProject(
+		transaction: TransactionSQL,
+		input: AddUserProject,
+	): Promise<AddUserProjectResult> {
+		await this.#lockUser(transaction, input.userId);
+		let [existing] = await transaction<ProjectRow[]>`
+			SELECT ${transaction.unsafe(PROJECT_COLUMNS)}
+			FROM user_projects
+			WHERE user_id = ${input.userId} AND repository_id = ${input.repositoryId}
+		`;
+		if (existing) return { project: project(existing), added: false };
+		let [saved] = await transaction<ProjectRow[]>`
+			INSERT INTO user_projects (
+				user_id, repository_id, repository_owner, repository_name, position, added_at
+			)
+			SELECT
+				${input.userId}, ${input.repositoryId}, ${input.repositoryOwner},
+				${input.repositoryName}, COALESCE(MAX(position) + 1, 0), ${input.now}
+			FROM user_projects
+			WHERE user_id = ${input.userId}
+			RETURNING ${transaction.unsafe(PROJECT_COLUMNS)}
+		`;
+		if (!saved) throw corrupt("adding a project returned no record");
+		return { project: project(saved), added: true };
+	}
+
+	async #saveNavigation(
+		sql: SQL | TransactionSQL,
+		userId: string,
+		documentId: string | undefined,
+		now: Date,
+	): Promise<UserNavigation> {
+		let [saved] = await sql<NavigationRow[]>`
+			INSERT INTO user_navigation (user_id, last_document_id, updated_at)
+			VALUES (${userId}, ${documentId ?? null}, ${now})
+			ON CONFLICT (user_id) DO UPDATE SET
+				last_document_id = EXCLUDED.last_document_id,
+				updated_at = EXCLUDED.updated_at
+			RETURNING ${sql.unsafe(NAVIGATION_COLUMNS)}
+		`;
+		if (!saved) throw corrupt("saving navigation returned no record");
+		return navigation(saved);
+	}
+
+	async #requireUser(userId: string): Promise<void> {
+		let [found] = await this.#sql<{ id: string }[]>`
+			SELECT id FROM users WHERE id = ${userId}
+		`;
+		if (!found) throw missing(`user ${userId} does not exist`);
+	}
+
+	async #lockUser(transaction: TransactionSQL, userId: string): Promise<void> {
+		let [found] = await transaction<{ id: string }[]>`
+			SELECT id FROM users WHERE id = ${userId} FOR UPDATE
+		`;
+		if (!found) throw missing(`user ${userId} does not exist`);
+	}
+
+	async #requireDocument(
+		transaction: TransactionSQL,
+		documentId: string,
+		repositoryId: string,
+	): Promise<void> {
+		let [found] = await transaction<{ id: string }[]>`
+			SELECT id FROM channels
+			WHERE id = ${documentId} AND repository_id = ${repositoryId}
+			FOR KEY SHARE
+		`;
+		if (!found) throw missing(`channel ${documentId} does not exist in repository ${repositoryId}`);
+	}
+}


### PR DESCRIPTION
## Summary

- Persist each user's repository list and most recently opened document in PostgreSQL
- Expose authenticated navigation routes that revalidate current GitHub repository access
- Record visits through canonical, historical, and legacy document URLs
- Keep databases that recorded navigation as migration 002 compatible with the current migration sequence

## Testing

- `bun test`
- PostgreSQL storage suite
- `bun run types`
- `bun run ci`