### PR TITLE
Wire purposeful motion into app surfaces

### DIFF
--- a/apps/web/src/add-project-dialog.tsx
+++ b/apps/web/src/add-project-dialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "./repository-cache";
 
 import type { RepositorySnapshot } from "./repository-cache";
+import type { NavigationDialogMotion } from "./navigation-dialog";
 
 function message(error: unknown): string {
 	return error instanceof Error ? error.message : "Could not load repositories.";
@@ -19,11 +20,13 @@ function message(error: unknown): string {
 export function AddProjectDialog(
 	{
 		added,
+		motion,
 		onAdded,
 		onDismiss,
 		userId,
 	}: {
 		added: Api.NavigationProject[];
+		motion: NavigationDialogMotion;
 		onAdded: (project: Api.NavigationProject) => void;
 		onDismiss: () => void;
 		userId: string;
@@ -82,7 +85,12 @@ export function AddProjectDialog(
 	}
 
 	return (
-		<NavigationDialog initialFocus={input} onDismiss={onDismiss} title="Add Project">
+		<NavigationDialog
+			initialFocus={input}
+			motion={motion}
+			onDismiss={onDismiss}
+			title="Add Project"
+		>
 			<div className="mt-4">
 				<label className="sr-only" htmlFor="add-project-search">Search repositories</label>
 				<input

--- a/apps/web/src/anchored-picker.tsx
+++ b/apps/web/src/anchored-picker.tsx
@@ -5,7 +5,7 @@ import type { CSSProperties } from "react";
 
 type Position = Pick<
 	CSSProperties,
-	"height" | "left" | "maxHeight" | "top" | "visibility" | "width"
+	"height" | "left" | "maxHeight" | "top" | "transformOrigin" | "visibility" | "width"
 >;
 
 /** Shared portal geometry, focus, and dismissal for header picker controls. */
@@ -55,6 +55,7 @@ export function useAnchoredPicker(
 				left,
 				maxHeight,
 				top: Math.max(topEdge, Math.min(wantedTop, bottomEdge - maxHeight)),
+				transformOrigin: useAbove ? "bottom left" : "top left",
 				visibility: "visible",
 				width,
 			});

--- a/apps/web/src/delete-document-dialog.tsx
+++ b/apps/web/src/delete-document-dialog.tsx
@@ -3,13 +3,17 @@ import { useRef, useState } from "react";
 import * as Api from "./api";
 import { NavigationDialog } from "./navigation-dialog";
 
+import type { NavigationDialogMotion } from "./navigation-dialog";
+
 export function DeleteDocumentDialog(
 	{
 		channel,
+		motion,
 		onDeleted,
 		onDismiss,
 	}: {
 		channel: Api.Channel;
+		motion: NavigationDialogMotion;
 		onDeleted: () => void;
 		onDismiss: () => void;
 	},
@@ -36,6 +40,7 @@ export function DeleteDocumentDialog(
 	return (
 		<NavigationDialog
 			initialFocus={cancel}
+			motion={motion}
 			onDismiss={dismiss}
 			title="Delete document permanently?"
 		>

--- a/apps/web/src/document-picker.tsx
+++ b/apps/web/src/document-picker.tsx
@@ -1,4 +1,5 @@
 import { CaretDownIcon, CheckIcon, PlusIcon } from "@phosphor-icons/react";
+import { useTransitionPresence } from "@chopin/editor/transition-presence";
 import { documentPath } from "@chopin/protocol/document-url";
 import { createPortal } from "react-dom";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
@@ -7,6 +8,7 @@ import { useAnchoredPicker } from "./anchored-picker";
 import * as Api from "./api";
 import { rememberChannel } from "./channel-recovery";
 import { DocumentRename } from "./document-rename";
+import { motionImmediately } from "./motion-input";
 
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 
@@ -71,6 +73,11 @@ export function DocumentPicker(
 		setOpen(next);
 	};
 	let { panel, position, search, trigger } = useAnchoredPicker(open, setPickerOpen, pickerContent);
+	let popupPresence = useTransitionPresence(
+		open ? true : undefined,
+		150,
+		motionImmediately(),
+	);
 
 	useEffect(() => {
 		if (!open) return;
@@ -179,10 +186,12 @@ export function DocumentPicker(
 		requestAnimationFrame(() => search.current?.focus());
 	}
 
-	let popup = open && createPortal(
+	let popup = popupPresence.phase !== "closed" && createPortal(
 		<div
-			className="fixed z-50 flex flex-col rounded-lg bg-page ring-hairline shadow-overlay"
+			aria-hidden={popupPresence.phase === "closing" ? "true" : undefined}
+			className={`motion-dropdown ${popupPresence.className} fixed z-50 flex flex-col rounded-lg bg-page ring-hairline shadow-overlay`}
 			id={panelId}
+			inert={popupPresence.phase === "closing"}
 			ref={panel}
 			style={position}
 		>
@@ -192,7 +201,7 @@ export function DocumentPicker(
 					aria-activedescendant={activeChannel ? optionId(listId, activeChannel) : undefined}
 					aria-autocomplete="list"
 					aria-controls={listId}
-					aria-expanded="true"
+					aria-expanded={open}
 					className="document-picker-search field h-8 w-full px-2 text-sm"
 					id={`${listId}-search`}
 					onChange={event => {

--- a/apps/web/src/document-search-dialog.tsx
+++ b/apps/web/src/document-search-dialog.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef, useState } from "react";
 import * as Api from "./api";
 import { NavigationDialog } from "./navigation-dialog";
 
+import type { NavigationDialogMotion } from "./navigation-dialog";
+
 export type DocumentSearchResult = {
 	project: Api.NavigationProject;
 	channel: Api.Channel;
@@ -55,11 +57,13 @@ export async function searchAvailableDocuments(
 export function DocumentSearchDialog(
 	{
 		includeArchived,
+		motion,
 		onDismiss,
 		onSelect,
 		projects,
 	}: {
 		includeArchived: boolean;
+		motion: NavigationDialogMotion;
 		onDismiss: () => void;
 		onSelect: (documentId: string) => void;
 		projects: Api.NavigationProject[];
@@ -105,7 +109,12 @@ export function DocumentSearchDialog(
 
 	let results = search.status === "ready" ? search.results : [];
 	return (
-		<NavigationDialog initialFocus={input} onDismiss={onDismiss} title="Search documents">
+		<NavigationDialog
+			initialFocus={input}
+			motion={motion}
+			onDismiss={onDismiss}
+			title="Search documents"
+		>
 			<div className="mt-4">
 				<label className="sr-only" htmlFor="document-search">Search documents</label>
 				<input

--- a/apps/web/src/motion-input.test.ts
+++ b/apps/web/src/motion-input.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test";
+import { motionImmediately } from "./motion-input";
+
+test("settles keyboard-owned surfaces immediately", () => {
+	expect(motionImmediately({ motionInput: "keyboard" })).toBe(true);
+	expect(motionImmediately({ motionInput: "pointer" })).toBe(false);
+	expect(motionImmediately({})).toBe(false);
+	expect(motionImmediately()).toBe(false);
+});

--- a/apps/web/src/motion-input.ts
+++ b/apps/web/src/motion-input.ts
@@ -1,5 +1,11 @@
 import { useEffect } from "react";
 
+export function motionImmediately(dataset?: { motionInput?: string }): boolean {
+	let source = dataset
+		?? (typeof document === "undefined" ? undefined : document.documentElement.dataset);
+	return source?.motionInput === "keyboard";
+}
+
 export function useMotionInput(): void {
 	useEffect(() => {
 		let recordKeyboard = () => {

--- a/apps/web/src/navigation-dialog.tsx
+++ b/apps/web/src/navigation-dialog.tsx
@@ -4,33 +4,47 @@ import { useId, useRef } from "react";
 import { NavigationFocusScope } from "./navigation-focus";
 
 import type { ReactNode, RefObject } from "react";
+import type { TransitionPresence } from "@chopin/editor/transition-presence";
+
+export type NavigationDialogMotion = Pick<
+	Exclude<TransitionPresence<unknown>, { phase: "closed" }>,
+	"className" | "phase"
+>;
 
 /** A small modal primitive that owns the browser-only focus contract for navigation flows. */
 export function NavigationDialog(
 	{
 		children,
 		initialFocus,
+		motion,
 		onDismiss,
 		title,
 	}: {
 		children: ReactNode;
 		initialFocus?: RefObject<HTMLElement | null>;
+		motion: NavigationDialogMotion;
 		onDismiss: () => void;
 		title: string;
 	},
 ) {
 	let dialog = useRef<HTMLDivElement>(null);
 	let titleId = useId();
+	let active = motion.phase !== "closing";
 
 	return createPortal(
-		<div className="navigation-modal" role="presentation">
+		<div
+			aria-hidden={active ? undefined : "true"}
+			className={`navigation-modal motion-modal ${motion.className}`}
+			inert={!active}
+			role="presentation"
+		>
 			<button
 				aria-label={`Close ${title}`}
 				className="navigation-modal-backdrop"
 				onClick={onDismiss}
 				type="button"
 			/>
-			<NavigationFocusScope initialFocus={initialFocus} onDismiss={onDismiss}>
+			<NavigationFocusScope active={active} initialFocus={initialFocus} onDismiss={onDismiss}>
 				<div
 					aria-labelledby={titleId}
 					aria-modal="true"

--- a/apps/web/src/navigation-focus.tsx
+++ b/apps/web/src/navigation-focus.tsx
@@ -10,10 +10,12 @@ function focusable(node: HTMLElement): HTMLElement[] {
 
 export function NavigationFocusScope(
 	{
+		active = true,
 		children,
 		initialFocus,
 		onDismiss,
 	}: {
+		active?: boolean;
 		children: ReactNode;
 		initialFocus?: RefObject<HTMLElement | null>;
 		onDismiss: () => void;
@@ -25,6 +27,7 @@ export function NavigationFocusScope(
 	);
 
 	useEffect(() => {
+		if (!active) return;
 		let frame = requestAnimationFrame(() => {
 			(initialFocus?.current ?? focusable(scope.current!)[0] ?? scope.current)?.focus();
 		});
@@ -32,9 +35,10 @@ export function NavigationFocusScope(
 			cancelAnimationFrame(frame);
 			if (previous.current?.isConnected) previous.current.focus();
 		};
-	}, [initialFocus]);
+	}, [active, initialFocus]);
 
 	function keyDown(event: KeyboardEvent<HTMLDivElement>) {
+		if (!active) return;
 		if (event.key === "Escape") {
 			event.preventDefault();
 			onDismiss();
@@ -59,7 +63,13 @@ export function NavigationFocusScope(
 	}
 
 	return (
-		<div className="navigation-focus-scope" onKeyDown={keyDown} ref={scope} tabIndex={-1}>
+		<div
+			className="navigation-focus-scope"
+			inert={!active}
+			onKeyDown={keyDown}
+			ref={scope}
+			tabIndex={active ? -1 : undefined}
+		>
 			{children}
 		</div>
 	);

--- a/apps/web/src/navigation-shell.tsx
+++ b/apps/web/src/navigation-shell.tsx
@@ -11,6 +11,7 @@ import {
 	useState,
 	useSyncExternalStore,
 } from "react";
+import { useTransitionPresence } from "@chopin/editor/transition-presence";
 import { documentPath, researchWorkspacePath } from "@chopin/protocol/document-url";
 
 import * as Api from "./api";
@@ -18,6 +19,7 @@ import { forgetChannel } from "./channel-recovery";
 import { newestDocument } from "./document-actions";
 import type { DocumentAction } from "./document-actions-menu";
 import { NavigationFocusScope } from "./navigation-focus";
+import { motionImmediately } from "./motion-input";
 import {
 	activeProject,
 	beginProjectCreation,
@@ -39,6 +41,7 @@ import { useProjectDocuments } from "./use-project-documents";
 import { useProjectResearch } from "./use-project-research";
 
 import type { Research } from "@chopin/protocol";
+import type { TransitionPresence } from "@chopin/editor/transition-presence";
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import type { NavigationMode } from "./navigation-model";
 
@@ -203,17 +206,31 @@ function SidebarResizeHandle(
 }
 
 function NavigationDrawer(
-	{ children, onDismiss }: { children: ReactNode; onDismiss: () => void },
+	{
+		children,
+		motion,
+		onDismiss,
+	}: {
+		children: ReactNode;
+		motion: Exclude<TransitionPresence<boolean>, { phase: "closed" }>;
+		onDismiss: () => void;
+	},
 ) {
+	let active = motion.phase !== "closing";
 	return (
-		<div className="navigation-drawer" role="presentation">
+		<div
+			aria-hidden={active ? undefined : "true"}
+			className={`navigation-drawer motion-drawer ${motion.className}`}
+			inert={!active}
+			role="presentation"
+		>
 			<button
 				aria-label="Close Projects sidebar"
 				className="navigation-drawer-backdrop"
 				onClick={onDismiss}
 				type="button"
 			/>
-			<NavigationFocusScope onDismiss={onDismiss}>
+			<NavigationFocusScope active={active} onDismiss={onDismiss}>
 				<div
 					aria-label="Projects"
 					aria-modal="true"
@@ -276,6 +293,20 @@ export function NavigationShell(
 	let [focusProjectId, setFocusProjectId] = useState<string>();
 	let [width, resize] = useSidebarWidth();
 	let mode = useNavigationMode();
+	let immediateMotion = motionImmediately();
+	let drawerPresence = useTransitionPresence(
+		mode === "drawer" && drawerOpen ? true : undefined,
+		180,
+		immediateMotion,
+	);
+	let dialogPresence = useTransitionPresence(dialog, 150, immediateMotion);
+	let accountPresence = useTransitionPresence(
+		accountOpen ? true : undefined,
+		150,
+		immediateMotion,
+	);
+	let dialogMotion = dialogPresence.phase === "closed" ? undefined : dialogPresence;
+	let presentedDialog = dialogMotion?.value;
 	let sidebarVisible = mode === "inline" && !collapsed;
 	let triggerVisible = !sidebarVisible && !drawerOpen;
 	let {
@@ -710,11 +741,17 @@ export function NavigationShell(
 	let sidebar = (
 		<Suspense fallback={null}>
 			<ProjectSidebar
-				accountMenu={accountOpen && (
-					<div className="navigation-account-menu" role="menu">
+				accountMenu={accountPresence.phase !== "closed" && (
+					<div
+						aria-hidden={accountPresence.phase === "closing" ? "true" : undefined}
+						className={`navigation-account-menu motion-dropdown ${accountPresence.className}`}
+						inert={accountPresence.phase === "closing"}
+						role="menu"
+					>
 						<button onClick={() => void signOut()} role="menuitem" type="button">Sign out</button>
 					</div>
 				)}
+				accountMenuOpen={accountOpen}
 				canCreateDocument={!active || canManageProject(active)}
 				creatingProjectIds={creatingProjectIdsForView}
 				creatingNewDocument={!!active && creatingProjectIdsForView.has(active.repositoryId)}
@@ -789,8 +826,8 @@ export function NavigationShell(
 						onExpand={() => mode === "drawer" ? setDrawerOpen(true) : setCollapsed(false)}
 					/>
 				)}
-				{mode === "drawer" && drawerOpen && (
-					<NavigationDrawer onDismiss={dismissDrawer}>
+				{drawerPresence.phase !== "closed" && (
+					<NavigationDrawer motion={drawerPresence} onDismiss={dismissDrawer}>
 						{sidebar}
 					</NavigationDrawer>
 				)}
@@ -811,11 +848,12 @@ export function NavigationShell(
 							{content}
 						</div>
 					)}
-				{dialog === "add" && (
+				{dialogMotion && presentedDialog === "add" && (
 					<LazyDialogBoundary>
 						<Suspense fallback={null}>
 							<AddProjectDialog
 								added={navigation?.projects ?? []}
+								motion={dialogMotion}
 								onAdded={project => {
 									catalogueRefreshes.current.set(project.repositoryId, Date.now());
 									setFocusProjectId(project.repositoryId);
@@ -827,11 +865,12 @@ export function NavigationShell(
 						</Suspense>
 					</LazyDialogBoundary>
 				)}
-				{dialog === "search" && (
+				{dialogMotion && presentedDialog === "search" && (
 					<LazyDialogBoundary>
 						<Suspense fallback={null}>
 							<DocumentSearchDialog
 								includeArchived={catalogueMode === "archived"}
+								motion={dialogMotion}
 								onDismiss={() => setDialog(undefined)}
 								onSelect={navigateToDocument}
 								projects={navigation?.projects ?? []}
@@ -839,40 +878,46 @@ export function NavigationShell(
 						</Suspense>
 					</LazyDialogBoundary>
 				)}
-				{typeof dialog === "object" && dialog.type === "rename" && (
+				{dialogMotion && typeof presentedDialog === "object"
+					&& presentedDialog.type === "rename" && (
 					<LazyDialogBoundary>
 						<Suspense fallback={null}>
 							<RenameDocumentDialog
-								channel={dialog.channel}
+								channel={presentedDialog.channel}
+								motion={dialogMotion}
 								onDismiss={() => setDialog(undefined)}
 								onRenamed={acceptChannel}
 							/>
 						</Suspense>
 					</LazyDialogBoundary>
 				)}
-				{typeof dialog === "object" && dialog.type === "delete" && (
+				{dialogMotion && typeof presentedDialog === "object"
+					&& presentedDialog.type === "delete" && (
 					<LazyDialogBoundary>
 						<Suspense fallback={null}>
 							<DeleteDocumentDialog
-								channel={dialog.channel}
-								onDeleted={() => documentDeleted(dialog.channel.id)}
+								channel={presentedDialog.channel}
+								motion={dialogMotion}
+								onDeleted={() => documentDeleted(presentedDialog.channel.id)}
 								onDismiss={() => setDialog(undefined)}
 							/>
 						</Suspense>
 					</LazyDialogBoundary>
 				)}
-				{typeof dialog === "object" && dialog.type === "research" && (
+				{dialogMotion && typeof presentedDialog === "object"
+					&& presentedDialog.type === "research" && (
 					<LazyDialogBoundary>
 						<Suspense fallback={null}>
 							<NewResearchDialog
-								channel={dialog.channel}
+								channel={presentedDialog.channel}
+								motion={dialogMotion}
 								onCreated={workspace => {
-									upsertResearchWorkspace(dialog.channel, workspace);
+									upsertResearchWorkspace(presentedDialog.channel, workspace);
 									setDialog(undefined);
 									navigate(researchWorkspacePath(
-										dialog.channel.repositoryOwner,
-										dialog.channel.repositoryName,
-										dialog.channel.slug,
+										presentedDialog.channel.repositoryOwner,
+										presentedDialog.channel.repositoryName,
+										presentedDialog.channel.slug,
 										workspace.id,
 									));
 								}}

--- a/apps/web/src/navigation.css
+++ b/apps/web/src/navigation.css
@@ -284,6 +284,38 @@
 	z-index: 40;
 }
 
+.motion-drawer {
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity var(--drawer-open-dur) var(--motion-smooth-out);
+	will-change: opacity;
+}
+
+.motion-drawer .navigation-focus-scope {
+	transform: translateX(calc(-1 * var(--drawer-distance)));
+	transition: transform var(--drawer-open-dur) var(--motion-smooth-out);
+	will-change: transform;
+}
+
+.motion-drawer.is-open {
+	pointer-events: auto;
+	opacity: 1;
+}
+
+.motion-drawer.is-open .navigation-focus-scope {
+	transform: translateX(0);
+}
+
+.motion-drawer.is-closing {
+	opacity: 0;
+	transition-duration: var(--drawer-close-dur);
+}
+
+.motion-drawer.is-closing .navigation-focus-scope {
+	transform: translateX(calc(-1 * var(--drawer-distance)));
+	transition-duration: var(--drawer-close-dur);
+}
+
 .navigation-drawer-backdrop {
 	position: absolute;
 	inset: 0;
@@ -325,6 +357,38 @@
 	display: grid;
 	place-items: center;
 	padding: 16px;
+}
+
+.motion-modal {
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity var(--modal-open-dur) var(--modal-ease);
+	will-change: opacity;
+}
+
+.motion-modal .navigation-modal-content {
+	transform: scale(var(--modal-scale));
+	transition: transform var(--modal-open-dur) var(--modal-ease);
+	will-change: transform;
+}
+
+.motion-modal.is-open {
+	pointer-events: auto;
+	opacity: 1;
+}
+
+.motion-modal.is-open .navigation-modal-content {
+	transform: scale(1);
+}
+
+.motion-modal.is-closing {
+	opacity: 0;
+	transition-duration: var(--modal-close-dur);
+}
+
+.motion-modal.is-closing .navigation-modal-content {
+	transform: scale(var(--modal-scale-close));
+	transition-duration: var(--modal-close-dur);
 }
 
 .navigation-modal-backdrop {
@@ -387,6 +451,7 @@
 	background: var(--color-page);
 	padding: 4px;
 	box-shadow: var(--shadow-overlay);
+	transform-origin: bottom left;
 }
 
 .navigation-account-menu button {
@@ -491,4 +556,13 @@
 .document-title-trigger:hover:not(:disabled),
 .document-title-trigger:focus-visible {
 	background: var(--color-hover);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.motion-drawer,
+	.motion-drawer .navigation-focus-scope,
+	.motion-modal,
+	.motion-modal .navigation-modal-content {
+		transition: none;
+	}
 }

--- a/apps/web/src/project-sidebar.tsx
+++ b/apps/web/src/project-sidebar.tsx
@@ -218,6 +218,7 @@ function Project(
 export function ProjectSidebar(
 	{
 		accountMenu,
+		accountMenuOpen,
 		canCreateDocument,
 		creatingNewDocument,
 		creatingProjectIds,
@@ -239,6 +240,7 @@ export function ProjectSidebar(
 		user,
 	}: {
 		accountMenu?: ReactNode;
+		accountMenuOpen?: boolean;
 		canCreateDocument: boolean;
 		catalogueMode: "active" | "archived";
 		creatingNewDocument: boolean;
@@ -388,7 +390,7 @@ export function ProjectSidebar(
 				{accountMenu}
 				<button
 					className="project-sidebar-account"
-					aria-expanded={!!accountMenu}
+					aria-expanded={accountMenuOpen ?? !!accountMenu}
 					onClick={onAccount}
 					type="button"
 				>

--- a/apps/web/src/rename-document-dialog.tsx
+++ b/apps/web/src/rename-document-dialog.tsx
@@ -2,20 +2,23 @@ import { DocumentRename } from "./document-rename";
 import { NavigationDialog } from "./navigation-dialog";
 
 import type * as Api from "./api";
+import type { NavigationDialogMotion } from "./navigation-dialog";
 
 export function RenameDocumentDialog(
 	{
 		channel,
+		motion,
 		onDismiss,
 		onRenamed,
 	}: {
 		channel: Api.Channel;
+		motion: NavigationDialogMotion;
 		onDismiss: () => void;
 		onRenamed: (channel: Api.Channel) => void;
 	},
 ) {
 	return (
-		<NavigationDialog onDismiss={onDismiss} title="Rename document">
+		<NavigationDialog motion={motion} onDismiss={onDismiss} title="Rename document">
 			<DocumentRename
 				channel={channel}
 				className="mt-4"

--- a/apps/web/src/repository-picker.tsx
+++ b/apps/web/src/repository-picker.tsx
@@ -1,10 +1,12 @@
 import { CaretDownIcon, CheckIcon } from "@phosphor-icons/react";
+import { useTransitionPresence } from "@chopin/editor/transition-presence";
 import { documentsPath } from "@chopin/protocol/document-url";
 import { createPortal } from "react-dom";
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 
 import { useAnchoredPicker } from "./anchored-picker";
 import * as Api from "./api";
+import { motionImmediately } from "./motion-input";
 import {
 	clearRepositoryCache,
 	installedRepositoryGroups,
@@ -80,6 +82,11 @@ export function RepositoryPicker(
 		[error, installed, loading, matches.length, normalized, refreshing],
 	);
 	let { panel, position, search, trigger } = useAnchoredPicker(open, setOpen, pickerContent);
+	let popupPresence = useTransitionPresence(
+		open ? true : undefined,
+		150,
+		motionImmediately(),
+	);
 
 	useEffect(() => {
 		mounted.current = true;
@@ -171,10 +178,12 @@ export function RepositoryPicker(
 		event.preventDefault();
 	}
 
-	let popup = open && createPortal(
+	let popup = popupPresence.phase !== "closed" && createPortal(
 		<div
-			className="fixed z-50 flex flex-col rounded-lg bg-page ring-hairline shadow-overlay"
+			aria-hidden={popupPresence.phase === "closing" ? "true" : undefined}
+			className={`motion-dropdown ${popupPresence.className} fixed z-50 flex flex-col rounded-lg bg-page ring-hairline shadow-overlay`}
 			id={panelId}
+			inert={popupPresence.phase === "closing"}
 			ref={panel}
 			style={position}
 		>
@@ -184,7 +193,7 @@ export function RepositoryPicker(
 					aria-activedescendant={activeRepository ? optionId(listId, activeRepository) : undefined}
 					aria-autocomplete="list"
 					aria-controls={listId}
-					aria-expanded="true"
+					aria-expanded={open}
 					className="repository-picker-search field h-8 w-full px-2 text-sm"
 					id={`${listId}-search`}
 					onChange={event => {

--- a/apps/web/src/research-actions.tsx
+++ b/apps/web/src/research-actions.tsx
@@ -5,15 +5,18 @@ import { NavigationDialog } from "./navigation-dialog";
 import { beginResearchSubmission, editResearchSubmission } from "./research-workspace-model";
 
 import type { Research } from "@chopin/protocol";
+import type { NavigationDialogMotion } from "./navigation-dialog";
 import type { ResearchSubmission } from "./research-workspace-model";
 
 export function NewResearchDialog(
 	{
 		channel,
+		motion,
 		onCreated,
 		onDismiss,
 	}: {
 		channel: Api.Channel;
+		motion: NavigationDialogMotion;
 		onCreated: (workspace: Research.WorkspaceSummary) => void;
 		onDismiss: () => void;
 	},
@@ -45,6 +48,7 @@ export function NewResearchDialog(
 	return (
 		<NavigationDialog
 			initialFocus={input}
+			motion={motion}
 			onDismiss={creating ? () => {} : onDismiss}
 			title={`New research in ${channel.title}`}
 		>

--- a/apps/web/src/room-workspace.tsx
+++ b/apps/web/src/room-workspace.tsx
@@ -25,6 +25,7 @@ import { Chat } from "./chat/chat";
 import { rememberChannel } from "./channel-recovery";
 import { decisionAttention, DecisionViewControl } from "./decision-view-control";
 import { DocumentActionsMenu } from "./document-actions-menu";
+import { motionImmediately } from "./motion-input";
 import { useNavigationDocument } from "./navigation-shell";
 import { NavigationIcon } from "./project-sidebar";
 import { peopleHere } from "./presence";
@@ -43,6 +44,10 @@ type ManagedHello = Session.Hello & { archivedAt?: string; canManage: boolean };
 type ManagedChannel = Session.Channel & { archivedAt?: string; canManage: boolean };
 type ManagedAccess = Session.Access & { canManage: boolean };
 type WorkspaceMetadata = Pick<Api.Channel, "title" | "slug" | "updatedAt" | "archivedAt">;
+
+function settleMotionImmediately(): boolean {
+	return motionImmediately();
+}
 
 export function Header(
 	{
@@ -463,6 +468,7 @@ export function RoomWorkspace(
 					commentPresentation={mode === "split" ? "popover" : "sheet"}
 					connection={status === "deleted" ? "closed" : status}
 					key={workspaceArchivedAt ? "archived" : "active"}
+					motionImmediately={settleMotionImmediately}
 					onScrollTop={setPlanScrollTop}
 					questions={questions}
 					readOnly={!workspaceCanEdit}

--- a/apps/web/src/theme.css
+++ b/apps/web/src/theme.css
@@ -418,6 +418,27 @@ body {
 	height: var(--app-height, 100dvh);
 }
 
+.motion-dropdown {
+	opacity: 0;
+	transform: scale(var(--dropdown-pre-scale));
+	transition:
+		opacity var(--dropdown-open-dur) var(--dropdown-ease),
+		transform var(--dropdown-open-dur) var(--dropdown-ease);
+	will-change: opacity, transform;
+}
+
+.motion-dropdown.is-open {
+	opacity: 1;
+	transform: scale(1);
+}
+
+.motion-dropdown.is-closing {
+	pointer-events: none;
+	opacity: 0;
+	transform: scale(var(--dropdown-closing-scale));
+	transition-duration: var(--dropdown-close-dur);
+}
+
 body {
 	margin: 0;
 	background: var(--color-ground);
@@ -456,6 +477,33 @@ body {
 
 .workspace-frame #pane-chat {
 	border-color: rgb(0 0 0 / 9%);
+}
+
+.motion-panel {
+	opacity: 0;
+	transform: translateX(var(--panel-distance));
+	transition:
+		opacity var(--panel-open-dur) var(--motion-smooth-out),
+		transform var(--panel-open-dur) var(--motion-smooth-out);
+	will-change: opacity, transform;
+}
+
+.motion-panel.is-open {
+	opacity: 1;
+	transform: translateX(0);
+}
+
+.motion-panel.is-closing {
+	pointer-events: none;
+	opacity: 0;
+	transform: translateX(var(--panel-distance));
+	transition-duration: var(--panel-close-dur);
+}
+
+.workspace-root:not([data-workspace-mode="split"]) .workspace-conversation-panel {
+	position: absolute;
+	inset: 0;
+	z-index: 10;
 }
 
 .conversation-composer .field {
@@ -641,6 +689,11 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
+	.motion-dropdown,
+	.motion-panel {
+		transition: none;
+	}
+
 	.animate-enter {
 		animation: none;
 	}

--- a/apps/web/src/workspace.tsx
+++ b/apps/web/src/workspace.tsx
@@ -1,6 +1,7 @@
 /** Three panes on one ground, with the document as the only raised surface. */
 
 import { useEffect, useLayoutEffect, useReducer, useRef, useSyncExternalStore } from "react";
+import { useTransitionPresence } from "@chopin/editor/transition-presence";
 
 import {
 	presentWorkspace,
@@ -11,6 +12,7 @@ import {
 import conversationCloseIcon from "./assets/icons/conversation-close.svg";
 import conversationIcon from "./assets/icons/conversation.svg";
 import { ResizeHandle, usePaneWidth } from "./resizable-pane";
+import { motionImmediately } from "./motion-input";
 
 import type { Dispatch, ReactNode, RefObject } from "react";
 import type {
@@ -207,10 +209,15 @@ export function Workspace(
 ) {
 	let [chatWidth, resizeChat] = usePaneWidth({ active: mode === "split", ...CHAT_PANE });
 	let presentation = presentWorkspace(state, mode, view);
+	let conversationPresence = useTransitionPresence(
+		presentation.conversationVisible ? true : undefined,
+		220,
+		motionImmediately(),
+	);
 	let opener = useRef<HTMLElement | undefined>(undefined);
 	let edgeTab = useRef<HTMLButtonElement>(null);
 	let previousConversationOpen = useRef(state.conversationOpen);
-	let conversationHidden = !presentation.conversationVisible;
+	let conversationInactive = !presentation.conversationVisible;
 	let planHidden = !presentation.documentVisible || presentation.documentView !== "plan";
 	let decisionsHidden = !presentation.documentVisible
 		|| presentation.documentView !== "decisions";
@@ -258,7 +265,10 @@ export function Workspace(
 	};
 
 	return (
-		<div className="flex h-full flex-col overflow-hidden bg-ground">
+		<div
+			className="workspace-root flex h-full flex-col overflow-hidden bg-ground"
+			data-workspace-mode={mode}
+		>
 			{header}
 
 			<div
@@ -268,17 +278,17 @@ export function Workspace(
 						: "pb-2"
 				}`}
 			>
-				{/* `hidden` preserves pane state and subscriptions while removing it from layout. */}
+				{/* `hidden` preserves pane state and subscriptions after its closing transition. */}
 				{chat && (
 					<aside
-						aria-hidden={conversationHidden || undefined}
+						aria-hidden={conversationInactive || undefined}
 						aria-labelledby={HEADING.conversation}
-						className={`order-2 relative flex min-w-0 flex-col overflow-hidden bg-conversation-pane ${
+						className={`workspace-conversation-panel motion-panel ${conversationPresence.className} order-2 relative flex min-w-0 flex-col overflow-hidden bg-conversation-pane ${
 							mode === "split" ? "hairline-l hairline-r hairline-b" : ""
 						}`}
-						hidden={conversationHidden}
+						hidden={conversationPresence.phase === "closed"}
 						id={paneId("chat")}
-						inert={conversationHidden}
+						inert={conversationInactive}
 						onKeyDown={event => {
 							if (event.key === "Escape" && mode !== "split") {
 								event.preventDefault();

--- a/e2e/document-navigation.e2e.ts
+++ b/e2e/document-navigation.e2e.ts
@@ -64,6 +64,22 @@ test("the room header renames the current document and the sidebar creates one i
 	await expect(headerDocument(page)).toHaveAccessibleName(/^Document: [a-z]+-[a-z]+$/);
 });
 
+test("a pointer-dismissed navigation dialog releases focus while it exits", async ({ join }) => {
+	let page = await join("ana");
+	let trigger = sidebar(page).getByRole("button", { name: "Search", exact: true });
+	await trigger.click();
+	await expect(page.getByRole("textbox", { name: "Search documents" })).toBeFocused();
+	let modal = page.locator(".navigation-modal");
+	await page.getByRole("button", { name: "Close Search documents" }).click({
+		position: { x: 8, y: 8 },
+	});
+
+	await expect(modal).toHaveAttribute("aria-hidden", "true");
+	await expect(modal).toHaveAttribute("inert", "");
+	await expect(trigger).toBeFocused();
+	await expect(modal).toHaveCount(0);
+});
+
 test("a stale catalogue response cannot remove a newly created document", async ({ join, page }) => {
 	let captured = Promise.withResolvers<void>();
 	let release = Promise.withResolvers<void>();

--- a/e2e/responsive-comments.e2e.ts
+++ b/e2e/responsive-comments.e2e.ts
@@ -53,8 +53,11 @@ test("a representative compact viewport keeps a passage above the sheet and rest
 		let passageBox = await passage.boundingBox();
 		return sheetBox!.y >= passageBox!.y + passageBox!.height;
 	}).toBe(true);
-	await page.keyboard.press("Escape");
-	await expect(sheet).toHaveCount(0);
+	await sheet.getByRole("button", { name: "Close comment" }).click();
+	let closing = page.locator(".motion-comment-surface.is-closing");
+	await expect(closing).toHaveAttribute("aria-hidden", "true");
+	await expect(closing).toHaveAttribute("inert", "");
+	await expect(closing).toHaveCount(0);
 	await expect.poll(() => scroller.evaluate(element => element.scrollTop)).toBeCloseTo(
 		originalScroll,
 		0,

--- a/e2e/responsive-workspace.e2e.ts
+++ b/e2e/responsive-workspace.e2e.ts
@@ -87,6 +87,37 @@ test("a representative compact phone exposes one mounted destination at a time",
 	await expectNoHorizontalOverflow(page);
 });
 
+test("a pointer-dismissed Projects drawer becomes inert while it exits", async ({ join, seed }) => {
+	await seed(RESPONSIVE_SOURCE);
+	let page = await join("ana", { hasTouch: true, viewport: { width: 390, height: 844 } });
+	let opener = page.getByRole("button", { name: "Open Projects sidebar" });
+	await opener.click();
+	let drawer = page.locator(".navigation-drawer");
+	await page.getByRole("button", { name: "Close Projects sidebar" }).click({
+		position: { x: 382, y: 422 },
+	});
+
+	await expect(drawer).toHaveAttribute("aria-hidden", "true");
+	await expect(drawer).toHaveAttribute("inert", "");
+	await expect(opener).toBeFocused();
+	await expect(drawer).toHaveCount(0);
+});
+
+test("enabling reduced motion settles an active drawer exit", async ({ join, seed }) => {
+	await seed(RESPONSIVE_SOURCE);
+	let page = await join("ana", { hasTouch: true, viewport: { width: 390, height: 844 } });
+	await page.emulateMedia({ reducedMotion: "no-preference" });
+	await page.getByRole("button", { name: "Open Projects sidebar" }).click();
+	let drawer = page.locator(".navigation-drawer");
+	await page.getByRole("button", { name: "Close Projects sidebar" }).click({
+		position: { x: 382, y: 422 },
+	});
+	await expect(drawer).toHaveAttribute("aria-hidden", "true");
+
+	await page.emulateMedia({ reducedMotion: "reduce" });
+	await expect(drawer).toHaveCount(0, { timeout: 100 });
+});
+
 test("a shifted visual viewport keeps workspace controls in the exposed rectangle", async ({ browser, baseURL, room, seed }) => {
 	await seed(RESPONSIVE_SOURCE);
 	let context = await browser.newContext({

--- a/e2e/sidecar.e2e.ts
+++ b/e2e/sidecar.e2e.ts
@@ -662,6 +662,14 @@ test("a touch comment opens as a modal sheet and restores its marker", async ({ 
 	await expect(sheet).toBeVisible();
 	await expect(sheet.getByRole("button", { name: "Close comment" })).toBeFocused();
 	await expect(content(page)).toHaveAttribute("inert", "");
+	await expect.poll(async () => {
+		let sheetBox = await sheet.boundingBox();
+		let documentBox = await page.locator("[data-plan-scroll]").boundingBox();
+		if (!sheetBox || !documentBox) return Number.POSITIVE_INFINITY;
+		return Math.abs(
+			sheetBox.y + sheetBox.height - documentBox.y - documentBox.height,
+		);
+	}).toBeLessThan(0.5);
 	await page.keyboard.press("Escape");
 	await expect(sheet).toHaveCount(0);
 	await expect(marker).toBeFocused();

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -15,6 +15,10 @@
 			"types": "./src/pointer.ts",
 			"default": "./src/pointer.ts"
 		},
+		"./transition-presence": {
+			"types": "./src/transition-presence.ts",
+			"default": "./src/transition-presence.ts"
+		},
 		"./styles.css": "./src/styles.css"
 	},
 	"dependencies": {

--- a/packages/editor/src/comment-layer.tsx
+++ b/packages/editor/src/comment-layer.tsx
@@ -14,9 +14,10 @@ import { $rangeOf } from "./marks";
 import { blockElement } from "./scroll";
 import { COARSE_POINTER_QUERY, hasCoarsePointer } from "./pointer";
 import { useThreads } from "./threads";
+import { useTransitionPresence } from "./transition-presence";
 import { widgets$ } from "./widget-options";
 
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import type { Point, Rect } from "./comment-geometry";
 import type { PassageHit } from "./comment-hits";
 import type { ThreadStore, ThreadView } from "./threads";
@@ -67,6 +68,52 @@ function Preview({
 	);
 }
 
+type CommentSurfaceValue = {
+	ariaLabel: string;
+	children: ReactNode;
+	className: string;
+	id?: string;
+	onMeasure?: (element: HTMLDivElement | null) => void;
+	onMouseEnter?: () => void;
+	onMouseLeave?: () => void;
+	style?: CSSProperties;
+};
+
+function CommentSurface(
+	{
+		compact,
+		immediately,
+		value,
+	}: {
+		compact: boolean;
+		immediately: boolean;
+		value?: CommentSurfaceValue;
+	},
+) {
+	let presence = useTransitionPresence(value, compact ? 180 : 150, immediately);
+	if (presence.phase === "closed") return null;
+	let surface = presence.value;
+	let active = presence.phase !== "closing";
+	return (
+		<div
+			aria-hidden={active ? undefined : "true"}
+			aria-label={surface.ariaLabel}
+			aria-modal={active && compact ? true : undefined}
+			className={`${surface.className} motion-comment-surface ${presence.className}`}
+			data-motion-presentation={compact ? "sheet" : "popover"}
+			id={surface.id}
+			inert={!active}
+			onMouseEnter={surface.onMouseEnter}
+			onMouseLeave={surface.onMouseLeave}
+			ref={surface.onMeasure}
+			role="dialog"
+			style={surface.style}
+		>
+			{surface.children}
+		</div>
+	);
+}
+
 function replyState(view: ThreadView): string {
 	let replies = Math.max(0, view.thread.notes.length - 1);
 	return replies === 0
@@ -110,6 +157,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 	let options = useCellValue(widgets$);
 	let canEdit = options.canEdit !== false;
 	let compact = options.commentPresentation === "sheet";
+	let immediately = options.motionImmediately?.() ?? false;
 	let draft = canEdit ? state.draft : undefined;
 
 	useEffect(() => {
@@ -518,47 +566,51 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 								view={view}
 							/>
 						)}
-						{shown && (
-							<div
-								aria-label="Comment thread"
-								aria-modal={compact || undefined}
-								className="plan-comment-card"
-								id={`plan-comment-thread-${view.thread.id}`}
-								ref={element => rememberHeight(view.thread.id, element)}
-								onMouseEnter={() => hover(view.thread.id)}
-								onMouseLeave={() => unhover(view.thread.id)}
-								role="dialog"
-								style={cardPoint}
-							>
-								{card(view)}
-							</div>
-						)}
+						<CommentSurface
+							compact={compact}
+							immediately={immediately}
+							value={shown
+								? {
+									ariaLabel: "Comment thread",
+									children: card(view),
+									className: "plan-comment-card",
+									id: `plan-comment-thread-${view.thread.id}`,
+									onMeasure: element => rememberHeight(view.thread.id, element),
+									onMouseEnter: () => hover(view.thread.id),
+									onMouseLeave: () => unhover(view.thread.id),
+									style: cardPoint,
+								}
+								: undefined}
+						/>
 					</div>
 				);
 			})}
 
-			{draft?.placement && (
-				<div
-					aria-label="New comment"
-					aria-modal={compact || undefined}
-					className="plan-comment-card"
-					role="dialog"
-					ref={element => rememberHeight("draft", element)}
-					style={popoverPoint(
-						draft.placement,
-						page,
-						cardWidth,
-						cardHeights.draft ?? 0,
-					)}
-				>
-					<DraftCard
-						busy={false}
-						onCancel={cancelDraft}
-						onSend={text => store.start(text)}
-						quote={draft.quote}
-					/>
-				</div>
-			)}
+			<CommentSurface
+				compact={compact}
+				immediately={immediately}
+				value={draft?.placement
+					? {
+						ariaLabel: "New comment",
+						children: (
+							<DraftCard
+								busy={false}
+								onCancel={cancelDraft}
+								onSend={text => store.start(text)}
+								quote={draft.quote}
+							/>
+						),
+						className: "plan-comment-card",
+						onMeasure: element => rememberHeight("draft", element),
+						style: popoverPoint(
+							draft.placement,
+							page,
+							cardWidth,
+							cardHeights.draft ?? 0,
+						),
+					}
+					: undefined}
+			/>
 
 			{orphaned.length > 0 && (
 				<div className="plan-comment-orphans">
@@ -575,17 +627,18 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 					>
 						{orphaned.length} comments without prose
 					</button>
-					{pinned === "orphans" && (
-						<div
-							aria-label="Orphaned comments"
-							aria-modal={compact || undefined}
-							className="plan-comment-card plan-comment-orphan-card"
-							id="plan-comment-thread-orphans"
-							role="dialog"
-						>
-							{orphaned.map(card)}
-						</div>
-					)}
+					<CommentSurface
+						compact={compact}
+						immediately={immediately}
+						value={pinned === "orphans"
+							? {
+								ariaLabel: "Orphaned comments",
+								children: orphaned.map(card),
+								className: "plan-comment-card plan-comment-orphan-card",
+								id: "plan-comment-thread-orphans",
+							}
+							: undefined}
+					/>
 				</div>
 			)}
 		</div>,

--- a/packages/editor/src/plan-editor.tsx
+++ b/packages/editor/src/plan-editor.tsx
@@ -62,6 +62,8 @@ export type PlanEditorProps = {
 	connection?: Connection;
 	/** How comment threads are presented by the surrounding workspace. */
 	commentPresentation?: CommentPresentation;
+	/** App-owned input policy for interactions that should settle without motion. */
+	motionImmediately?: () => boolean;
 	/** Identity for this client's remote cursor. */
 	user: { name: string; color: string };
 	/** Read-only while an agent turn may be rewriting the plan. */
@@ -99,6 +101,7 @@ export function PlanEditor(
 		className,
 		commentPresentation = "popover",
 		connection,
+		motionImmediately,
 		onScrollTop,
 		questions,
 		readOnly,
@@ -248,6 +251,7 @@ export function PlanEditor(
 					}),
 					widgetsPlugin({
 						commentPresentation,
+						motionImmediately,
 						questions,
 						threads,
 						changes,
@@ -267,6 +271,7 @@ export function PlanEditor(
 			onChanges,
 			questions,
 			commentPresentation,
+			motionImmediately,
 			threads,
 			changes,
 			offline,

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -238,6 +238,39 @@
 	box-shadow: var(--shadow-overlay);
 }
 
+.motion-comment-surface {
+	opacity: 0;
+	transform: scale(var(--dropdown-pre-scale));
+	transform-origin: top right;
+	transition:
+		opacity var(--dropdown-open-dur) var(--dropdown-ease),
+		transform var(--dropdown-open-dur) var(--dropdown-ease);
+	will-change: opacity, transform;
+}
+
+.motion-comment-surface[data-motion-presentation="sheet"] {
+	transform: translateY(var(--drawer-distance));
+	transform-origin: bottom center;
+	transition-duration: var(--drawer-open-dur);
+}
+
+.motion-comment-surface.is-open {
+	opacity: 1;
+	transform: none;
+}
+
+.motion-comment-surface.is-closing {
+	pointer-events: none;
+	opacity: 0;
+	transform: scale(var(--dropdown-closing-scale));
+	transition-duration: var(--dropdown-close-dur);
+}
+
+.motion-comment-surface[data-motion-presentation="sheet"].is-closing {
+	transform: translateY(var(--drawer-distance));
+	transition-duration: var(--drawer-close-dur);
+}
+
 .plan-comment-orphans {
 	pointer-events: auto;
 	position: absolute;
@@ -265,6 +298,12 @@
 	max-height: calc(100% - 0.5rem);
 	padding-bottom: env(safe-area-inset-bottom, 0px);
 	border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.motion-comment-surface {
+		transition: none;
+	}
 }
 
 .plan-decisions {

--- a/packages/editor/src/widget-options.ts
+++ b/packages/editor/src/widget-options.ts
@@ -9,6 +9,7 @@ export type CommentPresentation = "popover" | "sheet";
 
 export type WidgetOptions = {
 	commentPresentation?: CommentPresentation;
+	motionImmediately?: () => boolean;
 	questions?: QuestionnaireStore;
 	threads?: ThreadStore;
 	changes?: ChangeStore;


### PR DESCRIPTION
Stacked on and consumes the transition foundation in #111.

- wires semantic presence into navigation drawers/dialogs, dropdowns, the Conversation pane, and comment popovers/sheets
- keeps keyboard-driven interactions immediate and passes the app-owned motion policy into the editor
- retains closing surfaces only while inert and hidden from accessibility, with reduced-motion coverage

Verification:
- bun test (966 passed, 2 skipped, 0 failed)
- bun run types
- bun run ci
- bun run build
- relevant Playwright files (25 passed)
