### PR TITLE
Add document archival and deletion

### DIFF
--- a/apps/server/src/channels/routes.test.ts
+++ b/apps/server/src/channels/routes.test.ts
@@ -111,12 +111,29 @@ async function setup(random?: () => number) {
 	let router = new Router();
 	let reset: string[] = [];
 	let renamed: string[] = [];
+	let archived: Array<{ id: string; changed: boolean }> = [];
+	let restored: Array<{ id: string; changed: boolean }> = [];
+	let deleted: string[] = [];
 	registerChannelRoutes(router, auth, {
 		onAgentReset: async id => {
 			reset.push(id);
 		},
+		onChannelArchived: async (id, at) => {
+			let result = await storage.channels.archive({ id, now: at });
+			archived.push({ id, changed: result.changed });
+			return result;
+		},
+		onChannelDeleted: async id => {
+			deleted.push(id);
+			return storage.channels.delete(id);
+		},
 		onChannelRenamed: channel => {
 			renamed.push(channel.title);
+		},
+		onChannelRestored: async (id, at) => {
+			let result = await storage.channels.restore({ id, now: at });
+			restored.push({ id, changed: result.changed });
+			return result;
 		},
 		random,
 	});
@@ -128,6 +145,9 @@ async function setup(random?: () => number) {
 		sessionId: issued.id,
 		reset,
 		renamed,
+		archived,
+		restored,
+		deleted,
 		now,
 	};
 }
@@ -136,6 +156,18 @@ function request(path: string, cookie?: string, init: RequestInit = {}): Request
 	let headers = new Headers(init.headers);
 	if (cookie) headers.set("cookie", cookie);
 	return new Request(`https://chopin.test${path}`, { ...init, headers });
+}
+
+function createChannel(storage: MemoryStorage, now: Date, title: string) {
+	return storage.channels.create({
+		id: crypto.randomUUID(),
+		repositoryId: "R_score",
+		repositoryOwner: "octo-org",
+		repositoryName: "score",
+		title,
+		createdBy: "U_octocat",
+		now,
+	});
 }
 
 describe("channel routes", () => {
@@ -444,6 +476,209 @@ describe("channel routes", () => {
 			cookie,
 		));
 		expect(mismatch!.status).toBe(400);
+	});
+
+	it("excludes archived documents by default and binds cursors to archive mode", async () => {
+		let { router, storage, cookie, now } = await setup();
+		let first = await createChannel(storage, now, "First active");
+		let second = await createChannel(storage, now, "Second active");
+		let archived = await createChannel(storage, now, "Archived plan");
+		let archivedAt = new Date(now.getTime() + 1_000);
+		await storage.channels.archive({ id: archived.id, now: archivedAt });
+
+		let defaultResponse = await router.handle(request(
+			"/api/repositories/octo-org/score/channels",
+			cookie,
+		));
+		expect(defaultResponse!.status).toBe(200);
+		let defaultPage = await defaultResponse!.json();
+		expect(defaultPage.channels.map((channel: { id: string }) => channel.id).sort()).toEqual(
+			[first.id, second.id].sort(),
+		);
+		expect(defaultPage.channels.every((channel: object) => !("archivedAt" in channel))).toBe(true);
+
+		let includedResponse = await router.handle(request(
+			"/api/repositories/octo-org/score/channels?includeArchived=true",
+			cookie,
+		));
+		expect(includedResponse!.status).toBe(200);
+		let includedPage = await includedResponse!.json();
+		expect(includedPage.channels).toHaveLength(3);
+		expect(
+			includedPage.channels.find((channel: { id: string }) => channel.id === archived.id),
+		).toMatchObject({ id: archived.id, archivedAt: archivedAt.toISOString() });
+
+		let activeFirst = await router.handle(request(
+			"/api/repositories/octo-org/score/channels?limit=1",
+			cookie,
+		));
+		let activeCursor = (await activeFirst!.json()).nextCursor;
+		expect(activeCursor).toBeString();
+		let activeCursorInArchiveMode = await router.handle(request(
+			`/api/repositories/octo-org/score/channels?limit=1&includeArchived=true&cursor=${activeCursor}`,
+			cookie,
+		));
+		expect(activeCursorInArchiveMode!.status).toBe(400);
+
+		let includedFirst = await router.handle(request(
+			"/api/repositories/octo-org/score/channels?limit=1&includeArchived=true",
+			cookie,
+		));
+		let includedCursor = (await includedFirst!.json()).nextCursor;
+		expect(includedCursor).toBeString();
+		let includedCursorInActiveMode = await router.handle(request(
+			`/api/repositories/octo-org/score/channels?limit=1&cursor=${includedCursor}`,
+			cookie,
+		));
+		expect(includedCursorInActiveMode!.status).toBe(400);
+	});
+
+	it("opens archived documents by slug and UUID as manageable but read-only", async () => {
+		let { router, storage, cookie, now } = await setup();
+		let channel = await createChannel(storage, now, "Archived direct read");
+		let archivedAt = new Date(now.getTime() + 1_000);
+		await storage.channels.archive({ id: channel.id, now: archivedAt });
+
+		for (
+			let path of [
+				`/api/repositories/octo-org/score/documents/${channel.slug}`,
+				`/api/channels/${channel.id}`,
+			]
+		) {
+			let response = await router.handle(request(path, cookie));
+			expect(response!.status).toBe(200);
+			expect(await response!.json()).toMatchObject({
+				canEdit: false,
+				canManage: true,
+				channel: { id: channel.id, archivedAt: archivedAt.toISOString() },
+			});
+		}
+	});
+
+	it("lets viewers read archived documents but not archive, restore or delete", async () => {
+		let { router, storage, github, cookie, archived, restored, deleted, now } = await setup();
+		let active = await createChannel(storage, now, "Viewer active");
+		let inactive = await createChannel(storage, now, "Viewer archived");
+		await storage.channels.archive({
+			id: inactive.id,
+			now: new Date(now.getTime() + 1_000),
+		});
+		github.repo = { ...github.repo, permissions: { pull: true, push: false, admin: false } };
+
+		let read = await router.handle(request(`/api/channels/${inactive.id}`, cookie));
+		expect(read!.status).toBe(200);
+		expect(await read!.json()).toMatchObject({ canEdit: false, canManage: false });
+
+		for (
+			let [method, path] of [
+				["POST", `/api/channels/${active.id}/archive`],
+				["POST", `/api/channels/${inactive.id}/restore`],
+				["DELETE", `/api/channels/${inactive.id}`],
+			] as const
+		) {
+			let response = await router.handle(request(path, cookie, {
+				method,
+				headers: { origin: "https://chopin.test" },
+			}));
+			expect(response!.status).toBe(403);
+		}
+		expect(archived).toEqual([]);
+		expect(restored).toEqual([]);
+		expect(deleted).toEqual([]);
+		expect((await storage.channels.get(active.id))!.archivedAt).toBeUndefined();
+		expect((await storage.channels.get(inactive.id))!.archivedAt).toBeDate();
+	});
+
+	it("archives and restores idempotently for a writer", async () => {
+		let { router, storage, cookie, archived, restored, now } = await setup();
+		let channel = await createChannel(storage, now, "Lifecycle");
+		let transition = (action: "archive" | "restore") =>
+			router.handle(request(`/api/channels/${channel.id}/${action}`, cookie, {
+				method: "POST",
+				headers: { origin: "https://chopin.test" },
+			}));
+
+		let firstArchive = await transition("archive");
+		expect(firstArchive!.status).toBe(200);
+		let archivedBody = await firstArchive!.json();
+		expect(archivedBody).toMatchObject({ canEdit: false, canManage: true });
+		expect(archivedBody.channel.archivedAt).toBeString();
+		let repeatedArchive = await transition("archive");
+		expect(repeatedArchive!.status).toBe(200);
+		expect((await repeatedArchive!.json()).channel.archivedAt)
+			.toBe(archivedBody.channel.archivedAt);
+		expect(archived).toEqual([
+			{ id: channel.id, changed: true },
+			{ id: channel.id, changed: false },
+		]);
+
+		let firstRestore = await transition("restore");
+		expect(firstRestore!.status).toBe(200);
+		let restoredBody = await firstRestore!.json();
+		expect(restoredBody).toMatchObject({ canEdit: true, canManage: true });
+		expect(restoredBody.channel).not.toHaveProperty("archivedAt");
+		let repeatedRestore = await transition("restore");
+		expect(repeatedRestore!.status).toBe(200);
+		expect((await repeatedRestore!.json()).channel).not.toHaveProperty("archivedAt");
+		expect(restored).toEqual([
+			{ id: channel.id, changed: true },
+			{ id: channel.id, changed: false },
+		]);
+	});
+
+	it("requires the exact configured Origin for lifecycle mutations", async () => {
+		let { router, storage, cookie, archived, restored, deleted, now } = await setup();
+		let active = await createChannel(storage, now, "Origin active");
+		let inactive = await createChannel(storage, now, "Origin archived");
+		await storage.channels.archive({
+			id: inactive.id,
+			now: new Date(now.getTime() + 1_000),
+		});
+
+		for (
+			let [method, path] of [
+				["POST", `/api/channels/${active.id}/archive`],
+				["POST", `/api/channels/${inactive.id}/restore`],
+				["DELETE", `/api/channels/${inactive.id}`],
+			] as const
+		) {
+			for (let origin of [undefined, "https://chopin.test/", "https://chopin.test.evil"]) {
+				let response = await router.handle(request(path, cookie, {
+					method,
+					headers: origin ? { origin } : undefined,
+				}));
+				expect(response!.status).toBe(403);
+			}
+		}
+		expect(archived).toEqual([]);
+		expect(restored).toEqual([]);
+		expect(deleted).toEqual([]);
+	});
+
+	it("requires archival before deletion and delegates archived deletion", async () => {
+		let { router, storage, cookie, deleted, now } = await setup();
+		let channel = await createChannel(storage, now, "Delete lifecycle");
+		let remove = () =>
+			router.handle(request(`/api/channels/${channel.id}`, cookie, {
+				method: "DELETE",
+				headers: { origin: "https://chopin.test" },
+			}));
+
+		let active = await remove();
+		expect(active!.status).toBe(409);
+		expect(deleted).toEqual([]);
+		expect(await storage.channels.get(channel.id)).toBeDefined();
+
+		await storage.channels.archive({
+			id: channel.id,
+			now: new Date(now.getTime() + 1_000),
+		});
+		let archived = await remove();
+		expect(archived!.status).toBe(204);
+		expect(archived!.headers.get("cache-control")).toBe("no-store");
+		expect(await archived!.text()).toBe("");
+		expect(deleted).toEqual([channel.id]);
+		expect(await storage.channels.get(channel.id)).toBeUndefined();
 	});
 
 	it("creates a unique generated document when a title is omitted", async () => {

--- a/apps/server/src/channels/routes.ts
+++ b/apps/server/src/channels/routes.ts
@@ -12,7 +12,7 @@ import type { HostedAuth } from "../auth/routes";
 import type { AuthenticatedSession } from "../auth/session";
 import type { Repository } from "../github/client";
 import type { Router } from "../http/router";
-import type { ChannelCursor, ChannelRecord } from "../storage/model";
+import type { ChannelArchiveResult, ChannelCursor, ChannelRecord } from "../storage/model";
 
 const OWNER = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
 const REPOSITORY = /^[A-Za-z0-9._-]{1,100}$/;
@@ -40,6 +40,7 @@ function serialized(channel: ChannelRecord) {
 		revision: channel.revision,
 		createdAt: channel.createdAt.toISOString(),
 		updatedAt: channel.updatedAt.toISOString(),
+		...(channel.archivedAt ? { archivedAt: channel.archivedAt.toISOString() } : {}),
 	};
 }
 
@@ -57,18 +58,19 @@ function repository(value: Repository) {
 	};
 }
 
-function encoded(cursor: ChannelCursor, query: string): string {
+function encoded(cursor: ChannelCursor, query: string, includeArchived: boolean): string {
 	return Buffer.from(JSON.stringify({
-		v: 2,
+		v: 3,
 		updatedAt: cursor.updatedAt.toISOString(),
 		id: cursor.id,
 		query,
+		includeArchived,
 	})).toString("base64url");
 }
 
 function decoded(
 	value: string | null,
-): { cursor: ChannelCursor; query: string } | undefined | false {
+): { cursor: ChannelCursor; query: string; includeArchived: boolean } | undefined | false {
 	if (value === null) return undefined;
 	if (!/^[A-Za-z0-9_-]+$/.test(value)) return false;
 	try {
@@ -76,16 +78,21 @@ function decoded(
 		if (!parsed || typeof parsed !== "object") return false;
 		let item = parsed as Record<string, unknown>;
 		if (
-			item.v !== 2
+			item.v !== 3
 			|| typeof item.updatedAt !== "string"
 			|| typeof item.id !== "string"
 			|| typeof item.query !== "string"
+			|| typeof item.includeArchived !== "boolean"
 		) {
 			return false;
 		}
 		let updatedAt = new Date(item.updatedAt);
 		if (Number.isNaN(updatedAt.getTime()) || !isChannelId(item.id)) return false;
-		return { cursor: { updatedAt, id: item.id }, query: item.query };
+		return {
+			cursor: { updatedAt, id: item.id },
+			query: item.query,
+			includeArchived: item.includeArchived,
+		};
 	} catch {
 		return false;
 	}
@@ -104,6 +111,13 @@ function limit(url: URL): number | undefined {
 	if (values.length !== 1 || !/^\d+$/.test(values[0]!)) return undefined;
 	let parsed = Number(values[0]);
 	return Number.isSafeInteger(parsed) && parsed >= 1 && parsed <= 100 ? parsed : undefined;
+}
+
+function archived(url: URL): boolean | undefined {
+	let values = url.searchParams.getAll("includeArchived");
+	if (values.length === 0) return false;
+	if (values.length !== 1 || values[0] !== "true") return undefined;
+	return true;
 }
 
 async function requestedTitle(
@@ -173,9 +187,11 @@ function openedDocument(
 	channel: ChannelRecord,
 ) {
 	if (repo.id !== channel.repositoryId || !repo.permissions.pull) return undefined;
+	let canManage = repo.permissions.push || repo.permissions.admin;
 	return {
 		repository: repository(repo),
-		canEdit: repo.permissions.push || repo.permissions.admin,
+		canEdit: canManage && !channel.archivedAt,
+		canManage,
 		channel: serialized(channel),
 	};
 }
@@ -186,7 +202,10 @@ export function registerChannelRoutes(
 	auth: HostedAuth,
 	options: {
 		onAgentReset?: (channelId: string) => Promise<void>;
+		onChannelArchived?: (channelId: string, now: Date) => Promise<ChannelArchiveResult>;
+		onChannelDeleted?: (channelId: string) => Promise<boolean>;
 		onChannelRenamed?: (channel: ChannelRecord) => void;
+		onChannelRestored?: (channelId: string, now: Date) => Promise<ChannelArchiveResult>;
 		random?: () => number;
 	} = {},
 ): void {
@@ -208,12 +227,19 @@ export function registerChannelRoutes(
 				}
 				let requestedLimit = limit(url);
 				let requestedQuery = query(url);
+				let includeArchived = archived(url);
 				let cursorValues = url.searchParams.getAll("cursor");
 				let cursor = cursorValues.length <= 1 ? decoded(cursorValues[0] ?? null) : false;
-				if (!requestedLimit || requestedQuery === false || cursor === false) {
+				if (
+					!requestedLimit || requestedQuery === false || includeArchived === undefined
+					|| cursor === false
+				) {
 					return json({ error: "invalid channel pagination" }, 400);
 				}
-				if (cursor && cursor.query !== requestedQuery) {
+				if (
+					cursor
+					&& (cursor.query !== requestedQuery || cursor.includeArchived !== includeArchived)
+				) {
 					return json({ error: "invalid channel pagination" }, 400);
 				}
 				let page = await auth.storage.channels.list(
@@ -221,12 +247,16 @@ export function registerChannelRoutes(
 					requestedLimit,
 					cursor?.cursor,
 					requestedQuery || undefined,
+					includeArchived,
 				);
+				let canManage = repo.permissions.push || repo.permissions.admin;
 				return json({
 					repository: repository(repo),
-					canEdit: repo.permissions.push || repo.permissions.admin,
+					canEdit: canManage,
 					channels: page.channels.map(serialized),
-					nextCursor: page.next ? encoded(page.next, requestedQuery) : undefined,
+					nextCursor: page.next
+						? encoded(page.next, requestedQuery, includeArchived)
+						: undefined,
 				});
 			} catch (err) {
 				return failure(err, request, auth);
@@ -284,7 +314,12 @@ export function registerChannelRoutes(
 				}
 				if (!channel) throw new StorageError("conflict", "could not reserve a generated title");
 				return json(
-					{ repository: repository(repo), canEdit: true, channel: serialized(channel) },
+					{
+						repository: repository(repo),
+						canEdit: true,
+						canManage: true,
+						channel: serialized(channel),
+					},
 					201,
 					undefined,
 					documentPath(repo.owner, repo.name, channel.slug),
@@ -376,12 +411,95 @@ export function registerChannelRoutes(
 			return json({
 				repository: repository(repo),
 				canEdit: true,
+				canManage: true,
 				channel: serialized(renamed.channel),
 			});
 		} catch (err) {
 			if (err instanceof StorageError && err.failure === "conflict") {
 				return json({ error: "a document with this title already exists" }, 409);
 			}
+			return failure(err, request, auth);
+		}
+	});
+
+	let registerArchiveTransition = (
+		path: string,
+		action: "archive" | "restore",
+	) => {
+		router.on("POST", path, async (request, _url, params) => {
+			if (request.headers.get("origin") !== auth.config.origin) {
+				return json({ error: "origin is not allowed" }, 403);
+			}
+			try {
+				let session = await auth.sessions.authenticate(request);
+				if (!session) return json({ error: "authentication required" }, 401);
+				let id = params.channelId!;
+				if (!isChannelId(id)) return json({ error: "channel not found" }, 404);
+				let channel = await auth.storage.channels.get(id);
+				if (!channel) return json({ error: "channel not found" }, 404);
+				let repo = await authorizedRepository(
+					auth,
+					session,
+					channel.repositoryOwner,
+					channel.repositoryName,
+				);
+				if (repo.id !== channel.repositoryId || !repo.permissions.pull) {
+					return json({ error: "channel not found" }, 404);
+				}
+				if (!repo.permissions.push && !repo.permissions.admin) {
+					return json({ error: "repository write access is required" }, 403);
+				}
+				let now = auth.clock();
+				let result = action === "archive"
+					? await (options.onChannelArchived
+						? options.onChannelArchived(id, now)
+						: auth.storage.channels.archive({ id, now }))
+					: await (options.onChannelRestored
+						? options.onChannelRestored(id, now)
+						: auth.storage.channels.restore({ id, now }));
+				let opened = openedDocument(repo, result.channel);
+				return opened ? json(opened) : json({ error: "channel not found" }, 404);
+			} catch (err) {
+				return failure(err, request, auth);
+			}
+		});
+	};
+	registerArchiveTransition("/api/channels/:channelId/archive", "archive");
+	registerArchiveTransition("/api/channels/:channelId/restore", "restore");
+
+	router.on("DELETE", "/api/channels/:channelId", async (request, _url, params) => {
+		if (request.headers.get("origin") !== auth.config.origin) {
+			return json({ error: "origin is not allowed" }, 403);
+		}
+		try {
+			let session = await auth.sessions.authenticate(request);
+			if (!session) return json({ error: "authentication required" }, 401);
+			let id = params.channelId!;
+			if (!isChannelId(id)) return json({ error: "channel not found" }, 404);
+			let channel = await auth.storage.channels.get(id);
+			if (!channel) return json({ error: "channel not found" }, 404);
+			let repo = await authorizedRepository(
+				auth,
+				session,
+				channel.repositoryOwner,
+				channel.repositoryName,
+			);
+			if (repo.id !== channel.repositoryId || !repo.permissions.pull) {
+				return json({ error: "channel not found" }, 404);
+			}
+			if (!repo.permissions.push && !repo.permissions.admin) {
+				return json({ error: "repository write access is required" }, 403);
+			}
+			if (!channel.archivedAt) {
+				return json({ error: "document must be archived before deletion" }, 409);
+			}
+			let deleted = options.onChannelDeleted
+				? await options.onChannelDeleted(id)
+				: await auth.storage.channels.delete(id);
+			return deleted
+				? new Response(null, { status: 204, headers: { "cache-control": "no-store" } })
+				: json({ error: "channel not found" }, 404);
+		} catch (err) {
 			return failure(err, request, auth);
 		}
 	});

--- a/apps/server/src/jobs/document-summary.test.ts
+++ b/apps/server/src/jobs/document-summary.test.ts
@@ -240,6 +240,56 @@ describe("document summary coordinator", () => {
 			await value.storage.close();
 		}
 	});
+
+	it("suspends pending and admitted scheduling until resumed", async () => {
+		let current = target();
+		let definition = documentSummaryDefinition({
+			config: { agent: true, model: "summary-model" },
+			current: async () => current,
+			refresh: async () => {},
+			commitCurrent,
+			engine: async () => ({ summary: "summary", model: "summary-model" }),
+		});
+		let value = await serviceContext(definition);
+		let timers: Array<{ cancelled: boolean; action: () => void }> = [];
+		let currentCalls = 0;
+		let coordinator = new DocumentSummaryCoordinator({
+			service: value.service,
+			current: async channelId => {
+				currentCalls++;
+				return { ...current, channelId };
+			},
+			debounceMs: 10,
+			after: (_delay, action) => {
+				let timer = { cancelled: false, action };
+				timers.push(timer);
+				return () => timer.cancelled = true;
+			},
+		});
+		try {
+			let scheduled = { ...current, channelId: value.channelId };
+			coordinator.schedule(scheduled);
+			let admitted = coordinator.enqueueNow(scheduled);
+			await coordinator.suspend(value.channelId);
+			await admitted;
+			expect(timers[0]!.cancelled).toBe(true);
+			timers[0]!.action();
+
+			coordinator.schedule(scheduled);
+			await coordinator.ensure(value.channelId);
+			await coordinator.enqueueNow(scheduled);
+			expect(currentCalls).toBe(0);
+			expect((await value.storage.jobs.list(value.channelId, 10))!.jobs).toEqual([]);
+
+			coordinator.resume(value.channelId);
+			await coordinator.ensure(value.channelId);
+			expect(currentCalls).toBe(2);
+			expect((await value.storage.jobs.list(value.channelId, 10))!.jobs).toHaveLength(1);
+		} finally {
+			coordinator.close();
+			await value.storage.close();
+		}
+	});
 });
 
 async function waitFor(check: () => boolean | Promise<boolean>): Promise<void> {

--- a/apps/server/src/jobs/runner.test.ts
+++ b/apps/server/src/jobs/runner.test.ts
@@ -769,6 +769,61 @@ describe("background job runner", () => {
 		}
 	});
 
+	it("cancelChannel cancels pending work and fences later claims", async () => {
+		let executions = 0;
+		let value = await setup(definition(async () => {
+			executions++;
+			return { report: "unexpected" };
+		}));
+		try {
+			let pending = await enqueue(value.service, value.channelId, "pending");
+			await value.runner.cancelChannel(value.channelId);
+			expect(await value.service.get(value.channelId, pending.job.id)).toMatchObject({
+				job: { state: "cancelled", attempts: 0 },
+			});
+
+			let blocked = await enqueue(value.service, value.channelId, "blocked");
+			value.runner.start();
+			await waitFor(async () =>
+				(await value.service.get(value.channelId, blocked.job.id))?.job.state === "cancelled"
+			);
+			expect(executions).toBe(0);
+			expect(value.errors).toEqual([]);
+		} finally {
+			await value.runner.shutdown();
+			await value.storage.close();
+		}
+	});
+
+	it("cancelChannel aborts and cancels running work", async () => {
+		let started = deferred<void>();
+		let aborted = deferred<void>();
+		let value = await setup(definition(async execution => {
+			started.resolve();
+			return await new Promise<JsonValue>((_resolve, reject) => {
+				execution.signal.addEventListener("abort", () => {
+					aborted.resolve();
+					reject(execution.signal.reason);
+				}, { once: true });
+			});
+		}));
+		try {
+			let running = await enqueue(value.service, value.channelId);
+			value.runner.start();
+			await started.promise;
+			await value.runner.cancelChannel(value.channelId);
+			await aborted.promise;
+			expect(await value.service.get(value.channelId, running.job.id)).toMatchObject({
+				job: { state: "cancelled", attempts: 1 },
+				artifact: undefined,
+			});
+			expect(value.errors).toEqual([]);
+		} finally {
+			await value.runner.shutdown();
+			await value.storage.close();
+		}
+	});
+
 	it("requeues active work before shutdown returns", async () => {
 		let result = deferred<JsonValue>();
 		let started = false;

--- a/apps/server/src/jobs/runner.ts
+++ b/apps/server/src/jobs/runner.ts
@@ -112,6 +112,7 @@ export class JobRunner {
 	#pump?: Promise<void>;
 	#poll?: () => void;
 	#ownerRecovery = new Map<string, () => void>();
+	#blockedChannels = new Set<string>();
 	#shutdown?: Promise<void>;
 	#pollFailures = 0;
 
@@ -201,6 +202,37 @@ export class JobRunner {
 				&& attempt.credential?.credential.kind === "active-planner"
 			).map(attempt => this.#pause(attempt, "owner-unavailable")),
 		);
+	}
+
+	/** Fence and cancel every job owned by a document before that document is deleted. */
+	async cancelChannel(channelId: string): Promise<void> {
+		this.#blockedChannels.add(channelId);
+		this.#ownerRecovery.get(channelId)?.();
+		this.#ownerRecovery.delete(channelId);
+		let attempts = [...this.#attempts].filter(attempt => attempt.job.channelId === channelId);
+		for (let attempt of attempts) this.#detach(attempt, "document-deleted");
+
+		let cursor: BackgroundJobCursor | undefined;
+		do {
+			let page = await this.#options.service.list(channelId, 100, cursor);
+			if (!page) break;
+			for (let job of page.jobs) {
+				if (job.state !== "pending" && job.state !== "paused" && job.state !== "running") continue;
+				try {
+					await this.#options.service.cancel({ channelId, jobId: job.id }, true);
+				} catch (err) {
+					if (!expected(err)) throw err;
+				}
+			}
+			cursor = page.next;
+		} while (cursor);
+		await this.#withinGrace(Promise.allSettled(attempts.map(attempt => attempt.done)));
+	}
+
+	/** Used only when deletion failed before the channel row was removed. */
+	unblockChannel(channelId: string): void {
+		this.#blockedChannels.delete(channelId);
+		this.wake();
 	}
 
 	async ownerAvailable(channelId: string): Promise<void> {
@@ -315,6 +347,12 @@ export class JobRunner {
 	}
 
 	#start(job: BackgroundJob): Promise<void> | undefined {
+		if (this.#blockedChannels.has(job.channelId)) {
+			return this.#options.service.cancel({ channelId: job.channelId, jobId: job.id }, true)
+				.then(() => {}, err => {
+					if (!expected(err)) this.#options.fatal?.(err);
+				});
+		}
 		let previous = this.#active.get(job.id);
 		if (previous) {
 			this.#detach(previous, "claim-reclaimed");

--- a/apps/server/src/jobs/service.ts
+++ b/apps/server/src/jobs/service.ts
@@ -370,11 +370,12 @@ export class JobService {
 		return view(saved);
 	}
 
-	async cancel(request: JobIdentity): Promise<JobView> {
+	async cancel(request: JobIdentity, allowArchived = false): Promise<JobView> {
 		let saved = await this.#storage.jobs.cancel({
 			...request,
 			now: this.#time(),
 			lease: this.#lease(),
+			...(allowArchived ? { allowArchived: true } : {}),
 		});
 		this.#didChange(saved);
 		await this.#changed(request.channelId);

--- a/apps/server/src/jobs/summary-coordinator.ts
+++ b/apps/server/src/jobs/summary-coordinator.ts
@@ -21,6 +21,7 @@ export class DocumentSummaryCoordinator {
 	#pending = new Map<string, Pending>();
 	#chains = new Map<string, Promise<void>>();
 	#inflight = new Set<Promise<void>>();
+	#suspended = new Set<string>();
 	#closed = false;
 
 	constructor(options: SummaryCoordinatorOptions) {
@@ -32,7 +33,7 @@ export class DocumentSummaryCoordinator {
 	}
 
 	schedule(target: DocumentTarget): void {
-		if (this.#closed) return;
+		if (this.#closed || this.#suspended.has(target.channelId)) return;
 		let previous = this.#pending.get(target.channelId);
 		if (
 			previous?.target.revision === target.revision
@@ -65,15 +66,16 @@ export class DocumentSummaryCoordinator {
 	}
 
 	async ensure(channelId: string): Promise<void> {
-		if (this.#closed) return;
+		if (this.#closed || this.#suspended.has(channelId)) return;
 		let target = await this.#options.current(channelId);
 		if (target) await this.enqueueNow(target);
 	}
 
 	async enqueueNow(target: DocumentTarget): Promise<void> {
-		if (this.#closed) return;
+		if (this.#closed || this.#suspended.has(target.channelId)) return;
 		let previous = this.#chains.get(target.channelId) ?? Promise.resolve();
 		let operation = previous.then(async () => {
+			if (this.#suspended.has(target.channelId)) return;
 			let current = await this.#options.current(target.channelId);
 			if (!current) return;
 			await this.#options.service.enqueueScheduler({
@@ -94,12 +96,28 @@ export class DocumentSummaryCoordinator {
 		try {
 			await operation;
 		} catch (err) {
-			if (!this.#closed && !this.#pending.has(target.channelId)) this.#arm(target);
+			if (
+				!this.#closed && !this.#suspended.has(target.channelId)
+				&& !this.#pending.has(target.channelId)
+			) this.#arm(target);
 			throw err;
 		} finally {
 			this.#inflight.delete(operation);
 			if (this.#chains.get(target.channelId) === settled) this.#chains.delete(target.channelId);
 		}
+	}
+
+	/** Stop new summary work and wait for scheduling already admitted for one document. */
+	async suspend(channelId: string): Promise<void> {
+		this.#suspended.add(channelId);
+		let pending = this.#pending.get(channelId);
+		pending?.cancel();
+		this.#pending.delete(channelId);
+		await this.#chains.get(channelId);
+	}
+
+	resume(channelId: string): void {
+		this.#suspended.delete(channelId);
 	}
 
 	async flush(): Promise<void> {
@@ -124,6 +142,7 @@ export class DocumentSummaryCoordinator {
 
 	close(): void {
 		this.#closed = true;
+		this.#suspended.clear();
 		for (let pending of this.#pending.values()) pending.cancel();
 		this.#pending.clear();
 	}

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -83,6 +83,9 @@ let researchService: ResearchWorkspaceService | undefined;
 let referenceService: ReferenceService | undefined;
 let summaryCoordinator: DocumentSummaryCoordinator | undefined;
 let documentLocks = new Map<string, Promise<void>>();
+let documentTransitions = new Map<string, Promise<void>>();
+let archivingChannels = new Set<string>();
+let deletingChannels = new Set<string>();
 
 function withDocumentLock<T>(channelId: string, action: () => Promise<T>): Promise<T> {
 	let previous = documentLocks.get(channelId) ?? Promise.resolve();
@@ -91,6 +94,17 @@ function withDocumentLock<T>(channelId: string, action: () => Promise<T>): Promi
 	documentLocks.set(channelId, settled);
 	void settled.finally(() => {
 		if (documentLocks.get(channelId) === settled) documentLocks.delete(channelId);
+	});
+	return operation;
+}
+
+function withDocumentTransition<T>(channelId: string, action: () => Promise<T>): Promise<T> {
+	let previous = documentTransitions.get(channelId) ?? Promise.resolve();
+	let operation = previous.then(action, action);
+	let settled = operation.then(() => {}, () => {});
+	documentTransitions.set(channelId, settled);
+	void settled.finally(() => {
+		if (documentTransitions.get(channelId) === settled) documentTransitions.delete(channelId);
 	});
 	return operation;
 }
@@ -109,8 +123,10 @@ function presence(server: Server<SocketData>, room: Rooms.Room): void {
  * Two clients opening at the same moment must not build two documents, so the
  * first stores its promise and the second waits on it.
  */
-function plan(room: Rooms.Room, server: Server<SocketData>): Promise<Service.Plan> {
-	if (room.plan) return Promise.resolve(room.plan);
+async function plan(room: Rooms.Room, server: Server<SocketData>): Promise<Service.Plan> {
+	if (room.closing) await room.closing;
+	if (deletingChannels.has(room.id)) throw new Error("document is unavailable");
+	if (room.plan) return room.plan;
 	let backend: Service.Backend = {
 		storage,
 		lease: () => {
@@ -123,19 +139,24 @@ function plan(room: Rooms.Room, server: Server<SocketData>): Promise<Service.Pla
 		},
 		onDocumentPersisted: target => summaryCoordinator?.schedule(target),
 	};
-	return room.opening ??= withDocumentLock(room.id, () => Service.open(room.id, backend, server))
-		.then(async opened => {
-			room.plan = opened;
-			room.opening = undefined;
+	let opening = room.opening ??= withDocumentLock(room.id, async () => {
+		if (deletingChannels.has(room.id)) throw new Error("document is unavailable");
+		if (room.plan) return room.plan;
+		let opened = await Service.open(room.id, backend, server);
+		room.plan = opened;
+		let channel = await storage.channels.get(room.id);
+		if (!channel?.archivedAt) {
 			if (summaryCoordinator) void summaryCoordinator.ensure(room.id).catch(() => {});
 			if (Inject.enabled()) Inject.ask(opened, server, room.id);
 			if (Marks.enabled()) await Marks.mark(opened);
-			return opened;
-		})
-		.catch(err => {
-			room.opening = undefined;
-			throw err;
-		});
+		}
+		return opened;
+	});
+	try {
+		return await opening;
+	} finally {
+		if (room.opening === opening) room.opening = undefined;
+	}
 }
 
 /** A room's conversation, with everything it needs to run a turn. */
@@ -187,13 +208,31 @@ function conversation(room: Rooms.Room, ws: Socket): Chat.Room {
 	};
 }
 
+async function closeRoom(room: Rooms.Room, force = false): Promise<void> {
+	if (room.closing) return room.closing;
+	let closing = withDocumentLock(room.id, async () => {
+		if (!force && room.members.size > 0) return;
+		let held = room.plan;
+		room.plan = undefined;
+		if (held) await Service.close(held);
+		if (force || room.members.size === 0) Rooms.forget(room);
+	});
+	room.closing = closing;
+	try {
+		await closing;
+	} finally {
+		if (room.closing === closing) room.closing = undefined;
+	}
+}
+
 function evict(room: Rooms.Room): void {
 	if (room.eviction || room.members.size > 0) return;
 	room.eviction = setTimeout(() => {
+		room.eviction = undefined;
 		if (room.members.size > 0) return;
-		let held = room.plan;
-		Rooms.forget(room);
-		if (held) void Service.close(held);
+		void closeRoom(room).catch(err => {
+			console.error("chopin: room close failed -", err);
+		});
 	}, EVICT_MS);
 }
 
@@ -203,6 +242,10 @@ async function receive(ws: Socket, raw: string): Promise<void> {
 
 	let room = Rooms.get(ws.data.room);
 	if (!room) return;
+	if (deletingChannels.has(room.id)) {
+		if (frame.rid) fail(ws, frame.rid, "document is unavailable");
+		return;
+	}
 	if (!VIEWER_ALLOWED.has(frame.kind)) {
 		let access = await refreshAccess(ws);
 		if (access === "unavailable") {
@@ -364,6 +407,42 @@ async function refreshAccess(ws: Socket, forceGitHub = false): Promise<Authoriza
 	}
 }
 
+function applyChannelAccess(
+	ws: Socket,
+	channel: ChannelRecord,
+	canManage: boolean,
+	publish = true,
+): void {
+	let data = ws.data;
+	let archivedAt = channel.archivedAt?.toISOString();
+	let canEdit = canManage && !archivedAt && !archivingChannels.has(data.room);
+	if (
+		(channel.updatedAt.toISOString() !== data.channelUpdatedAt
+			|| archivedAt !== data.channelArchivedAt)
+		&& !data.closed && publish
+	) {
+		tell(ws, {
+			kind: "session:channel",
+			ts: 0,
+			channelId: channel.id,
+			title: channel.title,
+			slug: channel.slug,
+			updatedAt: channel.updatedAt.toISOString(),
+			canManage,
+			...(archivedAt ? { archivedAt } : {}),
+		});
+	}
+	if ((canEdit !== data.canEdit || canManage !== data.canManage) && !data.closed && publish) {
+		tell(ws, { kind: "session:access", ts: 0, canEdit, canManage });
+	}
+	data.channelTitle = channel.title;
+	data.channelSlug = channel.slug;
+	data.channelUpdatedAt = channel.updatedAt.toISOString();
+	data.channelArchivedAt = archivedAt;
+	data.canEdit = canEdit;
+	data.canManage = canManage;
+}
+
 async function checkAccess(ws: Socket, forceGitHub: boolean): Promise<AuthorizationResult> {
 	if (ws.data.closed) return "denied";
 	let data = ws.data;
@@ -379,7 +458,12 @@ async function checkAccess(ws: Socket, forceGitHub: boolean): Promise<Authorizat
 		let request = new Request(hostedAuth.config.origin, { headers: { cookie: data.credential } });
 		let session = await hostedAuth.sessions.authenticate(request);
 		if (!session || session.user.id !== data.principalId) return "denied";
+		let channel = deletingChannels.has(data.room)
+			? undefined
+			: await storage.channels.get(data.room);
+		if (!channel || channel.repositoryId !== data.repositoryId) return "denied";
 		if (!forceGitHub && Date.now() - (data.accessCheckedAt ?? 0) < ACCESS_RECHECK_MS) {
+			applyChannelAccess(ws, channel, data.canManage);
 			return "allowed";
 		}
 		let access = await hostedAuth.sessions.use(
@@ -395,11 +479,9 @@ async function checkAccess(ws: Socket, forceGitHub: boolean): Promise<Authorizat
 		if (!repository || repository.id !== data.repositoryId || !repository.permissions.pull) {
 			return "denied";
 		}
-		let canEdit = repository.permissions.push || repository.permissions.admin;
-		if (canEdit !== data.canEdit && !data.closed) {
-			tell(ws, { kind: "session:access", ts: 0, canEdit });
-		}
-		data.canEdit = canEdit;
+		if (channel.repositoryId !== repository.id) return "denied";
+		let canManage = repository.permissions.push || repository.permissions.admin;
+		applyChannelAccess(ws, channel, canManage);
 		data.accessCheckedAt = Date.now();
 		data.authorizedUntil = access.authenticated.session.expiresAt.getTime();
 		data.repositoryDefaultBranch = repository.defaultBranch;
@@ -425,22 +507,19 @@ function scheduleAuthorization(ws: Socket): void {
 	}, ACCESS_RECHECK_MS);
 }
 
-async function refreshChannelMetadata(ws: Socket, room: Rooms.Room): Promise<void> {
-	try {
-		let channel = await storage.channels.get(room.id);
-		if (!channel || channel.updatedAt <= new Date(ws.data.channelUpdatedAt)) return;
-		if (ws.data.closed) return;
-		tell(ws, {
-			kind: "session:channel",
-			ts: 0,
-			channelId: channel.id,
-			title: channel.title,
-			slug: channel.slug,
-			updatedAt: channel.updatedAt.toISOString(),
-		});
-	} catch {
-		// Hello already carried the admission snapshot; a later rename event can supersede it.
+async function validateOpenedSocket(ws: Socket): Promise<void> {
+	let channel = deletingChannels.has(ws.data.room)
+		? undefined
+		: await storage.channels.get(ws.data.room);
+	if (
+		!channel || channel.repositoryId !== ws.data.repositoryId || deletingChannels.has(channel.id)
+	) {
+		tell(ws, { kind: "session:deleted", ts: 0, channelId: ws.data.room });
+		ws.close(4404, "document deleted");
+		return;
 	}
+	if (ws.data.closed) return;
+	applyChannelAccess(ws, channel, ws.data.canManage);
 }
 
 function listen(): Server<SocketData> {
@@ -452,7 +531,10 @@ function listen(): Server<SocketData> {
 			let url = new URL(req.url);
 
 			if (url.pathname === "/ws") {
-				let outcome = await admit(req, url, hostedAuth);
+				let outcome = await admit(req, url, hostedAuth, {
+					deleting: channelId => deletingChannels.has(channelId),
+					readOnly: channelId => archivingChannels.has(channelId),
+				});
 				if ("status" in outcome) {
 					return new Response(outcome.reason, { status: outcome.status });
 				}
@@ -471,6 +553,10 @@ function listen(): Server<SocketData> {
 
 		websocket: {
 			open(ws: Socket) {
+				// Every mutation revalidates document state; the admission snapshot keeps startup stable.
+				ws.data.canEdit = ws.data.canEdit
+					&& !archivingChannels.has(ws.data.room)
+					&& !deletingChannels.has(ws.data.room);
 				ws.subscribe(topic(ws.data.room));
 				let room = Rooms.join(ws);
 				tell(ws, {
@@ -483,13 +569,18 @@ function listen(): Server<SocketData> {
 					you: { handle: ws.data.handle, client: ws.data.client },
 					members: Rooms.members(room),
 					canEdit: ws.data.canEdit,
+					canManage: ws.data.canManage,
+					...(ws.data.channelArchivedAt ? { archivedAt: ws.data.channelArchivedAt } : {}),
 					backgroundJobs: config.backgroundJobs,
 					webResearch: config.webResearch,
 					...CHAT_CAPABILITIES,
 				});
-				void refreshChannelMetadata(ws, room);
 				relay(ws, { kind: "session:presence", ts: 0, members: Rooms.members(room) });
 				scheduleAuthorization(ws);
+				void validateOpenedSocket(ws).catch(err => {
+					console.error("chopin: WebSocket open failed -", err);
+					ws.close(1011, "cannot open document");
+				});
 			},
 
 			message(ws: Socket, raw) {
@@ -625,15 +716,155 @@ async function resetOpenAgents(
 	);
 }
 
-function announceChannelRename(channel: ChannelRecord): void {
-	broadcast(server, channel.id, {
-		kind: "session:channel",
-		ts: 0,
-		channelId: channel.id,
-		title: channel.title,
-		slug: channel.slug,
-		updatedAt: channel.updatedAt.toISOString(),
-	});
+function announceChannel(channel: ChannelRecord): void {
+	let room = Rooms.get(channel.id);
+	if (!room) return;
+	for (let ws of room.members.values()) {
+		ws.data.channelTitle = channel.title;
+		ws.data.channelSlug = channel.slug;
+		ws.data.channelUpdatedAt = channel.updatedAt.toISOString();
+		ws.data.channelArchivedAt = channel.archivedAt?.toISOString();
+		ws.data.canEdit = ws.data.canManage && !channel.archivedAt;
+		tell(ws, {
+			kind: "session:channel",
+			ts: 0,
+			channelId: channel.id,
+			title: channel.title,
+			slug: channel.slug,
+			updatedAt: channel.updatedAt.toISOString(),
+			canManage: ws.data.canManage,
+			...(channel.archivedAt ? { archivedAt: channel.archivedAt.toISOString() } : {}),
+		});
+		tell(ws, {
+			kind: "session:access",
+			ts: 0,
+			canEdit: ws.data.canEdit,
+			canManage: ws.data.canManage,
+		});
+	}
+}
+
+async function archiveChannelLocked(channelId: string, now: Date) {
+	if (deletingChannels.has(channelId)) {
+		throw new StorageError("missing", `channel ${channelId} is being deleted`);
+	}
+	archivingChannels.add(channelId);
+	let room = Rooms.get(channelId);
+	for (let ws of room?.members.values() ?? []) ws.data.canEdit = false;
+	try {
+		await summaryCoordinator?.suspend(channelId);
+		let result = await withDocumentLock(channelId, async () => {
+			let active = Rooms.get(channelId)?.plan;
+			if (active) {
+				await Chat.resetAgent(active.chat, undefined, undefined, "This document was archived.");
+				await Service.drain(active);
+				await Service.persist(active);
+			}
+			return storage.channels.archive({ id: channelId, now });
+		});
+		announceChannel(result.channel);
+		return result;
+	} catch (err) {
+		summaryCoordinator?.resume(channelId);
+		for (let ws of room?.members.values() ?? []) ws.data.canEdit = ws.data.canManage;
+		throw err;
+	} finally {
+		archivingChannels.delete(channelId);
+	}
+}
+
+function archiveChannel(channelId: string, now: Date) {
+	return withDocumentTransition(channelId, () => archiveChannelLocked(channelId, now));
+}
+
+async function restoreChannelLocked(channelId: string, now: Date) {
+	if (deletingChannels.has(channelId)) {
+		throw new StorageError("missing", `channel ${channelId} is being deleted`);
+	}
+	let result = await withDocumentLock(
+		channelId,
+		() => storage.channels.restore({ id: channelId, now }),
+	);
+	summaryCoordinator?.resume(channelId);
+	announceChannel(result.channel);
+	if (summaryCoordinator) void summaryCoordinator.ensure(channelId).catch(() => {});
+	return result;
+}
+
+function restoreChannel(channelId: string, now: Date) {
+	return withDocumentTransition(channelId, () => restoreChannelLocked(channelId, now));
+}
+
+async function deleteChannelLocked(channelId: string): Promise<boolean> {
+	if (deletingChannels.has(channelId)) return false;
+	let channel = await storage.channels.get(channelId);
+	if (!channel) return false;
+	if (!channel.archivedAt) {
+		throw new StorageError("conflict", `channel ${channelId} must be archived before deletion`);
+	}
+	deletingChannels.add(channelId);
+	let room = Rooms.get(channelId);
+	for (let ws of room?.members.values() ?? []) ws.data.canEdit = false;
+	try {
+		await summaryCoordinator?.suspend(channelId);
+		await jobRunner?.cancelChannel(channelId);
+		ownerBindings?.revokeChannel(channelId);
+		let deleted = await withDocumentLock(channelId, async () => {
+			let activeRoom = Rooms.get(channelId);
+			let active = activeRoom?.plan;
+			if (activeRoom) activeRoom.plan = undefined;
+			if (active) await Service.close(active);
+			return storage.channels.delete(channelId);
+		});
+		if (!deleted) throw new StorageError("missing", `channel ${channelId} does not exist`);
+		for (let ws of room?.members.values() ?? []) {
+			tell(ws, { kind: "session:deleted", ts: 0, channelId });
+			ws.close(4404, "document deleted");
+		}
+		if (room) Rooms.forget(room);
+		summaryCoordinator?.resume(channelId);
+		return true;
+	} catch (err) {
+		deletingChannels.delete(channelId);
+		summaryCoordinator?.resume(channelId);
+		jobRunner?.unblockChannel(channelId);
+		let channel: ChannelRecord | undefined;
+		try {
+			channel = await storage.channels.get(channelId);
+		} catch {
+			for (let ws of room?.members.values() ?? []) {
+				ws.close(1012, "document state is temporarily unavailable");
+			}
+			throw err;
+		}
+		if (channel) {
+			let survivingRoom = Rooms.get(channelId);
+			if (survivingRoom?.members.size) {
+				try {
+					await plan(survivingRoom, server);
+				} catch {
+					for (let ws of survivingRoom.members.values()) {
+						ws.close(1012, "document reload required");
+					}
+				}
+			}
+			announceChannel(channel);
+		} else {
+			for (let ws of room?.members.values() ?? []) {
+				tell(ws, { kind: "session:deleted", ts: 0, channelId });
+				ws.close(4404, "document deleted");
+			}
+			if (room) Rooms.forget(room);
+		}
+		throw err;
+	} finally {
+		deletingChannels.delete(channelId);
+		jobRunner?.unblockChannel(channelId);
+	}
+}
+
+function deleteChannel(channelId: string): Promise<boolean> {
+	return withDocumentTransition(channelId, () => deleteChannelLocked(channelId));
 }
 
 async function announceJobsChanged(channelId: string): Promise<void> {
@@ -850,14 +1081,22 @@ registerMcpRoutes(router, hostedAuth, {
 		return heldLease;
 	},
 }, {
-	onChannelRenamed: announceChannelRename,
+	archiveChannel,
+	isChannelDeleting: channelId => deletingChannels.has(channelId),
+	onChannelRenamed: announceChannel,
 	onDocumentPersisted: target => {
 		if (summaryCoordinator) void summaryCoordinator.enqueueNow(target).catch(() => {});
 	},
+	restoreChannel,
+	serializeDocument: (channelId, action) =>
+		withDocumentTransition(channelId, () => withDocumentLock(channelId, action)),
 });
 registerChannelRoutes(router, hostedAuth, {
 	onAgentReset: channelOwnerReset,
-	onChannelRenamed: announceChannelRename,
+	onChannelArchived: archiveChannel,
+	onChannelDeleted: deleteChannel,
+	onChannelRenamed: announceChannel,
+	onChannelRestored: restoreChannel,
 });
 registerResearchWorkspaceRoutes(router, hostedAuth, {
 	service: researchService,

--- a/apps/server/src/mcp.test.ts
+++ b/apps/server/src/mcp.test.ts
@@ -165,6 +165,67 @@ describe("the MCP read protocol", () => {
 		});
 	});
 
+	it("maps unavailable implementation documents without reporting repository denial", async () => {
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			implementations: {
+				async readImplementation() {
+					return undefined;
+				},
+				async startImplementation() {
+					return { kind: "unavailable" };
+				},
+				async reportLifecycle() {
+					return { kind: "unavailable" };
+				},
+			},
+		});
+		let initialized = await mcp(request({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "initialize",
+			params: {},
+		}));
+		let session = initialized.headers.get("mcp-session-id")!;
+		let calls = [
+			{
+				name: "start_implementation",
+				arguments: {
+					id: document.id,
+					planRevision: 4,
+					graphVersion: 1,
+					graphRevision: 4,
+					repository: "githubnext/chopin",
+					branch: "tq/017",
+					commit: "deadbeef",
+				},
+			},
+			{
+				name: "start_task",
+				arguments: {
+					id: document.id,
+					runId: "run-1",
+					taskId: "model",
+					idempotencyKey: "start-model",
+				},
+			},
+		];
+		for (let [index, tool] of calls.entries()) {
+			let response = await json(
+				await mcp(request({
+					jsonrpc: "2.0",
+					id: index + 2,
+					method: "tools/call",
+					params: tool,
+				}, { headers: { "mcp-session-id": session } })),
+			);
+			expect((response.result as { structuredContent: unknown }).structuredContent).toEqual({
+				code: "document-unavailable",
+			});
+		}
+	});
+
 	it("advertises and dispatches lifecycle tools from one implementation capability", async () => {
 		let received: unknown;
 		type LifecycleReport = Awaited<
@@ -469,6 +530,12 @@ describe("the MCP read protocol", () => {
 			let [id, name, arguments_, error] of [
 				[5, "list_documents", { repository: "./chopin" }, "list_documents requires a repository"],
 				[6, "list_documents", { repository: "owner/.." }, "list_documents requires a repository"],
+				[
+					11,
+					"list_documents",
+					{ repository: "githubnext/chopin", extra: true },
+					"list_documents requires a repository",
+				],
 				[7, "read_document", { id: " \t" }, "read_document requires an id or URL"],
 				[
 					9,

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -26,6 +26,7 @@ export type { Brief, CreateDocumentInput, CreationOrigin } from "./mcp/create";
 export type DocumentSummary = {
 	id: string;
 	title: string;
+	archivedAt?: string;
 };
 
 export type Document = DocumentSummary & {
@@ -35,7 +36,11 @@ export type Document = DocumentSummary & {
 };
 
 export type DocumentReader<Caller> = {
-	list(caller: Caller, repository: string): Promise<DocumentSummary[] | "forbidden">;
+	list(
+		caller: Caller,
+		repository: string,
+		includeArchived?: boolean,
+	): Promise<DocumentSummary[] | "forbidden">;
 	read(caller: Caller, id: string): Promise<Document | undefined>;
 };
 
@@ -70,6 +75,7 @@ export type Implementations<Caller> = {
 		| { kind: "started"; run: Run }
 		| { kind: "active"; run: Run }
 		| { kind: "forbidden" }
+		| { kind: "unavailable" }
 		| { kind: "refused"; reason: string }
 	>;
 	reportLifecycle?(
@@ -78,6 +84,7 @@ export type Implementations<Caller> = {
 	): Promise<
 		| { kind: "accepted" | "replayed"; lifecycle: ImplementationLifecycle }
 		| { kind: "forbidden" }
+		| { kind: "unavailable" }
 		| { kind: "refused"; reason: string }
 	>;
 };
@@ -91,6 +98,7 @@ export type CreateDocument<Caller> = {
 		| { kind: "replayed"; document: CreatedDocument }
 		| { kind: "conflict" }
 		| { kind: "forbidden" }
+		| { kind: "unavailable" }
 	>;
 };
 
@@ -105,7 +113,27 @@ export type RenameDocument<Caller> = {
 		input: RenameDocumentInput,
 	): Promise<
 		| { kind: "renamed" | "unchanged"; document: DocumentSummary }
-		| { kind: "conflict" | "forbidden" | "missing" }
+		| { kind: "archived" | "conflict" | "forbidden" | "unavailable" }
+	>;
+};
+
+export type ArchiveDocument<Caller> = {
+	archive(
+		caller: Caller,
+		id: string,
+	): Promise<
+		| { kind: "archived" | "unchanged"; document: DocumentSummary }
+		| { kind: "forbidden" | "unavailable" }
+	>;
+};
+
+export type RestoreDocument<Caller> = {
+	restore(
+		caller: Caller,
+		id: string,
+	): Promise<
+		| { kind: "restored" | "unchanged"; document: DocumentSummary }
+		| { kind: "forbidden" | "unavailable" }
 	>;
 };
 
@@ -115,6 +143,8 @@ export type McpOptions<Caller> = {
 	documents: DocumentReader<Caller>;
 	create?: CreateDocument<Caller>;
 	rename?: RenameDocument<Caller>;
+	archive?: ArchiveDocument<Caller>;
+	restore?: RestoreDocument<Caller>;
 	implementations?: Implementations<Caller>;
 };
 
@@ -128,15 +158,41 @@ type Tool = {
 const MAX_DOCUMENT_ID_LENGTH = 128;
 const MAX_DOCUMENT_LOCATOR_LENGTH = 2_048;
 
+const DOCUMENT_IDENTITY = {
+	id: { type: "string" },
+	title: { type: "string" },
+};
+
+const ACTIVE_DOCUMENT = {
+	type: "object",
+	properties: DOCUMENT_IDENTITY,
+	required: ["id", "title"],
+	additionalProperties: false,
+};
+
 const DOCUMENT = {
 	type: "object",
 	properties: {
-		id: { type: "string" },
-		title: { type: "string" },
+		...DOCUMENT_IDENTITY,
+		archivedAt: { type: "string", format: "date-time" },
 	},
 	required: ["id", "title"],
 	additionalProperties: false,
 };
+
+const ARCHIVED_DOCUMENT = {
+	...DOCUMENT,
+	required: ["id", "title", "archivedAt"],
+};
+
+function outcome(codes: string[]) {
+	return {
+		type: "object",
+		properties: { code: { type: "string", enum: codes } },
+		required: ["code"],
+		additionalProperties: false,
+	};
+}
 
 const IMPLEMENTATION = {
 	type: "object",
@@ -170,6 +226,7 @@ export const TOOLS: Tool[] = [
 			type: "object",
 			properties: {
 				repository: { type: "string", pattern: REPOSITORY_PATH_PATTERN },
+				includeArchived: { type: "boolean", default: false },
 			},
 			required: ["repository"],
 			additionalProperties: false,
@@ -266,18 +323,59 @@ export const TOOLS: Tool[] = [
 		},
 		outputSchema: {
 			oneOf: [
-				DOCUMENT,
-				{
-					type: "object",
-					properties: {
-						code: {
-							type: "string",
-							enum: ["title-conflict", "repository-forbidden", "document-unavailable"],
-						},
-					},
-					required: ["code"],
-					additionalProperties: false,
+				ACTIVE_DOCUMENT,
+				outcome([
+					"document-archived",
+					"title-conflict",
+					"repository-forbidden",
+					"document-unavailable",
+				]),
+			],
+		},
+	},
+	{
+		name: "archive_document",
+		description: "Archive a Chopin document by ID or canonical URL.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				id: {
+					type: "string",
+					minLength: 1,
+					maxLength: MAX_DOCUMENT_LOCATOR_LENGTH,
+					pattern: "\\S",
 				},
+			},
+			required: ["id"],
+			additionalProperties: false,
+		},
+		outputSchema: {
+			oneOf: [
+				ARCHIVED_DOCUMENT,
+				outcome(["repository-forbidden", "document-unavailable"]),
+			],
+		},
+	},
+	{
+		name: "restore_document",
+		description: "Restore an archived Chopin document by ID or canonical URL.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				id: {
+					type: "string",
+					minLength: 1,
+					maxLength: MAX_DOCUMENT_LOCATOR_LENGTH,
+					pattern: "\\S",
+				},
+			},
+			required: ["id"],
+			additionalProperties: false,
+		},
+		outputSchema: {
+			oneOf: [
+				ACTIVE_DOCUMENT,
+				outcome(["repository-forbidden", "document-unavailable"]),
 			],
 		},
 	},
@@ -409,6 +507,24 @@ function isLocator(value: unknown): value is string {
 		&& value.trim().length > 0;
 }
 
+function listArguments(
+	value: Record<string, unknown>,
+): { repository: string; includeArchived: boolean } | undefined {
+	let keys = Object.keys(value);
+	if (
+		(keys.length !== 1 && keys.length !== 2)
+		|| !Object.hasOwn(value, "repository")
+		|| keys.some(key => key !== "repository" && key !== "includeArchived")
+		|| !isRepository(value.repository)
+		|| (Object.hasOwn(value, "includeArchived")
+			&& typeof value.includeArchived !== "boolean")
+	) return undefined;
+	return {
+		repository: value.repository,
+		includeArchived: value.includeArchived === true,
+	};
+}
+
 function renameArguments(value: Record<string, unknown>): RenameDocumentInput | undefined {
 	if (
 		Object.keys(value).length !== 2
@@ -459,7 +575,10 @@ function acceptsEvents(request: Request): boolean {
 
 function serviceInstructions(tools: Tool[]): string | undefined {
 	let documentMutations = tools.filter(tool =>
-		tool.name === "create_document" || tool.name === "rename_document"
+		tool.name === "create_document"
+		|| tool.name === "rename_document"
+		|| tool.name === "archive_document"
+		|| tool.name === "restore_document"
 	);
 	let implementation = tools
 		.filter(tool =>
@@ -514,16 +633,20 @@ async function requestBody(request: Request): Promise<{ body?: unknown; tooLarge
 	return { body: JSON.parse(new TextDecoder().decode(bytes)), tooLarge: false };
 }
 
-/** A stateless JSON-response Streamable HTTP MCP handler for read-only tools. */
+/** A stateless JSON-response Streamable HTTP MCP handler. */
 export function handler<Caller>(
 	options: McpOptions<Caller>,
 ): (request: Request) => Promise<Response> {
 	let creation = options.create;
 	let renaming = options.rename;
+	let archiving = options.archive;
+	let restoring = options.restore;
 	let sessions = new Map<string, { name: string; version: string }>();
 	let tools = TOOLS.filter(tool =>
 		(tool.name !== "create_document" || creation)
 		&& (tool.name !== "rename_document" || renaming)
+		&& (tool.name !== "archive_document" || archiving)
+		&& (tool.name !== "restore_document" || restoring)
 		&& (!["read_implementation", "start_implementation"].includes(tool.name)
 			|| options.implementations)
 		&& (!isLifecycleTool(tool.name) || options.implementations?.reportLifecycle)
@@ -574,14 +697,17 @@ export function handler<Caller>(
 						: error(call.id, -32602, "invalid tool arguments");
 				}
 				if (tool.name === "list_documents") {
-					if (
-						Object.keys(tool.arguments).length !== 1 || !isRepository(tool.arguments.repository)
-					) {
+					let input = listArguments(tool.arguments);
+					if (!input) {
 						return notification
 							? undefined
 							: error(call.id, -32602, "list_documents requires a repository");
 					}
-					let documents = await options.documents.list(caller, tool.arguments.repository);
+					let documents = await options.documents.list(
+						caller,
+						input.repository,
+						input.includeArchived,
+					);
 					return documents === "forbidden"
 						? respond(text({ code: "repository-forbidden" }, true))
 						: respond(text({ documents }));
@@ -610,6 +736,9 @@ export function handler<Caller>(
 					if (outcome.kind === "conflict") {
 						return respond(text({ code: "idempotency-conflict" }, true));
 					}
+					if (outcome.kind === "unavailable") {
+						return respond(text({ code: "document-unavailable" }, true));
+					}
 					return respond({ content: [], isError: true });
 				}
 				if (tool.name === "rename_document" && renaming) {
@@ -623,12 +752,46 @@ export function handler<Caller>(
 					if (outcome.kind === "renamed" || outcome.kind === "unchanged") {
 						return respond(text(outcome.document));
 					}
-					let code = outcome.kind === "conflict"
+					let code = outcome.kind === "archived"
+						? "document-archived"
+						: outcome.kind === "conflict"
 						? "title-conflict"
 						: outcome.kind === "forbidden"
 						? "repository-forbidden"
 						: "document-unavailable";
 					return respond(text({ code }, true));
+				}
+				if (tool.name === "archive_document" && archiving) {
+					if (Object.keys(tool.arguments).length !== 1 || !isLocator(tool.arguments.id)) {
+						return notification
+							? undefined
+							: error(call.id, -32602, "archive_document requires an id or URL");
+					}
+					let outcome = await archiving.archive(caller, tool.arguments.id);
+					if (outcome.kind === "archived" || outcome.kind === "unchanged") {
+						return respond(text(outcome.document));
+					}
+					return respond(text({
+						code: outcome.kind === "forbidden"
+							? "repository-forbidden"
+							: "document-unavailable",
+					}, true));
+				}
+				if (tool.name === "restore_document" && restoring) {
+					if (Object.keys(tool.arguments).length !== 1 || !isLocator(tool.arguments.id)) {
+						return notification
+							? undefined
+							: error(call.id, -32602, "restore_document requires an id or URL");
+					}
+					let outcome = await restoring.restore(caller, tool.arguments.id);
+					if (outcome.kind === "restored" || outcome.kind === "unchanged") {
+						return respond(text(outcome.document));
+					}
+					return respond(text({
+						code: outcome.kind === "forbidden"
+							? "repository-forbidden"
+							: "document-unavailable",
+					}, true));
 				}
 				if (tool.name === "read_implementation") {
 					if (Object.keys(tool.arguments).length !== 1 || !isLocator(tool.arguments.id)) {
@@ -673,6 +836,9 @@ export function handler<Caller>(
 					if (outcome.kind === "forbidden") {
 						return respond(text({ code: "repository-forbidden" }, true));
 					}
+					if (outcome.kind === "unavailable") {
+						return respond(text({ code: "document-unavailable" }, true));
+					}
 					return respond(text({ code: outcome.reason }, true));
 				}
 				let lifecycle = lifecycleCall(tool.name, tool.arguments);
@@ -693,6 +859,9 @@ export function handler<Caller>(
 					}
 					if (outcome.kind === "forbidden") {
 						return respond(text({ code: "repository-forbidden" }, true));
+					}
+					if (outcome.kind === "unavailable") {
+						return respond(text({ code: "document-unavailable" }, true));
 					}
 					return outcome.kind === "refused"
 						? respond(text({ code: outcome.reason }, true))

--- a/apps/server/src/mcp/archive.test.ts
+++ b/apps/server/src/mcp/archive.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "bun:test";
+
+import { handler, TOOLS } from "../mcp";
+
+import type { ArchiveDocument, DocumentReader, RestoreDocument } from "../mcp";
+
+let id = "f401c8d6-3717-4f1d-8473-cfdd0af894e4";
+let url = "/documents/githubnext/chopin/release-readiness";
+let archivedAt = "2026-08-23T12:34:56.000Z";
+
+function request(body: unknown): Request {
+	return new Request("https://chopin.test/mcp", {
+		method: "POST",
+		headers: {
+			authorization: "Bearer allowed",
+			"content-type": "application/json",
+		},
+		body: JSON.stringify(body),
+	});
+}
+
+function call(name: string, arguments_: Record<string, unknown>): Request {
+	return request({
+		jsonrpc: "2.0",
+		id: 1,
+		method: "tools/call",
+		params: { name, arguments: arguments_ },
+	});
+}
+
+function reader(): DocumentReader<string> {
+	return {
+		async list() {
+			return [];
+		},
+		async read() {
+			return undefined;
+		},
+	};
+}
+
+async function json(response: Response): Promise<Record<string, unknown>> {
+	return await response.json() as Record<string, unknown>;
+}
+
+describe("the MCP archive protocol", () => {
+	it("archives and restores document locators with strict public schemas", async () => {
+		let received: Array<{ action: string; caller: string; id: string }> = [];
+		let archive: ArchiveDocument<string> = {
+			async archive(caller, locator) {
+				received.push({ action: "archive", caller, id: locator });
+				return {
+					kind: "archived",
+					document: { id, title: "Release readiness", archivedAt },
+				};
+			},
+		};
+		let restore: RestoreDocument<string> = {
+			async restore(caller, locator) {
+				received.push({ action: "restore", caller, id: locator });
+				return { kind: "restored", document: { id, title: "Release readiness" } };
+			},
+		};
+		let mcp = handler({ caller: () => "octocat", documents: reader(), archive, restore });
+		let initialized = await json(
+			await mcp(request({ jsonrpc: "2.0", id: 0, method: "initialize", params: {} })),
+		);
+		expect((initialized.result as { instructions: string }).instructions).toContain(
+			"archive_document: Archive a Chopin document by ID or canonical URL.",
+		);
+		expect((initialized.result as { instructions: string }).instructions).toContain(
+			"restore_document: Restore an archived Chopin document by ID or canonical URL.",
+		);
+		let listed = await json(
+			await mcp(request({ jsonrpc: "2.0", id: 1, method: "tools/list" })),
+		);
+		let names = (listed.result as { tools: Array<{ name: string }> }).tools.map(tool => tool.name);
+		expect(names).toContain("archive_document");
+		expect(names).toContain("restore_document");
+		expect(names).not.toContain("delete_document");
+
+		let archived = await json(await mcp(call("archive_document", { id: url })));
+		let restored = await json(await mcp(call("restore_document", { id })));
+		expect((archived.result as { structuredContent: unknown }).structuredContent).toEqual({
+			id,
+			title: "Release readiness",
+			archivedAt,
+		});
+		expect((restored.result as { structuredContent: unknown }).structuredContent).toEqual({
+			id,
+			title: "Release readiness",
+		});
+		expect(received).toEqual([
+			{ action: "archive", caller: "octocat", id: url },
+			{ action: "restore", caller: "octocat", id },
+		]);
+
+		let archiveSchema = TOOLS.find(tool => tool.name === "archive_document")!.outputSchema as {
+			oneOf: Array<Record<string, unknown>>;
+		};
+		let restoreSchema = TOOLS.find(tool => tool.name === "restore_document")!.outputSchema as {
+			oneOf: Array<Record<string, unknown>>;
+		};
+		expect(archiveSchema.oneOf[0]).toMatchObject({
+			required: ["id", "title", "archivedAt"],
+			additionalProperties: false,
+		});
+		expect(restoreSchema.oneOf[0]).toMatchObject({
+			required: ["id", "title"],
+			additionalProperties: false,
+		});
+	});
+
+	it("validates locators and maps stable transition failures", async () => {
+		let called = false;
+		let mcp = handler({
+			caller: () => "octocat",
+			documents: reader(),
+			archive: {
+				async archive(_caller, locator) {
+					called = true;
+					return { kind: locator === "forbidden" ? "forbidden" : "unavailable" };
+				},
+			},
+			restore: {
+				async restore() {
+					return { kind: "unavailable" };
+				},
+			},
+		});
+		for (
+			let [name, arguments_] of [
+				["archive_document", { id: " " }],
+				["archive_document", { id, extra: true }],
+				["restore_document", { id: "x".repeat(2_049) }],
+			] as const
+		) {
+			let response = await json(await mcp(call(name, arguments_)));
+			expect(response).toMatchObject({ error: { code: -32602 } });
+		}
+		expect(called).toBe(false);
+
+		let forbidden = await json(await mcp(call("archive_document", { id: "forbidden" })));
+		let unavailable = await json(await mcp(call("archive_document", { id: "missing" })));
+		let restoreUnavailable = await json(await mcp(call("restore_document", { id })));
+		expect((forbidden.result as { structuredContent: unknown }).structuredContent).toEqual({
+			code: "repository-forbidden",
+		});
+		for (let response of [unavailable, restoreUnavailable]) {
+			expect((response.result as { structuredContent: unknown }).structuredContent).toEqual({
+				code: "document-unavailable",
+			});
+			expect((response.result as { isError: boolean }).isError).toBe(true);
+		}
+	});
+});

--- a/apps/server/src/mcp/documents.test.ts
+++ b/apps/server/src/mcp/documents.test.ts
@@ -127,4 +127,56 @@ describe("the MCP document protocol", () => {
 			structuredContent: { code: "repository-forbidden" },
 		});
 	});
+
+	it("defaults archived listing off and exposes archival metadata when requested", async () => {
+		let archivedAt = "2026-08-23T12:34:56.000Z";
+		let includeArchived: boolean[] = [];
+		let archived = { ...document, archivedAt };
+		let mcp = endpoint({
+			async list(_caller, _repository, include = false) {
+				includeArchived.push(include);
+				return include ? [{ id: document.id, title: document.title, archivedAt }] : [];
+			},
+			async read() {
+				return archived;
+			},
+		});
+		let calls = [
+			{ repository: "githubnext/chopin" },
+			{ repository: "githubnext/chopin", includeArchived: true },
+		];
+		let listed = [];
+		for (let [index, arguments_] of calls.entries()) {
+			let response = await json(
+				await mcp(request({
+					jsonrpc: "2.0",
+					id: index + 10,
+					method: "tools/call",
+					params: { name: "list_documents", arguments: arguments_ },
+				})),
+			);
+			listed.push((response.result as { structuredContent: unknown }).structuredContent);
+		}
+
+		expect(includeArchived).toEqual([false, true]);
+		expect(listed).toEqual([{ documents: [] }, {
+			documents: [{ id: document.id, title: document.title, archivedAt }],
+		}]);
+
+		let read = await json(
+			await mcp(request({
+				jsonrpc: "2.0",
+				id: 12,
+				method: "tools/call",
+				params: { name: "read_document", arguments: { id: document.id } },
+			})),
+		);
+		expect((read.result as { structuredContent: unknown }).structuredContent).toEqual(archived);
+		expect(
+			((TOOLS.find(tool => tool.name === "list_documents")!.inputSchema.properties) as Record<
+				string,
+				unknown
+			>).includeArchived,
+		).toEqual({ type: "boolean", default: false });
+	});
 });

--- a/apps/server/src/mcp/hosted.test.ts
+++ b/apps/server/src/mcp/hosted.test.ts
@@ -275,6 +275,114 @@ describe("the hosted MCP adapter", () => {
 		expect(await adapter.documents.list(caller, "octo-org/score")).toBe("forbidden");
 	});
 
+	it("archives, lists, reads, and restores documents through storage fallback", async () => {
+		let context = setup();
+		context.github.repositoryValue = {
+			...context.github.repositoryValue,
+			permissions: { pull: true, push: true, admin: false },
+		};
+		let opened = await plan(context);
+		await Service.close(opened.plan);
+		let adapter = hosted(context.auth);
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller || !adapter.archive || !adapter.restore) {
+			throw new Error("hosted archive adapter is unavailable");
+		}
+		let locator = "/documents/octo-org/score/release-readiness";
+
+		let archived = await adapter.archive.archive(caller, locator);
+		expect(archived).toMatchObject({
+			kind: "archived",
+			document: { id: opened.channel.id, title: "Release readiness" },
+		});
+		if (archived.kind !== "archived") throw new Error("test document was not archived");
+		expect(archived.document.archivedAt).toBeString();
+		expect(await adapter.archive.archive(caller, opened.channel.id)).toEqual({
+			kind: "unchanged",
+			document: archived.document,
+		});
+		expect(await adapter.documents.list(caller, "octo-org/score")).toEqual([]);
+		expect(await adapter.documents.list(caller, "octo-org/score", true)).toEqual([
+			archived.document,
+		]);
+		expect(await adapter.documents.read(caller, opened.channel.id)).toMatchObject({
+			id: opened.channel.id,
+			archivedAt: archived.document.archivedAt,
+		});
+
+		let restored = await adapter.restore.restore(caller, locator);
+		expect(restored).toEqual({
+			kind: "restored",
+			document: { id: opened.channel.id, title: "Release readiness" },
+		});
+		expect(await adapter.restore.restore(caller, opened.channel.id)).toEqual({
+			kind: "unchanged",
+			document: { id: opened.channel.id, title: "Release readiness" },
+		});
+	});
+
+	it("coordinates archive callbacks after direct GitHub authorization", async () => {
+		let context = setup();
+		let opened = await plan(context);
+		await Service.close(opened.plan);
+		let deleting = false;
+		let transitions: string[] = [];
+		let adapter = hosted(context.auth, undefined, {
+			archiveChannel: async (channelId, now) => {
+				transitions.push(`archive:${channelId}`);
+				return context.storage.channels.archive({ id: channelId, now });
+			},
+			isChannelDeleting: channelId => deleting && channelId === opened.channel.id,
+			restoreChannel: async (channelId, now) => {
+				transitions.push(`restore:${channelId}`);
+				return context.storage.channels.restore({ id: channelId, now });
+			},
+		});
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller || !adapter.archive || !adapter.rename || !adapter.restore) {
+			throw new Error("hosted archive adapter is unavailable");
+		}
+
+		expect(await adapter.archive.archive(caller, opened.channel.id)).toEqual({
+			kind: "forbidden",
+		});
+		context.github.repositoryValue = {
+			...context.github.repositoryValue,
+			permissions: { pull: false, push: true, admin: false },
+		};
+		expect(await adapter.archive.archive(caller, opened.channel.id)).toEqual({
+			kind: "unavailable",
+		});
+		context.github.repositoryValue = {
+			...context.github.repositoryValue,
+			permissions: { pull: true, push: true, admin: false },
+		};
+		expect(await adapter.archive.archive(caller, crypto.randomUUID())).toEqual({
+			kind: "unavailable",
+		});
+		deleting = true;
+		expect(await adapter.archive.archive(caller, opened.channel.id)).toEqual({
+			kind: "unavailable",
+		});
+		expect(
+			await adapter.rename.rename(caller, {
+				id: opened.channel.id,
+				title: "Unavailable rename",
+			}),
+		).toEqual({ kind: "unavailable" });
+		deleting = false;
+		expect(await adapter.archive.archive(caller, opened.channel.id)).toMatchObject({
+			kind: "archived",
+		});
+		expect(await adapter.restore.restore(caller, opened.channel.id)).toMatchObject({
+			kind: "restored",
+		});
+		expect(transitions).toEqual([
+			`archive:${opened.channel.id}`,
+			`restore:${opened.channel.id}`,
+		]);
+	});
+
 	it("creates a durable repository channel for a caller with write access", async () => {
 		let context = setup();
 		context.github.repositoryValue = {
@@ -354,6 +462,11 @@ describe("the hosted MCP adapter", () => {
 		let repeated = await adapter.rename.rename(caller, { id: channel.id, title: "Launch plan" });
 		expect(repeated.kind).toBe("unchanged");
 		expect(announcements).toEqual(["Launch plan"]);
+
+		await context.storage.channels.archive({ id: channel.id, now: context.now });
+		expect(await adapter.rename.rename(caller, { id: channel.id, title: "Archived plan" }))
+			.toEqual({ kind: "archived" });
+		expect(announcements).toEqual(["Launch plan"]);
 	});
 
 	it("refuses MCP renames without write access or a unique repository title", async () => {
@@ -395,7 +508,7 @@ describe("the hosted MCP adapter", () => {
 		});
 		context.github.accessible = false;
 		expect(await adapter.rename.rename(caller, { id: first.id, title: "Hidden" })).toEqual({
-			kind: "missing",
+			kind: "unavailable",
 		});
 	});
 
@@ -424,13 +537,20 @@ describe("the hosted MCP adapter", () => {
 		let first = await adapter.create.create(caller, creation);
 		expect(first.kind).toBe("created");
 		if (first.kind !== "created") return;
+		let archived = await context.storage.channels.archive({
+			id: first.document.id,
+			now: context.now,
+		});
 		expect(await adapter.create.create(caller, creation)).toEqual({
 			kind: "replayed",
 			document: {
 				...createdDocument(first.document.id),
+				archivedAt: archived.channel.archivedAt?.toISOString(),
 				url: "/documents/octo-org/score/created-plan",
 			},
 		});
+		expect((await context.storage.channels.get(first.document.id))?.archivedAt)
+			.toEqual(archived.channel.archivedAt);
 	});
 
 	it("rejects changed content under an accepted idempotency key", async () => {
@@ -585,7 +705,13 @@ describe("the hosted MCP adapter", () => {
 		} as unknown as Socket;
 		let live = Rooms.join(socket);
 		live.plan = opened.plan;
-		let adapter = hosted(context.auth, { lease: () => opened.lease });
+		let serialized: string[] = [];
+		let adapter = hosted(context.auth, { lease: () => opened.lease }, {
+			serializeDocument: async (channelId, action) => {
+				serialized.push(channelId);
+				return action();
+			},
+		});
 		let caller = await adapter.caller(request("Bearer allowed"));
 		if (!caller || !adapter.implementations) throw new Error("implementation adapter unavailable");
 
@@ -675,6 +801,7 @@ describe("the hosted MCP adapter", () => {
 					execution: { state: "idle" },
 					history: [{ outcome: { kind: "delivered" } }],
 				});
+			expect(serialized).toEqual(Array.from({ length: 6 }, () => opened.channel.id));
 		} finally {
 			Rooms.forget(live);
 			await Service.close(opened.plan);
@@ -768,6 +895,19 @@ describe("the hosted MCP adapter", () => {
 			kind: "active",
 			run: { session: "session-1" },
 		});
+		let archived = await context.storage.channels.archive({
+			id: opened.channel.id,
+			now: context.now,
+		});
+		expect(await adapter.implementations.readImplementation(caller, opened.channel.id))
+			.toMatchObject({
+				document: { archivedAt: archived.channel.archivedAt?.toISOString() },
+				execution: { state: "active" },
+			});
+		expect(await adapter.implementations.startImplementation(caller, input)).toEqual({
+			kind: "refused",
+			reason: "document-archived",
+		});
 		let report = adapter.implementations.reportLifecycle;
 		expect(report).toBeTypeOf("function");
 		if (!report) return;
@@ -817,6 +957,64 @@ describe("the hosted MCP adapter", () => {
 		});
 		expect(durable.lifecycle?.history[0]).not.toHaveProperty("outcome");
 		expect(durable.execution).toBeUndefined();
+	});
+
+	it("reports deleting, missing, and inaccessible implementation documents as unavailable", async () => {
+		let context = setup();
+		context.github.repositoryValue = {
+			...context.github.repositoryValue,
+			permissions: { pull: true, push: true, admin: false },
+		};
+		let opened = await plan(context);
+		await Service.close(opened.plan);
+		let deleting = true;
+		let adapter = hosted(context.auth, { lease: () => opened.lease }, {
+			isChannelDeleting: channelId => deleting && channelId === opened.channel.id,
+		});
+		let caller = await adapter.caller(request("Bearer allowed"));
+		if (!caller || !adapter.implementations?.reportLifecycle) {
+			throw new Error("implementation adapter unavailable");
+		}
+		let input = {
+			id: opened.channel.id,
+			planRevision: 0,
+			graphVersion: 1,
+			graphRevision: 1,
+			repository: "octo-org/score",
+			branch: "tq/017",
+			commit: "deadbeef",
+			client: { name: "Codex", version: "1.2.3", session: "session-1" },
+		};
+		let report = {
+			id: opened.channel.id,
+			kind: "start" as const,
+			runId: "run-1",
+			taskId: "claim",
+			idempotencyKey: "start-claim",
+		};
+
+		expect(await adapter.implementations.startImplementation(caller, input)).toEqual({
+			kind: "unavailable",
+		});
+		expect(await adapter.implementations.reportLifecycle(caller, report)).toEqual({
+			kind: "unavailable",
+		});
+		deleting = false;
+		let missingId = crypto.randomUUID();
+		expect(
+			await adapter.implementations.startImplementation(caller, { ...input, id: missingId }),
+		).toEqual({ kind: "unavailable" });
+		expect(
+			await adapter.implementations.reportLifecycle(caller, { ...report, id: missingId }),
+		).toEqual({ kind: "unavailable" });
+
+		context.github.accessible = false;
+		expect(await adapter.implementations.startImplementation(caller, input)).toEqual({
+			kind: "unavailable",
+		});
+		expect(await adapter.implementations.reportLifecycle(caller, report)).toEqual({
+			kind: "unavailable",
+		});
 	});
 
 	it("refuses a verified graph but claims a new version for a closed hosted plan", async () => {

--- a/apps/server/src/mcp/hosted.ts
+++ b/apps/server/src/mcp/hosted.ts
@@ -11,9 +11,15 @@ import { implementationLifecycle } from "../tasks/lifecycle";
 
 import type { HostedAuth } from "../auth/routes";
 import type { GitHubUser } from "../github/client";
-import type { Implementation, ImplementationInput, McpOptions, RenameDocumentInput } from "../mcp";
+import type {
+	DocumentSummary,
+	Implementation,
+	ImplementationInput,
+	McpOptions,
+	RenameDocumentInput,
+} from "../mcp";
 import type { LifecycleArguments } from "./lifecycle";
-import type { ChannelRecord, Lease } from "../storage/model";
+import type { ChannelArchiveResult, ChannelRecord, Lease } from "../storage/model";
 import type { ClaimResult, Run } from "../tasks/graphs";
 
 export type HostedCaller = {
@@ -23,6 +29,10 @@ export type HostedCaller = {
 
 export type ImplementationPersistence = { lease(): Lease };
 export type HostedCallbacks = {
+	archiveChannel?: (channelId: string, now: Date) => Promise<ChannelArchiveResult>;
+	restoreChannel?: (channelId: string, now: Date) => Promise<ChannelArchiveResult>;
+	isChannelDeleting?: (channelId: string) => boolean;
+	serializeDocument?: <T>(channelId: string, action: () => Promise<T>) => Promise<T>;
 	onChannelRenamed?: (channel: ChannelRecord) => void;
 	onDocumentPersisted?: (target: Plan.DocumentTarget) => void;
 };
@@ -35,12 +45,22 @@ type Document = {
 	creation?: Plan.CreationMetadata;
 	source: string;
 	revision: number;
+	archivedAt?: Date;
 	url?: string;
 };
 
-type PublicDocument = Omit<Document, "creation" | "url"> & {
+type PublicDocument = Omit<Document, "archivedAt" | "creation" | "url"> & {
 	brief?: Plan.CreationMetadata["brief"];
+	archivedAt?: string;
 };
+
+function summary(channel: ChannelRecord): DocumentSummary {
+	return {
+		id: channel.id,
+		title: channel.title,
+		...(channel.archivedAt ? { archivedAt: channel.archivedAt.toISOString() } : {}),
+	};
+}
 
 /** Strip durable idempotency and repository provenance from MCP responses. */
 function document(value: Document & { url: string }): PublicDocument & { url: string };
@@ -52,6 +72,7 @@ function document(value: Document): PublicDocument & { url?: string } {
 		...(value.creation ? { brief: value.creation.brief } : {}),
 		source: value.source,
 		revision: value.revision,
+		...(value.archivedAt ? { archivedAt: value.archivedAt.toISOString() } : {}),
 		...(value.url ? { url: value.url } : {}),
 	};
 }
@@ -82,6 +103,7 @@ function exposed(
 			creation: state.creation,
 			source: state.source,
 			revision: state.revision,
+			archivedAt: channel.archivedAt,
 		}),
 		repository: {
 			name: state.creation.origin.repository,
@@ -157,6 +179,18 @@ export function hosted(
 		return { channel, repository };
 	}
 
+	async function writableChannel(caller: HostedCaller, locator: string) {
+		let located = await locatedChannel(caller, locator);
+		if (!located || located === "forbidden") return { kind: "unavailable" as const };
+		if (callbacks.isChannelDeleting?.(located.channel.id)) {
+			return { kind: "unavailable" as const };
+		}
+		if (!located.repository.permissions.push && !located.repository.permissions.admin) {
+			return { kind: "forbidden" as const };
+		}
+		return { kind: "allowed" as const, ...located };
+	}
+
 	function run(caller: HostedCaller, input: ImplementationInput): Run {
 		return {
 			id: crypto.randomUUID(),
@@ -173,6 +207,10 @@ export function hosted(
 		};
 	}
 
+	function serializeDocument<T>(channelId: string, action: () => Promise<T>): Promise<T> {
+		return callbacks.serializeDocument?.(channelId, action) ?? action();
+	}
+
 	return {
 		async caller(request) {
 			let match = request.headers.get("authorization")?.match(BEARER);
@@ -186,7 +224,7 @@ export function hosted(
 			}
 		},
 		documents: {
-			async list(caller, repository) {
+			async list(caller, repository, includeArchived = false) {
 				let parts = repository.split("/");
 				if (parts.length !== 2 || !parts[0] || !parts[1]) return "forbidden";
 				let resolved = await directRepository(caller, parts[0], parts[1]);
@@ -195,11 +233,13 @@ export function hosted(
 				let documents = [];
 				let cursor;
 				do {
-					let page = await auth.storage.channels.scan(resolved.id, 100, cursor);
-					documents.push(...page.channels.map(channel => ({
-						id: channel.id,
-						title: channel.title,
-					})));
+					let page = await auth.storage.channels.scan(
+						resolved.id,
+						100,
+						cursor,
+						includeArchived,
+					);
+					documents.push(...page.channels.map(summary));
 					cursor = page.next;
 				} while (cursor);
 				return documents;
@@ -218,6 +258,7 @@ export function hosted(
 							creation: live.creation,
 							source: Plan.source(live),
 							revision: live.revision,
+							archivedAt: channel.archivedAt,
 						});
 					} catch {
 						return undefined;
@@ -240,6 +281,7 @@ export function hosted(
 						creation: projected.creation,
 						source: projected.source,
 						revision: projected.revision,
+						archivedAt: channel.archivedAt,
 					});
 				} catch {
 					return undefined;
@@ -248,38 +290,82 @@ export function hosted(
 		},
 		rename: {
 			async rename(caller, input: RenameDocumentInput) {
-				let channel = await auth.storage.channels.get(input.id);
-				if (!channel) return { kind: "missing" as const };
-				let repository = await directRepository(
-					caller,
-					channel.repositoryOwner,
-					channel.repositoryName,
-				);
-				if (
-					!repository
-					|| repository.id !== channel.repositoryId
-					|| !repository.permissions.pull
-				) return { kind: "missing" as const };
-				if (!repository.permissions.push && !repository.permissions.admin) {
+				let access = await writableChannel(caller, input.id);
+				if (access.kind === "unavailable") return access;
+				if (access.kind === "forbidden") {
 					return { kind: "forbidden" as const };
 				}
+				if (access.channel.archivedAt) return { kind: "archived" as const };
 				try {
 					let result = await auth.storage.channels.rename({
-						id: channel.id,
+						id: access.channel.id,
 						title: input.title,
 						now: auth.clock(),
 					});
 					if (result.changed) callbacks.onChannelRenamed?.(result.channel);
 					return {
 						kind: result.changed ? "renamed" as const : "unchanged" as const,
-						document: { id: result.channel.id, title: result.channel.title },
+						document: summary(result.channel),
 					};
 				} catch (err) {
 					if (err instanceof StorageError && err.failure === "conflict") {
+						let current = await auth.storage.channels.get(input.id);
+						if (!current || callbacks.isChannelDeleting?.(input.id)) {
+							return { kind: "unavailable" as const };
+						}
+						if (current.archivedAt) return { kind: "archived" as const };
 						return { kind: "conflict" as const };
 					}
 					if (err instanceof StorageError && err.failure === "missing") {
-						return { kind: "missing" as const };
+						return { kind: "unavailable" as const };
+					}
+					throw err;
+				}
+			},
+		},
+		archive: {
+			async archive(caller, id) {
+				let access = await writableChannel(caller, id);
+				if (access.kind !== "allowed") return access;
+				try {
+					let now = auth.clock();
+					let result = callbacks.archiveChannel
+						? await callbacks.archiveChannel(access.channel.id, now)
+						: await auth.storage.channels.archive({ id: access.channel.id, now });
+					if (!result.channel.archivedAt) {
+						throw new Error("archiving a document returned active metadata");
+					}
+					return {
+						kind: result.changed ? "archived" as const : "unchanged" as const,
+						document: summary(result.channel),
+					};
+				} catch (err) {
+					if (err instanceof StorageError && err.failure === "missing") {
+						return { kind: "unavailable" as const };
+					}
+					throw err;
+				}
+			},
+		},
+		restore: {
+			async restore(caller, id) {
+				let access = await writableChannel(caller, id);
+				if (access.kind !== "allowed") return access;
+				try {
+					let now = auth.clock();
+					let result = callbacks.restoreChannel
+						? await callbacks.restoreChannel(access.channel.id, now)
+						: await auth.storage.channels.restore({ id: access.channel.id, now });
+					if (result.channel.archivedAt) {
+						throw new Error("restoring a document returned archived metadata");
+					}
+					return {
+						kind: result.changed ? "restored" as const : "unchanged" as const,
+						document: summary(result.channel),
+					};
+				} catch (err) {
+					if (err instanceof StorageError && err.failure === "missing") {
+						return { kind: "unavailable" as const };
 					}
 					throw err;
 				}
@@ -293,6 +379,8 @@ export function hosted(
 				if (!repository || (!repository.permissions.push && !repository.permissions.admin)) {
 					return { kind: "forbidden" };
 				}
+				let id = deterministicChannelId(repository.id, input.idempotencyKey);
+				if (callbacks.isChannelDeleting?.(id)) return { kind: "unavailable" };
 				await auth.storage.users.put({
 					id: caller.user.id,
 					login: caller.user.login,
@@ -302,7 +390,6 @@ export function hosted(
 				let { brief, plan, ...origin } = input;
 				let creation: Plan.CreationMetadata = { brief, origin };
 				let initial = await Plan.initial(plan, creation);
-				let id = deterministicChannelId(repository.id, input.idempotencyKey);
 				let created: ChannelRecord;
 				try {
 					created = await auth.storage.channels.create({
@@ -317,6 +404,7 @@ export function hosted(
 					});
 				} catch (err) {
 					if (!(err instanceof StorageError) || err.failure !== "conflict") throw err;
+					if (callbacks.isChannelDeleting?.(id)) return { kind: "unavailable" };
 					let stored = await auth.storage.collaboration.load(id, auth.clock());
 					if (!stored || stored.channel.repositoryId !== repository.id) {
 						return { kind: "conflict" };
@@ -341,6 +429,7 @@ export function hosted(
 							creation: restored.creation,
 							source: restored.source,
 							revision: restored.revision,
+							archivedAt: stored.channel.archivedAt,
 							url: documentPath(
 								repository.owner,
 								repository.name,
@@ -391,130 +480,134 @@ export function hosted(
 						return stored ? exposed(channel, await Plan.readStored(stored)) : undefined;
 					},
 					async startImplementation(caller: HostedCaller, input: ImplementationInput) {
-						let channel = await auth.storage.channels.get(input.id);
-						if (
-							!channel
-							|| `${channel.repositoryOwner}/${channel.repositoryName}` !== input.repository
-						) {
-							return { kind: "forbidden" as const };
-						}
-						let repository = await directRepository(
-							caller,
-							channel.repositoryOwner,
-							channel.repositoryName,
-						);
-						if (
-							!repository
-							|| repository.id !== channel.repositoryId
-							|| (!repository.permissions.push && !repository.permissions.admin)
-						) return { kind: "forbidden" as const };
-						let claimRun = run(caller, input);
-						let live = Rooms.get(input.id)?.plan;
-						if (live) {
-							return claimResult(
-								await claimImplementation(live, {
+						return serializeDocument(input.id, async () => {
+							let access = await writableChannel(caller, input.id);
+							if (access.kind !== "allowed") return access;
+							let channel = access.channel;
+							if (`${channel.repositoryOwner}/${channel.repositoryName}` !== input.repository) {
+								return { kind: "forbidden" as const };
+							}
+							if (channel.archivedAt) {
+								return { kind: "refused" as const, reason: "document-archived" };
+							}
+							let claimRun = run(caller, input);
+							let live = Rooms.get(input.id)?.plan;
+							if (live) {
+								return claimResult(
+									await claimImplementation(live, {
+										planRevision: input.planRevision,
+										graphRevision: input.graphRevision,
+										run: claimRun,
+									}),
+								);
+							}
+							for (let attempt = 0; attempt < 2; attempt++) {
+								if (callbacks.isChannelDeleting?.(input.id)) {
+									return { kind: "unavailable" as const };
+								}
+								let stored = await auth.storage.collaboration.load(input.id, auth.clock());
+								if (!stored) return { kind: "unavailable" as const };
+								if (stored.channel.archivedAt) {
+									return { kind: "refused" as const, reason: "document-archived" };
+								}
+								if (!stored.snapshot) return { kind: "refused" as const, reason: "missing" };
+								let prepared = Plan.claimStored(stored, {
 									planRevision: input.planRevision,
 									graphRevision: input.graphRevision,
 									run: claimRun,
-								}),
-							);
-						}
-						for (let attempt = 0; attempt < 2; attempt++) {
-							let stored = await auth.storage.collaboration.load(input.id, auth.clock());
-							if (!stored?.snapshot) return { kind: "refused" as const, reason: "missing" };
-							let prepared = Plan.claimStored(stored, {
-								planRevision: input.planRevision,
-								graphRevision: input.graphRevision,
-								run: claimRun,
-							});
-							if (prepared.result.kind !== "started" || !prepared.sidecar) {
-								return claimResult(prepared.result);
-							}
-							try {
-								await auth.storage.collaboration.commit({
-									channelId: input.id,
-									lease: persistence.lease(),
-									expectedRevision: stored.channel.revision,
-									operationId: `implementation:${claimRun.id}`,
-									epoch: stored.snapshot.epoch,
-									sidecar: prepared.sidecar,
-									events: [],
-									now: auth.clock(),
 								});
-								return claimResult(prepared.result);
-							} catch (err) {
-								if (!(err instanceof StorageError) || err.failure !== "conflict") throw err;
+								if (prepared.result.kind !== "started" || !prepared.sidecar) {
+									return claimResult(prepared.result);
+								}
+								try {
+									await auth.storage.collaboration.commit({
+										channelId: input.id,
+										lease: persistence.lease(),
+										expectedRevision: stored.channel.revision,
+										operationId: `implementation:${claimRun.id}`,
+										epoch: stored.snapshot.epoch,
+										sidecar: prepared.sidecar,
+										events: [],
+										now: auth.clock(),
+									});
+									return claimResult(prepared.result);
+								} catch (err) {
+									if (err instanceof StorageError && err.failure === "missing") {
+										return { kind: "unavailable" as const };
+									}
+									if (!(err instanceof StorageError) || err.failure !== "conflict") throw err;
+								}
 							}
-						}
-						return { kind: "refused" as const, reason: "conflict" };
+							return { kind: "refused" as const, reason: "conflict" };
+						});
 					},
 					async reportLifecycle(caller: HostedCaller, input: LifecycleArguments) {
-						let channel = await auth.storage.channels.get(input.id);
-						if (!channel) return { kind: "forbidden" as const };
-						let repository = await directRepository(
-							caller,
-							channel.repositoryOwner,
-							channel.repositoryName,
-						);
-						if (
-							!repository
-							|| repository.id !== channel.repositoryId
-							|| (!repository.permissions.push && !repository.permissions.admin)
-						) return { kind: "forbidden" as const };
-						let { id: _id, ...event } = input;
-						let live = Rooms.get(input.id)?.plan;
-						if (live) {
-							let result = await reportImplementationLifecycle(live, event);
-							if (result.kind === "refused") return result;
-							return {
-								kind: result.kind,
-								lifecycle: implementationLifecycle({
-									graph: result.state.graph,
-									execution: result.state.execution,
-									lifecycle: result.state.lifecycle,
-								}),
-							};
-						}
-						for (let attempt = 0; attempt < 2; attempt++) {
-							let stored = await auth.storage.collaboration.load(input.id, auth.clock());
-							if (!stored?.snapshot) return { kind: "refused" as const, reason: "inactive" };
-							let prepared = Plan.lifecycleStored(stored, event);
-							if (prepared.result.kind === "refused") return prepared.result;
-							if (prepared.result.kind === "replayed") {
+						return serializeDocument(input.id, async () => {
+							let access = await writableChannel(caller, input.id);
+							if (access.kind !== "allowed") return access;
+							let { id: _id, ...event } = input;
+							let live = Rooms.get(input.id)?.plan;
+							if (live) {
+								let result = await reportImplementationLifecycle(live, event);
+								if (result.kind === "refused") return result;
 								return {
-									kind: "replayed" as const,
+									kind: result.kind,
 									lifecycle: implementationLifecycle({
-										graph: prepared.result.state.graph,
-										execution: prepared.result.state.execution,
-										lifecycle: prepared.result.state.lifecycle,
+										graph: result.state.graph,
+										execution: result.state.execution,
+										lifecycle: result.state.lifecycle,
 									}),
 								};
 							}
-							if (!prepared.sidecar) return { kind: "refused" as const, reason: "inactive" };
-							try {
-								await auth.storage.collaboration.commit({
-									channelId: input.id,
-									lease: persistence.lease(),
-									expectedRevision: stored.channel.revision,
-									operationId: `lifecycle:${input.idempotencyKey}`,
-									epoch: stored.snapshot.epoch,
-									sidecar: prepared.sidecar,
-									events: [],
-									now: auth.clock(),
-								});
-								return {
-									kind: "accepted" as const,
-									lifecycle: implementationLifecycle({
-										graph: prepared.result.state.graph,
-										execution: prepared.result.state.execution,
-										lifecycle: prepared.result.state.lifecycle,
-									}),
-								};
-							} catch (err) {
-								if (!(err instanceof StorageError) || err.failure !== "conflict") throw err;
+							for (let attempt = 0; attempt < 2; attempt++) {
+								if (callbacks.isChannelDeleting?.(input.id)) {
+									return { kind: "unavailable" as const };
+								}
+								let stored = await auth.storage.collaboration.load(input.id, auth.clock());
+								if (!stored) return { kind: "unavailable" as const };
+								if (!stored.snapshot) return { kind: "refused" as const, reason: "inactive" };
+								let prepared = Plan.lifecycleStored(stored, event);
+								if (prepared.result.kind === "refused") return prepared.result;
+								if (prepared.result.kind === "replayed") {
+									return {
+										kind: "replayed" as const,
+										lifecycle: implementationLifecycle({
+											graph: prepared.result.state.graph,
+											execution: prepared.result.state.execution,
+											lifecycle: prepared.result.state.lifecycle,
+										}),
+									};
+								}
+								if (!prepared.sidecar) return { kind: "refused" as const, reason: "inactive" };
+								try {
+									await auth.storage.collaboration.commit({
+										channelId: input.id,
+										lease: persistence.lease(),
+										expectedRevision: stored.channel.revision,
+										operationId: `lifecycle:${input.idempotencyKey}`,
+										epoch: stored.snapshot.epoch,
+										sidecar: prepared.sidecar,
+										events: [],
+										now: auth.clock(),
+										allowArchived: true,
+									});
+									return {
+										kind: "accepted" as const,
+										lifecycle: implementationLifecycle({
+											graph: prepared.result.state.graph,
+											execution: prepared.result.state.execution,
+											lifecycle: prepared.result.state.lifecycle,
+										}),
+									};
+								} catch (err) {
+									if (err instanceof StorageError && err.failure === "missing") {
+										return { kind: "unavailable" as const };
+									}
+									if (!(err instanceof StorageError) || err.failure !== "conflict") throw err;
+								}
 							}
-						}
-						return { kind: "refused" as const, reason: "conflict" };
+							return { kind: "refused" as const, reason: "conflict" };
+						});
 					},
 				},
 			}

--- a/apps/server/src/mcp/rename.test.ts
+++ b/apps/server/src/mcp/rename.test.ts
@@ -75,7 +75,7 @@ describe("the MCP rename protocol", () => {
 		let rename: RenameDocument<string> = {
 			async rename() {
 				called = true;
-				return { kind: "missing" };
+				return { kind: "unavailable" };
 			},
 		};
 		let mcp = handler({ caller: () => "octocat", documents: reader(), rename });
@@ -108,9 +108,10 @@ describe("the MCP rename protocol", () => {
 		}));
 		for (
 			let [kind, code] of [
+				["archived", "document-archived"],
 				["conflict", "title-conflict"],
 				["forbidden", "repository-forbidden"],
-				["missing", "document-unavailable"],
+				["unavailable", "document-unavailable"],
 			] as const
 		) {
 			let mcp = handler({

--- a/apps/server/src/mcp/routes.ts
+++ b/apps/server/src/mcp/routes.ts
@@ -29,7 +29,7 @@ function protectedResponse(response: Response): Response {
 	});
 }
 
-/** Register the hosted, read-only MCP endpoint. */
+/** Register the hosted MCP endpoint. */
 export function registerMcpRoutes(
 	router: Router,
 	auth: HostedAuth,

--- a/apps/server/src/plan/service.ts
+++ b/apps/server/src/plan/service.ts
@@ -517,6 +517,7 @@ async function commitHosted(
 	update: Uint8Array | undefined,
 	operationId: string,
 	captured: Captured,
+	allowArchived = false,
 ): Promise<void> {
 	let durable = plan.persistence;
 	if (!update && captured.sidecarText === durable.lastSidecar) {
@@ -535,6 +536,7 @@ async function commitHosted(
 			sidecar: captured.sidecar,
 			events: [],
 			now: new Date(),
+			...(allowArchived ? { allowArchived: true } : {}),
 		});
 		if (!result.repeated) {
 			durable.revision = result.revision;
@@ -550,6 +552,7 @@ async function commitHosted(
 				sidecar: captured.sidecar,
 				events: [],
 				now: new Date(),
+				...(allowArchived ? { allowArchived: true } : {}),
 			});
 			durable.revision = stateResult.revision;
 			durable.sequence = stateResult.sequence;
@@ -683,8 +686,14 @@ export function implementationActive(plan: Plan): boolean {
 }
 
 /** Sidecar-only commit for a caller already holding `exclusive`. */
-export function persistExclusive(plan: Plan): Promise<void> {
-	return commitHosted(plan, undefined, `state:${crypto.randomUUID()}`, capture(plan));
+export function persistExclusive(plan: Plan, allowArchived = false): Promise<void> {
+	return commitHosted(
+		plan,
+		undefined,
+		`state:${crypto.randomUUID()}`,
+		capture(plan),
+		allowArchived,
+	);
 }
 
 type RestoredHosted = {
@@ -1313,7 +1322,7 @@ export async function close(plan: Plan): Promise<void> {
 	persistence.checkpointTimer = undefined;
 	await Chat.close(plan.chat);
 	await plan.flushing;
-	await commitHosted(plan, undefined, `state:${crypto.randomUUID()}`, capture(plan));
+	await commitHosted(plan, undefined, `state:${crypto.randomUUID()}`, capture(plan), true);
 	await checkpointHosted(plan);
 	Questions.shutdown(plan.questions);
 	presence.destroy(plan.presence);

--- a/apps/server/src/research/routes.ts
+++ b/apps/server/src/research/routes.ts
@@ -208,7 +208,7 @@ export function registerResearchWorkspaceRoutes(
 	router.on(
 		"GET",
 		"/api/repositories/:owner/:repository/research-workspaces",
-		async (request, _url, params) => {
+		async (request, url, params) => {
 			try {
 				let session = await auth.sessions.authenticate(request);
 				if (!session) return json({ error: "authentication required" }, 401);
@@ -222,7 +222,12 @@ export function registerResearchWorkspaceRoutes(
 				if (!resolved.repository.permissions.pull) {
 					return json({ error: "repository read access is required" }, 403);
 				}
-				let listed = await service.listRepository(resolved.repository.id);
+				let includeArchived = url.searchParams.get("includeArchived") === "true";
+				let listed = await service.listRepository(
+					resolved.repository.id,
+					undefined,
+					includeArchived,
+				);
 				return json({
 					repository: repository(resolved.repository),
 					canEdit: canWrite(resolved.repository),
@@ -396,6 +401,9 @@ export function registerResearchWorkspaceRoutes(
 				if (!access) return json({ error: "research workspace not found" }, 404);
 				if (!canWrite(access.repository)) {
 					return json({ error: "repository write access is required" }, 403);
+				}
+				if (access.channel.archivedAt) {
+					return json({ error: "document is archived" }, 409);
 				}
 				let workspace = await service.cancelTurn({
 					channelId: access.channel.id,

--- a/apps/server/src/research/service.ts
+++ b/apps/server/src/research/service.ts
@@ -513,6 +513,7 @@ export class ResearchWorkspaceService {
 	async listRepository(
 		repositoryId: string,
 		limit = RESEARCH_REPOSITORY_WORKSPACE_LIMIT,
+		includeArchived = false,
 	): Promise<RepositoryResearchWorkspaceList> {
 		opaqueId(repositoryId, "Repository id");
 		if (
@@ -521,7 +522,11 @@ export class ResearchWorkspaceService {
 		) {
 			throw new ResearchWorkspaceError("invalid-request", "Repository listing limit is invalid.");
 		}
-		let listed = await this.#storage.research.listRepository(repositoryId, limit);
+		let listed = await this.#storage.research.listRepository(
+			repositoryId,
+			limit,
+			includeArchived,
+		);
 		return {
 			channels: listed.channels.map(group => ({
 				channel: group.channel,

--- a/apps/server/src/rooms.ts
+++ b/apps/server/src/rooms.ts
@@ -27,6 +27,8 @@ export type Room = {
 	plan?: Plan;
 	/** In flight while the first opener is building it, so the second waits. */
 	opening?: Promise<Plan>;
+	/** Final persistence is in flight; reopening waits for it to finish. */
+	closing?: Promise<void>;
 	/** Pending eviction, cancelled if somebody comes back. */
 	eviction?: ReturnType<typeof setTimeout>;
 };
@@ -60,7 +62,7 @@ export function join(ws: Socket): Room {
 export function leave(ws: Socket): Room | undefined {
 	let room = rooms.get(ws.data.room);
 	if (!room) return undefined;
-	room.members.delete(ws.data.client);
+	if (room.members.get(ws.data.client) === ws) room.members.delete(ws.data.client);
 	return room;
 }
 
@@ -71,7 +73,7 @@ export function all(): Room[] {
 
 export function forget(room: Room): void {
 	if (room.eviction) clearTimeout(room.eviction);
-	rooms.delete(room.id);
+	if (rooms.get(room.id) === room) rooms.delete(room.id);
 }
 
 export function members(room: Room): Identity[] {

--- a/apps/server/src/socket/admission.test.ts
+++ b/apps/server/src/socket/admission.test.ts
@@ -134,6 +134,7 @@ describe("socket admission", () => {
 			handle: "octocat",
 			principalId: "U_octocat",
 			canEdit: false,
+			canManage: false,
 		});
 		let probe = await admit(
 			new Request(url, {
@@ -162,7 +163,25 @@ describe("socket admission", () => {
 
 		github.push = true;
 		let editor = await admit(request, url, auth);
-		expect("data" in editor && editor.data.canEdit).toBe(true);
+		expect("data" in editor && editor.data).toMatchObject({
+			canEdit: true,
+			canManage: true,
+		});
+		if ("data" in editor) expect(editor.data).not.toHaveProperty("channelArchivedAt");
+
+		let archivedAt = new Date(now.getTime() + 1_000);
+		await storage.channels.archive({ id: channel.id, now: archivedAt });
+		let archived = await admit(request, url, auth);
+		expect("data" in archived && archived.data).toMatchObject({
+			canEdit: false,
+			canManage: true,
+			channelArchivedAt: archivedAt.toISOString(),
+		});
+		expect(await admit(request, url, auth, { deleting: id => id === channel.id })).toEqual({
+			status: 404,
+			reason: "channel not found",
+		});
+
 		github.repositoryId = "R_other";
 		let denied = await admit(request, url, auth);
 		expect(denied).toEqual({ status: 404, reason: "channel not found" });

--- a/apps/server/src/socket/admission.ts
+++ b/apps/server/src/socket/admission.ts
@@ -12,6 +12,10 @@ export async function admit(
 	request: Request,
 	url: URL,
 	auth: HostedAuth,
+	options: {
+		deleting?: (channelId: string) => boolean;
+		readOnly?: (channelId: string) => boolean;
+	} = {},
 ): Promise<Admission> {
 	try {
 		let probe = request.headers.get("x-chopin-socket-probe") === "1"
@@ -23,6 +27,7 @@ export async function admit(
 		if (!session) return { status: 401, reason: "authentication required" };
 		let id = (url.searchParams.get("channel") || "").toLowerCase();
 		if (!isChannelId(id)) return { status: 400, reason: "bad channel" };
+		if (options.deleting?.(id)) return { status: 404, reason: "channel not found" };
 		let channel = await auth.storage.channels.get(id);
 		if (!channel) return { status: 404, reason: "channel not found" };
 		let access = await auth.sessions.use(
@@ -40,15 +45,20 @@ export async function admit(
 		}
 		let credential = auth.sessions.credential(request);
 		if (!credential) return { status: 401, reason: "authentication required" };
+		let canManage = repository.permissions.push || repository.permissions.admin;
 		return {
 			data: {
 				room: channel.id,
 				channelTitle: channel.title,
 				channelSlug: channel.slug,
 				channelUpdatedAt: channel.updatedAt.toISOString(),
+				...(channel.archivedAt
+					? { channelArchivedAt: channel.archivedAt.toISOString() }
+					: {}),
 				handle: session.user.login,
 				client: uid(),
-				canEdit: repository.permissions.push || repository.permissions.admin,
+				canEdit: canManage && !channel.archivedAt && !options.readOnly?.(channel.id),
+				canManage,
 				principalId: session.user.id,
 				sessionId: session.session.id,
 				authorizedUntil: session.session.expiresAt.getTime(),

--- a/apps/server/src/storage/contract.ts
+++ b/apps/server/src/storage/contract.ts
@@ -18,6 +18,10 @@ async function opened(factory: Factory): Promise<StorageAdapter> {
 	return storage;
 }
 
+function attempt<T>(action: () => Promise<T>): Promise<T> {
+	return Promise.resolve().then(action);
+}
+
 async function userAndChannel(storage: StorageAdapter): Promise<{
 	userId: string;
 	sessionId: string;
@@ -352,6 +356,336 @@ export function storageContract(name: string, factory: Factory): void {
 				expect(page.channels).toHaveLength(1);
 				expect(page.channels[0]!.repositoryId).toBe(repositoryId);
 				expect(page.next).toBeUndefined();
+			} finally {
+				await storage.close();
+			}
+		});
+
+		it("archives and restores channels without hiding direct reads", async () => {
+			let storage = await opened(factory);
+			try {
+				let { userId, channelId, repositoryId } = await userAndChannel(storage);
+				let original = (await storage.channels.get(channelId))!;
+				let fallback = await storage.channels.create({
+					id: id("fallback-channel"),
+					repositoryId,
+					repositoryOwner: "octo-org",
+					repositoryName: "score",
+					title: "Fallback plan",
+					createdBy: userId,
+					now: new Date("2026-01-01T03:04:05.000Z"),
+				});
+				await storage.navigation.recordVisit({
+					userId,
+					repositoryId,
+					repositoryOwner: "octo-org",
+					repositoryName: "score",
+					documentId: channelId,
+					now: original.updatedAt,
+				});
+
+				let archived = await storage.channels.archive({ id: channelId, now: original.updatedAt });
+				expect(archived).toMatchObject({
+					changed: true,
+					channel: {
+						id: channelId,
+						title: original.title,
+						slug: original.slug,
+						revision: original.revision,
+					},
+				});
+				expect(archived.channel.updatedAt.getTime()).toBeGreaterThan(original.updatedAt.getTime());
+				expect(archived.channel.archivedAt).toEqual(archived.channel.updatedAt);
+				expect(
+					await storage.channels.archive({
+						id: channelId,
+						now: new Date("2026-01-05T03:04:05.000Z"),
+					}),
+				).toEqual({ channel: archived.channel, changed: false });
+
+				expect((await storage.channels.list(repositoryId, 1)).channels.map(value => value.id))
+					.toEqual([fallback.id]);
+				expect(
+					(await storage.channels.list(repositoryId, 1, undefined, undefined, true)).channels
+						.map(value => value.id),
+				).toEqual([channelId]);
+				expect((await storage.channels.scan(repositoryId, 1)).channels.map(value => value.id))
+					.toEqual([fallback.id]);
+				expect(
+					(await storage.channels.scan(repositoryId, 1, undefined, true)).channels
+						.map(value => value.id),
+				).toEqual([channelId]);
+				expect((await storage.channels.get(channelId))?.archivedAt)
+					.toEqual(archived.channel.archivedAt);
+				expect((await storage.channels.resolve(repositoryId, original.slug))?.id).toBe(channelId);
+				await expect(storage.channels.rename({
+					id: channelId,
+					title: original.title,
+					now: new Date("2026-01-06T03:04:05.000Z"),
+				})).rejects.toMatchObject({ failure: "conflict" });
+				await expect(storage.navigation.setLastDocument(
+					userId,
+					channelId,
+					new Date("2026-01-06T03:04:05.000Z"),
+				)).rejects.toMatchObject({ failure: "conflict" });
+				await expect(storage.navigation.recordVisit({
+					userId,
+					repositoryId,
+					repositoryOwner: "octo-org",
+					repositoryName: "score",
+					documentId: channelId,
+					now: new Date("2026-01-06T03:04:05.000Z"),
+				})).rejects.toMatchObject({ failure: "conflict" });
+
+				let snapshot = await storage.navigation.snapshot(userId);
+				expect(snapshot.navigation?.lastDocumentId).toBe(channelId);
+				expect(snapshot.lastDocumentRepositoryId).toBeUndefined();
+				expect(await storage.navigation.firstDocument(userId, [repositoryId])).toBe(fallback.id);
+				expect(
+					await storage.navigation.setLastDocumentIfCurrent(
+						userId,
+						snapshot.navigation?.revision,
+						fallback.id,
+						new Date("2026-01-06T03:04:05.000Z"),
+					),
+				).toMatchObject({ navigation: { lastDocumentId: fallback.id }, updated: true });
+
+				let restored = await storage.channels.restore({
+					id: channelId,
+					now: archived.channel.updatedAt,
+				});
+				expect(restored.changed).toBe(true);
+				expect(restored.channel.archivedAt).toBeUndefined();
+				expect(restored.channel.revision).toBe(original.revision);
+				expect(restored.channel.updatedAt.getTime())
+					.toBeGreaterThan(archived.channel.updatedAt.getTime());
+				expect((await storage.channels.list(repositoryId, 1)).channels[0]?.id).toBe(channelId);
+				expect(
+					await storage.channels.restore({
+						id: channelId,
+						now: new Date("2026-01-07T03:04:05.000Z"),
+					}),
+				).toEqual({ channel: restored.channel, changed: false });
+			} finally {
+				await storage.close();
+			}
+		});
+
+		it("deletes only archived channels and permits clean identity reuse", async () => {
+			let storage = await opened(factory);
+			try {
+				let { userId, sessionId, channelId, repositoryId, lease } = await userAndChannel(storage);
+				let operationId = id("delete-operation");
+				let workspaceInput = researchWorkspace(channelId, userId, lease, {
+					id: id("delete-workspace"),
+					idempotencyKey: id("delete-workspace-request"),
+					fingerprint: "sha256:delete-workspace",
+				});
+				let createdWorkspace = await storage.research.create(workspaceInput);
+				let confirmation = {
+					channelId,
+					workspaceId: createdWorkspace.workspace.id,
+					turnId: id("delete-turn"),
+					messageId: id("delete-member-message"),
+					requestId: id("delete-confirmation"),
+					fingerprint: "sha256:delete-confirmation",
+					confirmedQuery: "Which state must be deleted?",
+					confirmedBy: userId,
+					now: new Date("2026-01-07T03:05:05.000Z"),
+					lease,
+				};
+				let confirmed = await storage.research.confirm(confirmation);
+				let jobInput = backgroundJob(channelId, lease, {
+					id: id("delete-job"),
+					type: "research-answer",
+					targetKey:
+						`research-answer:workspace:${workspaceInput.id}:turn:${confirmation.turnId}:answer`,
+					idempotencyKey: id("delete-job-request"),
+					fingerprint: "sha256:delete-job",
+					now: new Date("2026-01-07T03:06:05.000Z"),
+					availableAt: new Date("2026-01-07T03:06:05.000Z"),
+				});
+				let queued = await storage.jobs.enqueue(jobInput);
+				let [claimed] = await storage.jobs.claim({
+					channelId,
+					claimOwner: "delete-worker",
+					count: 1,
+					ttlMs: 60_000,
+					now: new Date("2026-01-07T03:06:06.000Z"),
+					lease,
+				});
+				await storage.jobs.settle({
+					channelId,
+					jobId: queued.job.id,
+					claimOwner: "delete-worker",
+					claimGeneration: claimed!.claimGeneration,
+					artifact: { answer: "all channel-owned state" },
+					now: new Date("2026-01-07T03:06:07.000Z"),
+					lease,
+				});
+				await storage.research.linkJob({
+					channelId,
+					workspaceId: workspaceInput.id,
+					turnId: confirmed.turn.id,
+					role: "answer",
+					jobId: jobInput.id,
+					now: new Date("2026-01-07T03:06:08.000Z"),
+					lease,
+				});
+				let agentMessage = {
+					channelId,
+					workspaceId: workspaceInput.id,
+					id: id("delete-agent-message"),
+					turnId: confirmed.turn.id,
+					text: "Delete this transcript with its document.",
+					sourceJobId: jobInput.id,
+					now: new Date("2026-01-07T03:06:09.000Z"),
+					lease,
+				};
+				await storage.research.appendAgentMessage(agentMessage);
+				await storage.collaboration.commit({
+					channelId,
+					lease,
+					expectedRevision: 0,
+					operationId,
+					epoch: "delete-epoch",
+					update: new Uint8Array([1, 2, 3]),
+					sidecar: { deletion: "seeded" },
+					events: [{
+						id: id("delete-event"),
+						kind: "delete:test",
+						payload: { seeded: true },
+						createdAt: new Date("2026-01-07T03:07:05.000Z"),
+					}],
+					now: new Date("2026-01-07T03:07:05.000Z"),
+				});
+				await storage.collaboration.checkpoint({
+					channelId,
+					lease,
+					expectedRevision: 1,
+					generation: id("delete-generation"),
+					revision: 1,
+					throughSequence: 1,
+					epoch: "delete-epoch",
+					source: "# Delete me\n",
+					sourceHash: "sha256:delete-me",
+					document: new Uint8Array([4, 5, 6]),
+					sidecar: { deletion: "seeded" },
+					createdAt: new Date("2026-01-07T03:08:05.000Z"),
+				});
+				await storage.channels.claimAgentOwner(
+					channelId,
+					sessionId,
+					new Date("2026-01-07T03:09:05.000Z"),
+				);
+				await storage.navigation.setLastDocument(
+					userId,
+					channelId,
+					new Date("2026-01-07T03:09:05.000Z"),
+				);
+				let renamed = await storage.channels.rename({
+					id: channelId,
+					title: "Launch plan",
+					now: new Date("2026-01-08T03:04:05.000Z"),
+				});
+				await expect(storage.channels.delete(channelId))
+					.rejects.toMatchObject({ failure: "conflict" });
+				await storage.channels.archive({
+					id: channelId,
+					now: new Date("2026-01-09T03:04:05.000Z"),
+				});
+				expect(await storage.channels.delete(channelId)).toBe(true);
+				expect(await storage.channels.delete(channelId)).toBe(false);
+
+				expect(await storage.channels.get(channelId)).toBeUndefined();
+				expect(await storage.channels.resolve(repositoryId, "release-plan")).toBeUndefined();
+				expect(await storage.channels.resolve(repositoryId, renamed.channel.slug)).toBeUndefined();
+				expect(await storage.collaboration.load(channelId, new Date())).toBeUndefined();
+				expect(await storage.channels.readAgent(channelId, new Date())).toBeUndefined();
+				expect(await storage.jobs.list(channelId, 10)).toBeUndefined();
+				expect(await storage.jobs.get(channelId, jobInput.id)).toBeUndefined();
+				expect(await storage.research.list(channelId, 10)).toEqual([]);
+				expect(await storage.research.get(channelId, workspaceInput.id)).toBeUndefined();
+				expect((await storage.navigation.get(userId))?.lastDocumentId).toBeUndefined();
+				expect((await storage.navigation.snapshot(userId)).lastDocumentRepositoryId)
+					.toBeUndefined();
+
+				let recreated = await storage.channels.create({
+					id: channelId,
+					repositoryId,
+					repositoryOwner: "octo-org",
+					repositoryName: "score",
+					title: "Release plan",
+					createdBy: userId,
+					now: new Date("2026-01-10T03:04:05.000Z"),
+				});
+				expect(recreated).toMatchObject({ id: channelId, slug: "release-plan", revision: 0 });
+				expect(recreated.archivedAt).toBeUndefined();
+				let aliasReuse = await storage.channels.create({
+					id: id("alias-reuse-channel"),
+					repositoryId,
+					repositoryOwner: "octo-org",
+					repositoryName: "score",
+					title: "Launch plan",
+					createdBy: userId,
+					now: new Date("2026-01-10T03:04:06.000Z"),
+				});
+				expect(aliasReuse.slug).toBe("launch-plan");
+				let clean = (await storage.collaboration.load(channelId, new Date()))!;
+				expect(clean).toMatchObject({
+					latestSequence: 0,
+					snapshot: undefined,
+					updates: [],
+					events: [],
+					sidecar: null,
+					agent: undefined,
+				});
+				expect(
+					await storage.collaboration.commit({
+						channelId,
+						lease,
+						expectedRevision: 0,
+						operationId,
+						epoch: "recreated-epoch",
+						events: [],
+						now: new Date("2026-01-10T03:05:05.000Z"),
+					}),
+				).toEqual({ revision: 1, sequence: 1, repeated: false });
+
+				let recreatedWorkspace = await storage.research.create({
+					...workspaceInput,
+					now: new Date("2026-01-10T03:06:05.000Z"),
+				});
+				expect(recreatedWorkspace.repeated).toBe(false);
+				let recreatedConfirmation = await storage.research.confirm({
+					...confirmation,
+					now: new Date("2026-01-10T03:06:06.000Z"),
+				});
+				expect(recreatedConfirmation.repeated).toBe(false);
+				let recreatedJob = await storage.jobs.enqueue({
+					...jobInput,
+					availableAt: new Date("2026-01-10T03:06:07.000Z"),
+					now: new Date("2026-01-10T03:06:07.000Z"),
+				});
+				expect(recreatedJob.repeated).toBe(false);
+				expect((await storage.jobs.get(channelId, jobInput.id))?.artifact).toBeUndefined();
+				expect(
+					(await storage.research.linkJob({
+						channelId,
+						workspaceId: workspaceInput.id,
+						turnId: confirmation.turnId,
+						role: "answer",
+						jobId: jobInput.id,
+						now: new Date("2026-01-10T03:06:08.000Z"),
+						lease,
+					})).repeated,
+				).toBe(false);
+				expect(
+					(await storage.research.appendAgentMessage({
+						...agentMessage,
+						now: new Date("2026-01-10T03:06:09.000Z"),
+					})).repeated,
+				).toBe(false);
 			} finally {
 				await storage.close();
 			}
@@ -859,6 +1193,99 @@ export function storageContract(name: string, factory: Factory): void {
 			}
 		});
 
+		it("fences archived collaboration writes except sidecar-only maintenance", async () => {
+			let storage = await opened(factory);
+			try {
+				let { channelId, lease } = await userAndChannel(storage);
+				let archivedAt = new Date("2026-01-04T03:04:05.000Z");
+				await storage.channels.archive({ id: channelId, now: archivedAt });
+
+				await expect(attempt(() =>
+					storage.collaboration.commit({
+						channelId,
+						lease,
+						expectedRevision: 0,
+						operationId: id("archived-normal-commit"),
+						epoch: "archived-epoch",
+						sidecar: { maintenance: false },
+						events: [],
+						now: archivedAt,
+					})
+				)).rejects.toMatchObject({ failure: "conflict" });
+
+				let maintenance = await storage.collaboration.commit({
+					channelId,
+					lease,
+					expectedRevision: 0,
+					operationId: id("archived-sidecar-commit"),
+					epoch: "archived-epoch",
+					sidecar: { maintenance: true },
+					events: [],
+					now: new Date(archivedAt.getTime() + 1),
+					allowArchived: true,
+				});
+				expect(maintenance).toEqual({ revision: 1, sequence: 1, repeated: false });
+
+				await expect(attempt(() =>
+					storage.collaboration.commit({
+						channelId,
+						lease,
+						expectedRevision: 1,
+						operationId: id("archived-update-commit"),
+						epoch: "archived-epoch",
+						update: new Uint8Array([1]),
+						events: [],
+						now: new Date(archivedAt.getTime() + 2),
+						allowArchived: true,
+					})
+				)).rejects.toMatchObject({ failure: "conflict" });
+				await expect(attempt(() =>
+					storage.collaboration.commit({
+						channelId,
+						lease,
+						expectedRevision: 1,
+						operationId: id("archived-event-commit"),
+						epoch: "archived-epoch",
+						events: [{
+							id: id("archived-event"),
+							kind: "archive:test",
+							payload: { rejected: true },
+							createdAt: new Date(archivedAt.getTime() + 3),
+						}],
+						now: new Date(archivedAt.getTime() + 3),
+						allowArchived: true,
+					})
+				)).rejects.toMatchObject({ failure: "conflict" });
+
+				await expect(attempt(() =>
+					storage.collaboration.replace({
+						channelId,
+						lease,
+						expectedRevision: 1,
+						operationId: id("archived-replacement"),
+						generation: id("archived-generation"),
+						epoch: "replacement-epoch",
+						source: "# Rejected replacement\n",
+						sourceHash: "sha256:archived-replacement",
+						document: new Uint8Array([2]),
+						sidecar: { maintenance: false },
+						now: new Date(archivedAt.getTime() + 4),
+					})
+				)).rejects.toMatchObject({ failure: "conflict" });
+
+				let stored = await storage.collaboration.load(channelId, new Date());
+				expect(stored).toMatchObject({
+					channel: { revision: 1, archivedAt },
+					latestSequence: 1,
+					sidecar: { maintenance: true },
+					updates: [],
+					events: [],
+				});
+			} finally {
+				await storage.close();
+			}
+		});
+
 		it("replays only updates newer than the checkpoint", async () => {
 			let storage = await opened(factory);
 			try {
@@ -1092,6 +1519,25 @@ export function storageContract(name: string, factory: Factory): void {
 					.toEqual([channelBWorkspace]);
 				expect(listed.channels[2]!.workspaces.map(value => value.id))
 					.toEqual([oldChannelWorkspace]);
+				await storage.channels.archive({
+					id: channelB,
+					now: new Date("2026-01-16T03:04:05.000Z"),
+				});
+				expect(
+					(await storage.research.listRepository(repositoryId, 10)).channels
+						.map(group => group.channel.id),
+				).toEqual([channelA, channelId]);
+				expect(
+					(await storage.research.listRepository(repositoryId, 10, true)).channels
+						.map(group => group.channel.id),
+				).toEqual([channelA, channelB, channelId]);
+				expect((await storage.research.list(channelB, 10)).map(value => value.id))
+					.toEqual([channelBWorkspace]);
+				expect(await storage.research.get(channelB, channelBWorkspace)).toBeDefined();
+				await storage.channels.restore({
+					id: channelB,
+					now: new Date("2026-01-16T03:04:06.000Z"),
+				});
 
 				let bounded = await storage.research.listRepository(repositoryId, 2);
 				expect(bounded.truncated).toBe(true);
@@ -1223,6 +1669,113 @@ export function storageContract(name: string, factory: Factory): void {
 				detail!.turns[0]!.createdAt.setUTCFullYear(1999);
 				expect((await storage.research.get(channelId, draft.workspace.id))!.turns[0]!.createdAt)
 					.toEqual(confirmation.now);
+			} finally {
+				await storage.close();
+			}
+		});
+
+		it("rejects new archived research mutations but preserves exact replays", async () => {
+			let storage = await opened(factory);
+			try {
+				let { userId, channelId, lease } = await userAndChannel(storage);
+				let create = researchWorkspace(channelId, userId, lease, {
+					id: id("archive-replay-workspace"),
+					idempotencyKey: id("archive-replay-create"),
+					fingerprint: "sha256:archive-replay-create",
+				});
+				let created = await storage.research.create(create);
+				let unconfirmed = await storage.research.create(researchWorkspace(
+					channelId,
+					userId,
+					lease,
+					{
+						id: id("archive-unconfirmed-workspace"),
+						idempotencyKey: id("archive-unconfirmed-create"),
+						fingerprint: "sha256:archive-unconfirmed-create",
+					},
+				));
+				let confirmation = {
+					channelId,
+					workspaceId: created.workspace.id,
+					turnId: id("archive-initial-turn"),
+					messageId: id("archive-initial-message"),
+					requestId: id("archive-confirmation"),
+					fingerprint: "sha256:archive-confirmation",
+					confirmedQuery: "Which archive fences are durable?",
+					confirmedBy: userId,
+					confirmedByHandle: "octocat",
+					now: new Date("2026-01-07T03:05:05.000Z"),
+					lease,
+				};
+				let confirmed = await storage.research.confirm(confirmation);
+				let append = {
+					channelId,
+					workspaceId: created.workspace.id,
+					turnId: id("archive-follow-up-turn"),
+					messageId: id("archive-follow-up-message"),
+					kind: "follow-up" as const,
+					requestId: id("archive-follow-up"),
+					fingerprint: "sha256:archive-follow-up",
+					question: "Do exact retries remain available?",
+					requestedBy: userId,
+					requestedByHandle: "octocat",
+					now: new Date("2026-01-07T03:06:05.000Z"),
+					lease,
+				};
+				let appended = await storage.research.appendTurn(append);
+				await storage.channels.archive({
+					id: channelId,
+					now: new Date("2026-01-08T03:04:05.000Z"),
+				});
+
+				expect(await storage.research.create(create)).toMatchObject({
+					repeated: true,
+					workspace: { id: created.workspace.id },
+				});
+				expect(await storage.research.confirm(confirmation)).toMatchObject({
+					repeated: true,
+					turn: { id: confirmed.turn.id },
+					message: { id: confirmed.message.id },
+				});
+				expect(await storage.research.appendTurn(append)).toMatchObject({
+					repeated: true,
+					turn: { id: appended.turn.id },
+					message: { id: appended.message.id },
+				});
+
+				await expect(storage.research.create(researchWorkspace(
+					channelId,
+					userId,
+					lease,
+					{
+						id: id("archived-new-workspace"),
+						idempotencyKey: id("archived-new-create"),
+						fingerprint: "sha256:archived-new-create",
+					},
+				))).rejects.toMatchObject({ failure: "conflict" });
+				await expect(storage.research.confirm({
+					...confirmation,
+					workspaceId: unconfirmed.workspace.id,
+					turnId: id("archived-new-initial-turn"),
+					messageId: id("archived-new-initial-message"),
+					requestId: id("archived-new-confirmation"),
+					fingerprint: "sha256:archived-new-confirmation",
+				})).rejects.toMatchObject({ failure: "conflict" });
+				await expect(storage.research.appendTurn({
+					...append,
+					turnId: id("archived-new-follow-up-turn"),
+					messageId: id("archived-new-follow-up-message"),
+					requestId: id("archived-new-follow-up"),
+					fingerprint: "sha256:archived-new-follow-up",
+					question: "This new request must be fenced.",
+				})).rejects.toMatchObject({ failure: "conflict" });
+
+				expect((await storage.research.get(channelId, created.workspace.id))!.turns)
+					.toHaveLength(2);
+				expect(
+					(await storage.research.get(channelId, unconfirmed.workspace.id))!.workspace
+						.confirmedQuery,
+				).toBeUndefined();
 			} finally {
 				await storage.close();
 			}
@@ -1430,6 +1983,34 @@ export function storageContract(name: string, factory: Factory): void {
 				expect(await storage.collaboration.load(channelId, new Date())).toEqual(
 					beforeCollaboration,
 				);
+			} finally {
+				await storage.close();
+			}
+		});
+
+		it("requires an archive allowance to cancel background work", async () => {
+			let storage = await opened(factory);
+			try {
+				let { channelId, lease } = await userAndChannel(storage);
+				let now = new Date("2026-01-07T03:04:05.000Z");
+				let queued = await storage.jobs.enqueue(backgroundJob(channelId, lease, { now }));
+				await storage.channels.archive({
+					id: channelId,
+					now: new Date(now.getTime() + 1),
+				});
+
+				let cancellation = {
+					channelId,
+					jobId: queued.job.id,
+					now: new Date(now.getTime() + 2),
+					lease,
+				};
+				await expect(storage.jobs.cancel(cancellation))
+					.rejects.toMatchObject({ failure: "conflict" });
+				expect((await storage.jobs.get(channelId, queued.job.id))!.job.state).toBe("pending");
+
+				let cancelled = await storage.jobs.cancel({ ...cancellation, allowArchived: true });
+				expect(cancelled.state).toBe("cancelled");
 			} finally {
 				await storage.close();
 			}

--- a/apps/server/src/storage/memory/adapter.ts
+++ b/apps/server/src/storage/memory/adapter.ts
@@ -7,6 +7,8 @@ import type {
 	AddUserProject,
 	AddUserProjectResult,
 	AgentState,
+	ChannelArchiveInput,
+	ChannelArchiveResult,
 	ChannelCursor,
 	ChannelPage,
 	ChannelRecord,
@@ -73,7 +75,13 @@ function navigation(value: UserNavigation): UserNavigation {
 }
 
 function channel(value: ChannelRecord): ChannelRecord {
-	return { ...value, createdAt: new Date(value.createdAt), updatedAt: new Date(value.updatedAt) };
+	let { archivedAt, ...record } = value;
+	return {
+		...record,
+		createdAt: new Date(value.createdAt),
+		updatedAt: new Date(value.updatedAt),
+		...(archivedAt ? { archivedAt: new Date(archivedAt) } : {}),
+	};
 }
 
 function snapshot(value: ChannelSnapshot): ChannelSnapshot {
@@ -175,6 +183,7 @@ export class MemoryStorage implements StorageAdapter {
 			let selected = found?.lastDocumentId
 				? this.#channels.get(found.lastDocumentId)
 				: undefined;
+			if (selected?.archivedAt) selected = undefined;
 			return Promise.resolve({
 				projects: (this.#projects.get(userId) ?? []).map(project),
 				navigation: found ? navigation(found) : undefined,
@@ -193,7 +202,7 @@ export class MemoryStorage implements StorageAdapter {
 				.sort((left, right) => left.position - right.position);
 			for (let stored of projects) {
 				let first = [...this.#channels.values()]
-					.filter(value => value.repositoryId === stored.repositoryId)
+					.filter(value => value.repositoryId === stored.repositoryId && !value.archivedAt)
 					.sort((left, right) =>
 						right.updatedAt.getTime() - left.updatedAt.getTime()
 						|| left.id.localeCompare(right.id)
@@ -233,9 +242,13 @@ export class MemoryStorage implements StorageAdapter {
 			return Promise.resolve(found && channel(found));
 		},
 		rename: input => this.#renameChannel(input),
-		list: (repositoryId, limit, after, query) =>
-			this.#listChannels(repositoryId, limit, after, query),
-		scan: (repositoryId, limit, after) => this.#scanChannels(repositoryId, limit, after),
+		archive: input => this.#setChannelArchived(input, true),
+		restore: input => this.#setChannelArchived(input, false),
+		delete: id => this.#deleteChannel(id),
+		list: (repositoryId, limit, after, query, includeArchived) =>
+			this.#listChannels(repositoryId, limit, after, query, includeArchived),
+		scan: (repositoryId, limit, after, includeArchived) =>
+			this.#scanChannels(repositoryId, limit, after, includeArchived),
 		claimAgentOwner: (channelId, sessionId, now) =>
 			this.#claimAgentOwner(channelId, sessionId, now),
 		clearAgentOwner: (channelId, expectedSessionId, expectedGeneration, now) =>
@@ -251,12 +264,15 @@ export class MemoryStorage implements StorageAdapter {
 		checkpoint: input => this.#checkpoint(input),
 	};
 
-	readonly jobs: BackgroundJobStore = new MemoryBackgroundJobStore({
+	readonly #jobs = new MemoryBackgroundJobStore({
 		channelExists: channelId => this.#channels.has(channelId),
+		channelActive: channelId => !this.#channels.get(channelId)?.archivedAt,
 		assertLease: held => this.#assertLease(held),
 	});
-	readonly research: ResearchWorkspaceStore = new MemoryResearchWorkspaceStore({
+	readonly jobs: BackgroundJobStore = this.#jobs;
+	readonly #research = new MemoryResearchWorkspaceStore({
 		channelExists: channelId => this.#channels.has(channelId),
+		channelActive: channelId => !this.#channels.get(channelId)?.archivedAt,
 		channels: repositoryId =>
 			[...this.#channels.values()]
 				.filter(value => value.repositoryId === repositoryId)
@@ -265,6 +281,7 @@ export class MemoryStorage implements StorageAdapter {
 		job: (channelId, jobId) => this.jobs.get(channelId, jobId),
 		assertLease: held => this.#assertLease(held),
 	});
+	readonly research: ResearchWorkspaceStore = this.#research;
 
 	readonly leases: LeaseStore = {
 		acquire: (name, owner, ttlMs) => this.#acquire(name, owner, ttlMs),
@@ -319,8 +336,10 @@ export class MemoryStorage implements StorageAdapter {
 		now: Date,
 	): Promise<UserNavigation> {
 		this.#requireUser(userId);
-		if (documentId && !this.#channels.has(documentId)) {
-			throw missing(`channel ${documentId} does not exist`);
+		if (documentId) {
+			let document = this.#channels.get(documentId);
+			if (!document) throw missing(`channel ${documentId} does not exist`);
+			if (document.archivedAt) throw conflict(`channel ${documentId} is archived`);
 		}
 		let saved: UserNavigation = {
 			userId,
@@ -340,6 +359,7 @@ export class MemoryStorage implements StorageAdapter {
 				`channel ${input.documentId} does not exist in repository ${input.repositoryId}`,
 			);
 		}
+		if (document.archivedAt) throw conflict(`channel ${input.documentId} is archived`);
 		await this.#addProject(input);
 		return this.#setLastDocument(input.userId, input.documentId, input.now);
 	}
@@ -382,6 +402,7 @@ export class MemoryStorage implements StorageAdapter {
 	async #renameChannel(input: RenameChannel): Promise<RenameResult> {
 		let found = this.#channels.get(input.id);
 		if (!found) throw missing(`channel ${input.id} does not exist`);
+		if (found.archivedAt) throw conflict(`channel ${input.id} is archived`);
 		if (found.title === input.title) return { channel: channel(found), changed: false };
 		if (
 			[...this.#channels.values()].some(value =>
@@ -397,6 +418,59 @@ export class MemoryStorage implements StorageAdapter {
 		let saved = { ...found, title: input.title, slug, updatedAt };
 		this.#channels.set(saved.id, saved);
 		return { channel: channel(saved), changed: true };
+	}
+
+	async #setChannelArchived(
+		input: ChannelArchiveInput,
+		archived: boolean,
+	): Promise<ChannelArchiveResult> {
+		let found = this.#channels.get(input.id);
+		if (!found) throw missing(`channel ${input.id} does not exist`);
+		if ((found.archivedAt !== undefined) === archived) {
+			return { channel: channel(found), changed: false };
+		}
+		let updatedAt = input.now > found.updatedAt
+			? new Date(input.now)
+			: new Date(found.updatedAt.getTime() + 1);
+		let saved: ChannelRecord;
+		if (archived) {
+			saved = { ...found, updatedAt, archivedAt: new Date(updatedAt) };
+		} else {
+			let { archivedAt: _, ...active } = found;
+			saved = { ...active, updatedAt };
+		}
+		this.#channels.set(saved.id, saved);
+		return { channel: channel(saved), changed: true };
+	}
+
+	async #deleteChannel(id: string): Promise<boolean> {
+		let found = this.#channels.get(id);
+		if (!found) return false;
+		if (!found.archivedAt) throw conflict(`channel ${id} must be archived before deletion`);
+
+		this.#channels.delete(id);
+		await this.#research.deleteChannel(id);
+		this.#jobs.deleteChannel(id);
+		this.#snapshots.delete(id);
+		this.#sequences.delete(id);
+		this.#updates.delete(id);
+		this.#events.delete(id);
+		this.#sidecars.delete(id);
+		this.#operations.delete(id);
+		this.#agents.delete(id);
+		let aliases = this.#channelSlugs.get(found.repositoryId);
+		if (aliases) {
+			for (let [slug, owner] of aliases) {
+				if (owner === id) aliases.delete(slug);
+			}
+			if (aliases.size === 0) this.#channelSlugs.delete(found.repositoryId);
+		}
+		for (let [userId, saved] of this.#navigation) {
+			if (saved.lastDocumentId === id) {
+				this.#navigation.set(userId, { ...saved, lastDocumentId: undefined });
+			}
+		}
+		return true;
 	}
 
 	#reserveSlug(repositoryId: string, channelId: string, title: string): string {
@@ -420,10 +494,12 @@ export class MemoryStorage implements StorageAdapter {
 		limit: number,
 		after?: ChannelCursor,
 		query?: string,
+		includeArchived = false,
 	): Promise<ChannelPage> {
 		let count = Math.min(100, Math.max(1, limit));
 		let ordered = [...this.#channels.values()]
 			.filter(value => value.repositoryId === repositoryId)
+			.filter(value => includeArchived || !value.archivedAt)
 			.filter(value => !query || value.title.toLowerCase().includes(query.toLowerCase()))
 			.sort((left, right) =>
 				right.updatedAt.getTime() - left.updatedAt.getTime() || left.id.localeCompare(right.id)
@@ -448,10 +524,12 @@ export class MemoryStorage implements StorageAdapter {
 		repositoryId: string,
 		limit: number,
 		after?: ChannelScanCursor,
+		includeArchived = false,
 	): Promise<ChannelScanPage> {
 		let count = Math.min(100, Math.max(1, limit));
 		let ordered = [...this.#channels.values()]
 			.filter(value => value.repositoryId === repositoryId)
+			.filter(value => includeArchived || !value.archivedAt)
 			.sort((left, right) =>
 				right.createdAt.getTime() - left.createdAt.getTime() || left.id.localeCompare(right.id)
 			);
@@ -588,6 +666,12 @@ export class MemoryStorage implements StorageAdapter {
 		this.#operations.set(input.channelId, operations);
 		let repeated = operations.get(input.operationId);
 		if (repeated) return Promise.resolve({ ...repeated, repeated: true });
+		if (found.archivedAt && !input.allowArchived) {
+			throw conflict(`channel ${input.channelId} is archived`);
+		}
+		if (input.allowArchived && (input.update || input.events.length > 0)) {
+			throw conflict("archived channel maintenance must be sidecar-only");
+		}
 		if (found.revision !== input.expectedRevision) {
 			throw conflict(
 				`channel ${input.channelId} is at revision ${found.revision}, expected ${input.expectedRevision}`,
@@ -671,6 +755,7 @@ export class MemoryStorage implements StorageAdapter {
 		this.#operations.set(input.channelId, operations);
 		let repeated = operations.get(input.operationId);
 		if (repeated) return Promise.resolve({ ...repeated, repeated: true });
+		if (found.archivedAt) throw conflict(`channel ${input.channelId} is archived`);
 		if (found.revision !== input.expectedRevision) {
 			throw conflict(
 				`channel ${input.channelId} is at revision ${found.revision}, expected ${input.expectedRevision}`,

--- a/apps/server/src/storage/memory/jobs.ts
+++ b/apps/server/src/storage/memory/jobs.ts
@@ -30,6 +30,7 @@ import type { BackgroundJobStore } from "../port";
 
 type Options = {
 	channelExists: (channelId: string) => boolean;
+	channelActive: (channelId: string) => boolean;
 	assertLease: (lease: Lease) => void;
 };
 
@@ -322,6 +323,9 @@ export class MemoryBackgroundJobStore implements BackgroundJobStore {
 
 	readonly cancel = async (input: CancelBackgroundJob): Promise<BackgroundJob> => {
 		this.#options.assertLease(input.lease);
+		if (!input.allowArchived && !this.#options.channelActive(input.channelId)) {
+			throw conflict(`channel ${input.channelId} is archived`);
+		}
 		let found = this.#controlled(input, ["pending", "paused", "running"]);
 		return this.#controlTransition(found, "cancelled", input.now);
 	};
@@ -368,6 +372,24 @@ export class MemoryBackgroundJobStore implements BackgroundJobStore {
 		let found = this.#jobs.get(jobId);
 		return found?.channelId === channelId ? this.#detail(found) : undefined;
 	};
+
+	deleteChannel(channelId: string): void {
+		this.#revisions.delete(channelId);
+		for (let [targetKey, target] of this.#targets) {
+			if (target.channelId === channelId) this.#targets.delete(targetKey);
+		}
+		let jobIds = new Set<string>();
+		for (let [jobId, saved] of this.#jobs) {
+			if (saved.channelId === channelId) {
+				jobIds.add(jobId);
+				this.#jobs.delete(jobId);
+			}
+		}
+		for (let [idempotencyKey, jobId] of this.#idempotency) {
+			if (jobIds.has(jobId)) this.#idempotency.delete(idempotencyKey);
+		}
+		for (let jobId of jobIds) this.#artifacts.delete(jobId);
+	}
 
 	#write(channelId: string, held: Lease): void {
 		this.#options.assertLease(held);

--- a/apps/server/src/storage/memory/research.ts
+++ b/apps/server/src/storage/memory/research.ts
@@ -32,6 +32,7 @@ import type { ResearchWorkspaceStore } from "../port";
 
 type Options = {
 	channelExists: (channelId: string) => boolean;
+	channelActive: (channelId: string) => boolean;
 	channels: (repositoryId: string) => ChannelRecord[];
 	userExists: (userId: string) => boolean;
 	job: (channelId: string, jobId: string) => Promise<BackgroundJobDetail | undefined>;
@@ -120,6 +121,7 @@ export class MemoryResearchWorkspaceStore implements ResearchWorkspaceStore {
 				}
 				return { workspace: workspace(repeated), repeated: true };
 			}
+			this.#assertActiveChannel(input.channelId, input.lease);
 
 			this.#requireUser(input.createdBy);
 			required(input.id, "workspace id");
@@ -188,6 +190,7 @@ export class MemoryResearchWorkspaceStore implements ResearchWorkspaceStore {
 					repeated: true,
 				};
 			}
+			this.#assertActiveChannel(input.channelId, input.lease);
 			if (found.confirmedQuery !== undefined) {
 				throw conflict(`research workspace ${found.id} is already confirmed`);
 			}
@@ -256,6 +259,7 @@ export class MemoryResearchWorkspaceStore implements ResearchWorkspaceStore {
 					repeated: true,
 				};
 			}
+			this.#assertActiveChannel(input.channelId, input.lease);
 			if (found.confirmedQuery === undefined) {
 				throw conflict(`research workspace ${found.id} is not confirmed`);
 			}
@@ -427,11 +431,14 @@ export class MemoryResearchWorkspaceStore implements ResearchWorkspaceStore {
 	readonly listRepository = async (
 		repositoryId: string,
 		limit: number,
+		includeArchived = false,
 	): Promise<ResearchWorkspaceRepositoryList> => {
 		let count = Math.min(RESEARCH_REPOSITORY_WORKSPACE_LIMIT, Math.max(1, limit));
-		let orderedChannels = this.#options.channels(repositoryId).sort((left, right) =>
-			right.createdAt.getTime() - left.createdAt.getTime() || compareId(left.id, right.id)
-		);
+		let orderedChannels = this.#options.channels(repositoryId)
+			.filter(channel => includeArchived || !channel.archivedAt)
+			.sort((left, right) =>
+				right.createdAt.getTime() - left.createdAt.getTime() || compareId(left.id, right.id)
+			);
 		let workspacesByChannel = new Map<string, ResearchWorkspace[]>();
 		for (let saved of this.#workspaces.values()) {
 			let values = workspacesByChannel.get(saved.channelId) ?? [];
@@ -495,6 +502,40 @@ export class MemoryResearchWorkspaceStore implements ResearchWorkspaceStore {
 		return foundTurn && foundWorkspace?.channelId === channelId ? turn(foundTurn) : undefined;
 	};
 
+	deleteChannel(channelId: string): Promise<void> {
+		return this.#mutate(async () => {
+			let workspaceIds = new Set<string>();
+			for (let [workspaceId, saved] of this.#workspaces) {
+				if (saved.channelId === channelId) workspaceIds.add(workspaceId);
+			}
+			let turnIds = new Set<string>();
+			let messageIds = new Set<string>();
+			for (let workspaceId of workspaceIds) {
+				this.#workspaces.delete(workspaceId);
+				for (let saved of this.#turns.get(workspaceId) ?? []) turnIds.add(saved.id);
+				for (let saved of this.#messages.get(workspaceId) ?? []) messageIds.add(saved.id);
+				this.#turns.delete(workspaceId);
+				this.#messages.delete(workspaceId);
+				this.#nextOrdinals.delete(workspaceId);
+				this.#nextSequences.delete(workspaceId);
+			}
+			for (let [idempotencyKey, workspaceId] of this.#idempotency) {
+				if (workspaceIds.has(workspaceId)) this.#idempotency.delete(idempotencyKey);
+			}
+			for (let turnId of turnIds) this.#turnIds.delete(turnId);
+			for (let [requestKey, turnId] of this.#turnRequests) {
+				if (turnIds.has(turnId)) this.#turnRequests.delete(requestKey);
+			}
+			for (let messageId of messageIds) this.#messageIds.delete(messageId);
+			for (let [jobId, saved] of this.#agentMessagesByJob) {
+				if (workspaceIds.has(saved.workspaceId)) this.#agentMessagesByJob.delete(jobId);
+			}
+			for (let [jobId, linked] of this.#linkedJobs) {
+				if (turnIds.has(linked.turnId)) this.#linkedJobs.delete(jobId);
+			}
+		});
+	}
+
 	async #mutate<T>(execute: () => Promise<T>): Promise<T> {
 		let previous = this.#writeTail;
 		let next = Promise.withResolvers<void>();
@@ -512,6 +553,13 @@ export class MemoryResearchWorkspaceStore implements ResearchWorkspaceStore {
 		required(channelId, "channel id");
 		if (!this.#options.channelExists(channelId)) {
 			throw missing(`channel ${channelId} does not exist`);
+		}
+	}
+
+	#assertActiveChannel(channelId: string, held: Lease): void {
+		this.#assertChannel(channelId, held);
+		if (!this.#options.channelActive(channelId)) {
+			throw conflict(`channel ${channelId} is archived`);
 		}
 	}
 

--- a/apps/server/src/storage/model.ts
+++ b/apps/server/src/storage/model.ts
@@ -78,6 +78,7 @@ export type ChannelRecord = {
 	revision: number;
 	createdAt: Date;
 	updatedAt: Date;
+	archivedAt?: Date;
 };
 
 export type InitialChannel = Omit<
@@ -88,7 +89,7 @@ export type InitialChannel = Omit<
 export type CreateChannel =
 	& Omit<
 		ChannelRecord,
-		"slug" | "revision" | "createdAt" | "updatedAt"
+		"slug" | "revision" | "createdAt" | "updatedAt" | "archivedAt"
 	>
 	& {
 		now: Date;
@@ -103,6 +104,16 @@ export type RenameChannel = {
 };
 
 export type RenameResult = {
+	channel: ChannelRecord;
+	changed: boolean;
+};
+
+export type ChannelArchiveInput = {
+	id: string;
+	now: Date;
+};
+
+export type ChannelArchiveResult = {
 	channel: ChannelRecord;
 	changed: boolean;
 };
@@ -197,6 +208,8 @@ export type CommitChannel = {
 	sidecar?: JsonValue;
 	events: EventInput[];
 	now: Date;
+	/** Lifecycle and shutdown maintenance may persist after document archival. */
+	allowArchived?: boolean;
 };
 
 export type CommitResult = {
@@ -394,7 +407,9 @@ export type ControlBackgroundJob = {
 	lease: Lease;
 };
 
-export type CancelBackgroundJob = Omit<ControlBackgroundJob, "expectedRevision">;
+export type CancelBackgroundJob = Omit<ControlBackgroundJob, "expectedRevision"> & {
+	allowArchived?: boolean;
+};
 
 export type PauseBackgroundJob = ControlBackgroundJob & { reason: string };
 export type ResumeBackgroundJob = ControlBackgroundJob & { availableAt: Date };

--- a/apps/server/src/storage/port.ts
+++ b/apps/server/src/storage/port.ts
@@ -13,6 +13,8 @@ import type {
 	BackgroundJobPage,
 	CancelBackgroundJob,
 	ChannelAgent,
+	ChannelArchiveInput,
+	ChannelArchiveResult,
 	ChannelPage,
 	ChannelRecord,
 	ChannelScanCursor,
@@ -99,11 +101,25 @@ export interface ChannelStore {
 	get(id: string): Promise<ChannelRecord | undefined>;
 	resolve(repositoryId: string, slug: string): Promise<ChannelRecord | undefined>;
 	rename(channel: RenameChannel): Promise<RenameResult>;
-	list(repositoryId: string, limit: number, after?: {
-		updatedAt: Date;
-		id: string;
-	}, query?: string): Promise<ChannelPage>;
-	scan(repositoryId: string, limit: number, after?: ChannelScanCursor): Promise<ChannelScanPage>;
+	archive(input: ChannelArchiveInput): Promise<ChannelArchiveResult>;
+	restore(input: ChannelArchiveInput): Promise<ChannelArchiveResult>;
+	delete(id: string): Promise<boolean>;
+	list(
+		repositoryId: string,
+		limit: number,
+		after?: {
+			updatedAt: Date;
+			id: string;
+		},
+		query?: string,
+		includeArchived?: boolean,
+	): Promise<ChannelPage>;
+	scan(
+		repositoryId: string,
+		limit: number,
+		after?: ChannelScanCursor,
+		includeArchived?: boolean,
+	): Promise<ChannelScanPage>;
 	claimAgentOwner(channelId: string, sessionId: string, now: Date): Promise<AgentState>;
 	clearAgentOwner(
 		channelId: string,
@@ -157,7 +173,11 @@ export interface ResearchWorkspaceStore {
 		input: AppendResearchAgentMessage,
 	): Promise<AppendResearchAgentMessageResult>;
 	list(channelId: string, limit: number): Promise<ResearchWorkspaceSummary[]>;
-	listRepository(repositoryId: string, limit: number): Promise<ResearchWorkspaceRepositoryList>;
+	listRepository(
+		repositoryId: string,
+		limit: number,
+		includeArchived?: boolean,
+	): Promise<ResearchWorkspaceRepositoryList>;
 	get(channelId: string, workspaceId: string): Promise<ResearchWorkspaceDetail | undefined>;
 	findTurnByJob(channelId: string, jobId: string): Promise<ResearchTurn | undefined>;
 }

--- a/apps/server/src/storage/postgres/adapter.test.ts
+++ b/apps/server/src/storage/postgres/adapter.test.ts
@@ -44,10 +44,10 @@ if (url) {
 		let storage = new PostgresStorage(url);
 		let suffix = crypto.randomUUID();
 		let channelId = `job-channel-${suffix}`;
+		let userId = `job-user-${suffix}`;
 		try {
 			await storage.migrate();
 			let now = new Date();
-			let userId = `job-user-${suffix}`;
 			await storage.users.put({ id: userId, login: "jobs", avatarUrl: "", now });
 			await storage.channels.create({
 				id: channelId,
@@ -133,14 +133,19 @@ if (url) {
 				now: new Date(now.getTime() + 6),
 				lease: lease!,
 			});
+			await storage.navigation.setLastDocument(userId, channelId, new Date(now.getTime() + 7));
+			await storage.channels.archive({ id: channelId, now: new Date(now.getTime() + 8) });
+			expect(await storage.channels.delete(channelId)).toBe(true);
 		} finally {
 			await storage.close();
 		}
 
 		let sql = new SQL(url);
 		try {
-			await sql`DELETE FROM channels WHERE id = ${channelId}`;
 			let [counts] = await sql<{
+				documents: number;
+				slugs: number;
+				state: number;
 				channels: number;
 				targets: number;
 				jobs: number;
@@ -148,17 +153,25 @@ if (url) {
 				workspaces: number;
 				turns: number;
 				messages: number;
+				navigationRows: number;
 			}[]>`
 				SELECT
+					(SELECT count(*)::int FROM channels WHERE id = ${channelId}) AS documents,
+					(SELECT count(*)::int FROM channel_slugs WHERE channel_id = ${channelId}) AS slugs,
+					(SELECT count(*)::int FROM channel_state WHERE channel_id = ${channelId}) AS state,
 					(SELECT count(*)::int FROM background_job_channels WHERE channel_id = ${channelId}) AS channels,
 					(SELECT count(*)::int FROM background_job_targets WHERE channel_id = ${channelId}) AS targets,
 					(SELECT count(*)::int FROM background_jobs WHERE channel_id = ${channelId}) AS jobs,
 					(SELECT count(*)::int FROM background_job_artifacts WHERE job_id = ${`job-${suffix}`}) AS artifacts,
 					(SELECT count(*)::int FROM research_workspaces WHERE channel_id = ${channelId}) AS workspaces,
 					(SELECT count(*)::int FROM research_turns WHERE workspace_id = ${`workspace-${suffix}`}) AS turns,
-					(SELECT count(*)::int FROM research_messages WHERE workspace_id = ${`workspace-${suffix}`}) AS messages
+					(SELECT count(*)::int FROM research_messages WHERE workspace_id = ${`workspace-${suffix}`}) AS messages,
+					(SELECT count(*)::int FROM user_navigation WHERE user_id = ${userId} AND last_document_id IS NULL) AS "navigationRows"
 			`;
 			expect(counts).toEqual({
+				documents: 0,
+				slugs: 0,
+				state: 0,
 				channels: 0,
 				targets: 0,
 				jobs: 0,
@@ -166,6 +179,7 @@ if (url) {
 				workspaces: 0,
 				turns: 0,
 				messages: 0,
+				navigationRows: 1,
 			});
 		} finally {
 			await sql.close();
@@ -445,6 +459,7 @@ if (url) {
 				"007_research_workspaces",
 				"008_research_repository_listing",
 				"009_navigation_revision",
+				"010_document_archival",
 			]);
 			expect(await sql<{ table: string | null }[]>`SELECT to_regclass('channel_slugs') AS table`)
 				.toEqual([

--- a/apps/server/src/storage/postgres/adapter.ts
+++ b/apps/server/src/storage/postgres/adapter.ts
@@ -11,6 +11,8 @@ import type { TransactionSQL } from "bun";
 import type {
 	AgentState,
 	ChannelAgent,
+	ChannelArchiveInput,
+	ChannelArchiveResult,
 	ChannelCursor,
 	ChannelPage,
 	ChannelRecord,
@@ -75,6 +77,7 @@ type ChannelRow = {
 	nextSequence?: Integer;
 	createdAt: Timestamp;
 	updatedAt: Timestamp;
+	archivedAt: Timestamp | null;
 };
 
 type SnapshotRow = {
@@ -133,6 +136,7 @@ type OperationRow = {
 type ChannelLockRow = {
 	revision: Integer;
 	nextSequence: Integer;
+	archivedAt: Timestamp | null;
 };
 
 function date(value: Timestamp, field: string): Date {
@@ -194,12 +198,14 @@ function session(row: SessionRow): WebSession {
 
 function channel(row: ChannelRow): ChannelRecord {
 	if (!row.slug) throw corrupt(`channel ${row.id} has no canonical slug`);
+	let { archivedAt, ...record } = row;
 	return {
-		...row,
+		...record,
 		slug: row.slug,
 		revision: integer(row.revision, "channel revision"),
 		createdAt: date(row.createdAt, "channel creation time"),
 		updatedAt: date(row.updatedAt, "channel update time"),
+		...(archivedAt === null ? {} : { archivedAt: date(archivedAt, "channel archive time") }),
 	};
 }
 
@@ -294,7 +300,8 @@ const CHANNEL_COLUMNS = `
 	channels.created_by AS "createdBy",
 	channels.revision,
 	channels.created_at AS "createdAt",
-	channels.updated_at AS "updatedAt"
+	channels.updated_at AS "updatedAt",
+	channels.archived_at AS "archivedAt"
 `;
 
 const CHANNEL_RETURNING = `
@@ -306,7 +313,8 @@ const CHANNEL_RETURNING = `
 	created_by AS "createdBy",
 	revision,
 	created_at AS "createdAt",
-	updated_at AS "updatedAt"
+	updated_at AS "updatedAt",
+	archived_at AS "archivedAt"
 `;
 
 const SNAPSHOT_COLUMNS = `
@@ -514,9 +522,13 @@ export class PostgresStorage implements StorageAdapter {
 				return found ? channel(found) : undefined;
 			}),
 		rename: input => this.#renameChannel(input),
-		list: (repositoryId, limit, after, query) =>
-			this.#listChannels(repositoryId, limit, after, query),
-		scan: (repositoryId, limit, after) => this.#scanChannels(repositoryId, limit, after),
+		archive: input => this.#setChannelArchived(input, true),
+		restore: input => this.#setChannelArchived(input, false),
+		delete: id => this.#deleteChannel(id),
+		list: (repositoryId, limit, after, query, includeArchived) =>
+			this.#listChannels(repositoryId, limit, after, query, includeArchived),
+		scan: (repositoryId, limit, after, includeArchived) =>
+			this.#scanChannels(repositoryId, limit, after, includeArchived),
 		claimAgentOwner: (channelId, sessionId, now) =>
 			this.#claimAgentOwner(channelId, sessionId, now),
 		clearAgentOwner: (channelId, expectedSessionId, expectedGeneration, now) =>
@@ -625,6 +637,7 @@ export class PostgresStorage implements StorageAdapter {
 				`;
 				if (!current) throw missing(`channel ${input.id} does not exist`);
 				let existing = channel(current);
+				if (existing.archivedAt) throw conflict(`channel ${input.id} is archived`);
 				if (existing.title === input.title) {
 					return { channel: existing, changed: false };
 				}
@@ -646,6 +659,62 @@ export class PostgresStorage implements StorageAdapter {
 					input.now,
 				);
 				return { channel: channel({ ...saved, slug }), changed: true };
+			}));
+	}
+
+	#setChannelArchived(
+		input: ChannelArchiveInput,
+		archived: boolean,
+	): Promise<ChannelArchiveResult> {
+		return this.#run(
+			archived ? "archive channel" : "restore channel",
+			() =>
+				this.#sql.begin(async transaction => {
+					let [current] = await transaction<ChannelRow[]>`
+					SELECT ${transaction.unsafe(CHANNEL_COLUMNS)}
+					FROM channels
+					WHERE id = ${input.id}
+					FOR UPDATE
+				`;
+					if (!current) throw missing(`channel ${input.id} does not exist`);
+					let existing = channel(current);
+					if ((existing.archivedAt !== undefined) === archived) {
+						return { channel: existing, changed: false };
+					}
+					let updatedAt = input.now > existing.updatedAt
+						? input.now
+						: new Date(existing.updatedAt.getTime() + 1);
+					let archivedAt = archived ? updatedAt : null;
+					let [saved] = await transaction<ChannelRow[]>`
+					UPDATE channels
+					SET archived_at = ${archivedAt}, updated_at = ${updatedAt}
+					WHERE id = ${input.id}
+					RETURNING ${transaction.unsafe(CHANNEL_RETURNING)}
+				`;
+					if (!saved) throw corrupt("changing channel archival returned no record");
+					return { channel: channel({ ...saved, slug: existing.slug }), changed: true };
+				}),
+		);
+	}
+
+	#deleteChannel(id: string): Promise<boolean> {
+		return this.#run("delete archived channel", () =>
+			this.#sql.begin(async transaction => {
+				let [current] = await transaction<{ archivedAt: Timestamp | null }[]>`
+					SELECT archived_at AS "archivedAt"
+					FROM channels
+					WHERE id = ${id}
+					FOR UPDATE
+				`;
+				if (!current) return false;
+				if (current.archivedAt === null) {
+					throw conflict(`channel ${id} must be archived before deletion`);
+				}
+				let deleted = await transaction<{ id: string }[]>`
+					DELETE FROM channels WHERE id = ${id} RETURNING id
+				`;
+				if (deleted.length !== 1) throw corrupt("deleting a channel returned no record");
+				return true;
 			}));
 	}
 
@@ -696,6 +765,7 @@ export class PostgresStorage implements StorageAdapter {
 		limit: number,
 		after?: ChannelCursor,
 		query?: string,
+		includeArchived = false,
 	): Promise<ChannelPage> {
 		return this.#run("list channels", async () => {
 			let count = Math.min(100, Math.max(1, limit));
@@ -705,6 +775,7 @@ export class PostgresStorage implements StorageAdapter {
 					SELECT ${this.#sql.unsafe(CHANNEL_COLUMNS)}
 					FROM channels
 					WHERE repository_id = ${repositoryId}
+						AND (${includeArchived} OR archived_at IS NULL)
 						AND (${!query} OR title ILIKE ${pattern} ESCAPE '\\')
 						AND (
 							updated_at < ${after.updatedAt}
@@ -717,6 +788,7 @@ export class PostgresStorage implements StorageAdapter {
 					SELECT ${this.#sql.unsafe(CHANNEL_COLUMNS)}
 					FROM channels
 					WHERE repository_id = ${repositoryId}
+						AND (${includeArchived} OR archived_at IS NULL)
 						AND (${!query} OR title ILIKE ${pattern} ESCAPE '\\')
 					ORDER BY updated_at DESC, id ASC
 					LIMIT ${count + 1}
@@ -735,6 +807,7 @@ export class PostgresStorage implements StorageAdapter {
 		repositoryId: string,
 		limit: number,
 		after?: ChannelScanCursor,
+		includeArchived = false,
 	): Promise<ChannelScanPage> {
 		return this.#run("scan channels", async () => {
 			let count = Math.min(100, Math.max(1, limit));
@@ -743,6 +816,7 @@ export class PostgresStorage implements StorageAdapter {
 					SELECT ${this.#sql.unsafe(CHANNEL_COLUMNS)}
 					FROM channels
 					WHERE repository_id = ${repositoryId}
+						AND (${includeArchived} OR archived_at IS NULL)
 						AND (
 							created_at < ${after.createdAt}
 							OR (created_at = ${after.createdAt} AND id > ${after.id})
@@ -754,6 +828,7 @@ export class PostgresStorage implements StorageAdapter {
 					SELECT ${this.#sql.unsafe(CHANNEL_COLUMNS)}
 					FROM channels
 					WHERE repository_id = ${repositoryId}
+						AND (${includeArchived} OR archived_at IS NULL)
 					ORDER BY created_at DESC, id ASC
 					LIMIT ${count + 1}
 				`;
@@ -946,7 +1021,7 @@ export class PostgresStorage implements StorageAdapter {
 			this.#sql.begin(async transaction => {
 				await this.#assertLease(transaction, input.lease);
 				let [locked] = await transaction<ChannelLockRow[]>`
-				SELECT revision, next_sequence AS "nextSequence"
+				SELECT revision, next_sequence AS "nextSequence", archived_at AS "archivedAt"
 				FROM channels
 				WHERE id = ${input.channelId}
 				FOR UPDATE
@@ -963,6 +1038,12 @@ export class PostgresStorage implements StorageAdapter {
 						sequence: integer(previous.sequence, "operation sequence"),
 						repeated: true,
 					};
+				}
+				if (locked.archivedAt !== null && !input.allowArchived) {
+					throw conflict(`channel ${input.channelId} is archived`);
+				}
+				if (input.allowArchived && (input.update || input.events.length > 0)) {
+					throw conflict("archived channel maintenance must be sidecar-only");
 				}
 				let current = integer(locked.revision, "channel revision");
 				if (current !== input.expectedRevision) {
@@ -1072,7 +1153,7 @@ export class PostgresStorage implements StorageAdapter {
 			this.#sql.begin(async transaction => {
 				await this.#assertLease(transaction, input.lease);
 				let [locked] = await transaction<ChannelLockRow[]>`
-					SELECT revision, next_sequence AS "nextSequence"
+					SELECT revision, next_sequence AS "nextSequence", archived_at AS "archivedAt"
 					FROM channels
 					WHERE id = ${input.channelId}
 					FOR UPDATE
@@ -1089,6 +1170,9 @@ export class PostgresStorage implements StorageAdapter {
 						sequence: integer(previous.sequence, "operation sequence"),
 						repeated: true,
 					};
+				}
+				if (locked.archivedAt !== null) {
+					throw conflict(`channel ${input.channelId} is archived`);
 				}
 				let current = integer(locked.revision, "channel revision");
 				if (current !== input.expectedRevision) {

--- a/apps/server/src/storage/postgres/jobs.ts
+++ b/apps/server/src/storage/postgres/jobs.ts
@@ -671,6 +671,16 @@ export class PostgresBackgroundJobStore implements BackgroundJobStore {
 		return this.#run(action, () =>
 			this.#sql.begin(async transaction => {
 				await this.#fence(transaction, input.lease);
+				if (action === "cancel background job" && !(input as CancelBackgroundJob).allowArchived) {
+					let [channel] = await transaction<{ archived: boolean }[]>`
+						SELECT archived_at IS NOT NULL AS archived
+						FROM channels
+						WHERE id = ${input.channelId}
+						FOR UPDATE
+					`;
+					if (!channel) throw missing(`channel ${input.channelId} does not exist`);
+					if (channel.archived) throw conflict(`channel ${input.channelId} is archived`);
+				}
 				let found = await this.#lockControl(transaction, input, allowed);
 				let revision = await this.#bump(transaction, found.channelId);
 				let [saved] = await transaction<JobRow[]>`

--- a/apps/server/src/storage/postgres/migrations.ts
+++ b/apps/server/src/storage/postgres/migrations.ts
@@ -42,6 +42,9 @@ const MIGRATIONS = [{
 }, {
 	id: "009_navigation_revision",
 	path: join(import.meta.dir, "migrations/009_navigation_revision.sql"),
+}, {
+	id: "010_document_archival",
+	path: join(import.meta.dir, "migrations/010_document_archival.sql"),
 }] satisfies Migration[];
 
 /** Navigation shipped as 002 before document slugs claimed that number on main. */

--- a/apps/server/src/storage/postgres/migrations/010_document_archival.sql
+++ b/apps/server/src/storage/postgres/migrations/010_document_archival.sql
@@ -1,0 +1,6 @@
+ALTER TABLE channels
+	ADD COLUMN archived_at timestamptz;
+
+CREATE INDEX channels_repository_active_listing
+	ON channels (repository_id, updated_at DESC, id ASC)
+	WHERE archived_at IS NULL;

--- a/apps/server/src/storage/postgres/navigation.ts
+++ b/apps/server/src/storage/postgres/navigation.ts
@@ -122,7 +122,9 @@ export class PostgresNavigationStore implements NavigationStore {
 				FROM users
 				LEFT JOIN user_projects ON user_projects.user_id = users.id
 				LEFT JOIN user_navigation ON user_navigation.user_id = users.id
-				LEFT JOIN channels AS selected ON selected.id = user_navigation.last_document_id
+				LEFT JOIN channels AS selected
+					ON selected.id = user_navigation.last_document_id
+					AND selected.archived_at IS NULL
 				WHERE users.id = ${userId}
 				ORDER BY user_projects.position ASC
 			`;
@@ -187,6 +189,7 @@ export class PostgresNavigationStore implements NavigationStore {
 					SELECT channels.id
 					FROM channels
 					WHERE channels.repository_id = user_projects.repository_id
+						AND channels.archived_at IS NULL
 					ORDER BY channels.updated_at DESC, channels.id ASC
 					LIMIT 1
 				) AS selected
@@ -222,7 +225,11 @@ export class PostgresNavigationStore implements NavigationStore {
 		documentId: string | undefined,
 		now: Date,
 	): Promise<UserNavigation> =>
-		this.#run("save navigation", () => this.#saveNavigation(this.#sql, userId, documentId, now));
+		this.#run("save navigation", () =>
+			this.#sql.begin(async transaction => {
+				if (documentId) await this.#requireActiveDocument(transaction, documentId);
+				return this.#saveNavigation(transaction, userId, documentId, now);
+			}));
 
 	readonly setLastDocumentIfCurrent = (
 		userId: string,
@@ -232,6 +239,7 @@ export class PostgresNavigationStore implements NavigationStore {
 	): Promise<CompareNavigationResult> =>
 		this.#run("compare and save navigation", () =>
 			this.#sql.begin(async transaction => {
+				if (documentId) await this.#requireActiveDocument(transaction, documentId);
 				let saved: NavigationRow | undefined;
 				if (expectedRevision === undefined) {
 					[saved] = await transaction<NavigationRow[]>`
@@ -280,6 +288,7 @@ export class PostgresNavigationStore implements NavigationStore {
 			JOIN channels
 				ON channels.id = ${input.documentId}
 				AND channels.repository_id = user_projects.repository_id
+				AND channels.archived_at IS NULL
 			WHERE user_projects.user_id = ${input.userId}
 				AND user_projects.repository_id = ${input.repositoryId}
 			ON CONFLICT (user_id) DO UPDATE SET
@@ -355,11 +364,24 @@ export class PostgresNavigationStore implements NavigationStore {
 		documentId: string,
 		repositoryId: string,
 	): Promise<void> {
-		let [found] = await transaction<{ id: string }[]>`
-			SELECT id FROM channels
-			WHERE id = ${documentId} AND repository_id = ${repositoryId}
+		await this.#requireActiveDocument(transaction, documentId, repositoryId);
+	}
+
+	async #requireActiveDocument(
+		transaction: TransactionSQL,
+		documentId: string,
+		repositoryId?: string,
+	): Promise<void> {
+		let [found] = await transaction<{ archivedAt: Timestamp | null }[]>`
+			SELECT archived_at AS "archivedAt" FROM channels
+			WHERE id = ${documentId}
+				AND (${repositoryId === undefined} OR repository_id = ${repositoryId ?? ""})
 			FOR KEY SHARE
 		`;
-		if (!found) throw missing(`channel ${documentId} does not exist in repository ${repositoryId}`);
+		if (!found) {
+			let suffix = repositoryId ? ` in repository ${repositoryId}` : "";
+			throw missing(`channel ${documentId} does not exist${suffix}`);
+		}
+		if (found.archivedAt !== null) throw conflict(`channel ${documentId} is archived`);
 	}
 }

--- a/apps/server/src/storage/postgres/research.ts
+++ b/apps/server/src/storage/postgres/research.ts
@@ -361,10 +361,7 @@ export class PostgresResearchWorkspaceStore implements ResearchWorkspaceStore {
 				let channelId = required(input.channelId, "channel id");
 				let idempotencyKey = required(input.idempotencyKey, "workspace idempotency key");
 				let fingerprint = required(input.fingerprint, "workspace fingerprint");
-				let [parent] = await transaction<{ id: string }[]>`
-					SELECT id FROM channels WHERE id = ${channelId} FOR UPDATE
-				`;
-				if (!parent) throw missing(`channel ${channelId} does not exist`);
+				let archived = await this.#lockChannelArchiveState(transaction, channelId);
 				let [existing] = await transaction<WorkspaceRow[]>`
 					SELECT ${transaction.unsafe(WORKSPACE_COLUMNS)}
 					FROM research_workspaces
@@ -378,6 +375,7 @@ export class PostgresResearchWorkspaceStore implements ResearchWorkspaceStore {
 					}
 					return { workspace: repeated, repeated: true };
 				}
+				if (archived) throw conflict(`channel ${channelId} is archived`);
 
 				let id = required(input.id, "workspace id");
 				let title = required(input.title, "workspace title");
@@ -421,6 +419,7 @@ export class PostgresResearchWorkspaceStore implements ResearchWorkspaceStore {
 					input.confirmedByHandle,
 					"confirming member handle",
 				);
+				let archived = await this.#lockChannelArchiveState(transaction, channelId);
 				let locked = await this.#lockWorkspace(transaction, channelId, workspaceId);
 				let repeated = await this.#turnForRequest(transaction, workspaceId, requestId);
 				if (repeated) {
@@ -439,6 +438,7 @@ export class PostgresResearchWorkspaceStore implements ResearchWorkspaceStore {
 						repeated: true,
 					};
 				}
+				if (archived) throw conflict(`channel ${channelId} is archived`);
 				if (locked.workspace.confirmedQuery !== undefined) {
 					throw conflict(`research workspace ${workspaceId} is already confirmed`);
 				}
@@ -502,6 +502,7 @@ export class PostgresResearchWorkspaceStore implements ResearchWorkspaceStore {
 				if (input.kind !== "follow-up" && input.kind !== "search-more") {
 					throw conflict("research appended turn kind is invalid");
 				}
+				let archived = await this.#lockChannelArchiveState(transaction, channelId);
 				let locked = await this.#lockWorkspace(transaction, channelId, workspaceId);
 				let repeated = await this.#turnForRequest(transaction, workspaceId, requestId);
 				if (repeated) {
@@ -520,6 +521,7 @@ export class PostgresResearchWorkspaceStore implements ResearchWorkspaceStore {
 						repeated: true,
 					};
 				}
+				if (archived) throw conflict(`channel ${channelId} is archived`);
 				if (locked.workspace.confirmedQuery === undefined) {
 					throw conflict(`research workspace ${workspaceId} is not confirmed`);
 				}
@@ -713,6 +715,7 @@ export class PostgresResearchWorkspaceStore implements ResearchWorkspaceStore {
 	readonly listRepository = (
 		repositoryId: string,
 		limit: number,
+		includeArchived = false,
 	): Promise<ResearchWorkspaceRepositoryList> =>
 		this.#run(
 			"list repository research workspaces",
@@ -733,6 +736,7 @@ export class PostgresResearchWorkspaceStore implements ResearchWorkspaceStore {
 							) AS slug
 						FROM channels
 						WHERE channels.repository_id = ${repositoryId}
+							AND (${includeArchived} OR channels.archived_at IS NULL)
 						ORDER BY channels.created_at DESC, channels.id ASC
 						LIMIT ${RESEARCH_REPOSITORY_CHANNEL_LIMIT + 1}
 					`;
@@ -744,6 +748,7 @@ export class PostgresResearchWorkspaceStore implements ResearchWorkspaceStore {
 							SELECT channels.id, channels.created_at
 							FROM channels
 							WHERE channels.repository_id = ${repositoryId}
+								AND (${includeArchived} OR channels.archived_at IS NULL)
 							ORDER BY channels.created_at DESC, channels.id ASC
 							LIMIT ${RESEARCH_REPOSITORY_CHANNEL_LIMIT}
 						)
@@ -872,6 +877,20 @@ export class PostgresResearchWorkspaceStore implements ResearchWorkspaceStore {
 			throw missing(`research workspace ${workspaceId} does not exist in channel ${channelId}`);
 		}
 		return lockedWorkspace(row);
+	}
+
+	async #lockChannelArchiveState(
+		transaction: TransactionSQL,
+		channelId: string,
+	): Promise<boolean> {
+		let [row] = await transaction<{ archivedAt: Timestamp | null }[]>`
+			SELECT archived_at AS "archivedAt"
+			FROM channels
+			WHERE id = ${channelId}
+			FOR UPDATE
+		`;
+		if (!row) throw missing(`channel ${channelId} does not exist`);
+		return row.archivedAt !== null;
 	}
 
 	async #lockTurn(

--- a/apps/server/src/tasks/plan-graphs.ts
+++ b/apps/server/src/tasks/plan-graphs.ts
@@ -96,7 +96,7 @@ export function reportImplementationLifecycle(
 		plan.execution = result.state.execution;
 		plan.lifecycle = result.state.lifecycle;
 		try {
-			await persistExclusive(plan);
+			await persistExclusive(plan, true);
 		} catch {
 			plan.graph = previous.graph;
 			plan.execution = previous.execution;

--- a/apps/server/src/wire.ts
+++ b/apps/server/src/wire.ts
@@ -27,7 +27,9 @@ export type SocketData = Identity & {
 	channelTitle: string;
 	channelSlug: string;
 	channelUpdatedAt: string;
+	channelArchivedAt?: string;
 	canEdit: boolean;
+	canManage: boolean;
 	principalId: string;
 	sessionId: string;
 	authorizedUntil: number;

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { archiveChannel, channels, deleteChannel, restoreChannel } from "./api";
+
+let originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+describe("document lifecycle API", () => {
+	it("binds catalogue mode and uses the archive, restore, and delete contracts", async () => {
+		let requests: Array<{ method: string; path: string }> = [];
+		globalThis.fetch = Object.assign(
+			async (input: string | URL | Request, init?: RequestInit) => {
+				requests.push({ method: init?.method ?? "GET", path: String(input) });
+				return init?.method === "DELETE"
+					? new Response(null, { status: 204 })
+					: Response.json({});
+			},
+			{ preconnect: originalFetch.preconnect },
+		) as typeof fetch;
+
+		await channels("octo org", "score/card", {
+			cursor: "cursor:1",
+			includeArchived: true,
+			query: "release plan",
+		});
+		await channels("octo-org", "score", { includeArchived: false });
+		await archiveChannel("channel/one");
+		await restoreChannel("channel/one");
+		await deleteChannel("channel/one");
+
+		expect(requests).toEqual([{
+			method: "GET",
+			path:
+				"/api/repositories/octo%20org/score%2Fcard/channels?cursor=cursor%3A1&query=release+plan&includeArchived=true",
+		}, {
+			method: "GET",
+			path: "/api/repositories/octo-org/score/channels",
+		}, {
+			method: "POST",
+			path: "/api/channels/channel%2Fone/archive",
+		}, {
+			method: "POST",
+			path: "/api/channels/channel%2Fone/restore",
+		}, {
+			method: "DELETE",
+			path: "/api/channels/channel%2Fone",
+		}]);
+	});
+});

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -36,6 +36,7 @@ export type Channel = {
 	revision: number;
 	createdAt: string;
 	updatedAt: string;
+	archivedAt?: string;
 };
 
 export type RepositoryPage = {
@@ -80,7 +81,15 @@ export type ChannelPage = {
 export type ChannelDetail = {
 	repository: Repository;
 	canEdit: boolean;
+	canManage: boolean;
 	channel: Channel;
+};
+
+export type ChannelListOptions = {
+	cursor?: string;
+	query?: string;
+	includeArchived?: boolean;
+	signal?: AbortSignal;
 };
 
 export type ResearchParentChannel = Pick<
@@ -209,19 +218,18 @@ export function installationRepositories(
 export function channels(
 	owner: string,
 	repository: string,
-	cursor?: string,
-	query?: string,
-	signal?: AbortSignal,
+	options: ChannelListOptions = {},
 ): Promise<ChannelPage> {
 	let parameters = new URLSearchParams();
-	if (cursor) parameters.set("cursor", cursor);
-	if (query) parameters.set("query", query);
+	if (options.cursor) parameters.set("cursor", options.cursor);
+	if (options.query) parameters.set("query", options.query);
+	if (options.includeArchived) parameters.set("includeArchived", "true");
 	let suffix = parameters.size ? `?${parameters}` : "";
 	return response(
 		`/api/repositories/${encodeURIComponent(owner)}/${
 			encodeURIComponent(repository)
 		}/channels${suffix}`,
-		{ signal },
+		{ signal: options.signal },
 	);
 }
 
@@ -271,11 +279,13 @@ export function repositoryResearchWorkspaces(
 	owner: string,
 	repository: string,
 	signal?: AbortSignal,
+	includeArchived = false,
 ): Promise<RepositoryResearchPage> {
+	let suffix = includeArchived ? "?includeArchived=true" : "";
 	return response(
 		`/api/repositories/${encodeURIComponent(owner)}/${
 			encodeURIComponent(repository)
-		}/research-workspaces`,
+		}/research-workspaces${suffix}`,
 		{ signal },
 	);
 }
@@ -368,6 +378,18 @@ export function renameChannel(id: string, title: string): Promise<ChannelDetail>
 		headers: { "content-type": "application/json" },
 		body: JSON.stringify({ title }),
 	});
+}
+
+export function archiveChannel(id: string): Promise<ChannelDetail> {
+	return response(`/api/channels/${encodeURIComponent(id)}/archive`, { method: "POST" });
+}
+
+export function restoreChannel(id: string): Promise<ChannelDetail> {
+	return response(`/api/channels/${encodeURIComponent(id)}/restore`, { method: "POST" });
+}
+
+export function deleteChannel(id: string): Promise<void> {
+	return response(`/api/channels/${encodeURIComponent(id)}`, { method: "DELETE" });
 }
 
 export async function resetAgent(id: string): Promise<void> {

--- a/apps/web/src/channel-recovery.test.ts
+++ b/apps/web/src/channel-recovery.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
 
-import { readChannelRecovery, readDocumentRecovery, rememberChannel } from "./channel-recovery";
+import {
+	forgetChannel,
+	readChannelRecovery,
+	readDocumentRecovery,
+	rememberChannel,
+} from "./channel-recovery";
 
 class MemoryStorage implements Storage {
 	readonly #values = new Map<string, string>();
@@ -67,6 +72,27 @@ describe("channel recovery context", () => {
 		expect(readChannelRecovery("U_octocat", channel.id, storage)?.channel.title).toBe(
 			"Launch plan",
 		);
+	});
+
+	it("forgets both recovery addresses after deletion", () => {
+		let storage = new MemoryStorage();
+		rememberChannel("U_octocat", channel, repository, storage);
+		forgetChannel("U_octocat", {
+			...channel,
+			repositoryOwner: repository.owner,
+			repositoryName: repository.name,
+		}, storage);
+
+		expect(readChannelRecovery("U_octocat", channel.id, storage)).toBeUndefined();
+		expect(
+			readDocumentRecovery(
+				"U_octocat",
+				repository.owner,
+				repository.name,
+				channel.slug,
+				storage,
+			),
+		).toBeUndefined();
 	});
 
 	it("does not return another channel's context", () => {

--- a/apps/web/src/channel-recovery.ts
+++ b/apps/web/src/channel-recovery.ts
@@ -61,6 +61,29 @@ export function rememberChannel(
 	}
 }
 
+export function forgetChannel(
+	userId: string,
+	channel: Pick<Api.Channel, "id" | "repositoryOwner" | "repositoryName" | "slug">,
+	storage: Storage = sessionStorage,
+): void {
+	try {
+		let userPathPrefix = `${PATH_KEY}${encodeURIComponent(userId)}:`;
+		let keys = Array.from({ length: storage.length }, (_, index) => storage.key(index))
+			.filter((key): key is string => !!key);
+		for (let key of keys) {
+			if (key === `${KEY}${encodeURIComponent(userId)}:${channel.id}`) {
+				storage.removeItem(key);
+				continue;
+			}
+			if (!key.startsWith(userPathPrefix)) continue;
+			let value = JSON.parse(storage.getItem(key) ?? "null") as unknown;
+			if (recovery(value, channel.id)) storage.removeItem(key);
+		}
+	} catch {
+		// Recovery cleanup must not prevent deletion from completing locally.
+	}
+}
+
 export function readDocumentRecovery(
 	userId: string,
 	owner: string,

--- a/apps/web/src/chat/reference-picker.test.ts
+++ b/apps/web/src/chat/reference-picker.test.ts
@@ -145,8 +145,9 @@ describe("reference picker requests", () => {
 			"current",
 			new AbortController().signal,
 			{
-				channels: async (_owner, _repository, cursor) => {
-					calls.push(cursor);
+				channels: async (_owner, _repository, options) => {
+					calls.push(options?.cursor);
+					expect(options?.includeArchived).toBe(false);
 					let page = pages[calls.length - 1]!;
 					return { repository: REPOSITORY, canEdit: true, ...page };
 				},

--- a/apps/web/src/chat/reference-picker.tsx
+++ b/apps/web/src/chat/reference-picker.tsx
@@ -79,9 +79,12 @@ export async function searchReferenceTargets(
 			let page = await api.channels(
 				repository.owner,
 				repository.name,
-				cursor,
-				trigger.query || undefined,
-				signal,
+				{
+					cursor,
+					includeArchived: false,
+					query: trigger.query || undefined,
+					signal,
+				},
 			);
 			for (let [index, channel] of page.channels.entries()) {
 				if (channel.id !== room) channels.set(channel.id, channel);

--- a/apps/web/src/delete-document-dialog.tsx
+++ b/apps/web/src/delete-document-dialog.tsx
@@ -1,0 +1,72 @@
+import { useRef, useState } from "react";
+
+import * as Api from "./api";
+import { NavigationDialog } from "./navigation-dialog";
+
+export function DeleteDocumentDialog(
+	{
+		channel,
+		onDeleted,
+		onDismiss,
+	}: {
+		channel: Api.Channel;
+		onDeleted: () => void;
+		onDismiss: () => void;
+	},
+) {
+	let cancel = useRef<HTMLButtonElement>(null);
+	let [deleting, setDeleting] = useState(false);
+	let [error, setError] = useState<unknown>();
+	let dismiss = () => {
+		if (!deleting) onDismiss();
+	};
+	let remove = async () => {
+		if (deleting) return;
+		setDeleting(true);
+		setError(undefined);
+		try {
+			await Api.deleteChannel(channel.id);
+			onDeleted();
+		} catch (reason) {
+			setError(reason);
+			setDeleting(false);
+		}
+	};
+
+	return (
+		<NavigationDialog
+			initialFocus={cancel}
+			onDismiss={dismiss}
+			title="Delete document permanently?"
+		>
+			<p className="mt-3 text-sm text-text-secondary">
+				<strong className="font-semibold text-text-primary">{channel.title}</strong>{" "}
+				and its research workspaces will be permanently deleted. This cannot be undone.
+			</p>
+			{error !== undefined && (
+				<p className="mt-3 text-sm text-destructive-ink" role="alert">
+					{error instanceof Error ? error.message : "Could not delete the document."}
+				</p>
+			)}
+			<div className="mt-5 flex justify-end gap-2">
+				<button
+					className="btn btn-md btn-secondary"
+					disabled={deleting}
+					onClick={dismiss}
+					ref={cancel}
+					type="button"
+				>
+					Cancel
+				</button>
+				<button
+					className="btn btn-md btn-destructive"
+					disabled={deleting}
+					onClick={() => void remove()}
+					type="button"
+				>
+					{deleting ? "Deleting..." : "Delete permanently"}
+				</button>
+			</div>
+		</NavigationDialog>
+	);
+}

--- a/apps/web/src/document-actions-menu.test.ts
+++ b/apps/web/src/document-actions-menu.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+
+import { documentMenuItems, documentMenuKeyAction } from "./document-actions-menu";
+
+describe("document actions menu", () => {
+	it("offers only lifecycle-valid actions", () => {
+		expect(documentMenuItems({})).toEqual([
+			{ action: "rename", label: "Rename" },
+			{ action: "archive", label: "Archive" },
+		]);
+		expect(documentMenuItems({ archivedAt: "2026-08-23T00:00:00.000Z" })).toEqual([
+			{ action: "restore", label: "Restore" },
+			{ action: "delete", label: "Delete permanently", destructive: true },
+		]);
+	});
+
+	it("maps standard menu navigation keys without consuming unrelated keys", () => {
+		expect(documentMenuKeyAction("ArrowDown")).toBe("next");
+		expect(documentMenuKeyAction("ArrowUp")).toBe("previous");
+		expect(documentMenuKeyAction("Home")).toBe("first");
+		expect(documentMenuKeyAction("End")).toBe("last");
+		expect(documentMenuKeyAction("Escape")).toBe("close");
+		expect(documentMenuKeyAction("Tab")).toBeUndefined();
+	});
+});

--- a/apps/web/src/document-actions-menu.tsx
+++ b/apps/web/src/document-actions-menu.tsx
@@ -1,0 +1,189 @@
+import { createPortal } from "react-dom";
+import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+
+import type * as Api from "./api";
+import type { CSSProperties, KeyboardEvent, ReactNode } from "react";
+
+export type DocumentAction = "rename" | "archive" | "restore" | "delete";
+
+export type DocumentMenuItem = {
+	action: DocumentAction;
+	label: string;
+	destructive?: boolean;
+};
+
+export function documentMenuItems(channel: Pick<Api.Channel, "archivedAt">): DocumentMenuItem[] {
+	return channel.archivedAt
+		? [
+			{ action: "restore", label: "Restore" },
+			{ action: "delete", label: "Delete permanently", destructive: true },
+		]
+		: [
+			{ action: "rename", label: "Rename" },
+			{ action: "archive", label: "Archive" },
+		];
+}
+
+export type DocumentMenuKeyAction = "close" | "first" | "last" | "next" | "previous";
+
+export function documentMenuKeyAction(key: string): DocumentMenuKeyAction | undefined {
+	if (key === "Escape") return "close";
+	if (key === "Home") return "first";
+	if (key === "End") return "last";
+	if (key === "ArrowDown") return "next";
+	if (key === "ArrowUp") return "previous";
+	return undefined;
+}
+
+export function DocumentActionsMenu(
+	{
+		channel,
+		className = "",
+		onAction,
+		trigger,
+	}: {
+		channel: Pick<Api.Channel, "title" | "archivedAt">;
+		className?: string;
+		onAction: (action: DocumentAction) => void;
+		trigger: ReactNode;
+	},
+) {
+	let id = useId();
+	let button = useRef<HTMLButtonElement>(null);
+	let panel = useRef<HTMLDivElement>(null);
+	let initialItem = useRef(0);
+	let [open, setOpen] = useState(false);
+	let [position, setPosition] = useState<CSSProperties>({ visibility: "hidden" });
+	let items = documentMenuItems(channel);
+
+	useLayoutEffect(() => {
+		if (!open) return;
+		let place = () => {
+			let anchor = button.current?.getBoundingClientRect();
+			let menu = panel.current;
+			if (!anchor || !menu) return;
+			let margin = 8;
+			let gap = 4;
+			let width = Math.min(208, document.documentElement.clientWidth - margin * 2);
+			let height = menu.offsetHeight;
+			let below = window.innerHeight - anchor.bottom - margin;
+			let top = below >= height || anchor.top < height + margin
+				? anchor.bottom + gap
+				: anchor.top - height - gap;
+			setPosition({
+				left: Math.max(margin, Math.min(anchor.right - width, window.innerWidth - width - margin)),
+				top: Math.max(margin, Math.min(top, window.innerHeight - height - margin)),
+				visibility: "visible",
+				width,
+			});
+		};
+		place();
+		window.addEventListener("resize", place);
+		document.addEventListener("scroll", place, true);
+		return () => {
+			window.removeEventListener("resize", place);
+			document.removeEventListener("scroll", place, true);
+		};
+	}, [open]);
+
+	useEffect(() => {
+		if (!open) return;
+		let frame = requestAnimationFrame(() => {
+			panel.current?.querySelectorAll<HTMLButtonElement>("[role=menuitem]")[initialItem.current]
+				?.focus();
+		});
+		let outside = (event: Event) => {
+			let target = event.target;
+			if (!(target instanceof Node)) return;
+			if (!button.current?.contains(target) && !panel.current?.contains(target)) setOpen(false);
+		};
+		document.addEventListener("pointerdown", outside);
+		document.addEventListener("focusin", outside);
+		return () => {
+			cancelAnimationFrame(frame);
+			document.removeEventListener("pointerdown", outside);
+			document.removeEventListener("focusin", outside);
+		};
+	}, [open]);
+
+	let openAt = (index: number) => {
+		initialItem.current = index;
+		setPosition({ visibility: "hidden" });
+		setOpen(true);
+	};
+	let menuKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+		if (event.key === "Tab") {
+			setOpen(false);
+			return;
+		}
+		let action = documentMenuKeyAction(event.key);
+		if (!action) return;
+		event.preventDefault();
+		if (action === "close") {
+			setOpen(false);
+			button.current?.focus();
+			return;
+		}
+		let controls = [...event.currentTarget.querySelectorAll<HTMLButtonElement>("[role=menuitem]")];
+		if (controls.length === 0) return;
+		let current = Math.max(0, controls.indexOf(document.activeElement as HTMLButtonElement));
+		let next = action === "first"
+			? 0
+			: action === "last"
+			? controls.length - 1
+			: action === "next"
+			? (current + 1) % controls.length
+			: (current - 1 + controls.length) % controls.length;
+		controls[next]?.focus();
+	};
+
+	return (
+		<>
+			<button
+				aria-controls={open ? id : undefined}
+				aria-expanded={open}
+				aria-haspopup="menu"
+				aria-label={`Actions for ${channel.title}`}
+				className={className}
+				onClick={() => open ? setOpen(false) : openAt(0)}
+				onKeyDown={event => {
+					if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+					event.preventDefault();
+					openAt(event.key === "ArrowUp" ? items.length - 1 : 0);
+				}}
+				ref={button}
+				type="button"
+			>
+				{trigger}
+			</button>
+			{open && createPortal(
+				<div
+					aria-label={`Actions for ${channel.title}`}
+					className="document-actions-menu"
+					id={id}
+					onKeyDown={menuKeyDown}
+					ref={panel}
+					role="menu"
+					style={position}
+				>
+					{items.map(item => (
+						<button
+							className={item.destructive ? "document-actions-menu-destructive" : undefined}
+							key={item.action}
+							onClick={() => {
+								setOpen(false);
+								button.current?.focus();
+								onAction(item.action);
+							}}
+							role="menuitem"
+							type="button"
+						>
+							{item.label}
+						</button>
+					))}
+				</div>,
+				document.body,
+			)}
+		</>
+	);
+}

--- a/apps/web/src/document-actions.test.ts
+++ b/apps/web/src/document-actions.test.ts
@@ -5,6 +5,7 @@ import {
 	completeDocumentPage,
 	failDocumentLoad,
 	projectDocuments,
+	removeLoadedDocument,
 	replaceLoadedDocument,
 	updateLoadedDocument,
 } from "./document-actions";
@@ -102,8 +103,12 @@ describe("document actions", () => {
 
 	it("searches available Projects through every query-bound page", async () => {
 		let calls: string[] = [];
-		let load = async (owner: string, repository: string, cursor?: string, query?: string) => {
-			calls.push(`${owner}/${repository}:${cursor ?? "first"}:${query ?? ""}`);
+		let load: typeof Api.channels = async (owner, repository, options = {}) => {
+			calls.push(
+				`${owner}/${repository}:${options.cursor ?? "first"}:${options.query ?? ""}:${
+					options.includeArchived ?? false
+				}`,
+			);
 			let repositoryId = repository === "one" ? "R_one" : "R_two";
 			return {
 				repository: {
@@ -117,13 +122,16 @@ describe("document actions", () => {
 					url: `https://github.com/${owner}/${repository}`,
 				},
 				canEdit: true,
-				channels: [channel(`${repository}-${cursor ?? "first"}`, "Product", repositoryId)],
-				nextCursor: repository === "one" && !cursor ? "next" : undefined,
+				channels: [
+					channel(`${repository}-${options.cursor ?? "first"}`, "Product", repositoryId),
+				],
+				nextCursor: repository === "one" && !options.cursor ? "next" : undefined,
 			};
 		};
 		let search = await searchAvailableDocuments(
 			projects.map(entry => entry.project),
 			"product",
+			false,
 			load,
 		);
 
@@ -134,10 +142,30 @@ describe("document actions", () => {
 		]);
 		expect(search.failedProjectIds).toEqual([]);
 		expect(calls).toEqual([
-			"acme/one:first:product",
-			"acme/two:first:product",
-			"acme/one:next:product",
+			"acme/one:first:product:false",
+			"acme/two:first:product:false",
+			"acme/one:next:product:false",
 		]);
+	});
+
+	it("binds archived search pagination to the selected catalogue mode", async () => {
+		let modes: boolean[] = [];
+		await searchAvailableDocuments(
+			[projects[0]!.project],
+			"",
+			true,
+			async (_owner, _repository, options = {}) => {
+				modes.push(options.includeArchived === true);
+				return {
+					repository: {} as Api.Repository,
+					canEdit: true,
+					channels: [],
+					...(options.cursor ? {} : { nextCursor: "next" }),
+				};
+			},
+		);
+
+		expect(modes).toEqual([true, true]);
 	});
 
 	it("replaces a renamed document in its loaded Project", () => {
@@ -161,6 +189,18 @@ describe("document actions", () => {
 			title: "Socket title",
 			slug: "socket-title",
 		});
+	});
+
+	it("replaces an authoritative first page and removes deleted documents explicitly", () => {
+		let first = channel("first", "First", "R_one");
+		let stale = channel("stale", "Stale", "R_one");
+		let current = { status: "ready" as const, channels: [stale], nextCursor: "old" };
+		let refreshed = completeDocumentPage(current, [first], "next", true);
+		let loaded: LoadedDocuments = { R_one: refreshed };
+
+		expect(refreshed.channels.map(document => document.id)).toEqual(["first"]);
+		expect(removeLoadedDocument(loaded, first.id).R_one?.channels).toEqual([]);
+		expect(removeLoadedDocument(loaded, "missing")).toBe(loaded);
 	});
 
 	it("keeps newer document metadata when an older response arrives later", () => {

--- a/apps/web/src/document-actions.tsx
+++ b/apps/web/src/document-actions.tsx
@@ -36,8 +36,9 @@ export function completeDocumentPage(
 	current: DocumentLoadState,
 	channels: Api.Channel[],
 	nextCursor?: string,
+	replace = false,
 ): DocumentLoadState {
-	let byId = new Map(current.channels.map(channel => [channel.id, channel]));
+	let byId = new Map(replace ? [] : current.channels.map(channel => [channel.id, channel]));
 	for (let channel of channels) byId.set(channel.id, channel);
 	return {
 		status: "ready",
@@ -89,10 +90,27 @@ export function replaceLoadedDocument(
 	};
 }
 
+export function removeLoadedDocument(
+	documents: LoadedDocuments,
+	documentId: string,
+): LoadedDocuments {
+	for (let [repositoryId, state] of Object.entries(documents)) {
+		if (!state.channels.some(channel => channel.id === documentId)) continue;
+		return {
+			...documents,
+			[repositoryId]: {
+				...state,
+				channels: state.channels.filter(channel => channel.id !== documentId),
+			},
+		};
+	}
+	return documents;
+}
+
 export function updateLoadedDocument(
 	documents: LoadedDocuments,
 	documentId: string,
-	update: Pick<Api.Channel, "title" | "slug" | "updatedAt">,
+	update: Pick<Api.Channel, "title" | "slug" | "updatedAt" | "archivedAt">,
 ): LoadedDocuments {
 	for (let [repositoryId, state] of Object.entries(documents)) {
 		if (!state.channels.some(channel => channel.id === documentId)) continue;

--- a/apps/web/src/document-picker.tsx
+++ b/apps/web/src/document-picker.tsx
@@ -78,7 +78,10 @@ export function DocumentPicker(
 		let timer = window.setTimeout(() => {
 			setPage(undefined);
 			setListError(undefined);
-			Api.channels(repository.owner, repository.name, undefined, normalized).then(value => {
+			Api.channels(repository.owner, repository.name, {
+				includeArchived: false,
+				query: normalized || undefined,
+			}).then(value => {
 				if (request.current !== id) return;
 				setPage(value);
 				setActive(0);
@@ -118,7 +121,11 @@ export function DocumentPicker(
 		let id = request.current;
 		setLoadingMore(true);
 		try {
-			let next = await Api.channels(repository.owner, repository.name, page.nextCursor, normalized);
+			let next = await Api.channels(repository.owner, repository.name, {
+				cursor: page.nextCursor,
+				includeArchived: false,
+				query: normalized || undefined,
+			});
 			if (request.current !== id) return;
 			setPage(current =>
 				current && {

--- a/apps/web/src/document-search-dialog.tsx
+++ b/apps/web/src/document-search-dialog.tsx
@@ -11,6 +11,7 @@ export type DocumentSearchResult = {
 export async function searchAvailableDocuments(
 	projects: Api.NavigationProject[],
 	query: string,
+	includeArchived: boolean,
 	load: typeof Api.channels = Api.channels,
 	signal?: AbortSignal,
 ): Promise<{ results: DocumentSearchResult[]; failedProjectIds: string[] }> {
@@ -24,9 +25,12 @@ export async function searchAvailableDocuments(
 						let page = await load(
 							project.repositoryOwner,
 							project.repositoryName,
-							cursor,
-							query.trim() || undefined,
-							signal,
+							{
+								cursor,
+								includeArchived,
+								query: query.trim() || undefined,
+								signal,
+							},
 						);
 						channels.push(...page.channels);
 						cursor = page.nextCursor;
@@ -50,10 +54,12 @@ export async function searchAvailableDocuments(
 
 export function DocumentSearchDialog(
 	{
+		includeArchived,
 		onDismiss,
 		onSelect,
 		projects,
 	}: {
+		includeArchived: boolean;
 		onDismiss: () => void;
 		onSelect: (documentId: string) => void;
 		projects: Api.NavigationProject[];
@@ -73,7 +79,13 @@ export function DocumentSearchDialog(
 		let controller = new AbortController();
 		let timer = window.setTimeout(() => {
 			setSearch({ status: "loading" });
-			searchAvailableDocuments(projects, query, Api.channels, controller.signal).then(result => {
+			searchAvailableDocuments(
+				projects,
+				query,
+				includeArchived,
+				Api.channels,
+				controller.signal,
+			).then(result => {
 				if (active) setSearch({ status: "ready", ...result });
 			}, error => {
 				if (active && !controller.signal.aborted) {
@@ -89,7 +101,7 @@ export function DocumentSearchDialog(
 			window.clearTimeout(timer);
 			controller.abort();
 		};
-	}, [projects, query, retry]);
+	}, [includeArchived, projects, query, retry]);
 
 	let results = search.status === "ready" ? search.results : [];
 	return (
@@ -140,7 +152,10 @@ export function DocumentSearchDialog(
 						type="button"
 					>
 						<span className="min-w-0">
-							<span className="block truncate text-sm font-medium">{channel.title}</span>
+							<span className="flex min-w-0 items-center gap-2 text-sm font-medium">
+								<span className="truncate">{channel.title}</span>
+								{channel.archivedAt && <span className="document-status-badge">Archived</span>}
+							</span>
 							<span className="block truncate text-sm text-text-tertiary">
 								{project.repositoryOwner}/{project.repositoryName}
 							</span>

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -9,6 +9,7 @@ import {
 
 import * as Api from "./api";
 import { readChannelRecovery, readDocumentRecovery, rememberChannel } from "./channel-recovery";
+import { newestDocument } from "./document-actions";
 import { NavigationShell, useNavigationDocument } from "./navigation-shell";
 
 import type { ComponentType, ReactNode } from "react";
@@ -21,6 +22,8 @@ export type HostedWorkspaceProps = {
 	updatedAt: string;
 	repository: Api.Repository;
 	canEdit: boolean;
+	canManage: boolean;
+	archivedAt?: string;
 	agent?: boolean;
 	userId: string;
 };
@@ -298,11 +301,13 @@ function ChannelWorkspace(
 	if (!loaded) return <Loading label="Opening channel..." />;
 	let { detail } = loaded;
 	let channel = navigationChannel?.id === detail.channel.id
-		? navigationChannel
+		? newestDocument(detail.channel, navigationChannel)
 		: detail.channel;
 	let props: HostedWorkspaceProps = {
 		agent,
-		canEdit: detail.canEdit,
+		archivedAt: channel.archivedAt,
+		canEdit: !channel.archivedAt && (detail.canEdit || detail.canManage),
+		canManage: detail.canManage,
 		handle: user.login,
 		label: channel.title,
 		slug: channel.slug,

--- a/apps/web/src/navigation-chrome.test.ts
+++ b/apps/web/src/navigation-chrome.test.ts
@@ -34,10 +34,11 @@ describe("the Figma navigation chrome", () => {
 			onAddProject: () => {},
 			onCollapse: () => {},
 			onCreateDocument: () => {},
+			onDocumentAction: () => {},
 			onLoadMore: () => {},
 			onNewDocument: () => {},
-			onRenameDocument: () => {},
 			onSearch: () => {},
+			onShowArchivedChange: () => {},
 			projects: [{
 				documents: { status: "ready", channels: [] },
 				project: {
@@ -56,6 +57,7 @@ describe("the Figma navigation chrome", () => {
 					},
 				},
 			}],
+			showArchived: false,
 			user: { avatarUrl: "/user.png", id: "user-one", login: "MaggieAppleton" },
 		}));
 
@@ -93,11 +95,13 @@ describe("the Figma navigation chrome", () => {
 			onAddProject: () => {},
 			onCollapse: () => {},
 			onCreateDocument: () => {},
+			onDocumentAction: () => {},
 			onLoadMore: () => {},
 			onNewDocument: () => {},
-			onRenameDocument: () => {},
 			onSearch: () => {},
+			onShowArchivedChange: () => {},
 			projects: [],
+			showArchived: false,
 			user: { avatarUrl: "", id: "user-one", login: "MaggieAppleton" },
 		} satisfies ComponentProps<typeof ProjectSidebar>;
 		let closed = renderToStaticMarkup(createElement(ProjectSidebar, props));
@@ -119,10 +123,11 @@ describe("the Figma navigation chrome", () => {
 			onAddProject: () => {},
 			onCollapse: () => {},
 			onCreateDocument: () => {},
+			onDocumentAction: () => {},
 			onLoadMore: () => {},
 			onNewDocument: () => {},
-			onRenameDocument: () => {},
 			onSearch: () => {},
+			onShowArchivedChange: () => {},
 			projects: [{
 				documents: { status: "ready", channels: [], nextCursor: "next-page" },
 				project: {
@@ -133,6 +138,7 @@ describe("the Figma navigation chrome", () => {
 					repositoryOwner: "MaggieAppleton",
 				},
 			}],
+			showArchived: false,
 			user: { avatarUrl: "", id: "user-one", login: "MaggieAppleton" },
 		}));
 
@@ -141,17 +147,17 @@ describe("the Figma navigation chrome", () => {
 
 	test("keeps the document header to one project icon and document trigger", () => {
 		let props = {
-			canEdit: true,
+			canManage: true,
 			label: "Hushed mountain",
 			members: [{ handle: "MaggieAppleton", client: "tab-one" }],
-			onRename: () => {},
+			onAction: () => {},
 		};
 		let markup = renderToStaticMarkup(createElement(Header, props));
 
 		expect(markup).toMatch(/class="opacity-50"[^>]*src="[^"]*book-bookmark\.svg"/);
 		expect(markup).not.toContain('src="/repository.png"');
 		expect(markup).toContain('aria-label="Document: Hushed mountain"');
-		expect(markup).toContain('aria-label="Rename Hushed mountain"');
+		expect(markup).toContain('aria-label="Actions for Hushed mountain"');
 		expect(markup).toContain("gap-0.5");
 		expect(markup).toContain("lg:h-[calc(50px+env(safe-area-inset-top))]");
 		expect(markup).toContain('style="width:24px;height:24px"');
@@ -159,5 +165,21 @@ describe("the Figma navigation chrome", () => {
 		expect(markup).not.toContain('aria-label="Repository:');
 		expect(markup).not.toContain('href="/"');
 		expect(markup).not.toContain("hairline-b");
+	});
+
+	test("labels archived headers while keeping management actions from viewers", () => {
+		let props = {
+			archivedAt: "2026-08-23T00:00:00.000Z",
+			label: "Archived brief",
+			members: [],
+			onAction: () => {},
+		};
+		let manager = renderToStaticMarkup(createElement(Header, { ...props, canManage: true }));
+		let viewer = renderToStaticMarkup(createElement(Header, { ...props, canManage: false }));
+
+		expect(manager).toContain("Archived, read-only");
+		expect(manager).toContain('aria-label="Actions for Archived brief"');
+		expect(viewer).toContain("Archived, read-only");
+		expect(viewer).not.toContain('aria-label="Actions for Archived brief"');
 	});
 });

--- a/apps/web/src/navigation-model.test.ts
+++ b/apps/web/src/navigation-model.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "bun:test";
 import {
 	activeProject,
 	beginProjectCreation,
-	canEditProject,
+	canManageProject,
 	documentDestination,
 	finishProjectCreation,
 	landingDocument,
@@ -85,6 +85,26 @@ describe("navigation model", () => {
 		expect(landingDocument(projects, "channel-two")).toBe("channel-two");
 	});
 
+	it("never chooses an archived document for the active landing", () => {
+		let archived: ProjectDocuments[] = projects.map(entry =>
+			entry.project.repositoryId === "R_one" && entry.documents.status !== "unavailable"
+				? {
+					...entry,
+					documents: {
+						...entry.documents,
+						channels: entry.documents.channels.map(channel => ({
+							...channel,
+							archivedAt: "2026-08-23T00:00:00.000Z",
+						})),
+					},
+				}
+				: entry
+		);
+
+		expect(landingDocument(archived, "channel-one")).toBe("channel-two");
+		expect(landingDocument(archived)).toBe("channel-two");
+	});
+
 	it("has no landing document until an accessible Project has one", () => {
 		expect(landingDocument(projects.slice(0, 1))).toBeUndefined();
 		expect(landingDocument([])).toBeUndefined();
@@ -142,8 +162,8 @@ describe("navigation model", () => {
 			},
 		};
 
-		expect(canEditProject(viewerProject)).toBe(false);
-		expect(canEditProject(editorProject)).toBe(true);
-		expect(canEditProject(adminProject)).toBe(true);
+		expect(canManageProject(viewerProject)).toBe(false);
+		expect(canManageProject(editorProject)).toBe(true);
+		expect(canManageProject(adminProject)).toBe(true);
 	});
 });

--- a/apps/web/src/navigation-model.ts
+++ b/apps/web/src/navigation-model.ts
@@ -27,7 +27,7 @@ export function activeProject(
 	)?.project;
 }
 
-export function canEditProject(project: NavigationProject): boolean {
+export function canManageProject(project: NavigationProject): boolean {
 	return !!project.repository
 		&& (project.repository.permissions.push || project.repository.permissions.admin);
 }
@@ -67,8 +67,15 @@ export function landingDocument(
 	projects: ProjectDocuments[],
 	lastDocumentId?: string,
 ): string | undefined {
-	if (lastDocumentId) return lastDocumentId;
 	let available = projects.filter(({ documents }) => documents.status !== "unavailable");
+	let channels = available.flatMap(({ documents }) => documents.channels);
+	if (lastDocumentId) {
+		let last = channels.find(channel => channel.id === lastDocumentId);
+		if (last && !last.archivedAt) return last.id;
+		if (!last && available.some(({ documents }) => documents.status === "loading")) {
+			return lastDocumentId;
+		}
+	}
 	if (available.some(({ documents }) => documents.status === "loading")) return undefined;
-	return available.flatMap(({ documents }) => documents.channels)[0]?.id;
+	return channels.find(channel => !channel.archivedAt)?.id;
 }

--- a/apps/web/src/navigation-shell.tsx
+++ b/apps/web/src/navigation-shell.tsx
@@ -14,12 +14,14 @@ import {
 import { documentPath, researchWorkspacePath } from "@chopin/protocol/document-url";
 
 import * as Api from "./api";
+import { forgetChannel } from "./channel-recovery";
 import { newestDocument } from "./document-actions";
+import type { DocumentAction } from "./document-actions-menu";
 import { NavigationFocusScope } from "./navigation-focus";
 import {
 	activeProject,
 	beginProjectCreation,
-	canEditProject,
+	canManageProject,
 	documentDestination,
 	finishProjectCreation,
 	landingDocument,
@@ -27,12 +29,11 @@ import {
 	navigationMode,
 } from "./navigation-model";
 import {
-	ProjectSidebar,
 	ProjectSidebarExpandButton,
 	SIDEBAR_MAX,
 	SIDEBAR_MIN,
 	SIDEBAR_STORAGE_KEY,
-} from "./project-sidebar";
+} from "./project-sidebar-chrome";
 import { clearRepositoryCache } from "./repository-cache";
 import { useProjectDocuments } from "./use-project-documents";
 import { useProjectResearch } from "./use-project-research";
@@ -70,6 +71,9 @@ class LazyDialogBoundary extends Component<{ children: ReactNode }, { failed: bo
 let NewResearchDialog = lazy(() =>
 	import("./research-actions").then(module => ({ default: module.NewResearchDialog }))
 );
+let ProjectSidebar = lazy(() =>
+	import("./project-sidebar").then(module => ({ default: module.ProjectSidebar }))
+);
 let AddProjectDialog = lazy(() =>
 	import("./add-project-dialog").then(module => ({ default: module.AddProjectDialog }))
 );
@@ -78,6 +82,9 @@ let DocumentSearchDialog = lazy(() =>
 );
 let RenameDocumentDialog = lazy(() =>
 	import("./rename-document-dialog").then(module => ({ default: module.RenameDocumentDialog }))
+);
+let DeleteDocumentDialog = lazy(() =>
+	import("./delete-document-dialog").then(module => ({ default: module.DeleteDocumentDialog }))
 );
 
 type Route =
@@ -93,14 +100,16 @@ type Route =
 	}
 	| { page: "channel"; id: string };
 
-type NavigationFailure = { reason: unknown; retry: "refresh" | "visit" };
+type NavigationFailure = { reason: unknown; retry?: "refresh" | "visit" };
 
 let NavigationDocument = createContext<{
 	channel?: Api.Channel;
 	onDocumentChanged: (
 		documentId: string,
-		update: Pick<Api.Channel, "title" | "slug" | "updatedAt">,
+		update: Pick<Api.Channel, "title" | "slug" | "updatedAt" | "archivedAt">,
 	) => void;
+	onDocumentAction: (action: DocumentAction) => void;
+	onDocumentDeleted: (documentId: string) => void;
 	onDocumentLoaded: (channel: Api.Channel) => Promise<void>;
 	onRepositoryAccessChanged: () => void;
 	onResearchWorkspaceChanged: (
@@ -113,15 +122,15 @@ let NavigationDocument = createContext<{
 		workspace: Research.WorkspaceSummary,
 	) => void;
 	onResearchWorkspacesRefresh: (channel: Api.ResearchParentChannel) => void;
-	onRenameDocument: () => void;
 }>({
 	onDocumentChanged() {},
+	onDocumentAction() {},
+	onDocumentDeleted() {},
 	async onDocumentLoaded() {},
 	onRepositoryAccessChanged() {},
 	onResearchWorkspaceChanged() {},
 	onResearchWorkspaceLoaded() {},
 	onResearchWorkspacesRefresh() {},
-	onRenameDocument() {},
 });
 
 export function useNavigationDocument() {
@@ -246,15 +255,18 @@ export function NavigationShell(
 		channel: Api.Channel;
 		routeKey: string;
 	}>();
+	let resolvedDocumentRef = useRef(resolvedDocument);
+	resolvedDocumentRef.current = resolvedDocument;
 	let [collapsed, setCollapsed] = useState(() =>
 		localStorage.getItem(`${SIDEBAR_STORAGE_KEY}:collapsed`) === "true"
 	);
 	let [drawerOpen, setDrawerOpen] = useState(false);
 	let drawerOpener = useRef<HTMLButtonElement>(null);
+	let [showArchived, setShowArchived] = useState(false);
 	let [dialog, setDialog] = useState<
 		| "add"
 		| "search"
-		| { channel: Api.Channel; type: "rename" | "research" }
+		| { channel: Api.Channel; type: "delete" | "rename" | "research" }
 	>();
 	let [accountOpen, setAccountOpen] = useState(false);
 	let creatingProjectIds = useRef<Set<string>>(new Set());
@@ -266,15 +278,21 @@ export function NavigationShell(
 	let mode = useNavigationMode();
 	let sidebarVisible = mode === "inline" && !collapsed;
 	let triggerVisible = !sidebarVisible && !drawerOpen;
-	let { loadMore, projects, refreshProject, updateDocument, upsertDocument } = useProjectDocuments(
-		navigation,
-	);
+	let {
+		loadMore,
+		projects,
+		refreshProject,
+		removeDocument,
+		updateDocument,
+		upsertDocument,
+	} = useProjectDocuments(navigation, showArchived);
 	let {
 		groups: research,
 		refreshResearchChannel,
 		refreshResearchWorkspace,
+		removeResearchChannel,
 		upsertResearchWorkspace,
-	} = useProjectResearch(navigation, projects);
+	} = useProjectResearch(navigation, projects, showArchived);
 	let routeKey = route.page === "channel"
 		? `${route.page}:${route.id}`
 		: route.page === "research"
@@ -343,14 +361,31 @@ export function NavigationShell(
 		});
 		return request;
 	}, []);
+	let clearLastDocument = useCallback((documentId: string) => {
+		if (latestVisitedDocument.current === documentId) latestVisitedDocument.current = undefined;
+		let current = navigationRef.current;
+		if (current?.lastDocumentId !== documentId) return;
+		let next = { ...current };
+		delete next.lastDocumentId;
+		visitRevision.current++;
+		navigationRef.current = next;
+		setNavigation(next);
+	}, []);
 	let documentLoaded = useCallback(async (channel: Api.Channel) => {
-		setResolvedDocument(current => ({
-			channel: current?.routeKey === routeKey && current.channel.id === channel.id
-				? newestDocument(current.channel, channel)
+		let resolved = resolvedDocumentRef.current;
+		let loaded = {
+			channel: resolved?.routeKey === routeKey && resolved.channel.id === channel.id
+				? newestDocument(resolved.channel, channel)
 				: channel,
 			routeKey,
-		}));
-		upsertDocument(channel);
+		};
+		resolvedDocumentRef.current = loaded;
+		setResolvedDocument(loaded);
+		upsertDocument(loaded.channel);
+		if (loaded.channel.archivedAt) {
+			clearLastDocument(channel.id);
+			return;
+		}
 		let visited = visitTail.current.then(() => Api.visitDocument(channel.id));
 		visitTail.current = visited.catch(() => {});
 		try {
@@ -360,6 +395,10 @@ export function NavigationShell(
 			return;
 		}
 		setError(current => current?.retry === "visit" ? undefined : current);
+		if (
+			resolvedDocumentRef.current?.channel.id === channel.id
+			&& resolvedDocumentRef.current.channel.archivedAt
+		) return;
 		visitRevision.current++;
 		latestVisitedDocument.current = channel.id;
 		let current = navigationRef.current;
@@ -374,18 +413,30 @@ export function NavigationShell(
 			pendingVisitedRepository.current = channel.repositoryId;
 			await refresh();
 		}
-	}, [refresh, routeKey, upsertDocument]);
+	}, [clearLastDocument, refresh, routeKey, upsertDocument]);
 	let documentChanged = useCallback((
 		documentId: string,
-		update: Pick<Api.Channel, "title" | "slug" | "updatedAt">,
+		update: Pick<Api.Channel, "title" | "slug" | "updatedAt" | "archivedAt">,
 	) => {
-		updateDocument(documentId, update);
-		setResolvedDocument(current =>
-			current?.channel.id === documentId && current.channel.updatedAt <= update.updatedAt
-				? { ...current, channel: { ...current.channel, ...update } }
-				: current
-		);
-	}, [updateDocument]);
+		let current = resolvedDocumentRef.current;
+		if (current?.channel.id === documentId && current.channel.updatedAt <= update.updatedAt) {
+			let next = { ...current, channel: { ...current.channel, ...update } };
+			resolvedDocumentRef.current = next;
+			setResolvedDocument(next);
+			upsertDocument(next.channel);
+		} else updateDocument(documentId, update);
+		if (Object.hasOwn(update, "archivedAt")) {
+			if (update.archivedAt) {
+				clearLastDocument(documentId);
+				setDialog(current =>
+					typeof current === "object" && current.type === "research"
+						&& current.channel.id === documentId
+						? undefined
+						: current
+				);
+			}
+		}
+	}, [clearLastDocument, updateDocument, upsertDocument]);
 
 	useEffect(() => {
 		void refresh(false);
@@ -449,7 +500,7 @@ export function NavigationShell(
 	};
 
 	let createDocument = async (project: Api.NavigationProject) => {
-		if (!canEditProject(project) || !startProjectCreation(project.repositoryId)) return;
+		if (!canManageProject(project) || !startProjectCreation(project.repositoryId)) return;
 		try {
 			let created = await Api.createChannel(project.repositoryOwner, project.repositoryName);
 			upsertDocument(created.channel);
@@ -473,6 +524,15 @@ export function NavigationShell(
 		.find(channel => channel.id === currentDocumentId) ?? resolvedChannel;
 	let currentChannelRef = useRef<Api.Channel | undefined>(undefined);
 	currentChannelRef.current = currentChannel;
+	let knownChannelsRef = useRef(new Map<string, Api.Channel>());
+	knownChannelsRef.current = new Map(
+		[
+			...projects.flatMap(project => project.documents.channels),
+			...(resolvedChannel ? [resolvedChannel] : []),
+		].map(channel => [channel.id, channel]),
+	);
+	let currentDocumentIdRef = useRef(currentDocumentId);
+	currentDocumentIdRef.current = currentDocumentId;
 	let revalidateCatalogues = useCallback(() => {
 		let now = Date.now();
 		let navigationRefreshedAt = catalogueRefreshes.current.get("navigation") ?? 0;
@@ -506,17 +566,8 @@ export function NavigationShell(
 		};
 	}, [revalidateCatalogues]);
 	let newDocument = () => {
-		if (active && canEditProject(active)) void createDocument(active);
+		if (active && canManageProject(active)) void createDocument(active);
 		else showDialog("add");
-	};
-
-	let renamed = (channel: Api.Channel) => {
-		upsertDocument(channel);
-		setResolvedDocument(current =>
-			current?.channel.id === channel.id
-				? { ...current, channel: newestDocument(current.channel, channel) }
-				: current
-		);
 	};
 
 	let showDialog = useCallback((next: NonNullable<typeof dialog>) => {
@@ -524,10 +575,58 @@ export function NavigationShell(
 		setAccountOpen(false);
 		setDialog(next);
 	}, []);
-	let renameCurrentDocument = useCallback(() => {
+	let acceptChannel = useCallback((channel: Api.Channel) => {
+		if (channel.archivedAt) {
+			clearLastDocument(channel.id);
+		}
+		upsertDocument(channel);
+		let current = resolvedDocumentRef.current;
+		if (current?.channel.id !== channel.id) return;
+		let next = { ...current, channel: newestDocument(current.channel, channel) };
+		resolvedDocumentRef.current = next;
+		setResolvedDocument(next);
+	}, [clearLastDocument, upsertDocument]);
+	let documentDeleted = useCallback((documentId: string) => {
+		let channel = knownChannelsRef.current.get(documentId);
+		if (channel) forgetChannel(user.id, channel);
+		removeDocument(documentId);
+		removeResearchChannel(documentId);
+		clearLastDocument(documentId);
+		let current = resolvedDocumentRef.current;
+		if (current?.channel.id === documentId) {
+			resolvedDocumentRef.current = undefined;
+			setResolvedDocument(undefined);
+		}
+		setDialog(currentDialog =>
+			typeof currentDialog === "object" && currentDialog.channel.id === documentId
+				? undefined
+				: currentDialog
+		);
+		if (currentDocumentIdRef.current === documentId) navigate("/", { replace: true });
+	}, [clearLastDocument, navigate, removeDocument, removeResearchChannel, user.id]);
+	let documentAction = useCallback((channel: Api.Channel, action: DocumentAction) => {
+		setDrawerOpen(false);
+		setAccountOpen(false);
+		if (action === "rename") {
+			showDialog({ type: "rename", channel });
+			return;
+		}
+		if (action === "delete") {
+			showDialog({ type: "delete", channel });
+			return;
+		}
+		setError(undefined);
+		let mutation = action === "archive"
+			? Api.archiveChannel(channel.id)
+			: Api.restoreChannel(channel.id);
+		void mutation.then(detail => acceptChannel(detail.channel), reason => {
+			setError({ reason });
+		});
+	}, [acceptChannel, showDialog]);
+	let currentDocumentAction = useCallback((action: DocumentAction) => {
 		let channel = currentChannelRef.current;
-		if (channel) showDialog({ type: "rename", channel });
-	}, [showDialog]);
+		if (channel) documentAction(channel, action);
+	}, [documentAction]);
 	let researchWorkspaceChanged = useCallback((
 		channel: Api.ResearchParentChannel,
 		workspaceId: string,
@@ -546,18 +645,20 @@ export function NavigationShell(
 	}, [refresh]);
 	let navigationDocument = useMemo(() => ({
 		channel: currentChannel,
+		onDocumentAction: currentDocumentAction,
 		onDocumentChanged: documentChanged,
+		onDocumentDeleted: documentDeleted,
 		onDocumentLoaded: documentLoaded,
 		onRepositoryAccessChanged: repositoryAccessChanged,
 		onResearchWorkspaceChanged: researchWorkspaceChanged,
 		onResearchWorkspaceLoaded: researchWorkspaceLoaded,
 		onResearchWorkspacesRefresh: refreshResearchChannel,
-		onRenameDocument: renameCurrentDocument,
 	}), [
 		currentChannel,
+		currentDocumentAction,
 		documentChanged,
+		documentDeleted,
 		documentLoaded,
-		renameCurrentDocument,
 		repositoryAccessChanged,
 		researchWorkspaceChanged,
 		researchWorkspaceLoaded,
@@ -604,33 +705,39 @@ export function NavigationShell(
 		navigate(`${destination.pathname}${destination.search}${destination.hash}`);
 	};
 	let sidebar = (
-		<ProjectSidebar
-			accountMenu={accountOpen && (
-				<div className="navigation-account-menu" role="menu">
-					<button onClick={() => void signOut()} role="menuitem" type="button">Sign out</button>
-				</div>
-			)}
-			canCreateDocument={!active || canEditProject(active)}
-			creatingProjectIds={creatingProjectIdsForView}
-			creatingNewDocument={!!active && creatingProjectIdsForView.has(active.repositoryId)}
-			currentDocumentId={currentDocumentId}
-			currentResearchWorkspaceId={currentResearchWorkspaceId}
-			onAccount={() => setAccountOpen(open => !open)}
-			onAddProject={() => showDialog("add")}
-			onCollapse={() => {
-				setCollapsed(true);
-				if (drawerOpen) dismissDrawer();
-			}}
-			onCreateDocument={project => void createDocument(project)}
-			onLoadMore={loadMore}
-			onNewResearch={channel => showDialog({ type: "research", channel })}
-			onNewDocument={newDocument}
-			onRenameDocument={channel => showDialog({ type: "rename", channel })}
-			onSearch={() => showDialog("search")}
-			projects={projects}
-			research={research}
-			user={user}
-		/>
+		<Suspense fallback={null}>
+			<ProjectSidebar
+				accountMenu={accountOpen && (
+					<div className="navigation-account-menu" role="menu">
+						<button onClick={() => void signOut()} role="menuitem" type="button">Sign out</button>
+					</div>
+				)}
+				canCreateDocument={!active || canManageProject(active)}
+				creatingProjectIds={creatingProjectIdsForView}
+				creatingNewDocument={!!active && creatingProjectIdsForView.has(active.repositoryId)}
+				currentDocumentId={currentDocumentId}
+				currentResearchWorkspaceId={currentResearchWorkspaceId}
+				onAccount={() => setAccountOpen(open => !open)}
+				onAddProject={() => showDialog("add")}
+				onCollapse={() => {
+					setCollapsed(true);
+					if (drawerOpen) dismissDrawer();
+				}}
+				onCreateDocument={project => void createDocument(project)}
+				onDocumentAction={documentAction}
+				onLoadMore={loadMore}
+				onNewResearch={channel => {
+					if (!channel.archivedAt) showDialog({ type: "research", channel });
+				}}
+				onNewDocument={newDocument}
+				onSearch={() => showDialog("search")}
+				onShowArchivedChange={setShowArchived}
+				projects={projects}
+				research={research}
+				showArchived={showArchived}
+				user={user}
+			/>
+		</Suspense>
 	);
 	let content = (
 		<>
@@ -639,13 +746,15 @@ export function NavigationShell(
 					{error.reason instanceof Error
 						? error.reason.message
 						: "Could not update navigation."}
-					<button
-						className="btn btn-sm btn-secondary ml-2"
-						onClick={retryError}
-						type="button"
-					>
-						Try again
-					</button>
+					{error.retry && (
+						<button
+							className="btn btn-sm btn-secondary ml-2"
+							onClick={retryError}
+							type="button"
+						>
+							Try again
+						</button>
+					)}
 				</div>
 			)}
 			{children ?? (
@@ -719,6 +828,7 @@ export function NavigationShell(
 					<LazyDialogBoundary>
 						<Suspense fallback={null}>
 							<DocumentSearchDialog
+								includeArchived={showArchived}
 								onDismiss={() => setDialog(undefined)}
 								onSelect={navigateToDocument}
 								projects={navigation?.projects ?? []}
@@ -732,7 +842,18 @@ export function NavigationShell(
 							<RenameDocumentDialog
 								channel={dialog.channel}
 								onDismiss={() => setDialog(undefined)}
-								onRenamed={renamed}
+								onRenamed={acceptChannel}
+							/>
+						</Suspense>
+					</LazyDialogBoundary>
+				)}
+				{typeof dialog === "object" && dialog.type === "delete" && (
+					<LazyDialogBoundary>
+						<Suspense fallback={null}>
+							<DeleteDocumentDialog
+								channel={dialog.channel}
+								onDeleted={() => documentDeleted(dialog.channel.id)}
+								onDismiss={() => setDialog(undefined)}
 							/>
 						</Suspense>
 					</LazyDialogBoundary>

--- a/apps/web/src/navigation.css
+++ b/apps/web/src/navigation.css
@@ -104,6 +104,23 @@
 	color: color-mix(in srgb, var(--color-text-tertiary) 60%, transparent);
 }
 
+.project-sidebar-archived-toggle {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	padding: 3px 8px 8px;
+	font-size: 0.75rem;
+	color: var(--color-text-quaternary);
+	cursor: pointer;
+}
+
+.project-sidebar-archived-toggle input {
+	width: 14px;
+	height: 14px;
+	flex: 0 0 auto;
+	accent-color: var(--color-brand);
+}
+
 .project-sidebar-projects,
 .project-sidebar-documents,
 .project-sidebar-research {
@@ -124,6 +141,13 @@
 	border-radius: 8px;
 	padding: 4px 12px 4px 32px;
 	font-size: var(--text-sm);
+}
+
+.project-sidebar-document-link {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	overflow: hidden;
 }
 
 .project-sidebar-document-current {
@@ -388,6 +412,59 @@
 	background: var(--color-hover);
 }
 
+.document-actions-menu {
+	position: fixed;
+	z-index: 60;
+	display: flex;
+	flex-direction: column;
+	border-radius: var(--radius-md);
+	background: var(--color-page);
+	padding: 4px;
+	box-shadow: var(--shadow-overlay);
+}
+
+.document-actions-menu button {
+	min-height: 34px;
+	border-radius: var(--radius-sm);
+	padding: 7px 10px;
+	font-size: var(--text-sm);
+	text-align: left;
+	color: var(--color-text-secondary);
+}
+
+.document-actions-menu button:hover,
+.document-actions-menu button:focus-visible {
+	background: var(--color-hover);
+	color: var(--color-text-primary);
+}
+
+.document-actions-menu .document-actions-menu-destructive {
+	color: var(--color-destructive-ink);
+}
+
+.document-actions-menu .document-actions-menu-destructive:hover,
+.document-actions-menu .document-actions-menu-destructive:focus-visible {
+	color: var(--color-destructive-ink);
+}
+
+.document-status-badge {
+	display: inline-flex;
+	min-width: 0;
+	flex: 0 0 auto;
+	align-items: center;
+	border-radius: 9999px;
+	background: var(--color-warning-wash);
+	padding: 1px 6px;
+	font-size: 0.625rem;
+	font-weight: 600;
+	line-height: 1rem;
+	color: var(--color-warning-ink);
+}
+
+.document-read-only-status {
+	margin-left: 6px;
+}
+
 :root[data-plan-coarse-pointer]
 	.project-sidebar
 	:where(.project-sidebar-action, .project-sidebar-document-action, .project-sidebar-research-link) {
@@ -407,7 +484,12 @@
 	min-height: 44px;
 }
 
-.document-title-trigger {
+:root[data-plan-coarse-pointer] .document-actions-menu button {
+	min-height: 44px;
+}
+
+.document-title-trigger,
+.document-title-label {
 	display: flex;
 	min-width: 0;
 	align-items: center;

--- a/apps/web/src/project-sidebar-chrome.tsx
+++ b/apps/web/src/project-sidebar-chrome.tsx
@@ -1,0 +1,29 @@
+import sidebarOpenIcon from "./assets/figma/navigation/sidebar-right-3-hide.svg";
+
+import type { RefObject } from "react";
+
+export const SIDEBAR_MIN = 250;
+export const SIDEBAR_MAX = 400;
+export const SIDEBAR_STORAGE_KEY = "chopin:pane:projects";
+
+export function ProjectSidebarExpandButton(
+	{
+		buttonRef,
+		onExpand,
+	}: {
+		buttonRef?: RefObject<HTMLButtonElement | null>;
+		onExpand: () => void;
+	},
+) {
+	return (
+		<button
+			aria-label="Open Projects sidebar"
+			className="project-sidebar-expand btn btn-icon btn-ghost shrink-0"
+			onClick={onExpand}
+			ref={buttonRef}
+			type="button"
+		>
+			<img alt="" height="18" src={sidebarOpenIcon} width="18" />
+		</button>
+	);
+}

--- a/apps/web/src/project-sidebar.tsx
+++ b/apps/web/src/project-sidebar.tsx
@@ -5,19 +5,16 @@ import collapseIcon from "./assets/figma/navigation/collapse.svg";
 import documentActionsIcon from "./assets/figma/navigation/document-actions.svg";
 import newDocumentIcon from "./assets/figma/navigation/new-document.svg";
 import searchIcon from "./assets/figma/navigation/search.svg";
-import sidebarOpenIcon from "./assets/figma/navigation/sidebar-right-3-hide.svg";
-import { canEditProject } from "./navigation-model";
+import { DocumentActionsMenu } from "./document-actions-menu";
+import { canManageProject } from "./navigation-model";
 import { documentPath, researchWorkspacePath } from "@chopin/protocol/document-url";
 
 import { useState } from "react";
 import type * as Api from "./api";
+import type { DocumentAction } from "./document-actions-menu";
 import type { ProjectDocuments } from "./document-actions";
-import type { ReactNode, RefObject } from "react";
+import type { ReactNode } from "react";
 import type { ResearchChannelGroup } from "./research-navigation";
-
-export const SIDEBAR_MIN = 250;
-export const SIDEBAR_MAX = 400;
-export const SIDEBAR_STORAGE_KEY = "chopin:pane:projects";
 
 export function NavigationIcon(
 	{ alt = "", className, src }: { alt?: string; className?: string; src: string },
@@ -51,9 +48,9 @@ function Project(
 		entry,
 		expanded,
 		onCreateDocument,
+		onDocumentAction,
 		onLoadMore,
 		onNewResearch,
-		onRenameDocument,
 		research,
 		onToggle,
 	}: {
@@ -63,9 +60,9 @@ function Project(
 		entry: ProjectDocuments;
 		expanded: boolean;
 		onCreateDocument: (project: Api.NavigationProject) => void;
+		onDocumentAction: (channel: Api.Channel, action: DocumentAction) => void;
 		onLoadMore: (entry: ProjectDocuments) => void;
 		onNewResearch?: (channel: Api.Channel) => void;
-		onRenameDocument: (channel: Api.Channel) => void;
 		research: ReadonlyMap<string, ResearchChannelGroup>;
 		onToggle: () => void;
 	},
@@ -73,7 +70,7 @@ function Project(
 	let { documents, project } = entry;
 	let { channels } = documents;
 	let label = project.repository?.name ?? project.repositoryName;
-	let canEdit = canEditProject(project);
+	let canManage = canManageProject(project);
 	let creating = creatingProjectIds.has(project.repositoryId);
 	return (
 		<li
@@ -91,7 +88,7 @@ function Project(
 					<NavigationIcon className="opacity-50" src={bookBookmarkIcon} />
 					<span className="truncate text-sm font-bold">{label}</span>
 				</button>
-				{project.available && canEdit && (
+				{project.available && canManage && (
 					<button
 						aria-label={`New document in ${label}`}
 						className="project-sidebar-action"
@@ -136,14 +133,15 @@ function Project(
 								>
 									<a
 										aria-current={parentCurrent && !researchCurrent ? "page" : undefined}
-										className="min-w-0 flex-1 truncate text-left text-sm font-medium"
+										className="project-sidebar-document-link min-w-0 flex-1 text-left text-sm font-medium"
 										href={parentHref}
 									>
-										{channel.title}
+										<span className="truncate">{channel.title}</span>
+										{channel.archivedAt && <span className="document-status-badge">Archived</span>}
 									</a>
-									{canEdit && (
+									{canManage && (
 										<div className="project-sidebar-document-actions">
-											{onNewResearch && (
+											{onNewResearch && !channel.archivedAt && (
 												<button
 													aria-label={`New research in ${channel.title}`}
 													className="project-sidebar-document-action"
@@ -153,14 +151,14 @@ function Project(
 													<NavigationIcon className="h-auto w-3.5" src={searchIcon} />
 												</button>
 											)}
-											<button
-												aria-label={`Rename ${channel.title}`}
+											<DocumentActionsMenu
+												channel={channel}
 												className="project-sidebar-document-action"
-												onClick={() => onRenameDocument(channel)}
-												type="button"
-											>
-												<NavigationIcon className="h-auto w-3.5" src={documentActionsIcon} />
-											</button>
+												onAction={action => onDocumentAction(channel, action)}
+												trigger={
+													<NavigationIcon className="h-auto w-3.5" src={documentActionsIcon} />
+												}
+											/>
 										</div>
 									)}
 								</div>
@@ -225,13 +223,15 @@ export function ProjectSidebar(
 		onAddProject,
 		onCollapse,
 		onCreateDocument,
+		onDocumentAction,
 		onLoadMore,
 		onNewResearch,
 		onNewDocument,
-		onRenameDocument,
 		onSearch,
+		onShowArchivedChange,
 		projects,
 		research = new Map(),
+		showArchived,
 		user,
 	}: {
 		accountMenu?: ReactNode;
@@ -244,13 +244,15 @@ export function ProjectSidebar(
 		onAddProject: () => void;
 		onCollapse: () => void;
 		onCreateDocument: (project: Api.NavigationProject) => void;
+		onDocumentAction: (channel: Api.Channel, action: DocumentAction) => void;
 		onLoadMore: (entry: ProjectDocuments) => void;
 		onNewResearch?: (channel: Api.Channel) => void;
 		onNewDocument: () => void;
-		onRenameDocument: (channel: Api.Channel) => void;
 		onSearch: () => void;
+		onShowArchivedChange: (show: boolean) => void;
 		projects: ProjectDocuments[];
 		research?: ReadonlyMap<string, ResearchChannelGroup>;
+		showArchived: boolean;
 		user: Api.User;
 	},
 ) {
@@ -303,6 +305,14 @@ export function ProjectSidebar(
 							<NavigationIcon className="size-3.5" src={addProjectIcon} />
 						</button>
 					</div>
+					<label className="project-sidebar-archived-toggle">
+						<input
+							checked={showArchived}
+							onChange={event => onShowArchivedChange(event.target.checked)}
+							type="checkbox"
+						/>
+						<span>Show archived documents</span>
+					</label>
 					<ul className="project-sidebar-projects gap-2">
 						{[...projects].sort((first, second) => first.project.position - second.project.position)
 							.map(entry => (
@@ -314,9 +324,9 @@ export function ProjectSidebar(
 									expanded={!collapsedProjectIds.has(entry.project.repositoryId)}
 									key={entry.project.repositoryId}
 									onCreateDocument={onCreateDocument}
+									onDocumentAction={onDocumentAction}
 									onLoadMore={onLoadMore}
 									onNewResearch={onNewResearch}
-									onRenameDocument={onRenameDocument}
 									research={research}
 									onToggle={() =>
 										setCollapsedProjectIds(current =>
@@ -350,27 +360,5 @@ export function ProjectSidebar(
 				</button>
 			</div>
 		</aside>
-	);
-}
-
-export function ProjectSidebarExpandButton(
-	{
-		buttonRef,
-		onExpand,
-	}: {
-		buttonRef?: RefObject<HTMLButtonElement | null>;
-		onExpand: () => void;
-	},
-) {
-	return (
-		<button
-			aria-label="Open Projects sidebar"
-			className="project-sidebar-expand btn btn-icon btn-ghost shrink-0"
-			onClick={onExpand}
-			ref={buttonRef}
-			type="button"
-		>
-			<img alt="" height="18" src={sidebarOpenIcon} width="18" />
-		</button>
 	);
 }

--- a/apps/web/src/research-navigation.test.ts
+++ b/apps/web/src/research-navigation.test.ts
@@ -4,6 +4,7 @@ import {
 	beginResearchLoad,
 	completeResearchLoad,
 	currentResearchRequest,
+	removeLoadedResearchChannel,
 	upsertLoadedResearch,
 } from "./research-navigation";
 
@@ -83,5 +84,34 @@ describe("repository research state", () => {
 		});
 
 		expect(next.channels[0]?.workspaces[0]).toBe(created);
+	});
+
+	it("removes omitted groups from an authoritative repository refresh", () => {
+		let loaded = upsertLoadedResearch(
+			{},
+			"R_one",
+			channel,
+			workspace("research-old", 0, "2026-08-23T10:00:00.000Z"),
+		);
+		let next = completeResearchLoad(loaded.R_one!, {
+			repository,
+			canEdit: true,
+			channels: [],
+			truncated: false,
+		}, false);
+
+		expect(next.channels).toEqual([]);
+	});
+
+	it("removes every cached research workspace for a deleted document", () => {
+		let loaded = upsertLoadedResearch(
+			{},
+			"R_one",
+			channel,
+			workspace("research-one", 0, "2026-08-23T10:00:00.000Z"),
+		);
+
+		expect(removeLoadedResearchChannel(loaded, channel.id).R_one?.channels).toEqual([]);
+		expect(removeLoadedResearchChannel(loaded, "missing")).toBe(loaded);
 	});
 });

--- a/apps/web/src/research-navigation.ts
+++ b/apps/web/src/research-navigation.ts
@@ -45,6 +45,7 @@ export function newestResearchWorkspace(
 export function completeResearchLoad(
 	current: ResearchRepositoryState,
 	page: Api.RepositoryResearchPage,
+	preserveMissing = true,
 ): ResearchRepositoryState {
 	let groups = new Map<string, ResearchChannelGroup>();
 	for (let group of page.channels) {
@@ -55,17 +56,17 @@ export function completeResearchLoad(
 	}
 	for (let currentGroup of current.channels) {
 		let loaded = groups.get(currentGroup.channel.id);
-		if (!loaded) {
+		if (!loaded && (preserveMissing || page.truncated)) {
 			groups.set(currentGroup.channel.id, currentGroup);
 			continue;
 		}
+		if (!loaded) continue;
 		let workspaces = new Map(loaded.workspaces.map(workspace => [workspace.id, workspace]));
 		for (let workspace of currentGroup.workspaces) {
 			let replacement = workspaces.get(workspace.id);
-			workspaces.set(
-				workspace.id,
-				replacement ? newestResearchWorkspace(workspace, replacement) : workspace,
-			);
+			if (replacement) {
+				workspaces.set(workspace.id, newestResearchWorkspace(workspace, replacement));
+			} else if (preserveMissing || page.truncated) workspaces.set(workspace.id, workspace);
 		}
 		groups.set(currentGroup.channel.id, {
 			channel: loaded.channel,
@@ -115,6 +116,22 @@ export function upsertLoadedResearch(
 		})
 		: [...current.channels, { channel, workspaces: [workspace] }];
 	return { ...loaded, [repositoryId]: { ...current, channels } };
+}
+
+export function removeLoadedResearchChannel(
+	loaded: LoadedResearch,
+	channelId: string,
+): LoadedResearch {
+	let next = loaded;
+	for (let [repositoryId, state] of Object.entries(loaded)) {
+		if (!state.channels.some(group => group.channel.id === channelId)) continue;
+		if (next === loaded) next = { ...loaded };
+		next[repositoryId] = {
+			...state,
+			channels: state.channels.filter(group => group.channel.id !== channelId),
+		};
+	}
+	return next;
 }
 
 export function researchByChannel(

--- a/apps/web/src/research-sidebar.test.ts
+++ b/apps/web/src/research-sidebar.test.ts
@@ -47,11 +47,12 @@ let props = {
 	onAddProject: () => {},
 	onCollapse: () => {},
 	onCreateDocument: () => {},
+	onDocumentAction: () => {},
 	onLoadMore: () => {},
 	onNewDocument: () => {},
 	onNewResearch: () => {},
-	onRenameDocument: () => {},
 	onSearch: () => {},
+	onShowArchivedChange: () => {},
 	projects: [{
 		documents: { status: "ready" as const, channels: [channel] },
 		project: {
@@ -73,6 +74,7 @@ let props = {
 		channel,
 		workspaces: [older, newer],
 	}]]),
+	showArchived: false,
 	user: { avatarUrl: "", id: "user-one", login: "octocat" },
 } satisfies ComponentProps<typeof ProjectSidebar>;
 
@@ -82,7 +84,7 @@ describe("research sidebar hierarchy", () => {
 
 		expect(markup.match(/aria-current="page"/g)).toHaveLength(1);
 		expect(markup).toContain(
-			'<a aria-current="page" class="min-w-0 flex-1 truncate text-left text-sm font-medium" href="/documents/acme/one/release-plan">',
+			'<a aria-current="page" class="project-sidebar-document-link min-w-0 flex-1 text-left text-sm font-medium" href="/documents/acme/one/release-plan">',
 		);
 		expect(markup).not.toContain('role="tree"');
 	});
@@ -100,6 +102,40 @@ describe("research sidebar hierarchy", () => {
 		);
 		expect(markup.indexOf(newer.title)).toBeLessThan(markup.indexOf(older.title));
 		expect(markup).toContain('aria-label="New research in Release plan"');
-		expect(markup).toContain('aria-label="Rename Release plan"');
+		expect(markup).toContain('aria-label="Actions for Release plan"');
+	});
+
+	it("labels archived rows without exposing research or management to viewers", () => {
+		let archived = { ...channel, archivedAt: "2026-08-23T00:00:00.000Z" };
+		let writer = renderToStaticMarkup(createElement(ProjectSidebar, {
+			...props,
+			projects: [{
+				...props.projects[0]!,
+				documents: { status: "ready", channels: [archived] },
+			}],
+			showArchived: true,
+		}));
+		let viewer = renderToStaticMarkup(createElement(ProjectSidebar, {
+			...props,
+			projects: [{
+				...props.projects[0]!,
+				documents: { status: "ready", channels: [archived] },
+				project: {
+					...props.projects[0]!.project,
+					repository: {
+						...props.projects[0]!.project.repository!,
+						permissions: { pull: true, push: false, admin: false },
+					},
+				},
+			}],
+			showArchived: true,
+		}));
+
+		expect(writer).toContain("Archived");
+		expect(writer).toContain('aria-label="Actions for Release plan"');
+		expect(writer).not.toContain('aria-label="New research in Release plan"');
+		expect(writer).toContain('checked=""');
+		expect(viewer).toContain("Archived");
+		expect(viewer).not.toContain('aria-label="Actions for Release plan"');
 	});
 });

--- a/apps/web/src/research-workspace.css
+++ b/apps/web/src/research-workspace.css
@@ -58,6 +58,7 @@
 }
 
 .research-connection[data-status="denied"] > span,
+.research-connection[data-status="deleted"] > span,
 .research-connection[data-status="closed"] > span {
 	background: var(--color-destructive);
 }

--- a/apps/web/src/research-workspace.tsx
+++ b/apps/web/src/research-workspace.tsx
@@ -3,6 +3,7 @@ import { documentPath, researchWorkspacePath } from "@chopin/protocol/document-u
 
 import * as Api from "./api";
 import { rememberChannel } from "./channel-recovery";
+import { DocumentActionsMenu } from "./document-actions-menu";
 import { useNavigationDocument } from "./navigation-shell";
 import {
 	activeResearchJob,
@@ -29,6 +30,10 @@ import type {
 import type { Status } from "./wire";
 
 type ResearchWorkspaceProps = HostedWorkspaceProps & { workspaceId: string };
+type ManagedHello = Session.Hello & { archivedAt?: string; canManage: boolean };
+type ManagedChannel = Session.Channel & { archivedAt?: string; canManage: boolean };
+type ManagedAccess = Session.Access & { canManage: boolean };
+type WorkspaceMetadata = Pick<Api.Channel, "title" | "slug" | "updatedAt" | "archivedAt">;
 
 function timestamp(value: string): string {
 	let date = new Date(value);
@@ -569,6 +574,8 @@ function connectionLabel(status: Status): string {
 			return "Reconnecting";
 		case "denied":
 			return "Access changed";
+		case "deleted":
+			return "Document deleted";
 		case "closed":
 			return "Disconnected";
 	}
@@ -577,7 +584,9 @@ function connectionLabel(status: Status): string {
 export function ResearchWorkspace(
 	{
 		agent = true,
+		archivedAt,
 		canEdit,
+		canManage,
 		label,
 		repository,
 		room,
@@ -588,7 +597,9 @@ export function ResearchWorkspace(
 	}: ResearchWorkspaceProps,
 ) {
 	let {
+		onDocumentAction,
 		onDocumentChanged,
+		onDocumentDeleted,
 		onRepositoryAccessChanged,
 		onResearchWorkspaceChanged,
 		onResearchWorkspaceLoaded,
@@ -599,9 +610,16 @@ export function ResearchWorkspace(
 	let [error, setError] = useState<unknown>();
 	let [refreshing, setRefreshing] = useState(false);
 	let [status, setStatus] = useState<Status>("connecting");
-	let [effectiveCanEdit, setEffectiveCanEdit] = useState(canEdit);
+	let [effectiveCanEdit, setEffectiveCanEdit] = useState(canEdit && !archivedAt);
+	let [effectiveCanManage, setEffectiveCanManage] = useState(canManage);
+	let [deleted, setDeleted] = useState(false);
 	let [capabilities, setCapabilities] = useState({ backgroundJobs: false, webResearch: false });
-	let [metadata, setMetadata] = useState({ title: label, slug, updatedAt });
+	let [metadata, setMetadata] = useState<WorkspaceMetadata>({
+		archivedAt,
+		title: label,
+		slug,
+		updatedAt,
+	});
 	let metadataRef = useRef(metadata);
 	let requestGeneration = useRef(0);
 	let requestController = useRef<AbortController | undefined>(undefined);
@@ -654,16 +672,22 @@ export function ResearchWorkspace(
 		) void refresh();
 	}, [accept, refresh]);
 
-	let updateMetadata = useCallback((next: { title: string; slug: string; updatedAt: string }) => {
+	let updateMetadata = useCallback((next: WorkspaceMetadata) => {
 		if (Date.parse(next.updatedAt) < Date.parse(metadataRef.current.updatedAt)) return;
-		metadataRef.current = next;
-		setMetadata(next);
-		rememberChannel(userId, { id: room, title: next.title, slug: next.slug }, repository);
-		onDocumentChanged(room, next);
+		let metadata = {
+			archivedAt: next.archivedAt,
+			title: next.title,
+			slug: next.slug,
+			updatedAt: next.updatedAt,
+		};
+		metadataRef.current = metadata;
+		setMetadata(metadata);
+		rememberChannel(userId, { id: room, title: metadata.title, slug: metadata.slug }, repository);
+		onDocumentChanged(room, metadata);
 		let path = researchWorkspacePath(
 			repository.owner,
 			repository.name,
-			next.slug,
+			metadata.slug,
 			workspaceId,
 		);
 		if (location.pathname !== path) {
@@ -672,11 +696,12 @@ export function ResearchWorkspace(
 	}, [onDocumentChanged, repository, room, userId, workspaceId]);
 
 	useEffect(() => {
-		let next = { title: label, slug, updatedAt };
+		let next = { archivedAt, title: label, slug, updatedAt };
 		metadataRef.current = next;
 		setMetadata(next);
-		setEffectiveCanEdit(canEdit);
-	}, [canEdit, label, room, slug, updatedAt]);
+		setEffectiveCanEdit(canEdit && !archivedAt);
+		setEffectiveCanManage(canManage);
+	}, [archivedAt, canEdit, canManage, label, room, slug, updatedAt]);
 
 	useEffect(() => {
 		void refresh();
@@ -690,14 +715,19 @@ export function ResearchWorkspace(
 		let socket = new Wire({
 			channelId: room,
 			onAuthenticationRequired: () => location.reload(),
+			onDeleted: () => {
+				setDeleted(true);
+				onDocumentDeleted(room);
+			},
 			onStatus: next => {
 				setStatus(next);
 				if (next === "connected") void refresh();
 			},
 		});
 		let off = [
-			socket.on<Session.Hello>("session:hello", frame => {
-				setEffectiveCanEdit(frame.canEdit);
+			socket.on<ManagedHello>("session:hello", frame => {
+				setEffectiveCanEdit(frame.canEdit && !frame.archivedAt);
+				setEffectiveCanManage(frame.canManage);
 				setCapabilities({
 					backgroundJobs: frame.backgroundJobs,
 					webResearch: frame.webResearch,
@@ -707,13 +737,16 @@ export function ResearchWorkspace(
 				onResearchWorkspacesRefresh(parentChannel(room, repository, metadataRef.current));
 				void refresh();
 			}),
-			socket.on<Session.Access>("session:access", frame => {
+			socket.on<ManagedAccess>("session:access", frame => {
 				setEffectiveCanEdit(frame.canEdit);
+				setEffectiveCanManage(frame.canManage);
 				onRepositoryAccessChanged();
 				void refresh();
 			}),
-			socket.on<Session.Channel>("session:channel", frame => {
+			socket.on<ManagedChannel>("session:channel", frame => {
 				if (frame.channelId !== room) return;
+				setEffectiveCanEdit(!frame.archivedAt && frame.canManage);
+				setEffectiveCanManage(frame.canManage);
 				updateMetadata(frame);
 				void refresh();
 			}),
@@ -738,6 +771,7 @@ export function ResearchWorkspace(
 			socket.dispose();
 		};
 	}, [
+		onDocumentDeleted,
 		onResearchWorkspaceChanged,
 		onResearchWorkspacesRefresh,
 		onRepositoryAccessChanged,
@@ -748,8 +782,10 @@ export function ResearchWorkspace(
 		workspaceId,
 	]);
 
+	let workspaceArchivedAt = archivedAt ?? metadata.archivedAt;
+	let workspaceCanEdit = effectiveCanEdit && !workspaceArchivedAt;
 	let cancel = async (turnId: string) => {
-		if (cancelling || status !== "connected" || !effectiveCanEdit) return;
+		if (cancelling || status !== "connected" || !workspaceCanEdit) return;
 		setCancelling(turnId);
 		setCancellationError(undefined);
 		try {
@@ -760,6 +796,13 @@ export function ResearchWorkspace(
 			setCancelling(undefined);
 		}
 	};
+	if (deleted) {
+		return (
+			<div className="research-route-state">
+				<p role="status">This document was deleted.</p>
+			</div>
+		);
+	}
 
 	let parentHref = documentPath(repository.owner, repository.name, metadata.slug);
 	let connected = status === "connected";
@@ -805,17 +848,34 @@ export function ResearchWorkspace(
 		: initial
 		? jobLabel(currentJob(initial))
 		: "Preparing research";
-	let canCancel = connected && effectiveCanEdit && !cancelling;
+	let canCancel = connected && workspaceCanEdit && !cancelling;
 
 	return (
 		<div className="research-workspace">
 			<header className="research-header room-header">
-				<a className="research-back-link research-control" href={parentHref}>
-					Back to {metadata.title}
-				</a>
-				<div className="research-connection" data-status={status} role="status">
-					<span aria-hidden="true" />
-					{refreshing && connected ? "Refreshing" : connection}
+				<div className="flex min-w-0 items-center">
+					<a className="research-back-link research-control" href={parentHref}>
+						Back to {metadata.title}
+					</a>
+					{workspaceArchivedAt && (
+						<span className="document-status-badge document-read-only-status">
+							Archived, read-only
+						</span>
+					)}
+				</div>
+				<div className="flex shrink-0 items-center gap-2">
+					{effectiveCanManage && (
+						<DocumentActionsMenu
+							channel={{ archivedAt: workspaceArchivedAt, title: metadata.title }}
+							className="btn btn-sm btn-ghost"
+							onAction={onDocumentAction}
+							trigger={<span>Actions</span>}
+						/>
+					)}
+					<div className="research-connection" data-status={status} role="status">
+						<span aria-hidden="true" />
+						{refreshing && connected ? "Refreshing" : connection}
+					</div>
 				</div>
 			</header>
 			<div className="research-scroll">
@@ -846,7 +906,7 @@ export function ResearchWorkspace(
 								<DraftConfirmation
 									agent={agent}
 									backgroundJobs={capabilities.backgroundJobs}
-									canEdit={effectiveCanEdit}
+									canEdit={workspaceCanEdit}
 									connected={connected}
 									onSaved={acceptMutation}
 									webResearch={capabilities.webResearch}
@@ -902,7 +962,7 @@ export function ResearchWorkspace(
 							agent={agent}
 							backgroundJobs={capabilities.backgroundJobs}
 							canCancel={canCancel}
-							canEdit={effectiveCanEdit}
+							canEdit={workspaceCanEdit}
 							connected={connected}
 							detail={detail}
 							onCancel={turnId => void cancel(turnId)}

--- a/apps/web/src/room-workspace.tsx
+++ b/apps/web/src/room-workspace.tsx
@@ -24,6 +24,7 @@ import chevronDownIcon from "./assets/icons/tool-chevron-down.svg";
 import { Chat } from "./chat/chat";
 import { rememberChannel } from "./channel-recovery";
 import { decisionAttention, DecisionViewControl } from "./decision-view-control";
+import { DocumentActionsMenu } from "./document-actions-menu";
 import { useNavigationDocument } from "./navigation-shell";
 import { NavigationIcon } from "./project-sidebar";
 import { peopleHere } from "./presence";
@@ -33,20 +34,29 @@ import { availableDocumentView, presentWorkspace, storedDocumentView } from "./w
 
 import type { Research, Session } from "@chopin/protocol";
 import type { DecisionView, DecisionViewState } from "@chopin/editor";
+import type * as Api from "./api";
+import type { DocumentAction } from "./document-actions-menu";
 import type { HostedWorkspaceProps } from "./hosted";
 import type { Status } from "./wire";
 
+type ManagedHello = Session.Hello & { archivedAt?: string; canManage: boolean };
+type ManagedChannel = Session.Channel & { archivedAt?: string; canManage: boolean };
+type ManagedAccess = Session.Access & { canManage: boolean };
+type WorkspaceMetadata = Pick<Api.Channel, "title" | "slug" | "updatedAt" | "archivedAt">;
+
 export function Header(
 	{
-		canEdit,
+		archivedAt,
+		canManage,
 		members,
 		label,
-		onRename,
+		onAction,
 	}: {
-		canEdit: boolean;
+		archivedAt?: string;
+		canManage: boolean;
 		members: Session.Member[];
 		label: string;
-		onRename: () => void;
+		onAction: (action: DocumentAction) => void;
 	},
 ) {
 	let people = peopleHere(members);
@@ -57,16 +67,31 @@ export function Header(
 				className="flex min-w-0 flex-1 items-center gap-0.5"
 			>
 				<NavigationIcon className="opacity-50" src={bookBookmarkIcon} />
-				<button
-					aria-label={`Rename ${label}`}
-					className="document-title-trigger"
-					disabled={!canEdit}
-					onClick={onRename}
-					type="button"
-				>
-					<span className="truncate">{label}</span>
-					<img alt="" aria-hidden="true" className="size-3.5 opacity-50" src={chevronDownIcon} />
-				</button>
+				{canManage
+					? (
+						<DocumentActionsMenu
+							channel={{ archivedAt, title: label }}
+							className="document-title-trigger"
+							onAction={onAction}
+							trigger={
+								<>
+									<span className="truncate">{label}</span>
+									<img
+										alt=""
+										aria-hidden="true"
+										className="size-3.5 opacity-50"
+										src={chevronDownIcon}
+									/>
+								</>
+							}
+						/>
+					)
+					: <span className="document-title-label truncate">{label}</span>}
+				{archivedAt && (
+					<span className="document-status-badge document-read-only-status">
+						Archived, read-only
+					</span>
+				)}
 			</div>
 			<div
 				aria-label={`People here: ${people.join(", ")}`}
@@ -94,7 +119,9 @@ export function Header(
 export function RoomWorkspace(
 	{
 		agent = true,
+		archivedAt,
 		canEdit = true,
+		canManage,
 		handle,
 		label,
 		repository,
@@ -106,15 +133,18 @@ export function RoomWorkspace(
 ) {
 	let [wire, setWire] = useState<Wire>();
 	let {
+		onDocumentAction,
 		onDocumentChanged,
-		onRenameDocument,
+		onDocumentDeleted,
 		onRepositoryAccessChanged,
 		onResearchWorkspaceChanged,
 		onResearchWorkspacesRefresh,
 	} = useNavigationDocument();
 	let [status, setStatus] = useState<Status>("connecting");
 	let [members, setMembers] = useState<Session.Member[]>([]);
-	let [effectiveCanEdit, setEffectiveCanEdit] = useState(canEdit);
+	let [effectiveCanEdit, setEffectiveCanEdit] = useState(canEdit && !archivedAt);
+	let [effectiveCanManage, setEffectiveCanManage] = useState(canManage);
+	let [deleted, setDeleted] = useState(false);
 	let [capabilities, setCapabilities] = useState({ backgroundJobs: false });
 	let [chatReferences, setChatReferences] = useState<{ wire?: Wire; enabled: boolean }>({
 		enabled: false,
@@ -122,7 +152,12 @@ export function RoomWorkspace(
 	let [chatSendAcks, setChatSendAcks] = useState<{ wire?: Wire; enabled: boolean }>({
 		enabled: false,
 	});
-	let [metadata, setMetadata] = useState({ title: label, slug, updatedAt });
+	let [metadata, setMetadata] = useState<WorkspaceMetadata>({
+		archivedAt,
+		title: label,
+		slug,
+		updatedAt,
+	});
 	let metadataRef = useRef(metadata);
 	let user = useMemo(() => cursor(handle), [handle]);
 	let mode = useWorkspaceMode();
@@ -151,6 +186,7 @@ export function RoomWorkspace(
 	);
 	let previousUnanswered = useRef(unanswered);
 	let latestCanEdit = useRef(canEdit);
+	let latestCanManage = useRef(canManage);
 	let [attention, setAttention] = useState(false);
 	let workspacePresentation = presentWorkspace(workspace, mode, view);
 	let conversationActive = workspacePresentation.conversationVisible;
@@ -166,13 +202,19 @@ export function RoomWorkspace(
 		},
 		[conversationActive],
 	);
-	let updateMetadata = useCallback((next: { title: string; slug: string; updatedAt: string }) => {
-		if (Date.parse(next.updatedAt) <= Date.parse(metadataRef.current.updatedAt)) return;
-		metadataRef.current = next;
-		setMetadata(next);
-		rememberChannel(userId, { id: room, title: next.title, slug: next.slug }, repository);
-		onDocumentChanged(room, next);
-		let path = documentPath(repository.owner, repository.name, next.slug);
+	let updateMetadata = useCallback((next: WorkspaceMetadata) => {
+		if (Date.parse(next.updatedAt) < Date.parse(metadataRef.current.updatedAt)) return;
+		let metadata = {
+			archivedAt: next.archivedAt,
+			title: next.title,
+			slug: next.slug,
+			updatedAt: next.updatedAt,
+		};
+		metadataRef.current = metadata;
+		setMetadata(metadata);
+		rememberChannel(userId, { id: room, title: metadata.title, slug: metadata.slug }, repository);
+		onDocumentChanged(room, metadata);
+		let path = documentPath(repository.owner, repository.name, metadata.slug);
 		if (location.pathname !== path) {
 			history.replaceState(null, "", `${path}${location.search}${location.hash}`);
 		}
@@ -237,20 +279,27 @@ export function RoomWorkspace(
 	};
 
 	useEffect(() => {
-		latestCanEdit.current = canEdit;
-		setEffectiveCanEdit(canEdit);
-	}, [canEdit, room]);
+		let editable = canEdit && !archivedAt;
+		latestCanEdit.current = editable;
+		latestCanManage.current = canManage;
+		setEffectiveCanEdit(editable);
+		setEffectiveCanManage(canManage);
+	}, [archivedAt, canEdit, canManage, room]);
 
 	useEffect(() => {
-		let next = { title: label, slug, updatedAt };
+		let next = { archivedAt, title: label, slug, updatedAt };
 		metadataRef.current = next;
 		setMetadata(next);
-	}, [label, room, slug, updatedAt]);
+	}, [archivedAt, label, room, slug, updatedAt]);
 
 	useEffect(() => {
 		let socket = new Wire({
 			channelId: room,
 			onAuthenticationRequired: () => location.reload(),
+			onDeleted: () => {
+				setDeleted(true);
+				onDocumentDeleted(room);
+			},
 			onStatus: next => {
 				setStatus(next);
 			},
@@ -258,11 +307,15 @@ export function RoomWorkspace(
 		setWire(socket);
 
 		let off = [
-			socket.on<Session.Hello>("session:hello", frame => {
-				let accessChanged = latestCanEdit.current !== frame.canEdit;
-				latestCanEdit.current = frame.canEdit;
+			socket.on<ManagedHello>("session:hello", frame => {
+				let editable = frame.canEdit && !frame.archivedAt;
+				let accessChanged = latestCanEdit.current !== editable
+					|| latestCanManage.current !== frame.canManage;
+				latestCanEdit.current = editable;
+				latestCanManage.current = frame.canManage;
 				setMembers(frame.members);
-				setEffectiveCanEdit(frame.canEdit);
+				setEffectiveCanEdit(editable);
+				setEffectiveCanManage(frame.canManage);
 				setCapabilities({ backgroundJobs: frame.backgroundJobs });
 				setChatReferences({ wire: socket, enabled: frame.chatReferences === true });
 				setChatSendAcks({ wire: socket, enabled: frame.chatSendAcks === true });
@@ -284,13 +337,24 @@ export function RoomWorkspace(
 					slug: metadataRef.current.slug,
 				});
 			}),
-			socket.on<Session.Channel>("session:channel", frame => {
-				if (frame.channelId === room) updateMetadata(frame);
+			socket.on<ManagedChannel>("session:channel", frame => {
+				if (frame.channelId !== room) return;
+				let editable = !frame.archivedAt && frame.canManage;
+				let accessChanged = latestCanEdit.current !== editable
+					|| latestCanManage.current !== frame.canManage;
+				latestCanEdit.current = editable;
+				latestCanManage.current = frame.canManage;
+				setEffectiveCanEdit(editable);
+				setEffectiveCanManage(frame.canManage);
+				updateMetadata(frame);
+				if (accessChanged) onRepositoryAccessChanged();
 			}),
 			socket.on<Session.Presence>("session:presence", frame => setMembers(frame.members)),
-			socket.on<Session.Access>("session:access", frame => {
+			socket.on<ManagedAccess>("session:access", frame => {
 				latestCanEdit.current = frame.canEdit;
+				latestCanManage.current = frame.canManage;
 				setEffectiveCanEdit(frame.canEdit);
+				setEffectiveCanManage(frame.canManage);
 				onRepositoryAccessChanged();
 			}),
 			socket.on<Research.Changed>("research:changed", frame => {
@@ -319,6 +383,7 @@ export function RoomWorkspace(
 	}, [
 		handle,
 		jobs,
+		onDocumentDeleted,
 		onResearchWorkspaceChanged,
 		onResearchWorkspacesRefresh,
 		onRepositoryAccessChanged,
@@ -328,13 +393,23 @@ export function RoomWorkspace(
 		updateMetadata,
 	]);
 
+	let workspaceArchivedAt = archivedAt ?? metadata.archivedAt;
+	let workspaceCanEdit = effectiveCanEdit && !workspaceArchivedAt;
+	if (deleted) {
+		return (
+			<div className="flex h-full items-center justify-center bg-ground p-4 text-sm text-text-secondary">
+				<p role="status">This document was deleted.</p>
+			</div>
+		);
+	}
+
 	return (
 		<Workspace
 			chat={
 				<Chat
 					active={conversationActive}
 					agent={agent}
-					connected={status === "connected" && effectiveCanEdit}
+					connected={status === "connected" && workspaceCanEdit}
 					handle={handle}
 					onActivity={onConversationActivity}
 					referencesEnabled={chatReferences.wire === wire && chatReferences.enabled}
@@ -352,10 +427,11 @@ export function RoomWorkspace(
 			}}
 			header={
 				<Header
-					canEdit={effectiveCanEdit}
+					archivedAt={workspaceArchivedAt}
+					canManage={effectiveCanManage}
 					members={members}
 					label={metadata.title}
-					onRename={onRenameDocument}
+					onAction={onDocumentAction}
 				/>
 			}
 			controls={
@@ -374,7 +450,7 @@ export function RoomWorkspace(
 			onDestination={selectDestination}
 			decisions={
 				<Decisions
-					connected={status === "connected" && effectiveCanEdit}
+					connected={status === "connected" && workspaceCanEdit}
 					headingId={HEADING.decisions}
 					onShowPlan={showPlan}
 					reveal={reveal}
@@ -385,10 +461,11 @@ export function RoomWorkspace(
 			plan={
 				<PlanEditor
 					commentPresentation={mode === "split" ? "popover" : "sheet"}
-					connection={status}
+					connection={status === "deleted" ? "closed" : status}
+					key={workspaceArchivedAt ? "archived" : "active"}
 					onScrollTop={setPlanScrollTop}
 					questions={questions}
-					readOnly={!effectiveCanEdit}
+					readOnly={!workspaceCanEdit}
 					scrollTop={planScrollTop}
 					threads={threads}
 					user={user}
@@ -398,7 +475,7 @@ export function RoomWorkspace(
 			backgroundWork={capabilities.backgroundJobs
 				? (
 					<BackgroundWork
-						canEdit={effectiveCanEdit}
+						canEdit={workspaceCanEdit}
 						connected={status === "connected"}
 						headingId={HEADING["background-work"]}
 						store={jobs}

--- a/apps/web/src/use-project-documents.ts
+++ b/apps/web/src/use-project-documents.ts
@@ -5,53 +5,107 @@ import {
 	beginDocumentLoad,
 	completeDocumentPage,
 	failDocumentLoad,
+	newestDocument,
 	projectDocuments,
+	removeLoadedDocument,
 	replaceLoadedDocument,
 	updateLoadedDocument,
 } from "./document-actions";
 
 import type { LoadedDocuments, ProjectDocuments } from "./document-actions";
 
-export function useProjectDocuments(navigation?: Api.Navigation) {
-	let [documents, setDocuments] = useState<LoadedDocuments>({});
+export function useProjectDocuments(navigation?: Api.Navigation, includeArchived = false) {
+	let [catalogue, setCatalogue] = useState<{
+		includeArchived: boolean;
+		documents: LoadedDocuments;
+	}>(() => ({ includeArchived, documents: {} }));
+	let includeArchivedRef = useRef(includeArchived);
+	includeArchivedRef.current = includeArchived;
+	let documents = catalogue.includeArchived === includeArchived ? catalogue.documents : {};
 	let loads = useRef(new Map<string, AbortController>());
+	let latestDocuments = useRef(new Map<string, Api.Channel>());
 
 	let load = useCallback(async (project: Api.NavigationProject, cursor?: string) => {
 		let id = project.repositoryId;
-		if (loads.current.has(id)) return;
+		let key = `${includeArchived ? "all" : "active"}:${id}`;
+		if (loads.current.has(key)) return;
 		let controller = new AbortController();
-		loads.current.set(id, controller);
-		setDocuments(current => ({
-			...current,
-			[id]: beginDocumentLoad(current[id]),
-		}));
+		loads.current.set(key, controller);
+		setCatalogue(current => {
+			let catalogueDocuments = current.includeArchived === includeArchived
+				? current.documents
+				: {};
+			return {
+				includeArchived,
+				documents: {
+					...catalogueDocuments,
+					[id]: beginDocumentLoad(catalogueDocuments[id]),
+				},
+			};
+		});
 		try {
 			let page = await Api.channels(
 				project.repositoryOwner,
 				project.repositoryName,
-				cursor,
-				undefined,
-				controller.signal,
+				{ cursor, includeArchived, signal: controller.signal },
 			);
-			if (loads.current.get(id) !== controller) return;
-			setDocuments(current => ({
-				...current,
-				[id]: completeDocumentPage(
-					current[id] ?? beginDocumentLoad(),
-					page.channels,
-					page.nextCursor,
-				),
-			}));
+			if (loads.current.get(key) !== controller) return;
+			let channels = page.channels.map(channel => {
+				let latest = latestDocuments.current.get(channel.id);
+				let accepted = latest ? newestDocument(latest, channel) : channel;
+				latestDocuments.current.set(channel.id, accepted);
+				return accepted;
+			}).filter(channel => includeArchived || !channel.archivedAt);
+			setCatalogue(current =>
+				current.includeArchived !== includeArchived
+					? current
+					: {
+						...current,
+						documents: {
+							...current.documents,
+							[id]: completeDocumentPage(
+								current.documents[id] ?? beginDocumentLoad(),
+								channels,
+								page.nextCursor,
+								cursor === undefined,
+							),
+						},
+					}
+			);
 		} catch (error) {
-			if (controller.signal.aborted || loads.current.get(id) !== controller) return;
-			setDocuments(current => ({
-				...current,
-				[id]: failDocumentLoad(current[id] ?? beginDocumentLoad(), error),
-			}));
+			if (controller.signal.aborted || loads.current.get(key) !== controller) return;
+			setCatalogue(current =>
+				current.includeArchived !== includeArchived
+					? current
+					: {
+						...current,
+						documents: {
+							...current.documents,
+							[id]: failDocumentLoad(
+								current.documents[id] ?? beginDocumentLoad(),
+								error,
+							),
+						},
+					}
+			);
 		} finally {
-			if (loads.current.get(id) === controller) loads.current.delete(id);
+			if (loads.current.get(key) === controller) loads.current.delete(key);
 		}
-	}, []);
+	}, [includeArchived]);
+
+	useEffect(() => {
+		let prefix = includeArchived ? "all:" : "active:";
+		for (let [key, controller] of loads.current) {
+			if (key.startsWith(prefix)) continue;
+			controller.abort();
+			loads.current.delete(key);
+		}
+		setCatalogue(current =>
+			current.includeArchived === includeArchived
+				? current
+				: { includeArchived, documents: {} }
+		);
+	}, [includeArchived]);
 
 	useEffect(() => {
 		if (!navigation) return;
@@ -59,23 +113,29 @@ export function useProjectDocuments(navigation?: Api.Navigation) {
 			navigation.projects.filter(project => project.available)
 				.map(project => project.repositoryId),
 		);
-		for (let [id, controller] of loads.current) {
-			if (!available.has(id)) controller.abort();
+		for (let [key, controller] of loads.current) {
+			let id = key.slice(key.indexOf(":") + 1);
+			if (!available.has(id)) {
+				controller.abort();
+				loads.current.delete(key);
+			}
 		}
-		setDocuments(current => {
-			let entries = Object.entries(current).filter(([id]) => available.has(id));
-			return entries.length === Object.keys(current).length
+		setCatalogue(current => {
+			if (current.includeArchived !== includeArchived) return current;
+			let entries = Object.entries(current.documents).filter(([id]) => available.has(id));
+			return entries.length === Object.keys(current.documents).length
 				? current
-				: Object.fromEntries(entries);
+				: { ...current, documents: Object.fromEntries(entries) };
 		});
 		for (let project of navigation.projects) {
 			let state = documents[project.repositoryId];
+			let key = `${includeArchived ? "all" : "active"}:${project.repositoryId}`;
 			if (
 				project.available
-				&& (!state || (state.status === "loading" && !loads.current.has(project.repositoryId)))
+				&& (!state || (state.status === "loading" && !loads.current.has(key)))
 			) void load(project);
 		}
-	}, [documents, load, navigation]);
+	}, [documents, includeArchived, load, navigation]);
 
 	useEffect(() => () => {
 		for (let controller of loads.current.values()) controller.abort();
@@ -94,14 +154,54 @@ export function useProjectDocuments(navigation?: Api.Navigation) {
 		void load(project);
 	}, [load]);
 	let upsertDocument = useCallback((channel: Api.Channel) => {
-		setDocuments(current => replaceLoadedDocument(current, channel));
+		let latest = latestDocuments.current.get(channel.id);
+		let accepted = latest ? newestDocument(latest, channel) : channel;
+		latestDocuments.current.set(channel.id, accepted);
+		setCatalogue(current => {
+			let visible = current.includeArchived === includeArchivedRef.current;
+			if (!visible) return current;
+			let existing = Object.values(current.documents).flatMap(state => state.channels)
+				.find(value => value.id === channel.id);
+			accepted = existing ? newestDocument(existing, accepted) : accepted;
+			latestDocuments.current.set(channel.id, accepted);
+			let documents = accepted.archivedAt && !includeArchivedRef.current
+				? removeLoadedDocument(current.documents, accepted.id)
+				: replaceLoadedDocument(current.documents, accepted);
+			return documents === current.documents ? current : { ...current, documents };
+		});
 	}, []);
 	let updateDocument = useCallback((
 		documentId: string,
-		update: Pick<Api.Channel, "title" | "slug" | "updatedAt">,
+		update: Pick<Api.Channel, "title" | "slug" | "updatedAt" | "archivedAt">,
 	) => {
-		setDocuments(current => updateLoadedDocument(current, documentId, update));
+		let latest = latestDocuments.current.get(documentId);
+		if (!latest || latest.updatedAt <= update.updatedAt) {
+			if (latest) latestDocuments.current.set(documentId, { ...latest, ...update });
+		}
+		setCatalogue(current => {
+			if (current.includeArchived !== includeArchivedRef.current) return current;
+			let existing = Object.values(current.documents).flatMap(state => state.channels)
+				.find(value => value.id === documentId);
+			if (existing && existing.updatedAt > update.updatedAt) return current;
+			let documents = update.archivedAt && !includeArchivedRef.current
+				? removeLoadedDocument(current.documents, documentId)
+				: updateLoadedDocument(current.documents, documentId, update);
+			return documents === current.documents ? current : { ...current, documents };
+		});
+	}, []);
+	let removeDocument = useCallback((documentId: string) => {
+		latestDocuments.current.delete(documentId);
+		for (let controller of loads.current.values()) controller.abort();
+		loads.current.clear();
+		setCatalogue(current => ({ ...current, documents: {} }));
 	}, []);
 
-	return { loadMore, projects, refreshProject, updateDocument, upsertDocument };
+	return {
+		loadMore,
+		projects,
+		refreshProject,
+		removeDocument,
+		updateDocument,
+		upsertDocument,
+	};
 }

--- a/apps/web/src/use-project-research.ts
+++ b/apps/web/src/use-project-research.ts
@@ -6,6 +6,7 @@ import {
 	completeResearchLoad,
 	currentResearchRequest,
 	failResearchLoad,
+	removeLoadedResearchChannel,
 	researchByChannel,
 	upsertLoadedResearch,
 } from "./research-navigation";
@@ -17,6 +18,7 @@ import type { LoadedResearch } from "./research-navigation";
 export function useProjectResearch(
 	navigation?: Api.Navigation,
 	documents: ProjectDocuments[] = [],
+	includeArchived = false,
 ) {
 	let [research, setResearch] = useState<LoadedResearch>({});
 	let loads = useRef(new Map<string, AbortController>());
@@ -44,11 +46,12 @@ export function useProjectResearch(
 				project.repositoryOwner,
 				project.repositoryName,
 				controller.signal,
+				includeArchived,
 			);
 			if (!currentResearchRequest(loads.current, id, controller)) return false;
 			setResearch(current => ({
 				...current,
-				[id]: completeResearchLoad(current[id] ?? beginResearchLoad(), page),
+				[id]: completeResearchLoad(current[id] ?? beginResearchLoad(), page, !replace),
 			}));
 			return true;
 		} catch (error) {
@@ -61,7 +64,13 @@ export function useProjectResearch(
 		} finally {
 			if (loads.current.get(id) === controller) loads.current.delete(id);
 		}
-	}, []);
+	}, [includeArchived]);
+
+	useEffect(() => {
+		for (let controller of loads.current.values()) controller.abort();
+		loads.current.clear();
+		setResearch({});
+	}, [includeArchived]);
 
 	useEffect(() => {
 		if (!navigation) return;
@@ -137,12 +146,18 @@ export function useProjectResearch(
 		let project = projects.current.get(channel.repositoryId);
 		if (project?.available) void load(project, true);
 	}, [load]);
+	let removeResearchChannel = useCallback((channelId: string) => {
+		for (let controller of loads.current.values()) controller.abort();
+		loads.current.clear();
+		setResearch(current => removeLoadedResearchChannel(current, channelId));
+	}, []);
 
 	let groups = useMemo(() => researchByChannel(research), [research]);
 	return {
 		groups,
 		refreshResearchChannel,
 		refreshResearchWorkspace,
+		removeResearchChannel,
 		research,
 		upsertResearchWorkspace,
 	};

--- a/apps/web/src/wire.test.ts
+++ b/apps/web/src/wire.test.ts
@@ -95,13 +95,44 @@ function restartable(): { port: number; deny: () => void; drop: () => void } {
 	};
 }
 
-function connect(port: number, seen: Status[], onAuthenticationRequired?: () => void): Wire {
+function deleted(mode: "frame" | "close"): { port: number; connections: () => number } {
+	let connections = 0;
+	let server = Bun.serve({
+		port: 0,
+		hostname: "127.0.0.1",
+		fetch(req, self) {
+			if (req.headers.get("x-chopin-socket-probe") === "1") {
+				return new Response(null, { status: 204 });
+			}
+			return self.upgrade(req) ? undefined : new Response("no", { status: 400 });
+		},
+		websocket: {
+			open(socket) {
+				connections++;
+				if (mode === "frame") {
+					socket.send(JSON.stringify({ kind: "session:deleted", ts: 1 }));
+				} else socket.close(4404, "deleted");
+			},
+			message() {},
+		},
+	});
+	servers.push(server);
+	return { port: server.port!, connections: () => connections };
+}
+
+function connect(
+	port: number,
+	seen: Status[],
+	onAuthenticationRequired?: () => void,
+	onDeleted?: () => void,
+): Wire {
 	// `location` is what the client derives its URL from, and there is none in
 	// a test runtime.
 	globalThis.location = { href: `http://127.0.0.1:${port}/`, protocol: "http:" } as Location;
 	let wire = new Wire({
 		channelId: "019c1234-1234-4123-8123-123456789abc",
 		onAuthenticationRequired,
+		onDeleted,
 		onStatus: status => seen.push(status),
 	});
 	wires.push(wire);
@@ -195,6 +226,22 @@ describe("status", () => {
 		);
 		expect(wire.status).toBe("connected");
 	});
+
+	for (let mode of ["frame", "close"] as const) {
+		it(`treats a deleted ${mode} as terminal`, async () => {
+			let service = deleted(mode);
+			let seen: Status[] = [];
+			let notifications = 0;
+			let wire = connect(service.port, seen, undefined, () => notifications++);
+
+			await until(() => wire.status === "deleted", "deleted");
+			await Bun.sleep(800);
+
+			expect(notifications).toBe(1);
+			expect(service.connections()).toBe(1);
+			expect(seen.at(-1)).toBe("deleted");
+		});
+	}
 
 	it("rejects a pending request when the connection goes away", async () => {
 		let port = endpoint(true);

--- a/apps/web/src/wire.ts
+++ b/apps/web/src/wire.ts
@@ -10,7 +10,13 @@
  * same build work on localhost, over a LAN address, and through a tunnel.
  */
 
-export type Status = "connecting" | "connected" | "reconnecting" | "denied" | "closed";
+export type Status =
+	| "connecting"
+	| "connected"
+	| "reconnecting"
+	| "denied"
+	| "deleted"
+	| "closed";
 
 export type Unsubscribe = () => void;
 
@@ -27,6 +33,7 @@ export type WireOptions = {
 	channelId: string;
 	onStatus?: (status: Status, reason?: string) => void;
 	onAuthenticationRequired?: () => void;
+	onDeleted?: () => void;
 };
 
 type Refusal = { reason: string; authentication: boolean };
@@ -65,6 +72,7 @@ export class Wire {
 	#status: Status | undefined;
 	#everConnected = false;
 	#disposed = false;
+	#terminal = false;
 
 	constructor(options: WireOptions) {
 		this.#options = options;
@@ -93,7 +101,7 @@ export class Wire {
 	}
 
 	#connect(): void {
-		if (this.#disposed) return;
+		if (this.#disposed || this.#terminal) return;
 		this.#set(this.#everConnected ? "reconnecting" : "connecting");
 
 		let socket = new WebSocket(endpoint(this.#options));
@@ -110,10 +118,14 @@ export class Wire {
 			this.#receive(event.data);
 		});
 
-		socket.addEventListener("close", () => {
+		socket.addEventListener("close", event => {
 			// A socket superseded by a reconnect must not drive status or retries.
 			if (this.#socket !== socket) return;
 			this.#socket = undefined;
+			if (event.code === 4404) {
+				this.#deleted();
+				return;
+			}
 			this.#abandon("connection lost");
 			void this.#retry();
 		});
@@ -145,10 +157,10 @@ export class Wire {
 	}
 
 	async #retry(): Promise<void> {
-		if (this.#disposed) return;
+		if (this.#disposed || this.#terminal) return;
 
 		let refusal = await this.#refusal();
-		if (this.#disposed) return;
+		if (this.#disposed || this.#terminal) return;
 		if (refusal) {
 			if (refusal.authentication) this.#options.onAuthenticationRequired?.();
 			return this.#set("denied", refusal.reason);
@@ -195,6 +207,20 @@ export class Wire {
 				console.error(`[wire] ${frame.kind} listener failed:`, err);
 			}
 		}
+		if (frame.kind === "session:deleted") this.#deleted();
+	}
+
+	#deleted(): void {
+		if (this.#disposed || this.#terminal) return;
+		this.#terminal = true;
+		if (this.#timer) clearTimeout(this.#timer);
+		this.#timer = undefined;
+		let socket = this.#socket;
+		this.#socket = undefined;
+		this.#abandon("document deleted");
+		this.#set("deleted", "document deleted");
+		socket?.close();
+		this.#options.onDeleted?.();
 	}
 
 	/** Reject everything still waiting; a reply cannot survive its connection. */
@@ -242,6 +268,6 @@ export class Wire {
 		this.#abandon("disposed");
 		this.#socket?.close();
 		this.#socket = undefined;
-		this.#set("closed");
+		if (!this.#terminal) this.#set("closed");
 	}
 }

--- a/docs/background-jobs.md
+++ b/docs/background-jobs.md
@@ -544,6 +544,23 @@ authorized parent-channel readers. Normalized job input is persisted but omitted
 from browser and Planner job projections. Private worker material is still sent
 to the hosted Copilot inference service under the active owner's credential.
 
+## Archive and deletion
+
+Archiving a document suspends its summary coordinator, cancels any pending
+summary debounce, and prevents new summary scheduling. It does not blanket-cancel
+background jobs already admitted for that channel. New Research Workspace
+drafts, confirmations, follow-ups, and searches are blocked while archived, but
+already-started evidence and answer jobs may settle, and their idempotent
+workspace reconciliation may still persist.
+
+Permanent deletion has a stronger boundary. The runner first blocks new claims
+for the channel while summary scheduling remains suspended, aborts its active
+attempts, cancels every pending, paused, or running job, and waits a bounded
+grace period. The server then closes the live plan before atomically deleting
+the archived channel. Claim fencing rejects any late worker progress or
+artifact, and the channel delete cascades job targets, jobs, artifacts, Research
+Workspaces, turns, and messages.
+
 ## Storage and retention
 
 The generic schema supports a new standalone job type without a migration:
@@ -569,8 +586,9 @@ deliberately persists the captured source snapshot. Store only material the
 workflow needs and document its retention boundary.
 
 There is no current pruning policy for jobs, artifacts, Research Workspaces, or
-their transcripts. Cancellation prevents publication; it does not erase input
-or history.
+their transcripts while their document remains stored. Cancellation prevents
+publication; it does not erase input or history. Full document deletion is the
+exception and removes all of that channel-owned state.
 
 ## Browser and Planner integration
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -16,13 +16,14 @@ authorization then depends on the surface:
 | Hosted agent (Planner)     | The owning browser user's GitHub App token | The installation, ownership generation, session, credential revision, and role are rechecked before tools run. |
 | Local MCP                  | Caller-supplied GitHub bearer              | GitHub is queried directly; no App installation is required.                                                   |
 
-Pull access may list and open documents. Push or administration access may create
-a document, edit it, change decisions, invoke the hosted agent, and
-mutate an implementation lifecycle. The same roles apply to document-attached
+Pull access may list and open active or archived documents. Push or
+administration access may create, edit, rename, archive, restore, and delete
+documents and mutate an implementation lifecycle. Deletion additionally
+requires the document to be archived. The same roles apply to document-attached
 Research Workspaces: pull may read, while push or administration may create a
-draft, confirm public search, ask follow-ups, search more, or cancel work. A
-public repository is not sufficient to
-expose its documents through the browser.
+draft, confirm public search, ask follow-ups, search more, or cancel work on an
+active document. A public repository is not sufficient to expose its documents
+through the browser.
 
 An MCP-created document outside the App installation remains unavailable to
 browser routes, WebSockets, and the hosted agent until an account owner adds
@@ -36,6 +37,9 @@ POST /api/repositories/:owner/:repository/channels
 GET  /api/repositories/:owner/:repository/documents/:slug
 GET  /api/channels/:channelId
 PATCH /api/channels/:channelId
+POST /api/channels/:channelId/archive
+POST /api/channels/:channelId/restore
+DELETE /api/channels/:channelId
 POST /api/channels/:channelId/agent/reset
 GET  /api/repositories/:owner/:repository/research-workspaces
 POST /api/channels/:channelId/research-workspaces
@@ -47,10 +51,12 @@ implementation. The repository-scoped `documents/:slug` route resolves both the
 current document slug and its historical aliases. Browser creation returns the
 readable canonical document route in `Location`, not a UUID route.
 
-The listing route accepts a case-insensitive `query`, an opaque `cursor`, and a
-`limit` from 1 through 100. The default limit is 50. Results sort by most recent
+The listing route accepts a case-insensitive `query`, an opaque `cursor`, a
+`limit` from 1 through 100, and `includeArchived=true`. The default limit is 50,
+and archived documents are excluded by default. Results sort by most recent
 update, with channel ID as the stable tie-breaker. A cursor is bound to its
-original query and cannot be reused with another search.
+original query and archive-inclusion mode and cannot be reused with another
+search.
 
 A title is optional during browser creation. Chopin generates one when omitted,
 or accepts a trimmed title from 1 through 120 characters. Titles are unique per
@@ -66,8 +72,44 @@ Slugs are derived from Unicode-normalized, lowercased titles. Unicode letters,
 numbers, and combining marks remain readable while punctuation and spacing
 collapse to hyphens. Slugs are scoped to a repository and receive numbered
 suffixes such as `-2` when they collide. Every former canonical slug remains a
-permanent alias for the same document and cannot be rebound to another one, so a
-rename changes the canonical route without breaking an old link.
+historical alias for the document's lifetime and cannot be rebound while it
+exists, so a rename changes the canonical route without breaking an old link.
+
+## Archive, restore, and delete
+
+Archive and restore are idempotent metadata transitions. An archived channel
+has an `archivedAt` timestamp; restore removes it. Both transitions update the
+channel activity timestamp without advancing the collaboration revision or
+sequence, Yjs epoch, document sequence, plan revision, or implementation graph
+counters.
+
+Repository lists, searches, storage scans, and repository-level Research
+Workspace listings consider only active documents by default; their explicit
+`includeArchived` option includes archived parents. Browser landing selection
+and saved navigation remain active-only. Direct slug and UUID reads still
+resolve an archived document, including historical slug aliases.
+
+An archived browser session is read-only, including for a repository writer,
+but retains `canManage` for writers so they can restore or delete the document.
+Archival blocks metadata and document edits, chat, question and comment
+mutations, new Planner and Research Workspace work, and
+`start_implementation`. An already active implementation may still accept
+lifecycle reports, and already-started background or research work may continue
+and persist. Archiving also ends the current Planner runtime; restoring does not
+replay an interrupted turn.
+
+The browser management routes are `POST /api/channels/:channelId/archive`,
+`POST /api/channels/:channelId/restore`, and `DELETE /api/channels/:channelId`.
+They require push or administration access and an exact browser Origin. Delete
+returns a conflict unless the document is archived. Before deletion, the server
+suspends summary scheduling, cancels and aborts the channel's background work,
+and closes the live plan. It then atomically deletes the channel and all
+dependent data, notifies connected clients with `session:deleted`, and closes
+them terminally. See [Storage](storage.md) for the deletion and backup boundary.
+
+MCP exposes `archive_document` and `restore_document`, and `list_documents`
+accepts `includeArchived`; direct MCP reads also remain available. MCP does not
+expose document deletion. See [Local agent MCP](local-agent-mcp.md).
 
 The reset endpoint releases Planner ownership and aborts its disposable runtime
 session. The current web application does not expose a control that calls it.
@@ -155,9 +197,9 @@ than simultaneous document panes.
    server can return only missing state when histories are compatible.
 5. Unacknowledged browser updates remain in an outbox and replay after a
    reconnect.
-6. The server rechecks the session, admission, installation, and repository role
-   while the socket remains open. A lost mutation role makes the connection
-   read-only; lost read access closes it.
+6. The server rechecks the session, admission, installation, repository role,
+   and archive state while the socket remains open. A lost mutation role or
+   archival makes the connection read-only; lost read access closes it.
 7. When a room becomes empty, the server removes its registry entry and starts
    an asynchronous final close and checkpoint. That close is not yet serialized
    against opening a replacement room for the same channel.
@@ -171,6 +213,7 @@ replay the outbox.
 A channel persists:
 
 - metadata and repository identity;
+- archive metadata;
 - canonical MDX, a complete Yjs checkpoint, and the accepted update journal
   after that checkpoint;
 - document sequence and plan revision counters plus a versioned sidecar;
@@ -179,8 +222,8 @@ A channel persists:
 - durable transcript and reserved hosted agent context fields;
 - MCP creation metadata and repository provenance when created through MCP;
 - implementation graph versions, active execution, task progress,
-  verification, and archived runs; and
-- token-free Planner ownership references and generation state.
+  verification, and archived runs;
+- token-free Planner ownership references and generation state; and
 - Research Workspace drafts, append-only turns and messages, and links to
   immutable background-job artifacts.
 

--- a/docs/implementation-lifecycle.md
+++ b/docs/implementation-lifecycle.md
@@ -57,7 +57,9 @@ without immediately superseding the prior approved version. The prior version
 is superseded only when the replacement is approved.
 
 These counters are separate from the Yjs epoch, document update sequence, and
-storage commit revision described in [Architecture](architecture.md).
+storage commit revision described in [Architecture](architecture.md). Archiving
+or restoring the document does not advance any collaboration, document, or
+graph counter.
 
 ## Intended workflow
 
@@ -108,6 +110,11 @@ identity. `read_implementation` returns the stable UUID as `document.id`, and
 `start_implementation` plus every task, pull-request, blocker, revision, and
 verification call continues using that UUID.
 
+Direct `read_implementation` remains available for an archived document.
+`start_implementation` refuses it with `document-archived`, while reports for a
+run that started before archival remain accepted under the normal run and graph
+checks.
+
 ## Lock behavior
 
 An active implementation locks the graph and prevents plan changes that would
@@ -117,6 +124,12 @@ revision. Progress and archived runs remain durable sidecar state.
 
 The protocol defines a `plan:lifecycle` projection for active progress and run
 history. The current web client does not yet render that projection.
+
+Archiving does not release an active graph lock or terminate its run. A coding
+agent can continue reporting task, pull-request, blocker, revision, and
+verification transitions while the document is archived. Permanent deletion is
+terminal instead: it cascades the graph, execution, and lifecycle sidecar with
+the channel, and later lifecycle reports return `document-unavailable`.
 
 ## Authorization
 

--- a/docs/local-agent-mcp.md
+++ b/docs/local-agent-mcp.md
@@ -43,9 +43,10 @@ the configured Chopin origin.
 
 The current MCP contract can:
 
-- list and read Chopin documents for the current repository;
+- list and read active or archived Chopin documents for the current repository;
 - create one document from a structured brief, canonical source supplied through
   the current `plan` input, and caller-supplied repository provenance;
+- rename, archive, and restore documents without deleting their durable state;
 - read an approved implementation graph and its document source; and
 - claim a graph and report task, pull-request, blocker, revision, and
   verification lifecycle transitions.
@@ -73,16 +74,22 @@ The `url` returned by `create_document` is the readable canonical route:
 /documents/:owner/:repository/:slug
 ```
 
-`read_document` and `read_implementation` accept either a document UUID or that
-canonical URL in their `id` input. The URL may be passed back exactly as
-returned; an absolute URL must use the configured Chopin origin. Both reads
-return the stable UUID as the document `id`.
+`read_document`, `read_implementation`, `archive_document`, and
+`restore_document` accept either a document UUID or that canonical URL in their
+`id` input. The URL may be passed back exactly as returned; an absolute URL must
+use the configured Chopin origin. Both reads return the stable UUID as the
+document `id`.
 
 The UUID remains the internal storage, API, WebSocket, and MCP identity. Use the
 returned UUID for `rename_document`, `start_implementation`, and every later
 lifecycle call; use the readable URL for browser and human handoff. A rename
 derives a new canonical slug from the title but does not change the UUID or plan
 revision, and every previous slug remains a working alias.
+
+`list_documents` excludes archived documents by default. Set
+`includeArchived: true` to include them; archived summaries and direct reads
+carry an `archivedAt` timestamp. Archiving and restoring are idempotent. MCP does
+not expose document deletion.
 
 ## Claude Code
 
@@ -150,10 +157,11 @@ token's `read:org` or Members access, SSO authorization, and GitHub availability
 
 `repository-forbidden` means the supplied token cannot expose the repository or
 lacks the operation's repository permission; it does not mean the GitHub App for
-Chopin must be installed. Pull access is enough for
-`list_documents`, `read_document`, and `read_implementation`. Push or admin
-access is required for create, rename, start, and report lifecycle operations.
-Use an account with the required access or ask a repository owner to grant it.
+Chopin must be installed. Pull access is enough for `list_documents`,
+`read_document`, and `read_implementation`. Pull plus push or admin access is
+required for create, rename, archive, restore, start, and report lifecycle
+operations. Use an account with the required access or ask a repository owner to
+grant it.
 
 Use the optional
 [creating-chopin-plans skill](../skills/creating-chopin-plans/SKILL.md) to turn a

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -8,11 +8,12 @@ runtime `STORAGE_DRIVER`.
 
 ## State model
 
-The database stores channel metadata, repository-scoped document slug aliases,
-collaboration recovery state, domain sidecars, token-free ownership references,
-Research Workspaces, durable background work, and the writer lease. GitHub
-tokens, browser-cookie verifiers, open rooms,
-Awareness presence, and Copilot SDK sessions never cross the storage boundary.
+The database stores channel metadata, including `channels.archived_at`,
+repository-scoped document slug aliases, collaboration recovery state, domain
+sidecars, token-free ownership references, Research Workspaces, durable
+background work, and the writer lease. GitHub tokens, browser-cookie verifiers,
+open rooms, Awareness presence, and Copilot SDK sessions never cross the storage
+boundary.
 
 The versioned sidecar is the atomic domain snapshot associated with a channel.
 It includes document sequence and plan revision counters, question and comment
@@ -35,6 +36,9 @@ Every adapter must provide:
 - monotonic storage sequences across checkpoints;
 - atomic checkpoint and epoch replacement;
 - atomic first-Planner ownership with a generation token;
+- active-only channel lists and scans by default, with explicit archived
+  inclusion and direct archived reads;
+- idempotent archive and restore transitions and archived-only atomic deletion;
 - repository-scoped canonical and historical slug resolution without rebinding
   aliases;
 - expiring, token-free process-session registry rows;
@@ -64,6 +68,11 @@ revision used by document block operations or the WebSocket document sequence.
 - The Yjs epoch is retained separately so incompatible collaborative histories
   cannot be combined.
 
+Archive and restore update only channel metadata (`archived_at` and
+`updated_at`). They do not advance the collaboration storage revision or
+sequence, Yjs epoch, document sequence, plan revision, or implementation graph
+version and revision.
+
 See the counter glossary in [Architecture](architecture.md) before changing
 recovery or acknowledgement behavior. See
 [Background jobs](background-jobs.md) for target and claim generations,
@@ -78,8 +87,8 @@ applied migration. The application schema contains:
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `users`                    | GitHub identity and attribution records.                                                                         |
 | `web_sessions`             | Token-free process-session IDs, user IDs, and expiry timestamps used by Planner ownership.                       |
-| `channels`                 | Repository identity, title, creator, storage revision, next sequence, and timestamps.                            |
-| `channel_slugs`            | One canonical title-derived slug per channel plus permanent repository-scoped historical aliases.                |
+| `channels`                 | Repository identity, title, creator, archive metadata, storage revision, next sequence, and timestamps.          |
+| `channel_slugs`            | One canonical title-derived slug per channel plus retained repository-scoped historical aliases.                 |
 | `channel_state`            | Current sidecar JSON for a channel.                                                                              |
 | `channel_snapshots`        | Complete Yjs checkpoint, canonical source, source hash, epoch, counters, and checkpoint sidecar.                 |
 | `channel_operations`       | Per-channel operation idempotency and the revision and sequence assigned to each operation.                      |
@@ -98,9 +107,29 @@ applied migration. The application schema contains:
 Channel titles have a case-insensitive unique constraint within each repository.
 Slug values are also unique per repository, with one canonical slug per channel.
 A rename promotes a new collision-suffixed slug but retains all former slugs as
-aliases that cannot be assigned to another channel. Foreign keys remove slug
-aliases and dependent collaboration state when a channel is deleted, although
-the current product has no channel-deletion route.
+aliases that cannot be assigned to another channel while it exists. Archived
+channels continue to reserve their titles and aliases.
+
+## Archival and deletion
+
+Channel `list` and `scan` operations exclude archived rows unless
+`includeArchived` is true. Direct UUID lookup and repository-scoped slug
+resolution do not apply that filter, so an archived document and its historical
+aliases remain readable. Navigation selection and repository-level Research
+Workspace listing apply the same active-only default.
+
+Archive and restore lock and update the channel row and are no-ops when it is
+already in the requested state. Deletion also locks the row and refuses an
+active channel. Deleting the archived parent row is one transaction: foreign
+keys cascade every channel-owned sidecar, snapshot, journal, event, operation,
+Planner state, implementation state, slug, background job and artifact, and
+Research Workspace record. A saved navigation reference is set to null.
+
+Full deletion leaves no live tombstone. It removes historical aliases and the
+MCP creation idempotency identity, so former slugs can be reused and the same
+MCP idempotency key can create a fresh document at its deterministic UUID. Reads
+and implementation lifecycle reports for the deleted document return
+unavailable.
 
 ## Commit and acknowledgement
 
@@ -133,6 +162,9 @@ Checkpointing does not prune `channel_operations` or `channel_events`. The
 current schema therefore retains operation idempotency records and any stored
 events until a separate retention policy or channel deletion removes them.
 Operators should account for that behavior in database monitoring and backups.
+Deleting a document removes it from the live database, not from backups already
+captured by an operator. Those copies remain governed by the operator's backup
+retention and restoration policy.
 
 The database is a recovery store, not a user-visible edit history. Canonical MDX
 and current domain records are durable, but the compacted Yjs journal is not an

--- a/e2e/document-navigation.e2e.ts
+++ b/e2e/document-navigation.e2e.ts
@@ -1,4 +1,4 @@
-import { authenticate, expect, roomPath, test } from "./room";
+import { authenticate, content, expect, roomPath, test } from "./room";
 
 function channel(id: string, title: string) {
 	return {
@@ -35,20 +35,25 @@ function headerDocument(page: import("@playwright/test").Page) {
 	return page.getByRole("banner").locator('[aria-label^="Document:"]');
 }
 
-function headerRename(page: import("@playwright/test").Page) {
-	return page.getByRole("banner").getByRole("button", { name: /^Rename / });
+function headerActions(page: import("@playwright/test").Page) {
+	return page.getByRole("banner").getByRole("button", { name: /^Actions for / });
+}
+
+async function headerAction(page: import("@playwright/test").Page, action: string) {
+	await headerActions(page).click();
+	await page.getByRole("menuitem", { name: action, exact: true }).click();
 }
 
 test("the room header renames the current document and the sidebar creates one immediately", async ({ join }) => {
 	let page = await join("ana");
 	let header = page.getByRole("banner");
-	let trigger = headerRename(page);
+	let trigger = headerActions(page);
 	let projects = sidebar(page);
 
 	await expect(headerDocument(page)).toBeVisible();
 	await expect(projects.locator('[aria-current="page"]')).toHaveCount(1);
 	await expect(header.getByRole("button", { name: /planner session/i })).toHaveCount(0);
-	await trigger.click();
+	await headerAction(page, "Rename");
 	let title = page.getByRole("textbox", { name: "Document title" });
 	await expect(title).toBeFocused();
 	await title.press("Escape");
@@ -67,6 +72,9 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 			path: new URL(request.url()).pathname,
 		}));
 	page = await join("ana");
+	let initialNavigationRequests =
+		requested.filter(request => request.method === "GET" && request.path === "/api/navigation")
+			.length;
 	let projects = sidebar(page);
 	let original = projects.locator('a[aria-current="page"]');
 	let originalTitle = (await original.textContent())!.trim();
@@ -80,7 +88,7 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 	await expect(projects.getByRole("link", { name: originalTitle, exact: true })).toBeVisible();
 	expect(
 		requested.filter(request => request.method === "GET" && request.path === "/api/navigation"),
-	).toHaveLength(1);
+	).toHaveLength(initialNavigationRequests);
 
 	let release = Promise.withResolvers<void>();
 	await page.route("**/api/repositories/octo-org/score/documents/*", async route => {
@@ -172,10 +180,9 @@ test("renaming the current document updates collaborators and survives reload", 
 	let title = `Launch plan ${room.slice(0, 8)}`;
 	let previousPath = roomPath(room);
 	let renamedPath = `/documents/octo-org/score/${title.toLowerCase().replaceAll(" ", "-")}`;
-	let anaTrigger = headerRename(ana);
 
 	await ana.setViewportSize({ width: 320, height: 568 });
-	await anaTrigger.click();
+	await headerAction(ana, "Rename");
 	let input = ana.getByRole("textbox", { name: "Document title" });
 	await expect(input).toBeFocused();
 	await input.fill(title);
@@ -206,15 +213,13 @@ test("a delayed rename response cannot overwrite a newer collaborator rename", a
 	});
 	let first = `First rename ${room.slice(0, 8)}`;
 	let latest = `Latest rename ${room.slice(0, 8)}`;
-	let anaTrigger = headerRename(ana);
-	let boTrigger = headerRename(bo);
 
-	await anaTrigger.click();
+	await headerAction(ana, "Rename");
 	await ana.getByRole("textbox", { name: "Document title" }).fill(first);
 	await ana.getByRole("button", { name: "Save" }).click();
 	await expect(headerDocument(bo)).toHaveAccessibleName(`Document: ${first}`);
 
-	await boTrigger.click();
+	await headerAction(bo, "Rename");
 	await bo.getByRole("textbox", { name: "Document title" }).fill(latest);
 	await bo.getByRole("button", { name: "Save" }).click();
 	await expect(headerDocument(ana)).toHaveAccessibleName(`Document: ${latest}`);
@@ -231,7 +236,7 @@ test("read-only visitors can browse documents while mutation actions stay disabl
 		"contenteditable",
 		"false",
 	);
-	await expect(headerRename(page)).toBeDisabled();
+	await expect(headerActions(page)).toHaveCount(0);
 	await expect(sidebar(page).getByRole("button", { name: "New document", exact: true }))
 		.toBeDisabled();
 	await sidebar(page).getByRole("button", { name: "Search", exact: true }).click();
@@ -250,8 +255,7 @@ test("document rename failures preserve the draft and can be retried", async ({ 
 		await route.continue();
 	});
 	let title = `Retry rename ${room.slice(0, 8)}`;
-	let trigger = headerRename(page);
-	await trigger.click();
+	await headerAction(page, "Rename");
 	let input = page.getByRole("textbox", { name: "Document title" });
 	await input.fill(title);
 	await page.getByRole("button", { name: "Save" }).click();
@@ -260,6 +264,51 @@ test("document rename failures preserve the draft and can be retried", async ({ 
 
 	await page.getByRole("button", { name: "Save" }).click();
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${title}`);
+});
+
+test("writers can archive, restore, and permanently delete a document", async ({ join, room }) => {
+	let ana = await join("ana");
+	let bo = await join("bo");
+	let title = `Test ${room.slice(0, 8)}`;
+	let path = roomPath(room);
+	let projects = sidebar(ana);
+
+	await headerAction(ana, "Archive");
+	await expect(ana.getByText("Archived, read-only", { exact: true })).toBeVisible();
+	await expect(bo.getByText("Archived, read-only", { exact: true })).toBeVisible();
+	await expect(content(ana)).toHaveAttribute("contenteditable", "false");
+	await expect(content(bo)).toHaveAttribute("contenteditable", "false");
+	await expect(projects.getByRole("link", { name: title, exact: true })).toHaveCount(0);
+
+	await bo.reload();
+	await expect(bo).toHaveURL(path);
+	await expect(content(bo)).toHaveAttribute("contenteditable", "false");
+
+	await projects.getByRole("checkbox", { name: "Show archived documents" }).check();
+	await expect(projects.getByRole("link", { name: `${title} Archived`, exact: true }))
+		.toBeVisible();
+	await projects.getByRole("button", { name: "Search", exact: true }).click();
+	let search = ana.getByRole("dialog", { name: "Search documents" });
+	let searchInput = search.getByRole("textbox", { name: "Search documents" });
+	await searchInput.fill(title);
+	await expect(search.getByRole("button", { name: new RegExp(`${title}.*Archived`) }))
+		.toBeVisible();
+	await searchInput.press("Escape");
+
+	await headerAction(ana, "Restore");
+	await expect(content(ana)).toHaveAttribute("contenteditable", "true");
+	await expect(content(bo)).toHaveAttribute("contenteditable", "true");
+	await expect(ana.getByText("Archived, read-only", { exact: true })).toHaveCount(0);
+
+	await headerAction(ana, "Archive");
+	await expect(content(ana)).toHaveAttribute("contenteditable", "false");
+	await headerAction(ana, "Delete permanently");
+	let confirmation = ana.getByRole("dialog", { name: "Delete document permanently?" });
+	await confirmation.getByRole("button", { name: "Delete permanently", exact: true }).click();
+	await expect(ana).not.toHaveURL(path);
+	await expect(bo).not.toHaveURL(path);
+	let unavailable = await ana.request.get(`/api/channels/${room}`);
+	expect(unavailable.status()).toBe(404);
 });
 
 test("sidebar creation failures remain retryable", async ({ join, page }) => {

--- a/e2e/responsive-activity.e2e.ts
+++ b/e2e/responsive-activity.e2e.ts
@@ -45,7 +45,7 @@ test("the compact room header preserves member identity and secondary actions", 
 	await join("eli-with-a-long-handle");
 	let header = page.getByRole("banner");
 	await expect(header.locator('[aria-label^="Document:"]')).toBeVisible();
-	await expect(header.getByRole("button", { name: /^Rename / })).toBeVisible();
+	await expect(header.getByRole("button", { name: /^Actions for / })).toBeVisible();
 	await expect(page.getByRole("button", { name: "Open Projects sidebar" })).toBeVisible();
 	let people = header.getByRole("group", { name: /People here:/ });
 	await expect(people).toBeVisible();

--- a/e2e/responsive-workspace.e2e.ts
+++ b/e2e/responsive-workspace.e2e.ts
@@ -29,7 +29,7 @@ async function expectCompactWorkspaceChrome(page: Page): Promise<void> {
 	let header = page.getByRole("banner");
 	let nav = page.getByRole("navigation", { name: "Workspace view" });
 	let projects = page.getByRole("button", { name: "Open Projects sidebar" });
-	let document = header.getByRole("button", { name: /^Rename / });
+	let document = header.getByRole("button", { name: /^Actions for / });
 	let destinations = nav.getByRole("button");
 
 	await expect(header.getByRole("button", { name: /conversation pane/ })).toHaveCount(0);

--- a/packages/editor/src/comment-layer.tsx
+++ b/packages/editor/src/comment-layer.tsx
@@ -107,7 +107,10 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 	let failures = useRef(new Set<string>());
 	let origin = useRef<HTMLElement | undefined>(undefined);
 	let draftOpen = useRef(false);
-	let compact = useCellValue(widgets$).commentPresentation === "sheet";
+	let options = useCellValue(widgets$);
+	let canEdit = options.canEdit !== false;
+	let compact = options.commentPresentation === "sheet";
+	let draft = canEdit ? state.draft : undefined;
 
 	useEffect(() => {
 		setHost(document.querySelector<HTMLElement>(".plan-document") ?? undefined);
@@ -215,6 +218,10 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 	useEffect(() => () => clearTimeout(close.current), []);
 
 	useEffect(() => {
+		if (!canEdit && state.draft) store.draft(undefined);
+	}, [canEdit, state.draft, store]);
+
+	useEffect(() => {
 		if (!host) return;
 		let over = (event: MouseEvent | PointerEvent): PlacedThread | undefined => {
 			let page = host.getBoundingClientRect();
@@ -307,14 +314,14 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 	}, [restoreOrigin, store]);
 
 	useLayoutEffect(() => {
-		let draft = !!state.draft;
-		if (draft && !draftOpen.current) {
+		let open = !!draft;
+		if (open && !draftOpen.current) {
 			let active = document.activeElement;
 			origin.current = active instanceof HTMLElement
 				? active
 				: editor.getRootElement() ?? undefined;
-		} else if (!draft && draftOpen.current) restoreOrigin();
-		draftOpen.current = draft;
+		} else if (!open && draftOpen.current) restoreOrigin();
+		draftOpen.current = open;
 
 		if (!pinned) return;
 		let available = pinned === "orphans"
@@ -327,7 +334,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 		setPreview(undefined);
 		store.focus(undefined);
 		restoreOrigin();
-	}, [editor, pinned, restoreOrigin, state.draft, state.threads, store]);
+	}, [draft, editor, pinned, restoreOrigin, state.threads, store]);
 
 	let sheetId = compact && pinned !== "orphans" ? pinned : undefined;
 	let sheet = placed.find(entry => entry.view.thread.id === sheetId);
@@ -362,7 +369,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 	}, [dismiss, pinned, preview]);
 
 	useLayoutEffect(() => {
-		if (!compact || (!pinned && !state.draft)) return;
+		if (!compact || (!pinned && !draft)) return;
 		let editorHost = editor.getRootElement();
 		let dialog = pinned
 			? document.getElementById(`plan-comment-thread-${pinned}`)
@@ -402,7 +409,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 			editorHost?.removeAttribute("inert");
 			document.removeEventListener("keydown", trap);
 		};
-	}, [cancelDraft, compact, dismiss, editor, pinned, state.draft]);
+	}, [cancelDraft, compact, dismiss, draft, editor, pinned]);
 
 	if (!host) return null;
 
@@ -410,6 +417,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 	let card = (view: ThreadView) => (
 		<ThreadCard
 			busy={false}
+			canEdit={canEdit}
 			focused={state.focused === view.thread.id}
 			inDocument
 			key={view.thread.id}
@@ -529,7 +537,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 				);
 			})}
 
-			{state.draft?.placement && (
+			{draft?.placement && (
 				<div
 					aria-label="New comment"
 					aria-modal={compact || undefined}
@@ -537,7 +545,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 					role="dialog"
 					ref={element => rememberHeight("draft", element)}
 					style={popoverPoint(
-						state.draft.placement,
+						draft.placement,
 						page,
 						cardWidth,
 						cardHeights.draft ?? 0,
@@ -547,7 +555,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 						busy={false}
 						onCancel={cancelDraft}
 						onSend={text => store.start(text)}
-						quote={state.draft.quote}
+						quote={draft.quote}
 					/>
 				</div>
 			)}

--- a/packages/editor/src/comments.test.tsx
+++ b/packages/editor/src/comments.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ThreadCard } from "./comments";
+
+import type { Comment } from "@chopin/protocol";
+import type { ThreadView } from "./threads";
+
+function view(status: Comment.Status, applied = false): ThreadView {
+	return {
+		thread: {
+			id: "thread-1",
+			status,
+			notes: [{ id: "note-1", handle: "ana", text: "Keep the rollout reversible.", ts: 1 }],
+			...(status === "open" ? {} : { resolver: "bo", at: 2 }),
+		},
+		places: [{ anchorKey: "block", anchorOffset: 0, focusKey: "block", focusOffset: 1 }],
+		orphaned: false,
+		drifted: false,
+		applied,
+		quote: "the rollout",
+	};
+}
+
+function render(value: ThreadView, canEdit: boolean): string {
+	return renderToStaticMarkup(
+		<ThreadCard
+			applied={value.applied}
+			canEdit={canEdit}
+			inDocument
+			onAccept={() => {}}
+			onBlur={() => {}}
+			onClose={() => {}}
+			onDismiss={() => {}}
+			onFocus={() => {}}
+			onReply={() => {}}
+			onRetry={() => {}}
+			onReveal={() => {}}
+			onTyping={() => {}}
+			quote={value.quote}
+			view={value}
+			writing={["cy"]}
+		/>,
+	);
+}
+
+describe("ThreadCard read-only controls", () => {
+	it("keeps reading and navigation while removing open-thread mutations", () => {
+		let editable = render(view("open"), true);
+		let readOnly = render(view("open"), false);
+
+		expect(editable).toContain("Reply");
+		expect(editable).toContain("Accept");
+		expect(editable).toContain("Dismiss");
+		expect(readOnly).toContain("Keep the rollout reversible.");
+		expect(readOnly).toContain("cy is writing");
+		expect(readOnly).toContain("show in plan");
+		expect(readOnly).toContain("Close comment");
+		expect(readOnly).not.toContain("Reply");
+		expect(readOnly).not.toContain("Accept");
+		expect(readOnly).not.toContain("Dismiss");
+		expect(readOnly).not.toContain("textarea");
+	});
+
+	it("keeps unapplied status while removing retry", () => {
+		let editable = render(view("accepted"), true);
+		let readOnly = render(view("accepted"), false);
+
+		expect(editable).toContain("Ask again");
+		expect(readOnly).toContain("Not yet applied");
+		expect(readOnly).toContain("Accepted by @bo");
+		expect(readOnly).not.toContain("Ask again");
+	});
+});

--- a/packages/editor/src/comments.tsx
+++ b/packages/editor/src/comments.tsx
@@ -258,6 +258,8 @@ export type ThreadCardProps = {
 	writing?: string[];
 	focused?: boolean;
 	busy?: boolean;
+	/** Whether durable thread actions are available to this viewer. */
+	canEdit?: boolean;
 	/** True once the agent has said what an accepted thread produced. */
 	applied?: boolean;
 	onReply: (text: string) => void;
@@ -278,6 +280,7 @@ export type ThreadCardProps = {
 export function ThreadCard({
 	applied,
 	busy,
+	canEdit = true,
 	focused,
 	onAccept,
 	onBlur,
@@ -305,14 +308,16 @@ export function ThreadCard({
 			footer={!open && !applied && (
 				<>
 					<span className="text-sm text-warning-ink">Not yet applied</span>
-					<button
-						className="btn btn-sm btn-ghost"
-						disabled={busy}
-						onClick={onRetry}
-						type="button"
-					>
-						Ask again
-					</button>
+					{canEdit && (
+						<button
+							className="btn btn-sm btn-ghost"
+							disabled={busy}
+							onClick={onRetry}
+							type="button"
+						>
+							Ask again
+						</button>
+					)}
 				</>
 			)}
 			label="Comment"
@@ -353,7 +358,7 @@ export function ThreadCard({
 				</p>
 			)}
 
-			{open && (
+			{open && canEdit && (
 				<>
 					<Composer
 						busy={busy}

--- a/packages/editor/src/plan-editor.tsx
+++ b/packages/editor/src/plan-editor.tsx
@@ -270,6 +270,7 @@ export function PlanEditor(
 			threads,
 			changes,
 			offline,
+			readOnly,
 		],
 	);
 

--- a/packages/editor/src/toolbar/bubble.tsx
+++ b/packages/editor/src/toolbar/bubble.tsx
@@ -299,7 +299,7 @@ export function SelectionBubble(
 		return listenToEditorGeometry(editor, place);
 	}, [anchor, editor, place]);
 
-	if (!anchor) return null;
+	if (!anchor || disabled) return null;
 
 	return (
 		<div

--- a/packages/editor/src/widgets/questionnaire.test.tsx
+++ b/packages/editor/src/widgets/questionnaire.test.tsx
@@ -58,6 +58,8 @@ test("a stored multi-question questionnaire keeps its tabbed compatibility view"
 test("a stored unanswered questionnaire keeps its compatibility view without a live record", () => {
 	let markup = renderToStaticMarkup(
 		createElement(QuestionnaireCard, {
+			canEdit: false,
+			connected: true,
 			value: {
 				id: "01K0N4TR8K7JGM4R1J7PW4R8YJ",
 				questions: [
@@ -81,5 +83,34 @@ test("a stored unanswered questionnaire keeps its compatibility view without a l
 	);
 
 	expect(markup).toContain('role="tablist"');
+	expect(markup).toContain("disabled");
+	expect(markup).toContain("Next");
 	expect(markup).not.toContain("Save answer");
+	expect(markup).not.toContain("Cancel");
+});
+
+test("a read-only decision remains linked but has no answer actions", () => {
+	let markup = renderToStaticMarkup(
+		createElement(QuestionnaireCard, {
+			canEdit: false,
+			connected: true,
+			onQuestionSelect() {},
+			places: { storage: 1 },
+			value: {
+				id: "01K0N4TR8K7JGM4R1J7PW4R8YJ",
+				questions: [{
+					id: "storage",
+					header: "Storage",
+					prompt: "Where should room state live?",
+					multiple: false,
+					options: [{ id: "mdx", label: "MDX on disk" }],
+				}],
+			},
+		}),
+	);
+
+	expect(markup).toContain("show in plan");
+	expect(markup).toContain("disabled");
+	expect(markup).not.toContain("Save answer");
+	expect(markup).not.toContain("Cancel");
 });

--- a/packages/editor/src/widgets/questionnaire.tsx
+++ b/packages/editor/src/widgets/questionnaire.tsx
@@ -47,6 +47,8 @@ export type QuestionnaireCardProps = {
 	value: Questionnaire;
 	wire?: Transport;
 	connected?: boolean;
+	/** Whether this viewer may change or resolve the shared draft. */
+	canEdit?: boolean;
 	/** How much prose each decision lives in. */
 	places?: { [question: string]: number };
 	onQuestionEnter?: (question: string) => void;
@@ -57,6 +59,7 @@ export type QuestionnaireCardProps = {
 
 export function QuestionnaireCard(
 	{
+		canEdit = true,
 		connected = false,
 		onQuestionEnter,
 		onQuestionLeave,
@@ -71,7 +74,15 @@ export function QuestionnaireCard(
 
 	return resolved
 		? <Decided resolved={resolved} value={value} {...pointing} />
-		: <Undecided connected={connected} value={value} wire={wire} {...pointing} />;
+		: (
+			<Undecided
+				canEdit={canEdit}
+				connected={connected}
+				value={value}
+				wire={wire}
+				{...pointing}
+			/>
+		);
 }
 
 type Pointing = {
@@ -82,8 +93,8 @@ type Pointing = {
 };
 
 function Undecided(
-	{ connected, value, wire, ...pointing }:
-		& { connected: boolean; value: Questionnaire; wire?: Transport }
+	{ canEdit, connected, value, wire, ...pointing }:
+		& { canEdit: boolean; connected: boolean; value: Questionnaire; wire?: Transport }
 		& Pointing,
 ) {
 	let state = useQuestionnaire({
@@ -94,6 +105,7 @@ function Undecided(
 	});
 
 	let answerable = connected && !!state.definition;
+	let editable = canEdit && answerable;
 
 	return (
 		<SidecarCard
@@ -106,12 +118,12 @@ function Undecided(
 				definition={state.definition ?? definition(value)}
 				// A draft that has not synced cannot be edited without discarding
 				// what other people have already put into it.
-				disabled={!answerable || state.syncing || state.submitting}
+				disabled={!editable || state.syncing || state.submitting}
 				drafts={state.drafts}
 				error={state.error}
-				onCancel={answerable ? state.cancel : undefined}
-				onChange={answerable ? state.change : undefined}
-				onSubmit={answerable ? state.submit : undefined}
+				onCancel={editable ? state.cancel : undefined}
+				onChange={editable ? state.change : undefined}
+				onSubmit={editable ? state.submit : undefined}
 				status="open"
 				submitting={state.submitting}
 				{...pointing}
@@ -149,6 +161,7 @@ function InlineQuestionnaire({ value }: { value: Questionnaire }) {
 
 	return (
 		<QuestionnaireCard
+			canEdit={options.canEdit}
 			connected={options.connected}
 			onQuestionEnter={question => options.questions?.highlight(value.id, question)}
 			onQuestionLeave={() => options.questions?.clear()}

--- a/packages/protocol/index.d.ts
+++ b/packages/protocol/index.d.ts
@@ -41,7 +41,7 @@ export type Request<T> = T & { rid: string };
 export declare namespace Session {
 	export type Incoming = Request<Ping>;
 
-	export type Outgoing = Hello | Presence | Access | Channel | Failure | Ping;
+	export type Outgoing = Hello | Presence | Access | Channel | Deleted | Failure | Ping;
 
 	/** A member, as everyone else sees them. */
 	export type Member = {
@@ -61,6 +61,9 @@ export declare namespace Session {
 		members: Member[];
 		/** Effective repository capability for this connection. */
 		canEdit: boolean;
+		/** Repository mutation capability, independent of document archival. */
+		canManage: boolean;
+		archivedAt?: string;
 		backgroundJobs: boolean;
 		webResearch: boolean;
 		chatReferences: boolean;
@@ -73,11 +76,19 @@ export declare namespace Session {
 		title: string;
 		slug: string;
 		updatedAt: string;
+		canManage: boolean;
+		archivedAt?: string;
 	};
 
-	/** Repository permission changed while the socket was open. */
+	/** Repository or document permission changed while the socket was open. */
 	export type Access = KIND<"session:access"> & {
 		canEdit: boolean;
+		canManage: boolean;
+	};
+
+	/** The durable document was permanently deleted. This connection is terminal. */
+	export type Deleted = KIND<"session:deleted"> & {
+		channelId: string;
 	};
 
 	/** Broadcast whenever the membership of the room changes. */

--- a/packages/protocol/session.test.ts
+++ b/packages/protocol/session.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+
+import type { Session } from "./index";
+
+describe("session archive frames", () => {
+	it("carries management, archive and deletion state", () => {
+		let hello: Session.Hello = {
+			kind: "session:hello",
+			ts: 1,
+			channelId: "channel",
+			title: "Archived plan",
+			slug: "archived-plan",
+			updatedAt: "2026-08-24T12:00:00.000Z",
+			you: { handle: "mona", client: "first" },
+			members: [{ handle: "mona", client: "first" }],
+			canEdit: false,
+			canManage: true,
+			archivedAt: "2026-08-24T12:00:00.000Z",
+			backgroundJobs: true,
+			webResearch: true,
+			chatReferences: true,
+			chatSendAcks: true,
+		};
+		let channel: Session.Channel = {
+			kind: "session:channel",
+			ts: 2,
+			channelId: "channel",
+			title: "Archived plan",
+			slug: "archived-plan",
+			updatedAt: "2026-08-24T12:00:00.000Z",
+			canManage: true,
+			archivedAt: "2026-08-24T12:00:00.000Z",
+		};
+		let access: Session.Access = {
+			kind: "session:access",
+			ts: 3,
+			canEdit: false,
+			canManage: true,
+		};
+		let deleted: Session.Deleted = {
+			kind: "session:deleted",
+			ts: 4,
+			channelId: "channel",
+		};
+		let outgoing: Session.Outgoing[] = [hello, channel, access, deleted];
+
+		expect(outgoing.map(frame => frame.kind)).toEqual([
+			"session:hello",
+			"session:channel",
+			"session:access",
+			"session:deleted",
+		]);
+		expect(hello).toMatchObject({ canEdit: false, canManage: true });
+		expect(channel.archivedAt).toBe(hello.archivedAt);
+		expect(deleted.channelId).toBe(hello.channelId);
+	});
+});


### PR DESCRIPTION
## Summary
- add durable archive, restore, and archived-only hard deletion with live-room, job, research, navigation, and lifecycle fencing
- add read-only archived document access, archived list/search controls, management menus, terminal deletion handling, and MCP archive/restore tools
- add storage, route, protocol, editor, browser, PostgreSQL, and lifecycle coverage plus updated documentation

## Verification
- `bun run ci`
- `bun run types`
- `bun test` (1191 passed, 2 skipped)
- fresh PostgreSQL contract suite (48 passed)
- `bun run build`
- `bun run e2e` (189 passed)
- focused document navigation and Research Workspace E2E after final cache hardening (14 passed)