### PR TITLE
Keep archive filter from reopening documents

### DIFF
--- a/apps/web/src/use-project-research.ts
+++ b/apps/web/src/use-project-research.ts
@@ -25,6 +25,8 @@ export function useProjectResearch(
 	let projects = useRef(new Map<string, Api.NavigationProject>());
 	let invalidations = useRef(new Map<string, number>());
 	let retryTimers = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+	let includeArchivedRef = useRef(includeArchived);
+	includeArchivedRef.current = includeArchived;
 
 	projects.current = new Map(
 		(navigation?.projects ?? []).map(project => [project.repositoryId, project]),
@@ -32,6 +34,7 @@ export function useProjectResearch(
 
 	let load = useCallback(async (project: Api.NavigationProject, replace = false) => {
 		let id = project.repositoryId;
+		let requestIncludesArchived = includeArchivedRef.current;
 		let pending = loads.current.get(id);
 		if (pending && !replace) return false;
 		pending?.abort();
@@ -46,16 +49,22 @@ export function useProjectResearch(
 				project.repositoryOwner,
 				project.repositoryName,
 				controller.signal,
-				includeArchived,
+				requestIncludesArchived,
 			);
-			if (!currentResearchRequest(loads.current, id, controller)) return false;
+			if (
+				requestIncludesArchived !== includeArchivedRef.current
+				|| !currentResearchRequest(loads.current, id, controller)
+			) return false;
 			setResearch(current => ({
 				...current,
 				[id]: completeResearchLoad(current[id] ?? beginResearchLoad(), page, !replace),
 			}));
 			return true;
 		} catch (error) {
-			if (!currentResearchRequest(loads.current, id, controller)) return false;
+			if (
+				requestIncludesArchived !== includeArchivedRef.current
+				|| !currentResearchRequest(loads.current, id, controller)
+			) return false;
 			setResearch(current => ({
 				...current,
 				[id]: failResearchLoad(current[id] ?? beginResearchLoad(), error),
@@ -64,7 +73,7 @@ export function useProjectResearch(
 		} finally {
 			if (loads.current.get(id) === controller) loads.current.delete(id);
 		}
-	}, [includeArchived]);
+	}, []);
 
 	useEffect(() => {
 		for (let controller of loads.current.values()) controller.abort();
@@ -100,7 +109,7 @@ export function useProjectResearch(
 				void load(project);
 			}
 		}
-	}, [documents, load, navigation, research]);
+	}, [documents, includeArchived, load, navigation, research]);
 
 	useEffect(() => () => {
 		for (let controller of loads.current.values()) controller.abort();

--- a/e2e/document-navigation.e2e.ts
+++ b/e2e/document-navigation.e2e.ts
@@ -168,6 +168,43 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${originalTitle}`);
 });
 
+test("the archive filter refreshes catalogues without reopening the document", async ({ join, page }) => {
+	let sockets = 0;
+	await page.routeWebSocket("**/ws?**", route => {
+		sockets++;
+		route.connectToServer();
+	});
+	page = await join("ana");
+	let initialSockets = sockets;
+	let path = page.url();
+	let catalogue = (endpoint: string, includeArchived: boolean) =>
+		page.waitForResponse(response => {
+			let url = new URL(response.url());
+			return response.request().method() === "GET"
+				&& url.pathname === `/api/repositories/octo-org/score/${endpoint}`
+				&& (url.searchParams.get("includeArchived") === "true") === includeArchived;
+		});
+	let toggle = sidebar(page).getByRole("checkbox", { name: "Show archived documents" });
+
+	let archived = Promise.all([
+		catalogue("channels", true),
+		catalogue("research-workspaces", true),
+	]);
+	await toggle.check();
+	await archived;
+	expect(page.url()).toBe(path);
+	expect(sockets).toBe(initialSockets);
+
+	let active = Promise.all([
+		catalogue("channels", false),
+		catalogue("research-workspaces", false),
+	]);
+	await toggle.uncheck();
+	await active;
+	expect(page.url()).toBe(path);
+	expect(sockets).toBe(initialSockets);
+});
+
 test("the sidebar paginates documents and global search queries beyond the loaded page", async ({ join, page }) => {
 	let requests: URL[] = [];
 	let first = Array.from(


### PR DESCRIPTION
## Summary
- keep research catalogue refresh callbacks stable across archive filter changes
- ignore research responses started for a superseded archive mode
- cover enabling and disabling the filter without reopening the document socket

## Testing
- `bun run fix`
- `bun test`
- `bun run types`
- `bun run ci`
- `E2E_SKIP_BUILD=1 bun run e2e -- e2e/document-navigation.e2e.ts`