### PR TITLE
Animate purposeful content swaps

### DIFF
--- a/apps/web/src/document-route-swap.test.ts
+++ b/apps/web/src/document-route-swap.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
 
-import { transitionDocumentRoute } from "./document-route-swap";
+import { documentRouteIdentity, transitionDocumentRoute } from "./document-route-swap";
 
-import type { DocumentRouteSwap } from "./document-route-swap";
+import type { DocumentRouteIdentity, DocumentRouteSwap } from "./document-route-swap";
 
 type Route = {
 	channel?: string;
@@ -31,6 +31,30 @@ let c: Route = {
 	source: { slug: "c" },
 };
 
+test("document route identities have one canonical encoding", () => {
+	let identity: DocumentRouteIdentity = documentRouteIdentity({
+		id: "channel-id",
+		page: "channel",
+	});
+	expect(String(identity)).toBe("channel:channel-id");
+	expect(String(documentRouteIdentity({
+		owner: "octo-org",
+		page: "document",
+		repository: "score",
+		slug: "launch-plan",
+	}))).toBe("document:octo-org/score/launch-plan");
+	expect(String(documentRouteIdentity({
+		owner: "octo-org",
+		page: "research",
+		repository: "score",
+		slug: "launch-plan",
+		workspaceId: "workspace-id",
+	}))).toBe("research:octo-org/score/launch-plan/workspace-id");
+	// @ts-expect-error Route identities must come from the canonical encoder.
+	let untyped: DocumentRouteIdentity = "document:octo-org/score/launch-plan";
+	void untyped;
+});
+
 test("a requested document remains pending until it resolves", () => {
 	let state: DocumentRouteSwap<Route> = { current: a };
 	state = transitionDocumentRoute(state, { route: b, type: "requested" });
@@ -45,14 +69,14 @@ test("reversing to a loaded route preserves metadata and updates input modality"
 	state = transitionDocumentRoute(state, { route: b, type: "requested" });
 	state = transitionDocumentRoute(state, { key: b.key, type: "ready" });
 	state = transitionDocumentRoute(state, {
-		channel: "loaded",
 		key: a.key,
+		resolution: "loaded",
 		type: "ready",
 	});
 	let requested = { ...a, immediately: false, source: { slug: "a" } };
 	state = transitionDocumentRoute(state, { route: requested, type: "requested" });
 	expect(state).toEqual({
-		current: { ...a, channel: "loaded", immediately: false },
+		current: { ...a, immediately: false, resolution: "loaded" },
 		previous: b,
 	});
 	expect(state.current.source).toBe(a.source);

--- a/apps/web/src/document-route-swap.test.ts
+++ b/apps/web/src/document-route-swap.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test";
+
+import {
+	closeDocumentRoute,
+	initialDocumentRouteSwap,
+	requestDocumentRoute,
+	resolveDocumentRoute,
+} from "./document-route-swap";
+
+let a = { key: "document:a", slug: "a" };
+let b = { key: "document:b", slug: "b" };
+let c = { key: "document:c", slug: "c" };
+
+test("a requested document remains pending until it resolves", () => {
+	let state = initialDocumentRouteSwap(a);
+	state = requestDocumentRoute(state, b);
+	expect(state).toEqual({ current: a, pending: b });
+
+	state = resolveDocumentRoute(state, b.key);
+	expect(state).toEqual({ current: b, previous: a });
+});
+
+test("requesting the outgoing route reverses an active swap", () => {
+	let state = resolveDocumentRoute(requestDocumentRoute(initialDocumentRouteSwap(a), b), b.key);
+	state = requestDocumentRoute(state, a);
+	expect(state).toEqual({ current: a, previous: b });
+});
+
+test("rapid requests cancel pending work and preserve the requested visible route", () => {
+	let state = resolveDocumentRoute(requestDocumentRoute(initialDocumentRouteSwap(a), b), b.key);
+	state = requestDocumentRoute(state, a);
+	state = requestDocumentRoute(state, c);
+	state = requestDocumentRoute(state, b);
+
+	expect(state.pending).toBeUndefined();
+	expect(state.current).toBe(b);
+});
+
+test("stale resolve and close events cannot replace or remove current content", () => {
+	let state = requestDocumentRoute(initialDocumentRouteSwap(a), b);
+	expect(resolveDocumentRoute(state, c.key)).toBe(state);
+
+	state = resolveDocumentRoute(state, b.key);
+	expect(closeDocumentRoute(state, c.key)).toBe(state);
+	expect(closeDocumentRoute(state, state.current.key)).toBe(state);
+	expect(closeDocumentRoute(state, a.key)).toEqual({ current: b, pending: undefined });
+});

--- a/apps/web/src/document-route-swap.test.ts
+++ b/apps/web/src/document-route-swap.test.ts
@@ -1,48 +1,85 @@
 import { expect, test } from "bun:test";
 
-import {
-	closeDocumentRoute,
-	initialDocumentRouteSwap,
-	requestDocumentRoute,
-	resolveDocumentRoute,
-} from "./document-route-swap";
+import { transitionDocumentRoute } from "./document-route-swap";
 
-let a = { immediately: true, key: "document:a", slug: "a" };
-let b = { immediately: false, key: "document:b", slug: "b" };
-let c = { immediately: false, key: "document:c", slug: "c" };
+import type { DocumentRouteSwap } from "./document-route-swap";
+
+type Route = {
+	channel?: string;
+	immediately: boolean;
+	key: string;
+	slug: string;
+	source: { slug: string };
+};
+
+let a: Route = {
+	immediately: true,
+	key: "document:a",
+	slug: "a",
+	source: { slug: "a" },
+};
+let b: Route = {
+	immediately: false,
+	key: "document:b",
+	slug: "b",
+	source: { slug: "b" },
+};
+let c: Route = {
+	immediately: false,
+	key: "document:c",
+	slug: "c",
+	source: { slug: "c" },
+};
 
 test("a requested document remains pending until it resolves", () => {
-	let state = initialDocumentRouteSwap(a);
-	state = requestDocumentRoute(state, b);
+	let state: DocumentRouteSwap<Route> = { current: a };
+	state = transitionDocumentRoute(state, { route: b, type: "requested" });
 	expect(state).toEqual({ current: a, pending: b });
 
-	state = resolveDocumentRoute(state, b.key);
+	state = transitionDocumentRoute(state, { key: b.key, type: "ready" });
 	expect(state).toEqual({ current: b, previous: a });
 });
 
-test("requesting the outgoing route reverses an active swap", () => {
-	let state = resolveDocumentRoute(requestDocumentRoute(initialDocumentRouteSwap(a), b), b.key);
-	let requested = { ...a, immediately: false };
-	state = requestDocumentRoute(state, requested);
-	expect(state).toEqual({ current: requested, previous: b });
+test("reversing to a loaded route preserves metadata and updates input modality", () => {
+	let state: DocumentRouteSwap<Route, string> = { current: a };
+	state = transitionDocumentRoute(state, { route: b, type: "requested" });
+	state = transitionDocumentRoute(state, { key: b.key, type: "ready" });
+	state = transitionDocumentRoute(state, {
+		channel: "loaded",
+		key: a.key,
+		type: "ready",
+	});
+	let requested = { ...a, immediately: false, source: { slug: "a" } };
+	state = transitionDocumentRoute(state, { route: requested, type: "requested" });
+	expect(state).toEqual({
+		current: { ...a, channel: "loaded", immediately: false },
+		previous: b,
+	});
+	expect(state.current.source).toBe(a.source);
 });
 
 test("rapid requests cancel pending work and preserve the requested visible route", () => {
-	let state = resolveDocumentRoute(requestDocumentRoute(initialDocumentRouteSwap(a), b), b.key);
-	state = requestDocumentRoute(state, a);
-	state = requestDocumentRoute(state, c);
-	state = requestDocumentRoute(state, b);
+	let state: DocumentRouteSwap<Route> = { current: a };
+	state = transitionDocumentRoute(state, { route: b, type: "requested" });
+	state = transitionDocumentRoute(state, { key: b.key, type: "ready" });
+	state = transitionDocumentRoute(state, { route: a, type: "requested" });
+	state = transitionDocumentRoute(state, { route: c, type: "requested" });
+	state = transitionDocumentRoute(state, { route: b, type: "requested" });
 
 	expect(state.pending).toBeUndefined();
-	expect(state.current).toBe(b);
+	expect(state.current).toEqual(b);
 });
 
-test("stale resolve and close events cannot replace or remove current content", () => {
-	let state = requestDocumentRoute(initialDocumentRouteSwap(a), b);
-	expect(resolveDocumentRoute(state, c.key)).toBe(state);
+test("stale ready and close events cannot replace or remove current content", () => {
+	let state: DocumentRouteSwap<Route> = { current: a };
+	state = transitionDocumentRoute(state, { route: b, type: "requested" });
+	expect(transitionDocumentRoute(state, { key: c.key, type: "ready" })).toBe(state);
 
-	state = resolveDocumentRoute(state, b.key);
-	expect(closeDocumentRoute(state, c.key)).toBe(state);
-	expect(closeDocumentRoute(state, state.current.key)).toBe(state);
-	expect(closeDocumentRoute(state, a.key)).toEqual({ current: b, pending: undefined });
+	state = transitionDocumentRoute(state, { key: b.key, type: "ready" });
+	expect(transitionDocumentRoute(state, { key: c.key, type: "closed" })).toBe(state);
+	expect(transitionDocumentRoute(state, { key: state.current.key, type: "closed" })).toBe(state);
+	expect(transitionDocumentRoute(state, { key: a.key, type: "closed" })).toEqual({
+		current: b,
+		pending: undefined,
+	});
 });

--- a/apps/web/src/document-route-swap.test.ts
+++ b/apps/web/src/document-route-swap.test.ts
@@ -7,9 +7,9 @@ import {
 	resolveDocumentRoute,
 } from "./document-route-swap";
 
-let a = { key: "document:a", slug: "a" };
-let b = { key: "document:b", slug: "b" };
-let c = { key: "document:c", slug: "c" };
+let a = { immediately: true, key: "document:a", slug: "a" };
+let b = { immediately: false, key: "document:b", slug: "b" };
+let c = { immediately: false, key: "document:c", slug: "c" };
 
 test("a requested document remains pending until it resolves", () => {
 	let state = initialDocumentRouteSwap(a);
@@ -22,8 +22,9 @@ test("a requested document remains pending until it resolves", () => {
 
 test("requesting the outgoing route reverses an active swap", () => {
 	let state = resolveDocumentRoute(requestDocumentRoute(initialDocumentRouteSwap(a), b), b.key);
-	state = requestDocumentRoute(state, a);
-	expect(state).toEqual({ current: a, previous: b });
+	let requested = { ...a, immediately: false };
+	state = requestDocumentRoute(state, requested);
+	expect(state).toEqual({ current: requested, previous: b });
 });
 
 test("rapid requests cancel pending work and preserve the requested visible route", () => {

--- a/apps/web/src/document-route-swap.ts
+++ b/apps/web/src/document-route-swap.ts
@@ -3,28 +3,58 @@ export type KeyedDocumentRoute = {
 	key: string;
 };
 
-type ReadyDocumentRoute<T extends KeyedDocumentRoute, C> = T & { channel?: C };
+declare const documentRouteIdentityBrand: unique symbol;
 
-export type DocumentRouteSwap<T extends KeyedDocumentRoute, C = unknown> = {
-	current: ReadyDocumentRoute<T, C>;
-	pending?: ReadyDocumentRoute<T, C>;
-	previous?: ReadyDocumentRoute<T, C>;
+export type DocumentRouteIdentity = string & {
+	readonly [documentRouteIdentityBrand]: true;
 };
 
-export type DocumentRouteAction<T extends KeyedDocumentRoute, C = unknown> =
+export type DocumentRouteIdentitySource =
+	| { id: string; page: "channel" }
+	| { owner: string; page: "document"; repository: string; slug: string }
+	| {
+		owner: string;
+		page: "research";
+		repository: string;
+		slug: string;
+		workspaceId: string;
+	};
+
+export function documentRouteIdentity(source: DocumentRouteIdentitySource): DocumentRouteIdentity {
+	switch (source.page) {
+		case "channel":
+			return `channel:${source.id}` as DocumentRouteIdentity;
+		case "document":
+			return `document:${source.owner}/${source.repository}/${source.slug}` as DocumentRouteIdentity;
+		case "research":
+			return (
+				`research:${source.owner}/${source.repository}/${source.slug}/${source.workspaceId}`
+			) as DocumentRouteIdentity;
+	}
+}
+
+type ReadyDocumentRoute<T extends KeyedDocumentRoute, R> = T & { resolution?: R };
+
+export type DocumentRouteSwap<T extends KeyedDocumentRoute, R = unknown> = {
+	current: ReadyDocumentRoute<T, R>;
+	pending?: ReadyDocumentRoute<T, R>;
+	previous?: ReadyDocumentRoute<T, R>;
+};
+
+export type DocumentRouteAction<T extends KeyedDocumentRoute, R = unknown> =
 	| { route: T; type: "requested" }
-	| { channel?: C; key: string; type: "ready" }
+	| { key: string; resolution?: R; type: "ready" }
 	| { key: string; type: "closed" };
 
-export function transitionDocumentRoute<T extends KeyedDocumentRoute, C = unknown>(
-	state: DocumentRouteSwap<T, C>,
-	action: DocumentRouteAction<T, C>,
-): DocumentRouteSwap<T, C> {
+export function transitionDocumentRoute<T extends KeyedDocumentRoute, R = unknown>(
+	state: DocumentRouteSwap<T, R>,
+	action: DocumentRouteAction<T, R>,
+): DocumentRouteSwap<T, R> {
 	if (action.type === "requested") {
 		let requested = action.route;
 		let reverse = (
-			route: ReadyDocumentRoute<T, C>,
-		): ReadyDocumentRoute<T, C> => ({ ...route, immediately: requested.immediately });
+			route: ReadyDocumentRoute<T, R>,
+		): ReadyDocumentRoute<T, R> => ({ ...route, immediately: requested.immediately });
 		if (requested.key === state.current.key) {
 			return state.pending
 				? {
@@ -42,19 +72,19 @@ export function transitionDocumentRoute<T extends KeyedDocumentRoute, C = unknow
 		return { ...state, pending: requested };
 	}
 	if (action.type === "ready") {
-		let ready = (route: ReadyDocumentRoute<T, C>): ReadyDocumentRoute<T, C> =>
-			action.channel === undefined
+		let ready = (route: ReadyDocumentRoute<T, R>): ReadyDocumentRoute<T, R> =>
+			action.resolution === undefined
 				? route
-				: { ...route, channel: action.channel };
+				: { ...route, resolution: action.resolution };
 		if (state.pending?.key === action.key) {
 			return { current: ready(state.pending), previous: state.current };
 		}
-		if (state.current.key === action.key && action.channel !== undefined) {
-			if (state.current.channel === action.channel) return state;
+		if (state.current.key === action.key && action.resolution !== undefined) {
+			if (state.current.resolution === action.resolution) return state;
 			return { ...state, current: ready(state.current) };
 		}
-		if (state.previous?.key === action.key && action.channel !== undefined) {
-			if (state.previous.channel === action.channel) return state;
+		if (state.previous?.key === action.key && action.resolution !== undefined) {
+			if (state.previous.resolution === action.resolution) return state;
 			return { ...state, previous: ready(state.previous) };
 		}
 		return state;

--- a/apps/web/src/document-route-swap.ts
+++ b/apps/web/src/document-route-swap.ts
@@ -1,43 +1,65 @@
-export type KeyedDocumentRoute = { key: string };
-
-export type DocumentRouteSwap<T extends KeyedDocumentRoute> = {
-	current: T;
-	pending?: T;
-	previous?: T;
+export type KeyedDocumentRoute = {
+	immediately: boolean;
+	key: string;
 };
 
-export function initialDocumentRouteSwap<T extends KeyedDocumentRoute>(
-	current: T,
-): DocumentRouteSwap<T> {
-	return { current };
-}
+type ReadyDocumentRoute<T extends KeyedDocumentRoute, C> = T & { channel?: C };
 
-export function requestDocumentRoute<T extends KeyedDocumentRoute>(
-	state: DocumentRouteSwap<T>,
-	requested: T,
-): DocumentRouteSwap<T> {
-	if (requested.key === state.current.key) {
-		return state.pending ? { current: state.current, previous: state.previous } : state;
+export type DocumentRouteSwap<T extends KeyedDocumentRoute, C = unknown> = {
+	current: ReadyDocumentRoute<T, C>;
+	pending?: ReadyDocumentRoute<T, C>;
+	previous?: ReadyDocumentRoute<T, C>;
+};
+
+export type DocumentRouteAction<T extends KeyedDocumentRoute, C = unknown> =
+	| { route: T; type: "requested" }
+	| { channel?: C; key: string; type: "ready" }
+	| { key: string; type: "closed" };
+
+export function transitionDocumentRoute<T extends KeyedDocumentRoute, C = unknown>(
+	state: DocumentRouteSwap<T, C>,
+	action: DocumentRouteAction<T, C>,
+): DocumentRouteSwap<T, C> {
+	if (action.type === "requested") {
+		let requested = action.route;
+		let reverse = (
+			route: ReadyDocumentRoute<T, C>,
+		): ReadyDocumentRoute<T, C> => ({ ...route, immediately: requested.immediately });
+		if (requested.key === state.current.key) {
+			return state.pending
+				? {
+					current: reverse(state.current),
+					previous: state.previous,
+				}
+				: state;
+		}
+		if (requested.key === state.previous?.key) {
+			return {
+				current: reverse(state.previous),
+				previous: state.current,
+			};
+		}
+		return { ...state, pending: requested };
 	}
-	if (requested.key === state.previous?.key) {
-		return { current: requested, previous: state.current };
+	if (action.type === "ready") {
+		let ready = (route: ReadyDocumentRoute<T, C>): ReadyDocumentRoute<T, C> =>
+			action.channel === undefined
+				? route
+				: { ...route, channel: action.channel };
+		if (state.pending?.key === action.key) {
+			return { current: ready(state.pending), previous: state.current };
+		}
+		if (state.current.key === action.key && action.channel !== undefined) {
+			if (state.current.channel === action.channel) return state;
+			return { ...state, current: ready(state.current) };
+		}
+		if (state.previous?.key === action.key && action.channel !== undefined) {
+			if (state.previous.channel === action.channel) return state;
+			return { ...state, previous: ready(state.previous) };
+		}
+		return state;
 	}
-	return { ...state, pending: requested };
-}
-
-export function resolveDocumentRoute<T extends KeyedDocumentRoute>(
-	state: DocumentRouteSwap<T>,
-	key: string,
-): DocumentRouteSwap<T> {
-	if (state.pending?.key !== key) return state;
-	return { current: state.pending, previous: state.current };
-}
-
-export function closeDocumentRoute<T extends KeyedDocumentRoute>(
-	state: DocumentRouteSwap<T>,
-	key: string,
-): DocumentRouteSwap<T> {
-	return state.previous?.key === key
+	return state.previous?.key === action.key
 		? { current: state.current, pending: state.pending }
 		: state;
 }

--- a/apps/web/src/document-route-swap.ts
+++ b/apps/web/src/document-route-swap.ts
@@ -20,7 +20,7 @@ export function requestDocumentRoute<T extends KeyedDocumentRoute>(
 		return state.pending ? { current: state.current, previous: state.previous } : state;
 	}
 	if (requested.key === state.previous?.key) {
-		return { current: state.previous, previous: state.current };
+		return { current: requested, previous: state.current };
 	}
 	return { ...state, pending: requested };
 }

--- a/apps/web/src/document-route-swap.ts
+++ b/apps/web/src/document-route-swap.ts
@@ -1,0 +1,43 @@
+export type KeyedDocumentRoute = { key: string };
+
+export type DocumentRouteSwap<T extends KeyedDocumentRoute> = {
+	current: T;
+	pending?: T;
+	previous?: T;
+};
+
+export function initialDocumentRouteSwap<T extends KeyedDocumentRoute>(
+	current: T,
+): DocumentRouteSwap<T> {
+	return { current };
+}
+
+export function requestDocumentRoute<T extends KeyedDocumentRoute>(
+	state: DocumentRouteSwap<T>,
+	requested: T,
+): DocumentRouteSwap<T> {
+	if (requested.key === state.current.key) {
+		return state.pending ? { current: state.current, previous: state.previous } : state;
+	}
+	if (requested.key === state.previous?.key) {
+		return { current: state.previous, previous: state.current };
+	}
+	return { ...state, pending: requested };
+}
+
+export function resolveDocumentRoute<T extends KeyedDocumentRoute>(
+	state: DocumentRouteSwap<T>,
+	key: string,
+): DocumentRouteSwap<T> {
+	if (state.pending?.key !== key) return state;
+	return { current: state.pending, previous: state.current };
+}
+
+export function closeDocumentRoute<T extends KeyedDocumentRoute>(
+	state: DocumentRouteSwap<T>,
+	key: string,
+): DocumentRouteSwap<T> {
+	return state.previous?.key === key
+		? { current: state.current, pending: state.pending }
+		: state;
+}

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { ContentSwapLayer } from "@chopin/editor/content-swap";
 import {
 	documentPath,
@@ -10,14 +10,18 @@ import {
 
 import * as Api from "./api";
 import { readChannelRecovery, readDocumentRecovery, rememberChannel } from "./channel-recovery";
-import { transitionDocumentRoute } from "./document-route-swap";
+import { documentRouteIdentity, transitionDocumentRoute } from "./document-route-swap";
 import { newestDocument } from "./document-actions";
 import { motionContract } from "./motion-contract";
 import { motionImmediately } from "./motion-input";
 import { NavigationShell, useNavigationDocument } from "./navigation-shell";
 
 import type { ComponentType, ReactNode } from "react";
-import type { DocumentRouteSwap as DocumentRouteSwapState } from "./document-route-swap";
+import type {
+	DocumentRouteIdentity,
+	DocumentRouteIdentitySource,
+	DocumentRouteSwap as DocumentRouteSwapState,
+} from "./document-route-swap";
 
 export type HostedWorkspaceProps = {
 	room: string;
@@ -36,66 +40,34 @@ export type HostedWorkspaceProps = {
 };
 
 export type HostedRoute =
+	| DocumentRouteIdentitySource
 	| { page: "repositories" }
 	| { page: "repository"; owner: string; repository: string }
-	| { page: "document"; owner: string; repository: string; slug: string }
-	| {
-		page: "research";
-		owner: string;
-		repository: string;
-		slug: string;
-		workspaceId: string;
-	}
-	| { page: "channel"; id: string }
 	| { page: "missing" };
 
-type DocumentRoute = Extract<HostedRoute, { page: "document" } | { page: "channel" }>;
-type ChannelSource =
-	| { id: string; type: "channel" }
-	| { owner: string; repository: string; slug: string; type: "document" }
-	| {
-		owner: string;
-		repository: string;
-		slug: string;
-		type: "research";
-		workspaceId: string;
-	};
-type DocumentSource = Exclude<ChannelSource, { type: "research" }>;
+type DocumentRoute = Exclude<DocumentRouteIdentitySource, { page: "research" }>;
+type ChannelSource = DocumentRouteIdentitySource;
+type DocumentSource = DocumentRoute;
 type DocumentRouteRequest = {
 	immediately: boolean;
-	key: string;
+	key: DocumentRouteIdentity;
 	source: DocumentSource;
 };
-type DocumentRouteLayer = DocumentRouteSwapState<DocumentRouteRequest, Api.Channel>["current"];
+type DocumentRouteResolution = { canonicalPath: string; channel: Api.Channel };
+type DocumentRouteLayer = DocumentRouteSwapState<
+	DocumentRouteRequest,
+	DocumentRouteResolution
+>["current"];
 
 function keyedDocumentRoute(
 	route: DocumentRoute,
 	immediately: boolean,
 ): DocumentRouteRequest {
-	let source: DocumentSource = route.page === "channel"
-		? { id: route.id, type: "channel" }
-		: {
-			owner: route.owner,
-			repository: route.repository,
-			slug: route.slug,
-			type: "document",
-		};
 	return {
 		immediately,
-		key: channelSourceKey(source),
-		source,
+		key: documentRouteIdentity(route),
+		source: route,
 	};
-}
-
-function channelSourceKey(source: ChannelSource): string {
-	switch (source.type) {
-		case "channel":
-			return `channel:${source.id}`;
-		case "document":
-			return `document:${source.owner}/${source.repository}/${source.slug}`;
-		case "research":
-			return `research:${source.owner}/${source.repository}/${source.slug}/${source.workspaceId}`;
-	}
 }
 
 function decoded(value: string): string | undefined {
@@ -250,7 +222,7 @@ export function githubLoginHref(pathname: string, search = "", hash = ""): strin
 function ChannelWorkspace(
 	{ agent, onReady, source, user }: {
 		agent: boolean;
-		onReady?: (key: string, channel?: Api.Channel) => void;
+		onReady?: (key: DocumentRouteIdentity, resolution?: DocumentRouteResolution) => void;
 		source: ChannelSource;
 		user: Api.User;
 	},
@@ -271,9 +243,9 @@ function ChannelWorkspace(
 	let [error, setError] = useState<unknown>();
 	let [retry, setRetry] = useState(0);
 	let { channel: navigationChannel } = useNavigationDocument();
-	let routeKey = channelSourceKey(source);
+	let routeKey = documentRouteIdentity(source);
 	let recovery;
-	switch (source.type) {
+	switch (source.page) {
 		case "channel":
 			recovery = readChannelRecovery(user.id, source.id);
 			break;
@@ -294,7 +266,7 @@ function ChannelWorkspace(
 		setLoaded(undefined);
 		setError(undefined);
 		let detail: Promise<Api.ChannelDetail>;
-		switch (source.type) {
+		switch (source.page) {
 			case "channel":
 				detail = Api.channel(source.id, controller.signal);
 				break;
@@ -309,33 +281,32 @@ function ChannelWorkspace(
 				break;
 		}
 		let prepared = detail.then(value => {
+			let canonicalPath: string;
+			switch (source.page) {
+				case "channel":
+				case "document":
+					canonicalPath = documentPath(
+						value.repository.owner,
+						value.repository.name,
+						value.channel.slug,
+					);
+					break;
+				case "research":
+					canonicalPath = researchWorkspacePath(
+						value.repository.owner,
+						value.repository.name,
+						value.channel.slug,
+						source.workspaceId,
+					);
+					break;
+			}
 			if (active) {
-				let canonicalPath: string;
-				switch (source.type) {
-					case "channel":
-					case "document":
-						canonicalPath = documentPath(
-							value.repository.owner,
-							value.repository.name,
-							value.channel.slug,
-						);
-						break;
-					case "research":
-						canonicalPath = researchWorkspacePath(
-							value.repository.owner,
-							value.repository.name,
-							value.channel.slug,
-							source.workspaceId,
-						);
-						break;
-				}
-				canonicalize(canonicalPath);
 				rememberChannel(user.id, value.channel, value.repository);
 			}
-			return value;
+			return { canonicalPath, detail: value };
 		});
 		let workspace;
-		switch (source.type) {
+		switch (source.page) {
 			case "channel":
 			case "document":
 				workspace = import("./room-workspace").then(module => ({
@@ -351,10 +322,13 @@ function ChannelWorkspace(
 				}));
 				break;
 		}
-		Promise.all([prepared, workspace]).then(([detail, selected]) => {
+		Promise.all([prepared, workspace]).then(([resolved, selected]) => {
 			if (active) {
-				setLoaded({ detail, ...selected } as LoadedWorkspace);
-				onReady?.(routeKey, detail.channel);
+				setLoaded({ detail: resolved.detail, ...selected } as LoadedWorkspace);
+				onReady?.(routeKey, {
+					canonicalPath: resolved.canonicalPath,
+					channel: resolved.detail.channel,
+				});
 			}
 		}, reason => {
 			if (active) {
@@ -371,7 +345,7 @@ function ChannelWorkspace(
 	if (error) {
 		let requestedRepository;
 		let requestedSlug;
-		switch (source.type) {
+		switch (source.page) {
 			case "channel":
 				break;
 			case "document":
@@ -430,8 +404,10 @@ function ActiveChannelWorkspace(
 	{ agent, source, user }: { agent: boolean; source: ChannelSource; user: Api.User },
 ) {
 	let { onDocumentLoaded } = useNavigationDocument();
-	let ready = useCallback((key: string, channel?: Api.Channel) => {
-		if (channel) void onDocumentLoaded(channel, key);
+	let ready = useCallback((key: DocumentRouteIdentity, resolution?: DocumentRouteResolution) => {
+		if (!resolution) return;
+		canonicalize(resolution.canonicalPath);
+		void onDocumentLoaded(resolution.channel, key);
 	}, [onDocumentLoaded]);
 	return <ChannelWorkspace agent={agent} onReady={ready} source={source} user={user} />;
 }
@@ -441,7 +417,7 @@ function DocumentRouteSwap(
 ) {
 	let requested = keyedDocumentRoute(route, motionImmediately());
 	let [state, dispatch] = useReducer(
-		transitionDocumentRoute<DocumentRouteRequest, Api.Channel>,
+		transitionDocumentRoute<DocumentRouteRequest, DocumentRouteResolution>,
 		{ current: requested },
 	);
 	let presentedRequest = state.pending ?? state.current;
@@ -452,15 +428,21 @@ function DocumentRouteSwap(
 		(layer): layer is DocumentRouteLayer => layer !== undefined,
 	);
 	let motion = motionContract("content-swap");
-	let ready = useCallback((key: string, channel?: Api.Channel) => {
-		dispatch({ channel, key, type: "ready" });
+	let ready = useCallback((
+		key: DocumentRouteIdentity,
+		resolution?: DocumentRouteResolution,
+	) => {
+		dispatch({ key, resolution, type: "ready" });
 	}, []);
 	let { onDocumentLoaded } = useNavigationDocument();
+	let published = useRef<DocumentRouteResolution | undefined>(undefined);
 	useEffect(() => {
-		if (state.current.channel) {
-			void onDocumentLoaded(state.current.channel, state.current.key);
-		}
-	}, [onDocumentLoaded, state.current.channel, state.current.key]);
+		let resolution = state.current.resolution;
+		if (!resolution || published.current === resolution) return;
+		published.current = resolution;
+		canonicalize(resolution.canonicalPath);
+		void onDocumentLoaded(resolution.channel, state.current.key);
+	}, [onDocumentLoaded, state.current.key, state.current.resolution]);
 
 	return (
 		<div className="document-route-swap content-swap-stack h-full">
@@ -524,18 +506,11 @@ export function HostedApp(
 			workspace = <DocumentRouteSwap agent={agent} route={route} user={user} />;
 			break;
 		case "research":
-			let source: ChannelSource = {
-				owner: route.owner,
-				repository: route.repository,
-				slug: route.slug,
-				type: "research",
-				workspaceId: route.workspaceId,
-			};
 			workspace = (
 				<ActiveChannelWorkspace
 					agent={agent}
-					key={channelSourceKey(source)}
-					source={source}
+					key={documentRouteIdentity(route)}
+					source={route}
 					user={user}
 				/>
 			);

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useReducer, useState } from "react";
+import { ContentSwapLayer } from "@chopin/editor/content-swap";
 import {
 	documentPath,
 	documentsPath,
@@ -9,10 +10,19 @@ import {
 
 import * as Api from "./api";
 import { readChannelRecovery, readDocumentRecovery, rememberChannel } from "./channel-recovery";
+import {
+	closeDocumentRoute,
+	initialDocumentRouteSwap,
+	requestDocumentRoute,
+	resolveDocumentRoute,
+} from "./document-route-swap";
 import { newestDocument } from "./document-actions";
+import { motionContract } from "./motion-contract";
+import { motionImmediately } from "./motion-input";
 import { NavigationShell, useNavigationDocument } from "./navigation-shell";
 
 import type { ComponentType, ReactNode } from "react";
+import type { DocumentRouteSwap as DocumentRouteSwapState } from "./document-route-swap";
 
 export type HostedWorkspaceProps = {
 	room: string;
@@ -43,6 +53,30 @@ export type HostedRoute =
 	}
 	| { page: "channel"; id: string }
 	| { page: "missing" };
+
+type DocumentRoute = Extract<HostedRoute, { page: "document" } | { page: "channel" }>;
+type KeyedDocumentRoute = { key: string; route: DocumentRoute };
+type DocumentRouteAction =
+	| { route: KeyedDocumentRoute; type: "requested" }
+	| { key: string; type: "resolved" | "closed" };
+
+function keyedDocumentRoute(route: DocumentRoute): KeyedDocumentRoute {
+	return {
+		key: route.page === "channel"
+			? `channel:${route.id}`
+			: `document:${route.owner}/${route.repository}/${route.slug}`,
+		route,
+	};
+}
+
+function transitionDocumentRoute(
+	state: DocumentRouteSwapState<KeyedDocumentRoute>,
+	action: DocumentRouteAction,
+): DocumentRouteSwapState<KeyedDocumentRoute> {
+	if (action.type === "requested") return requestDocumentRoute(state, action.route);
+	if (action.type === "resolved") return resolveDocumentRoute(state, action.key);
+	return closeDocumentRoute(state, action.key);
+}
 
 function decoded(value: string): string | undefined {
 	try {
@@ -194,12 +228,26 @@ export function githubLoginHref(pathname: string, search = "", hash = ""): strin
 }
 
 function ChannelWorkspace(
-	{ agent, id, owner, repository, researchWorkspaceId, slug, user }: {
+	{
+		agent,
+		id,
+		onResolved,
+		owner,
+		repository,
+		researchWorkspaceId,
+		routeKey,
+		showLoading = true,
+		slug,
+		user,
+	}: {
 		agent: boolean;
 		id?: string;
+		onResolved?: (key: string) => void;
 		owner?: string;
 		repository?: string;
 		researchWorkspaceId?: string;
+		routeKey: string;
+		showLoading?: boolean;
 		slug?: string;
 		user: Api.User;
 	},
@@ -250,7 +298,7 @@ function ChannelWorkspace(
 						),
 				);
 				rememberChannel(user.id, value.channel, value.repository);
-				void onDocumentLoaded(value.channel);
+				void onDocumentLoaded(value.channel, routeKey);
 			}
 			return value;
 		});
@@ -279,9 +327,15 @@ function ChannelWorkspace(
 		repository,
 		researchWorkspaceId,
 		retry,
+		routeKey,
 		slug,
 		user.id,
 	]);
+
+	useEffect(() => {
+		if (loaded || error !== undefined) onResolved?.(routeKey);
+	}, [error, loaded, onResolved, routeKey]);
+
 	if (error) {
 		let requestedRepository = owner && repository
 			? { owner, name: repository, fullName: `${owner}/${repository}` }
@@ -300,7 +354,7 @@ function ChannelWorkspace(
 			/>
 		);
 	}
-	if (!loaded) return <Loading label="Opening channel..." />;
+	if (!loaded) return showLoading ? <Loading label="Opening channel..." /> : null;
 	let { detail } = loaded;
 	let channel = navigationChannel?.id === detail.channel.id
 		? newestDocument(detail.channel, navigationChannel)
@@ -326,6 +380,58 @@ function ChannelWorkspace(
 	}
 	let Document = loaded.Workspace;
 	return <Document {...props} />;
+}
+
+function DocumentRouteSwap(
+	{ agent, route, user }: { agent: boolean; route: DocumentRoute; user: Api.User },
+) {
+	let requested = keyedDocumentRoute(route);
+	let [state, dispatch] = useReducer(
+		transitionDocumentRoute,
+		initialDocumentRouteSwap(requested),
+	);
+	let presentedRequest = state.pending ?? state.current;
+	if (requested.key !== presentedRequest.key) {
+		dispatch({ route: requested, type: "requested" });
+	}
+	let layers = [state.previous, state.current, state.pending].filter(
+		(layer): layer is KeyedDocumentRoute => layer !== undefined,
+	);
+	let immediately = motionImmediately();
+	let motion = motionContract("content-swap");
+	let resolved = useCallback((key: string) => dispatch({ key, type: "resolved" }), []);
+
+	return (
+		<div className="document-route-swap content-swap-stack h-full">
+			{layers.map(layer => (
+				<ContentSwapLayer
+					active={layer.key === state.current.key}
+					className="document-route-layer h-full min-h-0"
+					immediately={immediately}
+					key={layer.key}
+					motion={motion}
+					onClosed={layer.key === state.previous?.key
+						? () => dispatch({ key: layer.key, type: "closed" })
+						: undefined}
+				>
+					<ChannelWorkspace
+						agent={agent}
+						onResolved={resolved}
+						routeKey={layer.key}
+						showLoading={layer.key === state.current.key}
+						user={user}
+						{...(layer.route.page === "channel"
+							? { id: layer.route.id }
+							: {
+								owner: layer.route.owner,
+								repository: layer.route.repository,
+								slug: layer.route.slug,
+							})}
+					/>
+				</ContentSwapLayer>
+			))}
+		</div>
+	);
 }
 
 export function HostedApp(
@@ -361,16 +467,8 @@ export function HostedApp(
 		case "repository":
 			break;
 		case "document":
-			workspace = (
-				<ChannelWorkspace
-					agent={agent}
-					key={`document:${route.owner}/${route.repository}/${route.slug}`}
-					owner={route.owner}
-					repository={route.repository}
-					slug={route.slug}
-					user={user}
-				/>
-			);
+		case "channel":
+			workspace = <DocumentRouteSwap agent={agent} route={route} user={user} />;
 			break;
 		case "research":
 			workspace = (
@@ -380,14 +478,10 @@ export function HostedApp(
 					owner={route.owner}
 					repository={route.repository}
 					researchWorkspaceId={route.workspaceId}
+					routeKey={`research:${route.owner}/${route.repository}/${route.slug}/${route.workspaceId}`}
 					slug={route.slug}
 					user={user}
 				/>
-			);
-			break;
-		case "channel":
-			workspace = (
-				<ChannelWorkspace agent={agent} id={route.id} key={`channel:${route.id}`} user={user} />
 			);
 			break;
 	}

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -10,12 +10,7 @@ import {
 
 import * as Api from "./api";
 import { readChannelRecovery, readDocumentRecovery, rememberChannel } from "./channel-recovery";
-import {
-	closeDocumentRoute,
-	initialDocumentRouteSwap,
-	requestDocumentRoute,
-	resolveDocumentRoute,
-} from "./document-route-swap";
+import { transitionDocumentRoute } from "./document-route-swap";
 import { newestDocument } from "./document-actions";
 import { motionContract } from "./motion-contract";
 import { motionImmediately } from "./motion-input";
@@ -55,28 +50,52 @@ export type HostedRoute =
 	| { page: "missing" };
 
 type DocumentRoute = Extract<HostedRoute, { page: "document" } | { page: "channel" }>;
-type KeyedDocumentRoute = { immediately: boolean; key: string; route: DocumentRoute };
-type DocumentRouteAction =
-	| { route: KeyedDocumentRoute; type: "requested" }
-	| { key: string; type: "resolved" | "closed" };
+type ChannelSource =
+	| { id: string; type: "channel" }
+	| { owner: string; repository: string; slug: string; type: "document" }
+	| {
+		owner: string;
+		repository: string;
+		slug: string;
+		type: "research";
+		workspaceId: string;
+	};
+type DocumentSource = Exclude<ChannelSource, { type: "research" }>;
+type DocumentRouteRequest = {
+	immediately: boolean;
+	key: string;
+	source: DocumentSource;
+};
+type DocumentRouteLayer = DocumentRouteSwapState<DocumentRouteRequest, Api.Channel>["current"];
 
-function keyedDocumentRoute(route: DocumentRoute, immediately: boolean): KeyedDocumentRoute {
+function keyedDocumentRoute(
+	route: DocumentRoute,
+	immediately: boolean,
+): DocumentRouteRequest {
+	let source: DocumentSource = route.page === "channel"
+		? { id: route.id, type: "channel" }
+		: {
+			owner: route.owner,
+			repository: route.repository,
+			slug: route.slug,
+			type: "document",
+		};
 	return {
 		immediately,
-		key: route.page === "channel"
-			? `channel:${route.id}`
-			: `document:${route.owner}/${route.repository}/${route.slug}`,
-		route,
+		key: channelSourceKey(source),
+		source,
 	};
 }
 
-function transitionDocumentRoute(
-	state: DocumentRouteSwapState<KeyedDocumentRoute>,
-	action: DocumentRouteAction,
-): DocumentRouteSwapState<KeyedDocumentRoute> {
-	if (action.type === "requested") return requestDocumentRoute(state, action.route);
-	if (action.type === "resolved") return resolveDocumentRoute(state, action.key);
-	return closeDocumentRoute(state, action.key);
+function channelSourceKey(source: ChannelSource): string {
+	switch (source.type) {
+		case "channel":
+			return `channel:${source.id}`;
+		case "document":
+			return `document:${source.owner}/${source.repository}/${source.slug}`;
+		case "research":
+			return `research:${source.owner}/${source.repository}/${source.slug}/${source.workspaceId}`;
+	}
 }
 
 function decoded(value: string): string | undefined {
@@ -229,29 +248,10 @@ export function githubLoginHref(pathname: string, search = "", hash = ""): strin
 }
 
 function ChannelWorkspace(
-	{
-		active = true,
-		agent,
-		id,
-		onResolved,
-		owner,
-		repository,
-		researchWorkspaceId,
-		routeKey,
-		showLoading = true,
-		slug,
-		user,
-	}: {
-		active?: boolean;
+	{ agent, onReady, source, user }: {
 		agent: boolean;
-		id?: string;
-		onResolved?: (key: string) => void;
-		owner?: string;
-		repository?: string;
-		researchWorkspaceId?: string;
-		routeKey: string;
-		showLoading?: boolean;
-		slug?: string;
+		onReady?: (key: string, channel?: Api.Channel) => void;
+		source: ChannelSource;
 		user: Api.User;
 	},
 ) {
@@ -265,89 +265,128 @@ function ChannelWorkspace(
 			kind: "research";
 			detail: Api.ChannelDetail;
 			Workspace: ComponentType<HostedWorkspaceProps & { workspaceId: string }>;
+			workspaceId: string;
 		};
 	let [loaded, setLoaded] = useState<LoadedWorkspace>();
 	let [error, setError] = useState<unknown>();
 	let [retry, setRetry] = useState(0);
-	let { channel: navigationChannel, onDocumentLoaded } = useNavigationDocument();
-	let recovery = id
-		? readChannelRecovery(user.id, id)
-		: owner && repository && slug
-		? readDocumentRecovery(user.id, owner, repository, slug)
-		: undefined;
+	let { channel: navigationChannel } = useNavigationDocument();
+	let routeKey = channelSourceKey(source);
+	let recovery;
+	switch (source.type) {
+		case "channel":
+			recovery = readChannelRecovery(user.id, source.id);
+			break;
+		case "document":
+		case "research":
+			recovery = readDocumentRecovery(
+				user.id,
+				source.owner,
+				source.repository,
+				source.slug,
+			);
+			break;
+	}
 
 	useEffect(() => {
 		let active = true;
 		let controller = new AbortController();
 		setLoaded(undefined);
 		setError(undefined);
-		let detail = id
-			? Api.channel(id, controller.signal)
-			: Api.document(owner!, repository!, slug!, controller.signal);
+		let detail: Promise<Api.ChannelDetail>;
+		switch (source.type) {
+			case "channel":
+				detail = Api.channel(source.id, controller.signal);
+				break;
+			case "document":
+			case "research":
+				detail = Api.document(
+					source.owner,
+					source.repository,
+					source.slug,
+					controller.signal,
+				);
+				break;
+		}
 		let prepared = detail.then(value => {
 			if (active) {
-				canonicalize(
-					researchWorkspaceId
-						? researchWorkspacePath(
+				let canonicalPath: string;
+				switch (source.type) {
+					case "channel":
+					case "document":
+						canonicalPath = documentPath(
 							value.repository.owner,
 							value.repository.name,
 							value.channel.slug,
-							researchWorkspaceId,
-						)
-						: documentPath(
+						);
+						break;
+					case "research":
+						canonicalPath = researchWorkspacePath(
 							value.repository.owner,
 							value.repository.name,
 							value.channel.slug,
-						),
-				);
+							source.workspaceId,
+						);
+						break;
+				}
+				canonicalize(canonicalPath);
 				rememberChannel(user.id, value.channel, value.repository);
 			}
 			return value;
 		});
-		let workspace = researchWorkspaceId
-			? import("./research-workspace").then(module => ({
-				kind: "research" as const,
-				Workspace: module.ResearchWorkspace,
-			}))
-			: import("./room-workspace").then(module => ({
-				kind: "document" as const,
-				Workspace: module.RoomWorkspace,
-			}));
+		let workspace;
+		switch (source.type) {
+			case "channel":
+			case "document":
+				workspace = import("./room-workspace").then(module => ({
+					kind: "document" as const,
+					Workspace: module.RoomWorkspace,
+				}));
+				break;
+			case "research":
+				workspace = import("./research-workspace").then(module => ({
+					kind: "research" as const,
+					Workspace: module.ResearchWorkspace,
+					workspaceId: source.workspaceId,
+				}));
+				break;
+		}
 		Promise.all([prepared, workspace]).then(([detail, selected]) => {
-			if (active) setLoaded({ detail, ...selected } as LoadedWorkspace);
+			if (active) {
+				setLoaded({ detail, ...selected } as LoadedWorkspace);
+				onReady?.(routeKey, detail.channel);
+			}
 		}, reason => {
-			if (active) setError(reason);
+			if (active) {
+				setError(reason);
+				onReady?.(routeKey);
+			}
 		});
 		return () => {
 			active = false;
 			controller.abort();
 		};
-	}, [
-		id,
-		owner,
-		repository,
-		researchWorkspaceId,
-		retry,
-		routeKey,
-		slug,
-		user.id,
-	]);
-
-	useEffect(() => {
-		if (active && loaded) void onDocumentLoaded(loaded.detail.channel, routeKey);
-	}, [active, loaded, onDocumentLoaded, routeKey]);
-
-	useEffect(() => {
-		if (loaded || error !== undefined) onResolved?.(routeKey);
-	}, [error, loaded, onResolved, routeKey]);
+	}, [onReady, retry, routeKey, source, user.id]);
 
 	if (error) {
-		let requestedRepository = owner && repository
-			? { owner, name: repository, fullName: `${owner}/${repository}` }
-			: undefined;
+		let requestedRepository;
+		let requestedSlug;
+		switch (source.type) {
+			case "channel":
+				break;
+			case "document":
+			case "research":
+				requestedRepository = {
+					fullName: `${source.owner}/${source.repository}`,
+					name: source.repository,
+					owner: source.owner,
+				};
+				requestedSlug = source.slug;
+				break;
+		}
 		return (
 			<Failure
-				channel={recovery?.channel ?? (slug ? { slug } : undefined)}
+				channel={recovery?.channel ?? (requestedSlug ? { slug: requestedSlug } : undefined)}
 				error={error}
 				onRetry={retryableChannelFailure(error)
 					? () => {
@@ -359,7 +398,7 @@ function ChannelWorkspace(
 			/>
 		);
 	}
-	if (!loaded) return showLoading ? <Loading label="Opening channel..." /> : null;
+	if (!loaded) return <Loading label="Opening channel..." />;
 	let { detail } = loaded;
 	let channel = navigationChannel?.id === detail.channel.id
 		? newestDocument(detail.channel, navigationChannel)
@@ -381,10 +420,20 @@ function ChannelWorkspace(
 	};
 	if (loaded.kind === "research") {
 		let Research = loaded.Workspace;
-		return <Research {...props} workspaceId={researchWorkspaceId!} />;
+		return <Research {...props} workspaceId={loaded.workspaceId} />;
 	}
 	let Document = loaded.Workspace;
 	return <Document {...props} />;
+}
+
+function ActiveChannelWorkspace(
+	{ agent, source, user }: { agent: boolean; source: ChannelSource; user: Api.User },
+) {
+	let { onDocumentLoaded } = useNavigationDocument();
+	let ready = useCallback((key: string, channel?: Api.Channel) => {
+		if (channel) void onDocumentLoaded(channel, key);
+	}, [onDocumentLoaded]);
+	return <ChannelWorkspace agent={agent} onReady={ready} source={source} user={user} />;
 }
 
 function DocumentRouteSwap(
@@ -392,18 +441,26 @@ function DocumentRouteSwap(
 ) {
 	let requested = keyedDocumentRoute(route, motionImmediately());
 	let [state, dispatch] = useReducer(
-		transitionDocumentRoute,
-		initialDocumentRouteSwap(requested),
+		transitionDocumentRoute<DocumentRouteRequest, Api.Channel>,
+		{ current: requested },
 	);
 	let presentedRequest = state.pending ?? state.current;
 	if (requested.key !== presentedRequest.key) {
 		dispatch({ route: requested, type: "requested" });
 	}
 	let layers = [state.previous, state.current, state.pending].filter(
-		(layer): layer is KeyedDocumentRoute => layer !== undefined,
+		(layer): layer is DocumentRouteLayer => layer !== undefined,
 	);
 	let motion = motionContract("content-swap");
-	let resolved = useCallback((key: string) => dispatch({ key, type: "resolved" }), []);
+	let ready = useCallback((key: string, channel?: Api.Channel) => {
+		dispatch({ channel, key, type: "ready" });
+	}, []);
+	let { onDocumentLoaded } = useNavigationDocument();
+	useEffect(() => {
+		if (state.current.channel) {
+			void onDocumentLoaded(state.current.channel, state.current.key);
+		}
+	}, [onDocumentLoaded, state.current.channel, state.current.key]);
 
 	return (
 		<div className="document-route-swap content-swap-stack h-full">
@@ -419,19 +476,10 @@ function DocumentRouteSwap(
 						: undefined}
 				>
 					<ChannelWorkspace
-						active={layer.key === state.current.key}
 						agent={agent}
-						onResolved={resolved}
-						routeKey={layer.key}
-						showLoading={layer.key === state.current.key}
+						onReady={ready}
+						source={layer.source}
 						user={user}
-						{...(layer.route.page === "channel"
-							? { id: layer.route.id }
-							: {
-								owner: layer.route.owner,
-								repository: layer.route.repository,
-								slug: layer.route.slug,
-							})}
 					/>
 				</ContentSwapLayer>
 			))}
@@ -476,15 +524,18 @@ export function HostedApp(
 			workspace = <DocumentRouteSwap agent={agent} route={route} user={user} />;
 			break;
 		case "research":
+			let source: ChannelSource = {
+				owner: route.owner,
+				repository: route.repository,
+				slug: route.slug,
+				type: "research",
+				workspaceId: route.workspaceId,
+			};
 			workspace = (
-				<ChannelWorkspace
+				<ActiveChannelWorkspace
 					agent={agent}
-					key={`research:${route.owner}/${route.repository}/${route.slug}/${route.workspaceId}`}
-					owner={route.owner}
-					repository={route.repository}
-					researchWorkspaceId={route.workspaceId}
-					routeKey={`research:${route.owner}/${route.repository}/${route.slug}/${route.workspaceId}`}
-					slug={route.slug}
+					key={channelSourceKey(source)}
+					source={source}
 					user={user}
 				/>
 			);

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -55,13 +55,14 @@ export type HostedRoute =
 	| { page: "missing" };
 
 type DocumentRoute = Extract<HostedRoute, { page: "document" } | { page: "channel" }>;
-type KeyedDocumentRoute = { key: string; route: DocumentRoute };
+type KeyedDocumentRoute = { immediately: boolean; key: string; route: DocumentRoute };
 type DocumentRouteAction =
 	| { route: KeyedDocumentRoute; type: "requested" }
 	| { key: string; type: "resolved" | "closed" };
 
-function keyedDocumentRoute(route: DocumentRoute): KeyedDocumentRoute {
+function keyedDocumentRoute(route: DocumentRoute, immediately: boolean): KeyedDocumentRoute {
 	return {
+		immediately,
 		key: route.page === "channel"
 			? `channel:${route.id}`
 			: `document:${route.owner}/${route.repository}/${route.slug}`,
@@ -229,6 +230,7 @@ export function githubLoginHref(pathname: string, search = "", hash = ""): strin
 
 function ChannelWorkspace(
 	{
+		active = true,
 		agent,
 		id,
 		onResolved,
@@ -240,6 +242,7 @@ function ChannelWorkspace(
 		slug,
 		user,
 	}: {
+		active?: boolean;
 		agent: boolean;
 		id?: string;
 		onResolved?: (key: string) => void;
@@ -298,7 +301,6 @@ function ChannelWorkspace(
 						),
 				);
 				rememberChannel(user.id, value.channel, value.repository);
-				void onDocumentLoaded(value.channel, routeKey);
 			}
 			return value;
 		});
@@ -322,7 +324,6 @@ function ChannelWorkspace(
 		};
 	}, [
 		id,
-		onDocumentLoaded,
 		owner,
 		repository,
 		researchWorkspaceId,
@@ -331,6 +332,10 @@ function ChannelWorkspace(
 		slug,
 		user.id,
 	]);
+
+	useEffect(() => {
+		if (active && loaded) void onDocumentLoaded(loaded.detail.channel, routeKey);
+	}, [active, loaded, onDocumentLoaded, routeKey]);
 
 	useEffect(() => {
 		if (loaded || error !== undefined) onResolved?.(routeKey);
@@ -385,7 +390,7 @@ function ChannelWorkspace(
 function DocumentRouteSwap(
 	{ agent, route, user }: { agent: boolean; route: DocumentRoute; user: Api.User },
 ) {
-	let requested = keyedDocumentRoute(route);
+	let requested = keyedDocumentRoute(route, motionImmediately());
 	let [state, dispatch] = useReducer(
 		transitionDocumentRoute,
 		initialDocumentRouteSwap(requested),
@@ -397,7 +402,6 @@ function DocumentRouteSwap(
 	let layers = [state.previous, state.current, state.pending].filter(
 		(layer): layer is KeyedDocumentRoute => layer !== undefined,
 	);
-	let immediately = motionImmediately();
 	let motion = motionContract("content-swap");
 	let resolved = useCallback((key: string) => dispatch({ key, type: "resolved" }), []);
 
@@ -407,7 +411,7 @@ function DocumentRouteSwap(
 				<ContentSwapLayer
 					active={layer.key === state.current.key}
 					className="document-route-layer h-full min-h-0"
-					immediately={immediately}
+					immediately={state.current.immediately}
 					key={layer.key}
 					motion={motion}
 					onClosed={layer.key === state.previous?.key
@@ -415,6 +419,7 @@ function DocumentRouteSwap(
 						: undefined}
 				>
 					<ChannelWorkspace
+						active={layer.key === state.current.key}
 						agent={agent}
 						onResolved={resolved}
 						routeKey={layer.key}

--- a/apps/web/src/navigation-shell.tsx
+++ b/apps/web/src/navigation-shell.tsx
@@ -116,7 +116,7 @@ let NavigationDocument = createContext<{
 	) => void;
 	onDocumentAction: (action: DocumentAction) => void;
 	onDocumentDeleted: (documentId: string) => void;
-	onDocumentLoaded: (channel: Api.Channel) => Promise<void>;
+	onDocumentLoaded: (channel: Api.Channel, routeKey: string) => Promise<void>;
 	onRepositoryAccessChanged: () => void;
 	onResearchWorkspaceChanged: (
 		channel: Api.ResearchParentChannel,
@@ -416,13 +416,13 @@ export function NavigationShell(
 		navigationRef.current = next;
 		setNavigation(next);
 	}, []);
-	let documentLoaded = useCallback(async (channel: Api.Channel) => {
+	let documentLoaded = useCallback(async (channel: Api.Channel, loadedRouteKey: string) => {
 		let resolved = resolvedDocumentRef.current;
 		let loaded = {
-			channel: resolved?.routeKey === routeKey && resolved.channel.id === channel.id
+			channel: resolved?.routeKey === loadedRouteKey && resolved.channel.id === channel.id
 				? newestDocument(resolved.channel, channel)
 				: channel,
-			routeKey,
+			routeKey: loadedRouteKey,
 		};
 		resolvedDocumentRef.current = loaded;
 		setResolvedDocument(loaded);
@@ -436,7 +436,7 @@ export function NavigationShell(
 		try {
 			await visited;
 		} catch (reason) {
-			if (currentRouteKey.current === routeKey) setError({ reason, retry: "visit" });
+			if (currentRouteKey.current === loadedRouteKey) setError({ reason, retry: "visit" });
 			return;
 		}
 		setError(current => current?.retry === "visit" ? undefined : current);
@@ -458,7 +458,7 @@ export function NavigationShell(
 			pendingVisitedRepository.current = channel.repositoryId;
 			await refresh();
 		}
-	}, [clearLastDocument, refresh, routeKey, upsertDocument]);
+	}, [clearLastDocument, refresh, upsertDocument]);
 	let documentChanged = useCallback((
 		documentId: string,
 		update: DocumentMetadata,
@@ -729,7 +729,7 @@ export function NavigationShell(
 	let retryError = () => {
 		if (!error) return;
 		if (error.retry === "visit" && currentChannelRef.current) {
-			void documentLoaded(currentChannelRef.current);
+			void documentLoaded(currentChannelRef.current, currentRouteKey.current);
 		} else void refresh();
 	};
 	let dismissDrawer = () => {

--- a/apps/web/src/navigation-shell.tsx
+++ b/apps/web/src/navigation-shell.tsx
@@ -339,6 +339,8 @@ export function NavigationShell(
 		: route.page;
 	let currentRouteKey = useRef(routeKey);
 	currentRouteKey.current = routeKey;
+	let currentRoute = useRef(route);
+	currentRoute.current = route;
 	let resolvedChannel = resolvedDocument?.routeKey === routeKey
 		? resolvedDocument.channel
 		: undefined;
@@ -466,6 +468,29 @@ export function NavigationShell(
 			resolvedDocumentRef.current = next;
 			setResolvedDocument(next);
 			upsertDocument(next.channel);
+			let activeRoute = currentRoute.current;
+			if (
+				current.routeKey === currentRouteKey.current
+				&& (activeRoute.page === "channel"
+					|| activeRoute.page === "document"
+					|| activeRoute.page === "research")
+			) {
+				let path = activeRoute.page === "research"
+					? researchWorkspacePath(
+						accepted.repositoryOwner,
+						accepted.repositoryName,
+						accepted.slug,
+						activeRoute.workspaceId,
+					)
+					: documentPath(
+						accepted.repositoryOwner,
+						accepted.repositoryName,
+						accepted.slug,
+					);
+				if (location.pathname !== path) {
+					history.replaceState(null, "", `${path}${location.search}${location.hash}`);
+				}
+			}
 		} else updateDocument(documentId, update);
 		if (Object.hasOwn(update, "archivedAt")) {
 			let archived = accepted ? accepted.archivedAt : update.archivedAt;

--- a/apps/web/src/navigation-shell.tsx
+++ b/apps/web/src/navigation-shell.tsx
@@ -18,6 +18,7 @@ import { documentPath, researchWorkspacePath } from "@chopin/protocol/document-u
 import * as Api from "./api";
 import { forgetChannel } from "./channel-recovery";
 import { newestDocument, updateDocumentMetadata } from "./document-actions";
+import { documentRouteIdentity } from "./document-route-swap";
 import type { DocumentAction } from "./document-actions-menu";
 import { motionContract } from "./motion-contract";
 import { NavigationFocusScope } from "./navigation-focus";
@@ -46,6 +47,7 @@ import type { Research } from "@chopin/protocol";
 import type { TransitionPresence } from "@chopin/editor/transition-presence";
 import type { CSSProperties, MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import type { DocumentMetadata } from "./document-actions";
+import type { DocumentRouteIdentity, DocumentRouteIdentitySource } from "./document-route-swap";
 import type { NavigationMode } from "./navigation-model";
 
 export type Navigate = (destination: string, options?: { replace?: boolean }) => void;
@@ -94,17 +96,9 @@ let DeleteDocumentDialog = lazy(() =>
 );
 
 type Route =
+	| DocumentRouteIdentitySource
 	| { page: "repositories" }
-	| { page: "repository"; owner: string; repository: string }
-	| { page: "document"; owner: string; repository: string; slug: string }
-	| {
-		page: "research";
-		owner: string;
-		repository: string;
-		slug: string;
-		workspaceId: string;
-	}
-	| { page: "channel"; id: string };
+	| { page: "repository"; owner: string; repository: string };
 
 type NavigationFailure = { reason: unknown; retry?: "refresh" | "visit" };
 
@@ -116,7 +110,7 @@ let NavigationDocument = createContext<{
 	) => void;
 	onDocumentAction: (action: DocumentAction) => void;
 	onDocumentDeleted: (documentId: string) => void;
-	onDocumentLoaded: (channel: Api.Channel, routeKey: string) => Promise<void>;
+	onDocumentLoaded: (channel: Api.Channel, routeKey: DocumentRouteIdentity) => Promise<void>;
 	onRepositoryAccessChanged: () => void;
 	onResearchWorkspaceChanged: (
 		channel: Api.ResearchParentChannel,
@@ -273,7 +267,7 @@ export function NavigationShell(
 	let [error, setError] = useState<NavigationFailure>();
 	let [resolvedDocument, setResolvedDocument] = useState<{
 		channel: Api.Channel;
-		routeKey: string;
+		routeKey: DocumentRouteIdentity;
 	}>();
 	let resolvedDocumentRef = useRef(resolvedDocument);
 	resolvedDocumentRef.current = resolvedDocument;
@@ -339,11 +333,9 @@ export function NavigationShell(
 		upsertResearchWorkspace,
 	} = useProjectResearch(navigation, projects, catalogueMode === "archived");
 	let routeKey = route.page === "channel"
-		? `${route.page}:${route.id}`
-		: route.page === "research"
-		? `${route.page}:${route.owner}/${route.repository}/${route.slug}/${route.workspaceId}`
-		: route.page === "document"
-		? `${route.page}:${route.owner}/${route.repository}/${route.slug}`
+			|| route.page === "document"
+			|| route.page === "research"
+		? documentRouteIdentity(route)
 		: route.page;
 	let currentRouteKey = useRef(routeKey);
 	currentRouteKey.current = routeKey;
@@ -416,7 +408,10 @@ export function NavigationShell(
 		navigationRef.current = next;
 		setNavigation(next);
 	}, []);
-	let documentLoaded = useCallback(async (channel: Api.Channel, loadedRouteKey: string) => {
+	let documentLoaded = useCallback(async (
+		channel: Api.Channel,
+		loadedRouteKey: DocumentRouteIdentity,
+	) => {
 		let resolved = resolvedDocumentRef.current;
 		let loaded = {
 			channel: resolved?.routeKey === loadedRouteKey && resolved.channel.id === channel.id
@@ -728,8 +723,12 @@ export function NavigationShell(
 
 	let retryError = () => {
 		if (!error) return;
-		if (error.retry === "visit" && currentChannelRef.current) {
-			void documentLoaded(currentChannelRef.current, currentRouteKey.current);
+		if (
+			error.retry === "visit"
+			&& currentChannelRef.current
+			&& (route.page === "channel" || route.page === "document" || route.page === "research")
+		) {
+			void documentLoaded(currentChannelRef.current, documentRouteIdentity(route));
 		} else void refresh();
 	};
 	let dismissDrawer = () => {

--- a/apps/web/src/research-workspace.tsx
+++ b/apps/web/src/research-workspace.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { documentPath, researchWorkspacePath } from "@chopin/protocol/document-url";
+import { documentPath } from "@chopin/protocol/document-url";
 
 import * as Api from "./api";
 import { rememberChannel } from "./channel-recovery";
@@ -684,16 +684,7 @@ export function ResearchWorkspace(
 		setMetadata(metadata);
 		rememberChannel(userId, { id: room, title: metadata.title, slug: metadata.slug }, repository);
 		onDocumentChanged(room, metadata);
-		let path = researchWorkspacePath(
-			repository.owner,
-			repository.name,
-			metadata.slug,
-			workspaceId,
-		);
-		if (location.pathname !== path) {
-			history.replaceState(null, "", `${path}${location.search}${location.hash}`);
-		}
-	}, [onDocumentChanged, repository, room, userId, workspaceId]);
+	}, [onDocumentChanged, repository, room, userId]);
 
 	useEffect(() => {
 		let next: WorkspaceMetadata = {

--- a/apps/web/src/room-workspace.tsx
+++ b/apps/web/src/room-workspace.tsx
@@ -33,7 +33,7 @@ import { useNavigationDocument } from "./navigation-shell";
 import { NavigationIcon } from "./project-sidebar";
 import { peopleHere } from "./presence";
 import { Wire } from "./wire";
-import { HEADING, useWorkspaceMode, useWorkspaceState, Workspace } from "./workspace";
+import { useWorkspaceIds, useWorkspaceMode, useWorkspaceState, Workspace } from "./workspace";
 import { availableDocumentView, presentWorkspace, storedDocumentView } from "./workspace-model";
 
 import type { Research, Session } from "@chopin/protocol";
@@ -178,6 +178,7 @@ export function RoomWorkspace(
 	let metadataRef = useRef(metadata);
 	let user = useMemo(() => cursor(handle), [handle]);
 	let mode = useWorkspaceMode();
+	let workspaceIds = useWorkspaceIds();
 	let [workspace, dispatch] = useWorkspaceState();
 	let [questions] = useState(() => new QuestionnaireStore());
 	let [threads] = useState(() => new ThreadStore());
@@ -459,6 +460,7 @@ export function RoomWorkspace(
 					view={view}
 				/>
 			}
+			ids={workspaceIds}
 			mode={mode}
 			onDesktopConversationOpen={setDesktopConversationOpen}
 			onConversationOpen={open => dispatch({ type: "set-conversation", open })}
@@ -466,7 +468,7 @@ export function RoomWorkspace(
 			decisions={
 				<Decisions
 					connected={status === "connected" && workspaceCanEdit}
-					headingId={HEADING.decisions}
+					headingId={workspaceIds.heading.decisions}
 					motion={motionContract("collapse")}
 					motionImmediately={settleMotionImmediately}
 					onShowPlan={showPlan}
@@ -497,7 +499,7 @@ export function RoomWorkspace(
 					<BackgroundWork
 						canEdit={workspaceCanEdit}
 						connected={status === "connected"}
-						headingId={HEADING["background-work"]}
+						headingId={workspaceIds.heading["background-work"]}
 						motion={motionContract("collapse")}
 						motionImmediately={settleMotionImmediately}
 						store={jobs}

--- a/apps/web/src/room-workspace.tsx
+++ b/apps/web/src/room-workspace.tsx
@@ -51,6 +51,11 @@ function settleMotionImmediately(): boolean {
 	return motionImmediately();
 }
 
+const QUESTION_MOTION = {
+	contract: motionContract("content-swap"),
+	immediately: settleMotionImmediately,
+};
+
 export function Header(
 	{
 		archivedAt,
@@ -468,6 +473,7 @@ export function RoomWorkspace(
 					motion={motionContract("collapse")}
 					motionImmediately={settleMotionImmediately}
 					onShowPlan={showPlan}
+					questionMotion={QUESTION_MOTION}
 					reveal={reveal}
 					store={questions}
 					wire={wire}
@@ -480,6 +486,7 @@ export function RoomWorkspace(
 					key={workspaceArchivedAt ? "archived" : "active"}
 					motionImmediately={settleMotionImmediately}
 					onScrollTop={setPlanScrollTop}
+					questionMotion={QUESTION_MOTION}
 					questions={questions}
 					readOnly={!workspaceCanEdit}
 					scrollTop={planScrollTop}

--- a/apps/web/src/room-workspace.tsx
+++ b/apps/web/src/room-workspace.tsx
@@ -12,6 +12,7 @@ import {
 	JobStore,
 	PlanEditor,
 	QuestionnaireStore,
+	selectDecisionView,
 	ThreadStore,
 	useHasPlanContent,
 	useJobs,
@@ -249,11 +250,7 @@ export function RoomWorkspace(
 	}, [unanswered]);
 
 	let selectView = (next: DecisionView, revealFirst = true) => {
-		setDecisionView(state => ({
-			...state,
-			...(next === "background-work" ? { phase: "complete" as const } : {}),
-			preferred: next,
-		}));
+		setDecisionView(state => selectDecisionView(state, next));
 		if (hasPlanContent) localStorage.setItem("chopin:view:document", next);
 		if (next === "decisions" && revealFirst) {
 			let first = entries.find(entry =>

--- a/apps/web/src/room-workspace.tsx
+++ b/apps/web/src/room-workspace.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { documentPath } from "@chopin/protocol/document-url";
 import {
 	advanceDecisionView,
 	aggregateJobs,
@@ -226,10 +225,6 @@ export function RoomWorkspace(
 		setMetadata(metadata);
 		rememberChannel(userId, { id: room, title: metadata.title, slug: metadata.slug }, repository);
 		onDocumentChanged(room, metadata);
-		let path = documentPath(repository.owner, repository.name, metadata.slug);
-		if (location.pathname !== path) {
-			history.replaceState(null, "", `${path}${location.search}${location.hash}`);
-		}
 	}, [onDocumentChanged, repository, room, userId]);
 
 	useEffect(() => {

--- a/apps/web/src/theme.css
+++ b/apps/web/src/theme.css
@@ -596,7 +596,8 @@ body {
 
 .motion-content-swap.is-open {
 	opacity: 1;
-	transform: translateX(0);
+	transform: none;
+	will-change: auto;
 }
 
 .motion-content-swap.is-closing {

--- a/apps/web/src/theme.css
+++ b/apps/web/src/theme.css
@@ -551,7 +551,7 @@ body {
 	box-shadow: none;
 }
 
-.workspace-frame #pane-chat {
+.workspace-frame .workspace-conversation-panel {
 	border-color: rgb(0 0 0 / 9%);
 }
 

--- a/apps/web/src/theme.css
+++ b/apps/web/src/theme.css
@@ -576,6 +576,35 @@ body {
 	transition-duration: var(--panel-close-dur);
 }
 
+.content-swap-stack {
+	display: grid;
+}
+
+.content-swap-stack > .motion-content-swap {
+	grid-area: 1 / 1;
+	min-width: 0;
+}
+
+.motion-content-swap {
+	opacity: 0;
+	transform: translateX(var(--page-slide-distance));
+	transition:
+		opacity var(--page-slide-dur) var(--motion-smooth-out),
+		transform var(--page-slide-dur) var(--motion-smooth-out);
+	will-change: opacity, transform;
+}
+
+.motion-content-swap.is-open {
+	opacity: 1;
+	transform: translateX(0);
+}
+
+.motion-content-swap.is-closing {
+	pointer-events: none;
+	opacity: 0;
+	transform: translateX(calc(var(--page-slide-distance) * -1));
+}
+
 .workspace-root:not([data-workspace-mode="split"]) .workspace-conversation-panel {
 	position: absolute;
 	inset: 0;
@@ -768,6 +797,7 @@ body {
 	.motion-dropdown,
 	.motion-popover,
 	.motion-panel,
+	.motion-content-swap,
 	.motion-collapse,
 	.motion-collapse-content,
 	.motion-disclosure-icon {

--- a/apps/web/src/theme.test.ts
+++ b/apps/web/src/theme.test.ts
@@ -186,6 +186,18 @@ describe("motion contracts", () => {
 			/@media \(prefers-reduced-motion: reduce\)\s*{[\s\S]*?\.motion-comment-preview[\s\S]*?transition:\s*none;[\s\S]*?}/,
 		);
 	});
+
+	it("uses the page timing, distance, and smooth curve for content swaps", () => {
+		expect(THEME).toMatch(
+			/\.motion-content-swap\s*{[^}]*var\(--page-slide-distance\)[^}]*var\(--page-slide-dur\)[^}]*var\(--motion-smooth-out\)/s,
+		);
+	});
+
+	it("settles content swaps under reduced motion", () => {
+		expect(THEME).toMatch(
+			/@media \(prefers-reduced-motion: reduce\)\s*{[\s\S]*?\.motion-content-swap[\s\S]*?transition:\s*none;[\s\S]*?}/,
+		);
+	});
 });
 
 describe("disclosure motion", () => {

--- a/apps/web/src/theme.test.ts
+++ b/apps/web/src/theme.test.ts
@@ -193,6 +193,12 @@ describe("motion contracts", () => {
 		);
 	});
 
+	it("releases the transformed containing block after content swaps settle", () => {
+		expect(THEME).toMatch(
+			/\.motion-content-swap\.is-open\s*{[^}]*transform:\s*none;[^}]*will-change:\s*auto;/s,
+		);
+	});
+
 	it("settles content swaps under reduced motion", () => {
 		expect(THEME).toMatch(
 			/@media \(prefers-reduced-motion: reduce\)\s*{[\s\S]*?\.motion-content-swap[\s\S]*?transition:\s*none;[\s\S]*?}/,

--- a/apps/web/src/tokens.test.ts
+++ b/apps/web/src/tokens.test.ts
@@ -135,7 +135,7 @@ describe("palette", () => {
 
 	it("keeps the Conversation pane edge subtly stronger than the frame hairline", () => {
 		expect(THEME).toMatch(
-			/\.workspace-frame #pane-chat\s*\{\s*border-color:\s*rgb\(0 0 0 \/ 9%\);/,
+			/\.workspace-frame \.workspace-conversation-panel\s*\{\s*border-color:\s*rgb\(0 0 0 \/ 9%\);/,
 		);
 	});
 
@@ -549,7 +549,7 @@ describe("migration", () => {
 				"apps/web/src/workspace.tsx",
 				{
 					action: "pane toggle",
-					marker: 'aria-controls={paneId("chat")}',
+					marker: "aria-controls={controls}",
 					size: "btn-icon",
 					tiers: ["btn-ghost"],
 				},

--- a/apps/web/src/workspace.tsx
+++ b/apps/web/src/workspace.tsx
@@ -1,6 +1,7 @@
 /** Three panes on one ground, with the document as the only raised surface. */
 
 import { useEffect, useLayoutEffect, useReducer, useRef, useSyncExternalStore } from "react";
+import { ContentSwapLayer } from "@chopin/editor/content-swap";
 import { useTransitionPresence } from "@chopin/editor/transition-presence";
 
 import {
@@ -12,6 +13,7 @@ import {
 import conversationCloseIcon from "./assets/icons/conversation-close.svg";
 import conversationIcon from "./assets/icons/conversation.svg";
 import { ResizeHandle, usePaneWidth } from "./resizable-pane";
+import { motionContract } from "./motion-contract";
 import { motionImmediately } from "./motion-input";
 
 import type { Dispatch, ReactNode, RefObject } from "react";
@@ -209,20 +211,17 @@ export function Workspace(
 ) {
 	let [chatWidth, resizeChat] = usePaneWidth({ active: mode === "split", ...CHAT_PANE });
 	let presentation = presentWorkspace(state, mode, view);
+	let immediately = motionImmediately();
+	let contentSwapMotion = motionContract("content-swap");
 	let conversationPresence = useTransitionPresence(
 		presentation.conversationVisible ? true : undefined,
 		220,
-		motionImmediately(),
+		immediately,
 	);
 	let opener = useRef<HTMLElement | undefined>(undefined);
 	let edgeTab = useRef<HTMLButtonElement>(null);
 	let previousConversationOpen = useRef(state.conversationOpen);
 	let conversationInactive = !presentation.conversationVisible;
-	let planHidden = !presentation.documentVisible || presentation.documentView !== "plan";
-	let decisionsHidden = !presentation.documentVisible
-		|| presentation.documentView !== "decisions";
-	let backgroundWorkHidden = !presentation.documentVisible
-		|| presentation.documentView !== "background-work";
 	let destinations: WorkspaceDestination[] = backgroundWork
 		? ["conversation", "plan", "decisions", "background-work"]
 		: ["conversation", "plan", "decisions"];
@@ -365,37 +364,54 @@ export function Workspace(
 								{controls}
 							</div>
 						)}
-						<section
-							aria-hidden={planHidden || undefined}
-							aria-labelledby={HEADING.plan}
-							className="min-h-0 flex-1"
-							data-document-view="plan"
-							hidden={planHidden}
-							inert={planHidden}
-						>
-							<h2 className="sr-only" id={HEADING.plan} tabIndex={-1}>Document</h2>
-							{plan}
-						</section>
-						<section
-							aria-hidden={decisionsHidden || undefined}
-							aria-labelledby={HEADING.decisions}
-							className="min-h-0 flex-1"
-							data-document-view="decisions"
-							hidden={decisionsHidden}
-							inert={decisionsHidden}
-						>
-							{decisions}
-						</section>
-						<section
-							aria-hidden={backgroundWorkHidden || undefined}
-							aria-labelledby={HEADING["background-work"]}
-							className="min-h-0 flex-1 overflow-auto"
-							data-document-view="background-work"
-							hidden={backgroundWorkHidden}
-							inert={backgroundWorkHidden}
-						>
-							{backgroundWork}
-						</section>
+						<div className="workspace-document-swap content-swap-stack relative min-h-0 flex-1">
+							<ContentSwapLayer
+								active={presentation.documentVisible && presentation.documentView === "plan"}
+								className="workspace-document-layer min-h-0"
+								immediately={immediately}
+								motion={contentSwapMotion}
+							>
+								<section
+									aria-labelledby={HEADING.plan}
+									className="h-full min-h-0"
+									data-document-view="plan"
+								>
+									<h2 className="sr-only" id={HEADING.plan} tabIndex={-1}>Document</h2>
+									{plan}
+								</section>
+							</ContentSwapLayer>
+							<ContentSwapLayer
+								active={presentation.documentVisible && presentation.documentView === "decisions"}
+								className="workspace-document-layer min-h-0"
+								immediately={immediately}
+								motion={contentSwapMotion}
+							>
+								<section
+									aria-labelledby={HEADING.decisions}
+									className="h-full min-h-0"
+									data-document-view="decisions"
+								>
+									{decisions}
+								</section>
+							</ContentSwapLayer>
+							{backgroundWork && (
+								<ContentSwapLayer
+									active={presentation.documentVisible
+										&& presentation.documentView === "background-work"}
+									className="workspace-document-layer min-h-0"
+									immediately={immediately}
+									motion={contentSwapMotion}
+								>
+									<section
+										aria-labelledby={HEADING["background-work"]}
+										className="h-full min-h-0 overflow-auto"
+										data-document-view="background-work"
+									>
+										{backgroundWork}
+									</section>
+								</ContentSwapLayer>
+							)}
+						</div>
 					</div>
 				</main>
 			</div>

--- a/apps/web/src/workspace.tsx
+++ b/apps/web/src/workspace.tsx
@@ -364,7 +364,10 @@ export function Workspace(
 								{controls}
 							</div>
 						)}
-						<div className="workspace-document-swap content-swap-stack relative min-h-0 flex-1">
+						<div
+							className="workspace-document-swap content-swap-stack relative min-h-0 flex-1"
+							data-workspace-document-swap
+						>
 							<ContentSwapLayer
 								active={presentation.documentVisible && presentation.documentView === "plan"}
 								className="workspace-document-layer min-h-0"

--- a/apps/web/src/workspace.tsx
+++ b/apps/web/src/workspace.tsx
@@ -1,6 +1,6 @@
 /** Three panes on one ground, with the document as the only raised surface. */
 
-import { useEffect, useLayoutEffect, useReducer, useRef, useSyncExternalStore } from "react";
+import { useEffect, useId, useLayoutEffect, useReducer, useRef, useSyncExternalStore } from "react";
 import { ContentSwapLayer } from "@chopin/editor/content-swap";
 import { useTransitionPresence } from "@chopin/editor/transition-presence";
 
@@ -33,8 +33,22 @@ const CHAT_PANE = {
 	storageKey: "chopin:pane:chat",
 };
 
-export function paneId(pane: Pane): string {
-	return `pane-${pane}`;
+export type WorkspaceIds = {
+	heading: Record<WorkspaceDestination, string>;
+	pane: Record<Pane, string>;
+};
+
+export function useWorkspaceIds(): WorkspaceIds {
+	let instance = useId();
+	return {
+		heading: {
+			plan: `${instance}-workspace-plan-heading`,
+			decisions: `${instance}-workspace-decisions-heading`,
+			"background-work": `${instance}-workspace-background-work-heading`,
+			conversation: `${instance}-workspace-conversation-heading`,
+		},
+		pane: { chat: `${instance}-pane-chat` },
+	};
 }
 
 function currentMode(): WorkspaceMode {
@@ -78,6 +92,7 @@ export type WorkspaceProps = {
 	decisions: ReactNode;
 	backgroundWork?: ReactNode;
 	controls: ReactNode;
+	ids: WorkspaceIds;
 	mode: WorkspaceMode;
 	state: WorkspaceState;
 	view: "plan" | "decisions" | "background-work";
@@ -94,6 +109,7 @@ function ConversationToggle(
 		activity,
 		buttonRef,
 		className,
+		controls,
 		onToggle,
 		open,
 		swapOnHover = false,
@@ -101,6 +117,7 @@ function ConversationToggle(
 		activity: WorkspaceProps["conversationActivity"];
 		buttonRef?: RefObject<HTMLButtonElement | null>;
 		className?: string;
+		controls: string;
 		onToggle: () => void;
 		open: boolean;
 		swapOnHover?: boolean;
@@ -113,7 +130,7 @@ function ConversationToggle(
 		: undefined;
 	return (
 		<button
-			aria-controls={paneId("chat")}
+			aria-controls={controls}
 			aria-expanded={open}
 			aria-label={`${open ? "Hide" : "Show"} conversation pane${status ? `, ${status}` : ""}`}
 			className={`btn btn-icon btn-ghost relative shrink-0 ${className ?? ""}`}
@@ -154,13 +171,6 @@ function ConversationToggle(
 	);
 }
 
-export const HEADING: Record<WorkspaceDestination, string> = {
-	plan: "workspace-plan-heading",
-	decisions: "workspace-decisions-heading",
-	"background-work": "workspace-background-work-heading",
-	conversation: "workspace-conversation-heading",
-};
-
 function destinationLabel(
 	destination: WorkspaceDestination,
 	unanswered: number,
@@ -196,6 +206,7 @@ export function Workspace(
 		backgroundWork,
 		chat,
 		controls,
+		ids,
 		conversationActivity,
 		decisions,
 		header,
@@ -210,6 +221,7 @@ export function Workspace(
 	}: WorkspaceProps,
 ) {
 	let [chatWidth, resizeChat] = usePaneWidth({ active: mode === "split", ...CHAT_PANE });
+	let root = useRef<HTMLDivElement>(null);
 	let presentation = presentWorkspace(state, mode, view);
 	let immediately = motionImmediately();
 	let contentSwapMotion = motionContract("content-swap");
@@ -225,13 +237,17 @@ export function Workspace(
 	let destinations: WorkspaceDestination[] = backgroundWork
 		? ["conversation", "plan", "decisions", "background-work"]
 		: ["conversation", "plan", "decisions"];
+	let focusDestination = (destination: WorkspaceDestination) => {
+		root.current?.querySelector<HTMLElement>(`#${CSS.escape(ids.heading[destination])}`)
+			?.focus({ preventScroll: true });
+	};
 
 	useLayoutEffect(() => {
 		if (!previousConversationOpen.current && state.conversationOpen) {
 			let active = document.activeElement;
 			if (active instanceof HTMLElement) opener.current = active;
 			if (mode !== "split") {
-				document.getElementById(HEADING.conversation)?.focus({ preventScroll: true });
+				focusDestination("conversation");
 			}
 		}
 		previousConversationOpen.current = state.conversationOpen;
@@ -242,7 +258,7 @@ export function Workspace(
 		if (destination === "conversation") onConversationOpen(true);
 		else onDestination(destination);
 		requestAnimationFrame(() => {
-			document.getElementById(HEADING[destination])?.focus({ preventScroll: true });
+			focusDestination(destination);
 		});
 	};
 
@@ -259,7 +275,7 @@ export function Workspace(
 	let showDesktopConversation = () => {
 		onDesktopConversationOpen(true);
 		requestAnimationFrame(() => {
-			document.getElementById(HEADING.conversation)?.focus({ preventScroll: true });
+			focusDestination("conversation");
 		});
 	};
 
@@ -267,6 +283,7 @@ export function Workspace(
 		<div
 			className="workspace-root flex h-full flex-col overflow-hidden bg-ground"
 			data-workspace-mode={mode}
+			ref={root}
 		>
 			{header}
 
@@ -281,12 +298,12 @@ export function Workspace(
 				{chat && (
 					<aside
 						aria-hidden={conversationInactive || undefined}
-						aria-labelledby={HEADING.conversation}
+						aria-labelledby={ids.heading.conversation}
 						className={`workspace-conversation-panel motion-panel ${conversationPresence.className} order-2 relative flex min-w-0 flex-col overflow-hidden bg-conversation-pane ${
 							mode === "split" ? "hairline-l hairline-r hairline-b" : ""
 						}`}
 						hidden={conversationPresence.phase === "closed"}
-						id={paneId("chat")}
+						id={ids.pane.chat}
 						inert={conversationInactive}
 						onKeyDown={event => {
 							if (event.key === "Escape" && mode !== "split") {
@@ -315,20 +332,25 @@ export function Workspace(
 									<ConversationToggle
 										activity={conversationActivity}
 										className="conversation-header-control -ml-[5px] -mr-[5px]"
+										controls={ids.pane.chat}
 										onToggle={dismissConversation}
 										open
 										swapOnHover
 									/>
 									<h2
 										className="text-[14px] font-medium text-text-tertiary"
-										id={HEADING.conversation}
+										id={ids.heading.conversation}
 										tabIndex={-1}
 									>
 										Conversation
 									</h2>
 								</div>
 							)
-							: <h2 className="sr-only" id={HEADING.conversation} tabIndex={-1}>Conversation</h2>}
+							: (
+								<h2 className="sr-only" id={ids.heading.conversation} tabIndex={-1}>
+									Conversation
+								</h2>
+							)}
 						<div className="min-h-0 flex-1">
 							{chat}
 						</div>
@@ -341,6 +363,7 @@ export function Workspace(
 							activity={conversationActivity}
 							buttonRef={edgeTab}
 							className="rounded-l-none"
+							controls={ids.pane.chat}
 							onToggle={showDesktopConversation}
 							open={false}
 						/>
@@ -375,11 +398,11 @@ export function Workspace(
 								motion={contentSwapMotion}
 							>
 								<section
-									aria-labelledby={HEADING.plan}
+									aria-labelledby={ids.heading.plan}
 									className="h-full min-h-0"
 									data-document-view="plan"
 								>
-									<h2 className="sr-only" id={HEADING.plan} tabIndex={-1}>Document</h2>
+									<h2 className="sr-only" id={ids.heading.plan} tabIndex={-1}>Document</h2>
 									{plan}
 								</section>
 							</ContentSwapLayer>
@@ -390,7 +413,7 @@ export function Workspace(
 								motion={contentSwapMotion}
 							>
 								<section
-									aria-labelledby={HEADING.decisions}
+									aria-labelledby={ids.heading.decisions}
 									className="h-full min-h-0"
 									data-document-view="decisions"
 								>
@@ -406,7 +429,7 @@ export function Workspace(
 									motion={contentSwapMotion}
 								>
 									<section
-										aria-labelledby={HEADING["background-work"]}
+										aria-labelledby={ids.heading["background-work"]}
 										className="h-full min-h-0 overflow-auto"
 										data-document-view="background-work"
 									>

--- a/bun.lock
+++ b/bun.lock
@@ -148,6 +148,8 @@
       "devDependencies": {
         "@types/bun": "catalog:bun",
         "@types/react": "catalog:react",
+        "@types/react-dom": "catalog:react",
+        "react-dom": "catalog:react",
       },
       "peerDependencies": {
         "react": "catalog:react",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,6 +156,23 @@ are broadcast decoration: a browser retains at most 50 unseen marks until they
 enter the viewport, the editor is cleared, or the epoch changes. The server does
 not persist or replay them after a reconnect.
 
+## Browser content swaps
+
+The host that owns a changing surface also owns its motion contract and keyed
+retention. The shared `ContentSwapLayer` owns presence timing: it makes an
+inactive layer `inert` and `aria-hidden` immediately, then hides it and notifies
+the host after its visual exit. Pointer input follows the host's transition
+contract; keyboard input and reduced-motion preferences settle the transition
+immediately.
+
+The editor's questionnaire host renders the current question and retains at most
+one outgoing question until that layer closes. Document navigation similarly
+keeps the active route, at most one outgoing route, and an optional pending
+route. A pending document load stays mounted but hidden and inert until it is
+ready, so the existing document remains interactive. Navigation publishes only
+the active ready channel; readiness reported later by an outgoing route cannot
+replace it.
+
 ## Counters and identities
 
 Several independent counters prevent different classes of stale write. They are

--- a/e2e/chat-references.e2e.ts
+++ b/e2e/chat-references.e2e.ts
@@ -15,6 +15,10 @@ function port(baseURL: string): number {
 	return Number(new URL(baseURL).port);
 }
 
+function conversationPane(page: Page) {
+	return page.getByRole("complementary", { includeHidden: true, name: "Conversation" });
+}
+
 async function enablePlanner(page: Page): Promise<void> {
 	await page.route("**/api/session", async route => {
 		let response = await route.fetch();
@@ -201,7 +205,7 @@ test("a server without chat references leaves typed tokens ordinary", async ({ j
 		});
 	});
 
-	let conversation = (await join("ana")).locator("#pane-chat");
+	let conversation = conversationPane(await join("ana"));
 	let draft = conversation.getByPlaceholder("Use @chopin to ask Chopin");
 	await expect(draft).toHaveRole("textbox");
 	await expect(draft).not.toHaveAttribute("aria-autocomplete", "list");
@@ -230,7 +234,7 @@ test("an empty picker leaves arrows and Enter to the textarea", async ({ join, p
 		server.onMessage(message => route.send(message));
 	});
 
-	let conversation = (await join("ana")).locator("#pane-chat");
+	let conversation = conversationPane(await join("ana"));
 	let draft = conversation.getByPlaceholder("Use @chopin to ask Chopin");
 	let value = `No result #missing-${crypto.randomUUID()}`;
 	await draft.fill(value);
@@ -260,7 +264,7 @@ test("a disconnect rejects a pending send without losing its draft", async ({ jo
 		server.onMessage(message => route.send(message));
 	});
 
-	let conversation = (await join("ana")).locator("#pane-chat");
+	let conversation = conversationPane(await join("ana"));
 	let draft = conversation.getByPlaceholder("Use @chopin to ask Chopin");
 	let value = "Keep this draft through disconnect";
 	await draft.fill(value);
@@ -294,7 +298,7 @@ test("legacy delivery clears immediately without waiting for an acknowledgement"
 		});
 	});
 
-	let conversation = (await join("ana")).locator("#pane-chat");
+	let conversation = conversationPane(await join("ana"));
 	let draft = conversation.getByPlaceholder("Use @chopin to ask Chopin");
 	await draft.fill("Legacy delivery");
 	await conversation.getByRole("button", { name: "Send message" }).click();
@@ -324,7 +328,7 @@ test("the composer stays read-only until fresh chat history arrives", async ({ j
 		});
 	});
 
-	let conversation = (await join("ana")).locator("#pane-chat");
+	let conversation = conversationPane(await join("ana"));
 	let draft = conversation.getByPlaceholder("Use @chopin to ask Chopin");
 	await expect.poll(() => releaseHistory !== undefined).toBe(true);
 	await expect(draft).toHaveAttribute("readonly", "");

--- a/e2e/document-navigation.e2e.ts
+++ b/e2e/document-navigation.e2e.ts
@@ -1,4 +1,5 @@
 import { authenticate, content, expect, roomPath, test } from "./room";
+import { createChannel } from "./database";
 
 function channel(id: string, title: string, description?: string) {
 	return {
@@ -369,6 +370,62 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${originalTitle}`);
 	await expect(visibleRoutes).toHaveCount(1, { timeout: 100 });
 	await expect(outgoingRoutes).toHaveCount(0);
+});
+
+test("overlapping document workspaces keep IDs, ARIA targets, and focus instance-scoped", async ({ baseURL, join }) => {
+	let page = await join("ana", { viewport: { width: 390, height: 844 } });
+	let created = crypto.randomUUID();
+	await createChannel(Number(new URL(baseURL!).port), created);
+	let destination = roomPath(created);
+	await page.locator("body").dispatchEvent("pointerover", { pointerType: "mouse" });
+	await page.evaluate(path => {
+		history.pushState(null, "", path);
+		dispatchEvent(new PopStateEvent("popstate"));
+	}, destination);
+
+	let routes = page.locator(".document-route-swap > [data-content-swap-state]:not([hidden])");
+	await expect(routes).toHaveCount(2);
+	let audit = await routes.evaluateAll(async layers => {
+		let current = layers.find(layer => !layer.hasAttribute("inert"));
+		let decision = [...current!.querySelectorAll<HTMLButtonElement>(
+			'nav[aria-label="Workspace view"] button',
+		)].find(button => button.textContent?.includes("Decisions"));
+		decision!.click();
+		await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+		let roots = layers.flatMap(
+			layer => [...layer.querySelectorAll<HTMLElement>(".workspace-root")],
+		);
+		let ids = roots.flatMap(root => [...root.querySelectorAll<HTMLElement>("[id]")])
+			.map(element => element.id);
+		let counts = new Map<string, number>();
+		for (let id of ids) counts.set(id, (counts.get(id) ?? 0) + 1);
+		let duplicateIds = [...counts].filter(([, count]) => count > 1).map(([id]) => id).sort();
+		let invalidReferences = roots.flatMap(root =>
+			[...root.querySelectorAll<HTMLElement>("[aria-controls], [aria-labelledby]")]
+				.flatMap(element =>
+					["aria-controls", "aria-labelledby"].flatMap(attribute =>
+						(element.getAttribute(attribute)?.split(/\s+/) ?? []).flatMap(id =>
+							document.querySelectorAll(`#${CSS.escape(id)}`).length === 1
+								? []
+								: [`${attribute}:${id}`]
+						)
+					)
+				)
+		).sort();
+		let heading = current?.querySelector('[data-document-view="decisions"] h2');
+		return {
+			activeDecisionFocused: document.activeElement === heading,
+			duplicateIds,
+			invalidReferences,
+			workspaceCount: roots.length,
+		};
+	});
+	expect(audit).toEqual({
+		activeDecisionFocused: true,
+		duplicateIds: [],
+		invalidReferences: [],
+		workspaceCount: 2,
+	});
 });
 
 test("the archive view refreshes catalogues without reopening the document", async ({ join, page }) => {

--- a/e2e/document-navigation.e2e.ts
+++ b/e2e/document-navigation.e2e.ts
@@ -252,6 +252,8 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 	await expect(page).toHaveURL(/\/documents\/octo-org\/score\/[a-z]+-[a-z]+$/);
 	let created = projects.locator('a[aria-current="page"]');
 	let createdTitle = (await created.textContent())!.trim();
+	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${createdTitle}`);
+	await expect(page.locator(".document-route-layer:not([hidden])")).toHaveCount(1);
 	await expect(projects.getByRole("link", { name: originalTitle, exact: true })).toBeVisible();
 	expect(
 		requested.filter(request => request.method === "GET" && request.path === "/api/navigation"),
@@ -269,7 +271,9 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 	});
 	await projects.getByRole("link", { name: originalTitle, exact: true }).click();
 
-	await expect(page.getByText("Opening channel...", { exact: true })).toBeVisible();
+	await expect(page.getByText("Opening channel...", { exact: true })).toHaveCount(0);
+	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${createdTitle}`);
+	await expect(page.locator(".document-route-layer:not([hidden])")).toHaveCount(1);
 	await expect(projects.getByRole("link", { name: createdTitle, exact: true })).toBeVisible();
 	expect(
 		await page.evaluate(() =>
@@ -277,7 +281,13 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 		),
 	).toBe("preserved");
 	release.resolve();
+	let visibleRoutes = page.locator(".document-route-layer:not([hidden])");
+	await expect(visibleRoutes).toHaveCount(2);
+	await expect(page.locator(".document-route-layer:not([hidden]):not([inert])")).toHaveCount(1);
+	await expect(page.locator('.document-route-layer:not([hidden])[aria-hidden="true"][inert]'))
+		.toHaveCount(1);
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${originalTitle}`);
+	await expect(visibleRoutes).toHaveCount(1);
 	await expect(page).toHaveURL(originalPath!);
 
 	expect(requested.filter(request => request.path === "/api/session")).toHaveLength(0);
@@ -300,6 +310,13 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${createdTitle}`);
 	await page.evaluate(() => history.forward());
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${originalTitle}`);
+
+	let createdLink = projects.getByRole("link", { name: createdTitle, exact: true });
+	await createdLink.focus();
+	await page.keyboard.press("Enter");
+	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${createdTitle}`);
+	await expect(visibleRoutes).toHaveCount(1);
+	await expect(page.locator(".document-route-layer:not([hidden]).is-closing")).toHaveCount(0);
 });
 
 test("the archive view refreshes catalogues without reopening the document", async ({ join, page }) => {

--- a/e2e/document-navigation.e2e.ts
+++ b/e2e/document-navigation.e2e.ts
@@ -41,6 +41,12 @@ function headerActions(page: import("@playwright/test").Page) {
 	return page.getByRole("banner").getByRole("button", { name: /^Actions for / });
 }
 
+function documentRouteLayers(page: import("@playwright/test").Page, selector: string) {
+	return page.locator(selector).filter({
+		has: page.getByRole("banner", { includeHidden: true }),
+	});
+}
+
 async function headerAction(page: import("@playwright/test").Page, action: string) {
 	await headerActions(page).click();
 	await page.getByRole("menuitem", { name: action, exact: true }).click();
@@ -161,7 +167,8 @@ test("a pointer-dismissed navigation dialog releases focus while it exits", asyn
 	let trigger = sidebar(page).getByRole("button", { name: "Search", exact: true });
 	await trigger.click();
 	await expect(page.getByRole("textbox", { name: "Search documents" })).toBeFocused();
-	let modal = page.locator(".navigation-modal");
+	let modal = page.getByRole("dialog", { includeHidden: true, name: "Search documents" })
+		.locator("../..");
 	await page.getByRole("button", { name: "Close Search documents" }).click({
 		position: { x: 8, y: 8 },
 	});
@@ -264,7 +271,8 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 	let createdPath = await created.getAttribute("href");
 	expect(createdPath).toBeTruthy();
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${createdTitle}`);
-	await expect(page.locator(".document-route-layer:not([hidden])")).toHaveCount(1);
+	await expect(documentRouteLayers(page, "[data-content-swap-state]:not([hidden])"))
+		.toHaveCount(1);
 	await expect(projects.getByRole("link", { name: originalTitle, exact: true })).toBeVisible();
 	expect(
 		requested.filter(request => request.method === "GET" && request.path === "/api/navigation"),
@@ -285,9 +293,16 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 	});
 	await projects.getByRole("link", { name: originalTitle, exact: true }).click();
 
-	await expect(page.getByText("Opening channel...", { exact: true })).toHaveCount(0);
+	let interactiveRoutes = documentRouteLayers(
+		page,
+		"[data-content-swap-state]:not([hidden]):not([inert])",
+	);
+	await expect(page.getByText("Opening channel...", { exact: true })).toBeHidden();
+	await expect(interactiveRoutes).toHaveCount(1);
+	await expect(interactiveRoutes).toBeVisible();
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${createdTitle}`);
-	await expect(page.locator(".document-route-layer:not([hidden])")).toHaveCount(1);
+	await expect(documentRouteLayers(page, "[data-content-swap-state]:not([hidden])"))
+		.toHaveCount(1);
 	await expect(projects.getByRole("link", { name: createdTitle, exact: true })).toBeVisible();
 	expect(
 		await page.evaluate(() =>
@@ -296,11 +311,16 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 	).toBe("preserved");
 	await page.keyboard.press("Shift");
 	release.resolve();
-	let visibleRoutes = page.locator(".document-route-layer:not([hidden])");
+	let visibleRoutes = documentRouteLayers(page, "[data-content-swap-state]:not([hidden])");
+	let outgoingRoutes = documentRouteLayers(
+		page,
+		'[data-content-swap-state="outgoing"]:not([hidden])',
+	);
 	await expect(visibleRoutes).toHaveCount(2);
-	await expect(page.locator(".document-route-layer:not([hidden]):not([inert])")).toHaveCount(1);
-	await expect(page.locator('.document-route-layer:not([hidden])[aria-hidden="true"][inert]'))
-		.toHaveCount(1);
+	await expect(interactiveRoutes).toHaveCount(1);
+	await expect(outgoingRoutes).toHaveCount(1);
+	await expect(outgoingRoutes).toHaveAttribute("aria-hidden", "true");
+	await expect(outgoingRoutes).toHaveAttribute("inert", "");
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${originalTitle}`);
 	await expect(page).toHaveURL(originalPath!);
 
@@ -348,7 +368,7 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 	keyboardRelease.resolve();
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${originalTitle}`);
 	await expect(visibleRoutes).toHaveCount(1, { timeout: 100 });
-	await expect(page.locator(".document-route-layer:not([hidden]).is-closing")).toHaveCount(0);
+	await expect(outgoingRoutes).toHaveCount(0);
 });
 
 test("the archive view refreshes catalogues without reopening the document", async ({ join, page }) => {

--- a/e2e/document-navigation.e2e.ts
+++ b/e2e/document-navigation.e2e.ts
@@ -232,12 +232,21 @@ test("a stale catalogue response cannot remove a newly created document", async 
 });
 
 test("document switches preserve navigation state and avoid catalogue reloads", async ({ join, page }) => {
-	let requested: Array<{ method: string; path: string }> = [];
-	page.on("request", request =>
+	let requested: Array<{ documentId?: string; method: string; path: string }> = [];
+	page.on("request", request => {
+		let method = request.method();
+		let path = new URL(request.url()).pathname;
+		let body = method === "PATCH" && path === "/api/navigation"
+			? request.postDataJSON() as { documentId?: unknown }
+			: undefined;
 		requested.push({
-			method: request.method(),
-			path: new URL(request.url()).pathname,
-		}));
+			...(typeof body?.documentId === "string" ? { documentId: body.documentId } : {}),
+			method,
+			path,
+		});
+	});
+	let latestVisit = () =>
+		requested.findLast(request => request.method === "PATCH" && request.path === "/api/navigation");
 	page = await join("ana");
 	let initialNavigationRequests =
 		requested.filter(request => request.method === "GET" && request.path === "/api/navigation")
@@ -252,15 +261,20 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 	await expect(page).toHaveURL(/\/documents\/octo-org\/score\/[a-z]+-[a-z]+$/);
 	let created = projects.locator('a[aria-current="page"]');
 	let createdTitle = (await created.textContent())!.trim();
+	let createdPath = await created.getAttribute("href");
+	expect(createdPath).toBeTruthy();
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${createdTitle}`);
 	await expect(page.locator(".document-route-layer:not([hidden])")).toHaveCount(1);
 	await expect(projects.getByRole("link", { name: originalTitle, exact: true })).toBeVisible();
 	expect(
 		requested.filter(request => request.method === "GET" && request.path === "/api/navigation"),
 	).toHaveLength(initialNavigationRequests);
+	await expect.poll(() => latestVisit()?.documentId).not.toBeUndefined();
+	let createdDocumentId = latestVisit()!.documentId!;
 
+	let documentRoutePattern = "**/api/repositories/octo-org/score/documents/*";
 	let release = Promise.withResolvers<void>();
-	await page.route("**/api/repositories/octo-org/score/documents/*", async route => {
+	await page.route(documentRoutePattern, async route => {
 		await release.promise;
 		await route.continue();
 	});
@@ -280,6 +294,7 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 			(window as Window & { __chopinNavigationSentinel?: string }).__chopinNavigationSentinel
 		),
 	).toBe("preserved");
+	await page.keyboard.press("Shift");
 	release.resolve();
 	let visibleRoutes = page.locator(".document-route-layer:not([hidden])");
 	await expect(visibleRoutes).toHaveCount(2);
@@ -287,8 +302,15 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 	await expect(page.locator('.document-route-layer:not([hidden])[aria-hidden="true"][inert]'))
 		.toHaveCount(1);
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${originalTitle}`);
-	await expect(visibleRoutes).toHaveCount(1);
 	await expect(page).toHaveURL(originalPath!);
+
+	let createdLink = projects.getByRole("link", { name: createdTitle, exact: true });
+	await createdLink.click();
+	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${createdTitle}`);
+	await expect(visibleRoutes).toHaveCount(2);
+	await expect(visibleRoutes).toHaveCount(1);
+	await expect(page).toHaveURL(createdPath!);
+	await page.unroute(documentRoutePattern);
 
 	expect(requested.filter(request => request.path === "/api/session")).toHaveLength(0);
 	expect(
@@ -297,7 +319,8 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 	await expect.poll(() =>
 		requested.filter(request => request.method === "PATCH" && request.path === "/api/navigation")
 			.length
-	).toBe(1);
+	).toBe(2);
+	expect(latestVisit()?.documentId).toBe(createdDocumentId);
 	expect(requested.filter(request => request.path === "/api/repositories/octo-org/score/channels"))
 		.toHaveLength(0);
 	await expect.poll(() =>
@@ -307,15 +330,24 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 	).toBe(1);
 
 	await page.evaluate(() => history.back());
-	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${createdTitle}`);
-	await page.evaluate(() => history.forward());
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${originalTitle}`);
-
-	let createdLink = projects.getByRole("link", { name: createdTitle, exact: true });
-	await createdLink.focus();
-	await page.keyboard.press("Enter");
+	await page.evaluate(() => history.forward());
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${createdTitle}`);
 	await expect(visibleRoutes).toHaveCount(1);
+
+	let keyboardRelease = Promise.withResolvers<void>();
+	await page.route(documentRoutePattern, async route => {
+		await keyboardRelease.promise;
+		await route.continue();
+	});
+	let originalLink = projects.getByRole("link", { name: originalTitle, exact: true });
+	await originalLink.focus();
+	await page.keyboard.press("Enter");
+	await page.locator("body").dispatchEvent("pointerover", { pointerType: "mouse" });
+	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${createdTitle}`);
+	keyboardRelease.resolve();
+	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${originalTitle}`);
+	await expect(visibleRoutes).toHaveCount(1, { timeout: 100 });
 	await expect(page.locator(".document-route-layer:not([hidden]).is-closing")).toHaveCount(0);
 });
 

--- a/e2e/hosted.e2e.ts
+++ b/e2e/hosted.e2e.ts
@@ -99,6 +99,62 @@ test("a signed-out document link returns to the document after OAuth", async ({ 
 	await expect(page.getByRole("banner")).toBeVisible();
 });
 
+test("a stale outgoing route cannot canonicalize or publish over the active document", async ({ baseURL, page, room }) => {
+	let stale = {
+		...recoveryChannel,
+		descriptionRevision: 0,
+		id: "33333333-3333-4333-8333-333333333333",
+		slug: "stale-outgoing",
+		title: "Stale outgoing",
+	};
+	let captured = Promise.withResolvers<void>();
+	let release = Promise.withResolvers<void>();
+	let visits: string[] = [];
+	page.on("request", request => {
+		if (request.method() !== "PATCH" || new URL(request.url()).pathname !== "/api/navigation") {
+			return;
+		}
+		let body = request.postDataJSON() as { documentId?: unknown };
+		if (typeof body.documentId === "string") visits.push(body.documentId);
+	});
+	await page.route(new RegExp(`/api/channels/${stale.id}$`), async route => {
+		captured.resolve();
+		await release.promise;
+		await route.fulfill({
+			json: { canEdit: true, canManage: false, channel: stale, repository: score },
+		});
+	});
+	await authenticate(page, "stale-route", baseURL!);
+	await page.goto(`/channels/${stale.id}`);
+	await captured.promise;
+	await page.locator("body").dispatchEvent("pointerover", { pointerType: "mouse" });
+	let activePath = roomPath(room);
+	await page.evaluate(path => {
+		history.pushState(null, "", path);
+		dispatchEvent(new PopStateEvent("popstate"));
+	}, activePath);
+	let routes = page.locator(".document-route-swap > [data-content-swap-state]:not([hidden])");
+	let outgoing = page.locator(
+		'.document-route-swap > [data-content-swap-state="outgoing"]:not([hidden])',
+	);
+	await expect(routes).toHaveCount(2);
+	await expect(outgoing).toHaveAttribute("inert", "");
+	await expect.poll(() => visits).toEqual([room]);
+
+	let staleResponse = page.waitForResponse(response =>
+		new URL(response.url()).pathname === `/api/channels/${stale.id}`
+	);
+	release.resolve();
+	await staleResponse;
+	await page.evaluate(() =>
+		new Promise<void>(resolve =>
+			requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+		)
+	);
+	await expect(page).toHaveURL(activePath);
+	expect(visits).toEqual([room]);
+});
+
 test("a legacy repository path renders the global navigation shell", async ({ baseURL, page }) => {
 	await authenticate(page, "legacy-route", baseURL!);
 	await page.route(

--- a/e2e/hosted.e2e.ts
+++ b/e2e/hosted.e2e.ts
@@ -1,3 +1,4 @@
+import { createChannel } from "./database";
 import { authenticate, expect, roomPath, test } from "./room";
 import { expectInsideViewport, expectNoHorizontalOverflow } from "./responsive";
 import { installVisualViewport } from "./visual-viewport";
@@ -153,6 +154,65 @@ test("a stale outgoing route cannot canonicalize or publish over the active docu
 	);
 	await expect(page).toHaveURL(activePath);
 	expect(visits).toEqual([room]);
+});
+
+test("outgoing WebSocket metadata cannot canonicalize the active document", async ({ baseURL, page, room }) => {
+	let stale = crypto.randomUUID();
+	await createChannel(Number(new URL(baseURL!).port), stale);
+	let captured = Promise.withResolvers<void>();
+	let release = Promise.withResolvers<void>();
+	let title = `Renamed outgoing ${stale.slice(0, 8)}`;
+	let slug = `renamed-outgoing-${stale.slice(0, 8)}`;
+	await page.routeWebSocket("**/ws?**", route => {
+		let channel = new URL(route.url()).searchParams.get("channel");
+		let server = route.connectToServer();
+		route.onMessage(message => server.send(message));
+		server.onMessage(message => {
+			if (channel === stale && typeof message === "string") {
+				let frame = JSON.parse(message) as { kind?: string } & Record<string, unknown>;
+				if (frame.kind === "session:hello") {
+					captured.resolve();
+					void release.promise.then(() =>
+						route.send(JSON.stringify({
+							...frame,
+							slug,
+							title,
+							updatedAt: "2099-08-25T18:00:00.000Z",
+						}))
+					);
+					return;
+				}
+			}
+			route.send(message);
+		});
+	});
+
+	await authenticate(page, "stale-socket", baseURL!);
+	await page.goto(`/channels/${stale}`);
+	await captured.promise;
+	let projects = page.getByRole("complementary", { name: "Projects" });
+	await expect(projects.getByRole("link", {
+		name: `Test ${stale.slice(0, 8)}`,
+		exact: true,
+	})).toBeVisible();
+
+	await page.locator("body").dispatchEvent("pointerover", { pointerType: "mouse" });
+	let activePath = roomPath(room);
+	await page.evaluate(path => {
+		history.pushState(null, "", path);
+		dispatchEvent(new PopStateEvent("popstate"));
+	}, activePath);
+	let active = page.locator(
+		".document-route-swap > [data-content-swap-state]:not([hidden]):not([inert])",
+	);
+	await expect(active.getByRole("banner")).toContainText(`Test ${room.slice(0, 8)}`);
+	await expect(page.locator(
+		'.document-route-swap > [data-content-swap-state="outgoing"]:not([hidden])',
+	)).toHaveCount(1);
+
+	release.resolve();
+	await expect(projects.getByRole("link", { name: title, exact: true })).toBeVisible();
+	await expect(page).toHaveURL(activePath);
 });
 
 test("a legacy repository path renders the global navigation shell", async ({ baseURL, page }) => {

--- a/e2e/hosted.e2e.ts
+++ b/e2e/hosted.e2e.ts
@@ -75,9 +75,10 @@ test("an authenticated user adds a Project and creates its first document", asyn
 	await projects.getByRole("button", { name: "New document in score" }).click();
 
 	await expect(page).toHaveURL(/\/documents\/octo-org\/score\/[a-z]+-[a-z]+$/);
-	await expect(page.locator("#pane-chat")).toBeVisible();
-	await expect(page.getByRole("textbox", { name: "editable markdown" })).toBeVisible();
-	await expect(page.locator(".plan-decisions")).toBeAttached();
+	let activeRoute = page.locator(".document-route-layer:not([inert])");
+	await expect(activeRoute.locator("#pane-chat")).toBeVisible();
+	await expect(activeRoute.getByRole("textbox", { name: "editable markdown" })).toBeVisible();
+	await expect(activeRoute.locator(".plan-decisions")).toBeAttached();
 });
 
 test("a signed-out document link returns to the document after OAuth", async ({ baseURL, page, room }) => {

--- a/e2e/hosted.e2e.ts
+++ b/e2e/hosted.e2e.ts
@@ -75,10 +75,12 @@ test("an authenticated user adds a Project and creates its first document", asyn
 	await projects.getByRole("button", { name: "New document in score" }).click();
 
 	await expect(page).toHaveURL(/\/documents\/octo-org\/score\/[a-z]+-[a-z]+$/);
-	let activeRoute = page.locator(".document-route-layer:not([inert])");
-	await expect(activeRoute.locator("#pane-chat")).toBeVisible();
+	let activeRoute = page.locator("[data-content-swap-state]:not([inert])").filter({
+		has: page.getByRole("banner", { includeHidden: true }),
+	});
+	await expect(activeRoute.getByRole("complementary", { name: "Conversation" })).toBeVisible();
 	await expect(activeRoute.getByRole("textbox", { name: "editable markdown" })).toBeVisible();
-	await expect(activeRoute.locator(".plan-decisions")).toBeAttached();
+	await expect(activeRoute.locator("[data-plan-decisions-scroll]")).toBeAttached();
 });
 
 test("a signed-out document link returns to the document after OAuth", async ({ baseURL, page, room }) => {

--- a/e2e/responsive-selection.e2e.ts
+++ b/e2e/responsive-selection.e2e.ts
@@ -54,9 +54,9 @@ for (
 		await first.selectText();
 		await expect.poll(() => page.evaluate(() => getSelection()?.toString())).toBe(PROSE);
 		await activateDestination(nav, /^Decisions/, example.activation);
-		await expect(page.locator("#workspace-decisions-heading")).toBeFocused();
+		await expect(page.getByRole("heading", { name: "Decisions", exact: true })).toBeFocused();
 		await activateDestination(nav, "Document", example.activation);
-		await expect(page.locator("#workspace-plan-heading")).toBeFocused();
+		await expect(page.getByRole("heading", { name: "Document", exact: true })).toBeFocused();
 
 		await second.click();
 		await page.evaluate(() => new Promise(requestAnimationFrame));
@@ -88,12 +88,12 @@ for (
 		await selected.selectText();
 
 		await activateDestination(nav, /^Conversation/, "keyboard");
-		await expect(page.locator("#workspace-conversation-heading")).toBeFocused();
+		await expect(page.getByRole("heading", { name: "Conversation", exact: true })).toBeFocused();
 		await expect(page.locator("main")).toBeHidden();
 		await activateDestination(nav, /^Decisions/, "keyboard");
-		await expect(page.locator("#workspace-decisions-heading")).toBeFocused();
+		await expect(page.getByRole("heading", { name: "Decisions", exact: true })).toBeFocused();
 		await activateDestination(nav, "Document", "keyboard");
-		await expect(page.locator("#workspace-plan-heading")).toBeFocused();
+		await expect(page.getByRole("heading", { name: "Document", exact: true })).toBeFocused();
 
 		await page.keyboard.press("Tab");
 		await expect(content(page)).toBeFocused();

--- a/e2e/responsive-workspace.e2e.ts
+++ b/e2e/responsive-workspace.e2e.ts
@@ -53,6 +53,10 @@ async function expectCompactWorkspaceChrome(page: Page): Promise<void> {
 	await expectNoHorizontalOverflow(page);
 }
 
+function conversationPane(page: Page) {
+	return page.getByRole("complementary", { includeHidden: true, name: "Conversation" });
+}
+
 test("viewport containment rejects absent and invisible targets", async ({ page }) => {
 	await page.setContent(`
 		<button hidden id="hidden" type="button">Hidden target</button>
@@ -77,12 +81,12 @@ test("a representative compact phone exposes one mounted destination at a time",
 	await expect(projects).toBeFocused();
 	await expect(nav.getByRole("button", { name: "Document" })).toBeVisible();
 	await nav.getByRole("button", { name: /Conversation/ }).click();
-	await expect(page.locator("#pane-chat")).toBeVisible();
+	await expect(conversationPane(page)).toBeVisible();
 	await expect(page.locator('[aria-label="editable markdown"]')).toBeHidden();
 	await expect(page.locator("main")).toHaveAttribute("inert", "");
 	await nav.getByRole("button", { name: /^Decisions/ }).click();
 	await expect(page.locator('[data-document-view="decisions"]')).toBeVisible();
-	await expect(page.locator("#pane-chat")).toBeHidden();
+	await expect(conversationPane(page)).toBeHidden();
 	await expect(page.locator("#workspace-decisions-heading")).toBeFocused();
 	await expectNoHorizontalOverflow(page);
 });
@@ -91,24 +95,30 @@ test("content swaps retain one interactive destination across pointer and immedi
 	await seed(RESPONSIVE_SOURCE);
 	let page = await join("ana", { hasTouch: true, viewport: { width: 390, height: 844 } });
 	let nav = page.getByRole("navigation", { name: "Workspace view" });
-	let stack = page.locator(".workspace-document-swap");
-	let visible = stack.locator(":scope > .motion-content-swap:not([hidden])");
+	let stack = page.locator("[data-workspace-document-swap]");
+	let visible = stack.locator(":scope > [data-content-swap-state]:not([hidden])");
+	let outgoing = stack.locator(
+		':scope > [data-content-swap-state="outgoing"]:not([hidden])',
+	);
 	let decisions = nav.getByRole("button", { name: /^Decisions/ });
 	let document = nav.getByRole("button", { name: "Document", exact: true });
 
 	await decisions.click();
 	await expect(visible).toHaveCount(2);
-	await expect(stack.locator(":scope > .motion-content-swap:not([hidden]):not([inert])"))
+	await expect(stack.locator(":scope > [data-content-swap-state]:not([hidden]):not([inert])"))
 		.toHaveCount(1);
-	await expect(
-		stack.locator(':scope > .motion-content-swap:not([hidden])[aria-hidden="true"][inert]'),
-	)
-		.toHaveCount(1);
+	await expect(outgoing).toHaveCount(1);
+	await expect(outgoing).toHaveAttribute("aria-hidden", "true");
+	await expect(outgoing).toHaveAttribute("inert", "");
 	let sampledCounts = await stack.evaluate(async element => {
 		let counts: number[] = [];
 		for (let sample = 0; sample < 5; sample += 1) {
 			await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
-			counts.push(element.querySelectorAll(":scope > .motion-content-swap:not([hidden])").length);
+			counts.push(
+				element.querySelectorAll(
+					":scope > [data-content-swap-state]:not([hidden])",
+				).length,
+			);
 		}
 		return counts;
 	});
@@ -119,14 +129,12 @@ test("content swaps retain one interactive destination across pointer and immedi
 	await document.focus();
 	await page.keyboard.press("Enter");
 	await expect(visible).toHaveCount(1);
-	await expect(stack.locator(":scope > .motion-content-swap:not([hidden]).is-closing"))
-		.toHaveCount(0);
+	await expect(outgoing).toHaveCount(0);
 
 	await page.emulateMedia({ reducedMotion: "reduce" });
 	await decisions.click();
 	await expect(visible).toHaveCount(1);
-	await expect(stack.locator(":scope > .motion-content-swap:not([hidden]).is-closing"))
-		.toHaveCount(0);
+	await expect(outgoing).toHaveCount(0);
 
 	await page.emulateMedia({ reducedMotion: "no-preference" });
 	await document.click();
@@ -148,7 +156,7 @@ test("a pointer-dismissed Projects drawer becomes inert while it exits", async (
 	let page = await join("ana", { hasTouch: true, viewport: { width: 390, height: 844 } });
 	let opener = page.getByRole("button", { name: "Open Projects sidebar" });
 	await opener.click();
-	let drawer = page.locator(".navigation-drawer");
+	let drawer = page.getByRole("dialog", { includeHidden: true, name: "Projects" }).locator("../..");
 	await page.getByRole("button", { name: "Close Projects sidebar" }).click({
 		position: { x: 382, y: 422 },
 	});
@@ -164,7 +172,7 @@ test("enabling reduced motion settles an active drawer exit", async ({ join, see
 	let page = await join("ana", { hasTouch: true, viewport: { width: 390, height: 844 } });
 	await page.emulateMedia({ reducedMotion: "no-preference" });
 	await page.getByRole("button", { name: "Open Projects sidebar" }).click();
-	let drawer = page.locator(".navigation-drawer");
+	let drawer = page.getByRole("dialog", { includeHidden: true, name: "Projects" }).locator("../..");
 	await page.getByRole("button", { name: "Close Projects sidebar" }).click({
 		position: { x: 382, y: 422 },
 	});
@@ -344,7 +352,7 @@ test("the wide side of the Projects transition uses the inline sidebar", async (
 	await expect(projects).toBeVisible();
 	await expect(opener).toHaveCount(0);
 	await expect(page.getByRole("navigation", { name: "Workspace view" })).toHaveCount(0);
-	await expect(page.locator("#pane-chat")).toBeVisible();
+	await expect(conversationPane(page)).toBeVisible();
 	await expect(page.getByRole("separator", { name: "Resize the conversation" })).toBeVisible();
 	let documentView = page.getByRole("group", { name: "Document view" });
 	await expect(documentView).toBeVisible();
@@ -377,7 +385,7 @@ test("the wide side of the Projects transition uses the inline sidebar", async (
 test("a representative desktop retains the split Conversation layout", async ({ join, seed }) => {
 	await seed(RESPONSIVE_SOURCE);
 	let page = await join("ana", { viewport: { width: 1440, height: 900 } });
-	await expect(page.locator("#pane-chat")).toBeVisible();
+	await expect(conversationPane(page)).toBeVisible();
 	await expect(page.getByRole("separator", { name: "Resize the conversation" })).toBeVisible();
 	await expect(page.getByRole("navigation", { name: "Workspace view" })).toHaveCount(0);
 	await expect(page.getByRole("button", { name: /conversation pane/ })).toBeVisible();

--- a/e2e/responsive-workspace.e2e.ts
+++ b/e2e/responsive-workspace.e2e.ts
@@ -92,20 +92,23 @@ test("content swaps retain one interactive destination across pointer and immedi
 	let page = await join("ana", { hasTouch: true, viewport: { width: 390, height: 844 } });
 	let nav = page.getByRole("navigation", { name: "Workspace view" });
 	let stack = page.locator(".workspace-document-swap");
-	let visible = stack.locator(".motion-content-swap:not([hidden])");
+	let visible = stack.locator(":scope > .motion-content-swap:not([hidden])");
 	let decisions = nav.getByRole("button", { name: /^Decisions/ });
 	let document = nav.getByRole("button", { name: "Document", exact: true });
 
 	await decisions.click();
 	await expect(visible).toHaveCount(2);
-	await expect(stack.locator(".motion-content-swap:not([hidden]):not([inert])")).toHaveCount(1);
-	await expect(stack.locator('.motion-content-swap:not([hidden])[aria-hidden="true"][inert]'))
+	await expect(stack.locator(":scope > .motion-content-swap:not([hidden]):not([inert])"))
+		.toHaveCount(1);
+	await expect(
+		stack.locator(':scope > .motion-content-swap:not([hidden])[aria-hidden="true"][inert]'),
+	)
 		.toHaveCount(1);
 	let sampledCounts = await stack.evaluate(async element => {
 		let counts: number[] = [];
 		for (let sample = 0; sample < 5; sample += 1) {
 			await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
-			counts.push(element.querySelectorAll(".motion-content-swap:not([hidden])").length);
+			counts.push(element.querySelectorAll(":scope > .motion-content-swap:not([hidden])").length);
 		}
 		return counts;
 	});
@@ -116,12 +119,14 @@ test("content swaps retain one interactive destination across pointer and immedi
 	await document.focus();
 	await page.keyboard.press("Enter");
 	await expect(visible).toHaveCount(1);
-	await expect(stack.locator(".motion-content-swap:not([hidden]).is-closing")).toHaveCount(0);
+	await expect(stack.locator(":scope > .motion-content-swap:not([hidden]).is-closing"))
+		.toHaveCount(0);
 
 	await page.emulateMedia({ reducedMotion: "reduce" });
 	await decisions.click();
 	await expect(visible).toHaveCount(1);
-	await expect(stack.locator(".motion-content-swap:not([hidden]).is-closing")).toHaveCount(0);
+	await expect(stack.locator(":scope > .motion-content-swap:not([hidden]).is-closing"))
+		.toHaveCount(0);
 
 	await page.emulateMedia({ reducedMotion: "no-preference" });
 	await document.click();

--- a/e2e/responsive-workspace.e2e.ts
+++ b/e2e/responsive-workspace.e2e.ts
@@ -87,7 +87,7 @@ test("a representative compact phone exposes one mounted destination at a time",
 	await nav.getByRole("button", { name: /^Decisions/ }).click();
 	await expect(page.locator('[data-document-view="decisions"]')).toBeVisible();
 	await expect(conversationPane(page)).toBeHidden();
-	await expect(page.locator("#workspace-decisions-heading")).toBeFocused();
+	await expect(page.getByRole("heading", { name: "Decisions", exact: true })).toBeFocused();
 	await expectNoHorizontalOverflow(page);
 });
 
@@ -123,7 +123,7 @@ test("content swaps retain one interactive destination across pointer and immedi
 		return counts;
 	});
 	expect(sampledCounts).not.toContain(0);
-	await expect(page.locator("#workspace-decisions-heading")).toBeFocused();
+	await expect(page.getByRole("heading", { name: "Decisions", exact: true })).toBeFocused();
 	await expect(visible).toHaveCount(1);
 
 	await document.focus();
@@ -327,16 +327,16 @@ test("the compact side of the Projects transition keeps phone navigation", async
 	await expect(page.getByRole("button", { name: "Close conversation" })).toHaveCount(0);
 	await expect(content(page)).toBeHidden();
 	await expect(page.getByRole("separator", { name: "Resize the conversation" })).toHaveCount(0);
-	await expect(page.locator("#workspace-conversation-heading")).toBeFocused();
+	await expect(page.getByRole("heading", { name: "Conversation", exact: true })).toBeFocused();
 
 	await nav.getByRole("button", { name: "Document", exact: true }).click();
 	await expect(conversation).toBeHidden();
 	await expect(content(page)).toBeVisible();
-	await expect(page.locator("#workspace-plan-heading")).toBeFocused();
+	await expect(page.getByRole("heading", { name: "Document", exact: true })).toBeFocused();
 
 	await opener.click();
 	await expect(conversation).toBeVisible();
-	await expect(page.locator("#workspace-conversation-heading")).toBeFocused();
+	await expect(page.getByRole("heading", { name: "Conversation", exact: true })).toBeFocused();
 	await page.keyboard.press("Escape");
 	await expect(conversation).toBeHidden();
 	await expect(opener).toBeFocused();

--- a/e2e/responsive-workspace.e2e.ts
+++ b/e2e/responsive-workspace.e2e.ts
@@ -87,6 +87,57 @@ test("a representative compact phone exposes one mounted destination at a time",
 	await expectNoHorizontalOverflow(page);
 });
 
+test("content swaps retain one interactive destination across pointer and immediate paths", async ({ join, seed }) => {
+	await seed(RESPONSIVE_SOURCE);
+	let page = await join("ana", { hasTouch: true, viewport: { width: 390, height: 844 } });
+	let nav = page.getByRole("navigation", { name: "Workspace view" });
+	let stack = page.locator(".workspace-document-swap");
+	let visible = stack.locator(".motion-content-swap:not([hidden])");
+	let decisions = nav.getByRole("button", { name: /^Decisions/ });
+	let document = nav.getByRole("button", { name: "Document", exact: true });
+
+	await decisions.click();
+	await expect(visible).toHaveCount(2);
+	await expect(stack.locator(".motion-content-swap:not([hidden]):not([inert])")).toHaveCount(1);
+	await expect(stack.locator('.motion-content-swap:not([hidden])[aria-hidden="true"][inert]'))
+		.toHaveCount(1);
+	let sampledCounts = await stack.evaluate(async element => {
+		let counts: number[] = [];
+		for (let sample = 0; sample < 5; sample += 1) {
+			await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+			counts.push(element.querySelectorAll(".motion-content-swap:not([hidden])").length);
+		}
+		return counts;
+	});
+	expect(sampledCounts).not.toContain(0);
+	await expect(page.locator("#workspace-decisions-heading")).toBeFocused();
+	await expect(visible).toHaveCount(1);
+
+	await document.focus();
+	await page.keyboard.press("Enter");
+	await expect(visible).toHaveCount(1);
+	await expect(stack.locator(".motion-content-swap:not([hidden]).is-closing")).toHaveCount(0);
+
+	await page.emulateMedia({ reducedMotion: "reduce" });
+	await decisions.click();
+	await expect(visible).toHaveCount(1);
+	await expect(stack.locator(".motion-content-swap:not([hidden]).is-closing")).toHaveCount(0);
+
+	await page.emulateMedia({ reducedMotion: "no-preference" });
+	await document.click();
+	await expect(visible).toHaveCount(2);
+	await page.emulateMedia({ reducedMotion: "reduce" });
+	await expect(visible).toHaveCount(1, { timeout: 100 });
+
+	await page.emulateMedia({ reducedMotion: "no-preference" });
+	await decisions.click();
+	await expect(visible).toHaveCount(2);
+	await document.click();
+	await expect(visible).toHaveCount(2);
+	await expect(visible).toHaveCount(1);
+	await expect(page.locator('[data-document-view="plan"]')).toBeVisible();
+});
+
 test("a pointer-dismissed Projects drawer becomes inert while it exits", async ({ join, seed }) => {
 	await seed(RESPONSIVE_SOURCE);
 	let page = await join("ana", { hasTouch: true, viewport: { width: 390, height: 844 } });

--- a/e2e/shell.e2e.ts
+++ b/e2e/shell.e2e.ts
@@ -3,10 +3,14 @@
 import { expect, ready, test } from "./room";
 import { expectNoHorizontalOverflow } from "./responsive";
 
-import type { Locator } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 
 function box(target: Locator) {
 	return target.evaluate(element => element.getBoundingClientRect().toJSON() as DOMRect);
+}
+
+function conversationPane(page: Page) {
+	return page.getByRole("complementary", { includeHidden: true, name: "Conversation" });
 }
 
 test("a drag the browser takes away still puts the bar down", async ({ join, page }) => {
@@ -62,7 +66,10 @@ test("the compact workspace keeps the document unobstructed", async ({ join, pag
 test("split Conversation owns its controls and keeps its draft while hidden", async ({ join, page }) => {
 	await page.setViewportSize({ width: 1280, height: 800 });
 	await join("ana");
-	let draft = page.locator("#pane-chat textarea");
+	let pane = conversationPane(page);
+	let paneId = await pane.getAttribute("id");
+	expect(paneId).toBeTruthy();
+	let draft = pane.locator("textarea");
 	let header = page.getByRole("banner");
 	let heading = page.getByRole("heading", { name: "Conversation" });
 	let close = page.getByRole("button", { name: "Hide conversation pane" });
@@ -71,12 +78,12 @@ test("split Conversation owns its controls and keeps its draft while hidden", as
 	await expect(header.getByRole("button", { name: /conversation pane/ })).toHaveCount(0);
 	await expect(heading).toBeVisible();
 	await expect(close).toBeVisible();
-	await expect(close).toHaveAttribute("aria-controls", "pane-chat");
+	await expect(close).toHaveAttribute("aria-controls", paneId!);
 	await expect(close).toHaveAttribute("aria-expanded", "true");
 	await close.click();
 	let opener = page.getByRole("button", { name: "Show conversation pane" });
-	await expect(page.locator("#pane-chat")).toBeHidden();
-	await expect(opener).toHaveAttribute("aria-controls", "pane-chat");
+	await expect(pane).toBeHidden();
+	await expect(opener).toHaveAttribute("aria-controls", paneId!);
 	await expect(opener).toHaveAttribute("aria-expanded", "false");
 	await expect(opener).toBeFocused();
 	await opener.click();
@@ -89,16 +96,19 @@ test("the conversation rail remembers its width and visibility", async ({ join, 
 	await join("ana");
 
 	await page.getByRole("separator", { name: "Resize the conversation" }).press("End");
-	let rememberedWidth = (await box(page.locator("#pane-chat"))).width;
+	let pane = conversationPane(page);
+	let paneId = await pane.getAttribute("id");
+	expect(paneId).toBeTruthy();
+	let rememberedWidth = (await box(pane)).width;
 	let toggle = page.getByRole("button", { name: "Hide conversation pane" });
-	await expect(toggle).toHaveAttribute("aria-controls", "pane-chat");
+	await expect(toggle).toHaveAttribute("aria-controls", paneId!);
 	await toggle.click();
-	await expect(page.locator("#pane-chat")).toBeHidden();
+	await expect(pane).toBeHidden();
 
 	await page.reload();
 	await ready(page);
 	await page.getByRole("button", { name: "Show conversation pane" }).click();
-	await expect.poll(async () => (await box(page.locator("#pane-chat"))).width)
+	await expect.poll(async () => (await box(conversationPane(page))).width)
 		.toBeCloseTo(rememberedWidth, 0);
 });
 
@@ -106,21 +116,23 @@ test("compact navigation does not overwrite the desktop conversation preference"
 	await page.setViewportSize({ width: 1600, height: 800 });
 	await join("ana");
 	await page.getByRole("separator", { name: "Resize the conversation" }).press("End");
-	let rememberedWidth = (await box(page.locator("#pane-chat"))).width;
+	let pane = conversationPane(page);
+	let rememberedWidth = (await box(pane)).width;
 	await page.setViewportSize({ width: 390, height: 844 });
 	let nav = page.getByRole("navigation", { name: "Workspace view" });
 	await nav.getByRole("button", { name: /Conversation/ }).click();
 	await nav.getByRole("button", { name: "Document" }).click();
 
 	await page.setViewportSize({ width: 1600, height: 800 });
-	await expect(page.locator("#pane-chat")).toBeVisible();
-	await expect.poll(async () => (await box(page.locator("#pane-chat"))).width)
+	await expect(pane).toBeVisible();
+	await expect.poll(async () => (await box(pane)).width)
 		.toBeCloseTo(rememberedWidth, 0);
 });
 
 test("Escape leaves a persistent split Conversation pane open", async ({ join, page }) => {
 	await page.setViewportSize({ width: 1280, height: 800 });
 	await join("ana");
-	await page.locator("#pane-chat textarea").press("Escape");
-	await expect(page.locator("#pane-chat")).toBeVisible();
+	let pane = conversationPane(page);
+	await pane.locator("textarea").press("Escape");
+	await expect(pane).toBeVisible();
 });

--- a/e2e/sidecar.e2e.ts
+++ b/e2e/sidecar.e2e.ts
@@ -65,6 +65,11 @@ function questionnaire(page: import("@playwright/test").Page) {
 	return page.locator('[data-document-view="decisions"] article[data-plan-sidecar-questionnaire]');
 }
 
+function documentEditor(page: Page) {
+	return page.locator('[data-document-view="plan"]')
+		.getByRole("textbox", { includeHidden: true, name: "editable markdown" });
+}
+
 function commentButton(page: import("@playwright/test").Page) {
 	return page.getByRole("button", { name: /Comment on “/ });
 }
@@ -94,21 +99,26 @@ test("question step swaps overlap only for pointer input", async ({ join, seed }
 	let card = page.locator(
 		`[data-document-view="plan"] article[data-plan-sidecar-questionnaire="${WIDGET}"]`,
 	);
-	let stack = card.locator(".question-step-swap");
-	let visible = stack.locator(".question-step-layer:not([hidden])");
+	let stack = card.locator("[data-question-step-swap]");
+	let visible = stack.locator(":scope > [data-content-swap-state]:not([hidden])");
+	let outgoing = stack.locator(
+		':scope > [data-content-swap-state="outgoing"]:not([hidden])',
+	);
 	let scope = card.getByRole("tab", { name: "Scope" });
 
 	await scope.click();
 	await expect(visible).toHaveCount(2);
-	await expect(stack.locator(".question-step-layer:not([hidden]):not([inert])")).toHaveCount(1);
-	await expect(stack.locator('.question-step-layer:not([hidden])[aria-hidden="true"][inert]'))
+	await expect(stack.locator(":scope > [data-content-swap-state]:not([hidden]):not([inert])"))
 		.toHaveCount(1);
+	await expect(outgoing).toHaveCount(1);
+	await expect(outgoing).toHaveAttribute("aria-hidden", "true");
+	await expect(outgoing).toHaveAttribute("inert", "");
 	await expect(visible).toHaveCount(1);
 
 	await scope.focus();
 	await page.keyboard.press("ArrowLeft");
 	await expect(visible).toHaveCount(1);
-	await expect(stack.locator(".question-step-layer:not([hidden]).is-closing")).toHaveCount(0);
+	await expect(outgoing).toHaveCount(0);
 	await expect(card.getByRole("tab", { name: "Rollout" })).toHaveAttribute(
 		"aria-selected",
 		"true",
@@ -192,7 +202,10 @@ test("questions leave the chat pane free of a waiting row", async ({ join, seed 
 	let page = await join("ana");
 
 	await expect(questionnaire(page)).toHaveCount(2);
-	await expect(page.locator("#pane-chat").getByRole("button", { name: "Answer" })).toHaveCount(0);
+	await expect(
+		page.getByRole("complementary", { includeHidden: true, name: "Conversation" })
+			.getByRole("button", { name: "Answer" }),
+	).toHaveCount(0);
 
 	await page.getByRole("button", { name: /^Decisions/ }).click();
 	await expect(page.getByRole("button", { name: /^Decisions/ }))
@@ -217,13 +230,13 @@ test("switching views restores the plan scroll position", async ({ join, seed })
 async function expectCompactDestinationStatePreserved(page: Page): Promise<void> {
 	let nav = page.getByRole("navigation", { name: "Workspace view" });
 	let planScroller = page.locator("[data-plan-scroll]");
+	let draft = page.getByPlaceholder("Use @chopin to ask Chopin");
 	await planScroller.evaluate(element => {
 		element.scrollTop = 160;
 		element.dispatchEvent(new Event("scroll"));
 	});
-	await page.evaluate(() => {
+	await draft.evaluate(textarea => {
 		let plan = document.querySelector("[data-plan-scroll]")!;
-		let textarea = document.querySelector("#pane-chat textarea")!;
 		let tracker = {
 			plan,
 			textarea,
@@ -246,7 +259,6 @@ async function expectCompactDestinationStatePreserved(page: Page): Promise<void>
 	});
 
 	await nav.getByRole("button", { name: /Conversation/ }).click();
-	let draft = page.locator("#pane-chat textarea");
 	await draft.fill("unfinished compact thought");
 
 	await nav.getByRole("button", { name: /^Decisions/ }).click();
@@ -266,7 +278,7 @@ async function expectCompactDestinationStatePreserved(page: Page): Promise<void>
 	);
 	await nav.getByRole("button", { name: "Document" }).click();
 	expect(decisionScroll).toBeGreaterThan(0);
-	let identity = await page.evaluate(() => {
+	let identity = await draft.evaluate(textarea => {
 		let tracker = (window as typeof window & {
 			__workspaceTracker?: {
 				plan: Element;
@@ -278,7 +290,7 @@ async function expectCompactDestinationStatePreserved(page: Page): Promise<void>
 		tracker.observer.disconnect();
 		return {
 			plan: tracker.plan === document.querySelector("[data-plan-scroll]"),
-			textarea: tracker.textarea === document.querySelector("#pane-chat textarea"),
+			textarea: tracker.textarea === textarea,
 			removed: tracker.removed,
 		};
 	});
@@ -324,15 +336,12 @@ test("automatic Decisions changes reconcile after compact Conversation closes", 
 			"true",
 			{ timeout: 20_000 },
 		);
-		let planHost = bo.locator('.workspace-document-layer:has([data-document-view="plan"])');
-		await planHost.evaluate(element => {
-			(element as HTMLElement).hidden = false;
-			(element as HTMLElement).inert = false;
-			element.removeAttribute("aria-hidden");
-			element.classList.add("is-open");
-		});
-		await bo.locator('[aria-label="editable markdown"]').fill("Collaborative prose arrived.");
-		await expect(ana.locator('[aria-label="editable markdown"]')).toContainText(
+		await bo.getByRole("group", { name: "Document view" })
+			.getByRole("button", { name: "Document", exact: true })
+			.click();
+		await expect(documentEditor(bo)).toBeVisible();
+		await documentEditor(bo).fill("Collaborative prose arrived.");
+		await expect(documentEditor(ana)).toContainText(
 			"Collaborative prose arrived.",
 		);
 	} finally {

--- a/e2e/sidecar.e2e.ts
+++ b/e2e/sidecar.e2e.ts
@@ -26,6 +26,8 @@ const LONG_PLAN = Array.from({ length: 80 }, (_, index) => `Paragraph ${index + 
 const WIDGET = "01K0N4TR8K7JGM4R1J7PW4R8YJ";
 const QUESTION = "01K0N4V4E7Y6P4MJ5WD8XZF3B2";
 const OPTION = "01K0N4W3B7P27CBAEC7A8C8WEA";
+const SECOND_QUESTION = "01K0N4W3B7P27CBAEC7A8C8WEB";
+const SECOND_OPTION = "01K0N4W3B7P27CBAEC7A8C8WEC";
 const ANCHORED_DEFINITION = {
 	questions: [{
 		id: QUESTION,
@@ -44,6 +46,17 @@ const ANCHORED = `Anchored paragraph.
 </Questionnaire>
 `;
 const ANCHORED_DIGEST = "sha256:3ccc3e648811df8180799f8b012c6934bcf44a306f5eb8b8c9d2676b0493ccf4";
+const MULTI_QUESTIONNAIRE = `Multi-step decision.
+
+<Questionnaire id="${WIDGET}" by="ana">
+<Question id="${QUESTION}" header="Rollout" prompt="How should we deploy?" multiple="false">
+<Option id="${OPTION}" label="Canary" />
+</Question>
+<Question id="${SECOND_QUESTION}" header="Scope" prompt="What belongs in the first cut?" multiple="false">
+<Option id="${SECOND_OPTION}" label="Anchors" />
+</Question>
+</Questionnaire>
+`;
 
 /** What the injector will quote: the first forty-eight characters. */
 const QUOTED = "Room state lives on disk as MDX beside the trans";
@@ -73,6 +86,33 @@ test("the desktop document view switches through its segmented control", async (
 	await plan.click();
 	await expect(page.locator('[data-document-view="plan"]')).toBeVisible();
 	await expect(plan).toHaveAttribute("aria-pressed", "true");
+});
+
+test("question step swaps overlap only for pointer input", async ({ join, seed }) => {
+	await seed(MULTI_QUESTIONNAIRE);
+	let page = await join("ana");
+	let card = page.locator(
+		`[data-document-view="plan"] article[data-plan-sidecar-questionnaire="${WIDGET}"]`,
+	);
+	let stack = card.locator(".question-step-swap");
+	let visible = stack.locator(".question-step-layer:not([hidden])");
+	let scope = card.getByRole("tab", { name: "Scope" });
+
+	await scope.click();
+	await expect(visible).toHaveCount(2);
+	await expect(stack.locator(".question-step-layer:not([hidden]):not([inert])")).toHaveCount(1);
+	await expect(stack.locator('.question-step-layer:not([hidden])[aria-hidden="true"][inert]'))
+		.toHaveCount(1);
+	await expect(visible).toHaveCount(1);
+
+	await scope.focus();
+	await page.keyboard.press("ArrowLeft");
+	await expect(visible).toHaveCount(1);
+	await expect(stack.locator(".question-step-layer:not([hidden]).is-closing")).toHaveCount(0);
+	await expect(card.getByRole("tab", { name: "Rollout" })).toHaveAttribute(
+		"aria-selected",
+		"true",
+	);
 });
 
 async function rewriteFirstBlock(page: import("@playwright/test").Page, value: string) {

--- a/e2e/sidecar.e2e.ts
+++ b/e2e/sidecar.e2e.ts
@@ -324,10 +324,12 @@ test("automatic Decisions changes reconcile after compact Conversation closes", 
 			"true",
 			{ timeout: 20_000 },
 		);
-		let planHost = bo.locator('[data-document-view="plan"]');
+		let planHost = bo.locator('.workspace-document-layer:has([data-document-view="plan"])');
 		await planHost.evaluate(element => {
 			(element as HTMLElement).hidden = false;
 			(element as HTMLElement).inert = false;
+			element.removeAttribute("aria-hidden");
+			element.classList.add("is-open");
 		});
 		await bo.locator('[aria-label="editable markdown"]').fill("Collaborative prose arrived.");
 		await expect(ana.locator('[aria-label="editable markdown"]')).toContainText(

--- a/e2e/sidecar.e2e.ts
+++ b/e2e/sidecar.e2e.ts
@@ -113,6 +113,25 @@ test("question step swaps overlap only for pointer input", async ({ join, seed }
 	await expect(outgoing).toHaveCount(1);
 	await expect(outgoing).toHaveAttribute("aria-hidden", "true");
 	await expect(outgoing).toHaveAttribute("inert", "");
+	let accessibility = await card.evaluate(root => {
+		let ids = [...root.querySelectorAll<HTMLElement>("[id]")].map(element => element.id);
+		let counts = new Map<string, number>();
+		for (let id of ids) counts.set(id, (counts.get(id) ?? 0) + 1);
+		let duplicateIds = [...counts].filter(([, count]) => count > 1).map(([id]) => id).sort();
+		let invalidReferences = [...root.querySelectorAll<HTMLElement>(
+			"[aria-controls], [aria-labelledby]",
+		)].flatMap(element =>
+			["aria-controls", "aria-labelledby"].flatMap(attribute =>
+				(element.getAttribute(attribute)?.split(/\s+/) ?? []).flatMap(id =>
+					document.querySelectorAll(`#${CSS.escape(id)}`).length === 1
+						? []
+						: [`${attribute}:${id}`]
+				)
+			)
+		).sort();
+		return { duplicateIds, invalidReferences };
+	});
+	expect(accessibility).toEqual({ duplicateIds: [], invalidReferences: [] });
 	await expect(visible).toHaveCount(1);
 
 	await scope.focus();
@@ -348,7 +367,7 @@ test("automatic Decisions changes reconcile after compact Conversation closes", 
 		await boContext.close();
 	}
 
-	await ana.locator("#workspace-conversation-heading").press("Escape");
+	await ana.getByRole("heading", { name: "Conversation", exact: true }).press("Escape");
 	await expect(ana.locator('[data-document-view="plan"]')).toBeVisible();
 	await expect(nav.getByRole("button", { name: "Document" })).toHaveAttribute(
 		"aria-current",
@@ -384,8 +403,9 @@ for (
 		let first = questionnaire(page).first();
 
 		await decisions.click();
-		if (example.compact) await expect(page.locator("#workspace-decisions-heading")).toBeFocused();
-		else await expect(first).toBeFocused();
+		if (example.compact) {
+			await expect(page.getByRole("heading", { name: "Decisions", exact: true })).toBeFocused();
+		} else await expect(first).toBeFocused();
 
 		await stack.evaluate(element => {
 			element.scrollTop = element.scrollHeight;
@@ -398,7 +418,7 @@ for (
 		await decisions.click();
 		if (example.compact) {
 			await expect.poll(() => stack.evaluate(element => element.scrollTop)).toBe(scrolled);
-			await expect(page.locator("#workspace-decisions-heading")).toBeFocused();
+			await expect(page.getByRole("heading", { name: "Decisions", exact: true })).toBeFocused();
 		} else {
 			await expect.poll(() => stack.evaluate(element => element.scrollTop)).toBeLessThan(scrolled);
 			await expect(first).toBeFocused();

--- a/e2e/smoke.e2e.ts
+++ b/e2e/smoke.e2e.ts
@@ -12,6 +12,10 @@ import { content, expect, ready, roomPath, test } from "./room";
 import type { Chat } from "../packages/protocol/index";
 import type { Page, WebSocketRoute } from "@playwright/test";
 
+function conversationPane(page: Page) {
+	return page.getByRole("complementary", { includeHidden: true, name: "Conversation" });
+}
+
 async function injectChatHistory(
 	page: Page,
 	change: (frame: Chat.History) => Chat.History,
@@ -250,7 +254,7 @@ test("clicking an empty plan puts the caret at its first writing position", asyn
 
 test("chat uses one room-message composer when the planner is off", async ({ join }) => {
 	let page = await join("ana");
-	let chat = page.locator("#pane-chat");
+	let chat = conversationPane(page);
 	let draft = chat.getByPlaceholder("Use @chopin to ask Chopin");
 	let send = chat.getByRole("button", { name: "Send message" });
 
@@ -282,7 +286,7 @@ test("chat disables Send when its socket disconnects", async ({ join, page }) =>
 		sockets.push(route);
 	});
 
-	let chat = (await join("ana")).locator("#pane-chat");
+	let chat = conversationPane(await join("ana"));
 	let draft = chat.getByPlaceholder("Use @chopin to ask Chopin");
 	let send = chat.getByRole("button", { name: "Send message" });
 	await draft.fill("A draft left during reconnect.");
@@ -294,7 +298,7 @@ test("chat disables Send when its socket disconnects", async ({ join, page }) =>
 
 test("chat routes one Send action by @chopin without blocking room messages or its queue", async ({ join, page }) => {
 	let planner = await scriptPlanner(page);
-	let chat = (await join("ana")).locator("#pane-chat");
+	let chat = conversationPane(await join("ana"));
 	let draft = chat.getByPlaceholder("Use @chopin to ask Chopin");
 	let send = chat.getByRole("button", { name: "Send message" });
 
@@ -340,7 +344,7 @@ test("chat routes one Send action by @chopin without blocking room messages or i
 
 test("chat replaces the Planner working row with its response", async ({ join, page }) => {
 	let planner = await scriptPlanner(page);
-	let chat = (await join("ana")).locator("#pane-chat");
+	let chat = conversationPane(await join("ana"));
 
 	await chat.getByPlaceholder("Use @chopin to ask Chopin").fill(
 		"@chopin Draft the migration.",
@@ -372,7 +376,7 @@ test("chat replaces the Planner working row with its response", async ({ join, p
 
 test("chat clears the Planner working row when a turn stops or fails", async ({ join, page }) => {
 	let planner = await scriptPlanner(page);
-	let chat = (await join("ana")).locator("#pane-chat");
+	let chat = conversationPane(await join("ana"));
 
 	await chat.getByPlaceholder("Use @chopin to ask Chopin").fill(
 		"@chopin Draft the migration.",
@@ -393,12 +397,12 @@ test("chat clears the Planner working row when a turn stops or fails", async ({ 
 
 	await page.reload();
 	await ready(page);
-	await expect(page.locator('#pane-chat [data-chat-state="working"]')).toHaveCount(0);
+	await expect(conversationPane(page).locator('[data-chat-state="working"]')).toHaveCount(0);
 });
 
 test("chat keeps Working on it through tool activity and streamed prose", async ({ join, page }) => {
 	let planner = await scriptPlanner(page);
-	let chat = (await join("ana")).locator("#pane-chat");
+	let chat = conversationPane(await join("ana"));
 
 	await chat.getByPlaceholder("Use @chopin to ask Chopin").fill(
 		"@chopin Check the current plan.",
@@ -446,7 +450,7 @@ test("chat history keeps Working on it after Planner prose and a later room mess
 		],
 	}));
 
-	let chat = (await join("ana")).locator("#pane-chat");
+	let chat = conversationPane(await join("ana"));
 	await expect(chat.getByText("I found the issue.")).toBeVisible();
 	await expect(chat.getByText("Please include the examples.")).toBeVisible();
 	await expect(chat.locator('[data-chat-state="working"]')).toBeVisible();
@@ -479,7 +483,7 @@ test("chat waits for fresh history after reconnect before projecting a stale tur
 		});
 	});
 
-	let chat = (await join("ana")).locator("#pane-chat");
+	let chat = conversationPane(await join("ana"));
 	await expect(chat.locator('[data-chat-state="working"]')).toHaveCount(0);
 	await sockets[0]!.close();
 	await historyHeld.promise;
@@ -527,7 +531,7 @@ test(
 		}));
 
 		await join("ana");
-		let chat = page.locator("#pane-chat");
+		let chat = conversationPane(page);
 		let live = chat.getByText("Edit plan", { exact: true }).locator("..");
 
 		await expect(live).toContainText("7 done");
@@ -588,7 +592,7 @@ test(
 		});
 
 		let page = await join("ana");
-		let chat = page.locator("#pane-chat");
+		let chat = conversationPane(page);
 
 		await expect(chat.getByText("Maggie", { exact: true })).toHaveCount(1);
 		await expect(chat).toContainText("Can you draft the migration?");

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -11,6 +11,10 @@
 			"types": "./src/index.ts",
 			"default": "./src/index.ts"
 		},
+		"./content-swap": {
+			"types": "./src/content-swap.tsx",
+			"default": "./src/content-swap.tsx"
+		},
 		"./pointer": {
 			"types": "./src/pointer.ts",
 			"default": "./src/pointer.ts"

--- a/packages/editor/src/content-swap.test.tsx
+++ b/packages/editor/src/content-swap.test.tsx
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ContentSwapLayer } from "./content-swap";
+
+let motion = { className: "motion-content-swap", closeDuration: 250 };
+
+test("an active swap layer is the only exposed interactive frame", () => {
+	let markup = renderToStaticMarkup(
+		createElement(ContentSwapLayer, {
+			active: true,
+			children: createElement("button", { type: "button" }, "Current"),
+			immediately: true,
+			motion,
+		}),
+	);
+
+	expect(markup).toContain('class="motion-content-swap is-open"');
+	expect(markup).not.toContain("aria-hidden");
+	expect(markup).not.toContain("inert");
+});
+
+test("an inactive layer is hidden, inert, and absent from the accessibility tree", () => {
+	let markup = renderToStaticMarkup(
+		createElement(ContentSwapLayer, {
+			active: false,
+			children: createElement("button", { type: "button" }, "Outgoing"),
+			immediately: true,
+			motion,
+		}),
+	);
+
+	expect(markup).toContain('aria-hidden="true"');
+	expect(markup).toContain(' inert=""');
+	expect(markup).toContain(' hidden=""');
+});

--- a/packages/editor/src/content-swap.tsx
+++ b/packages/editor/src/content-swap.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from "react";
+
+import { useTransitionPresence } from "./transition-presence";
+
+import type { ReactNode } from "react";
+
+export type ContentSwapMotion = {
+	readonly className: string;
+	readonly closeDuration: number;
+};
+
+export type ContentSwapLayerProps = {
+	active: boolean;
+	children: ReactNode;
+	className?: string;
+	immediately: boolean;
+	motion: ContentSwapMotion;
+	onClosed?: () => void;
+};
+
+export function ContentSwapLayer(
+	{ active, children, className, immediately, motion, onClosed }: ContentSwapLayerProps,
+) {
+	let presence = useTransitionPresence(
+		active ? true : undefined,
+		motion.closeDuration,
+		immediately,
+	);
+	let notifiedClosed = useRef(false);
+	let onClosedRef = useRef(onClosed);
+	onClosedRef.current = onClosed;
+
+	useEffect(() => {
+		if (active) {
+			notifiedClosed.current = false;
+			return;
+		}
+		if (presence.phase !== "closed" || notifiedClosed.current) return;
+		notifiedClosed.current = true;
+		onClosedRef.current?.();
+	}, [active, presence.phase]);
+
+	let inactive = !active;
+	return (
+		<div
+			aria-hidden={inactive || undefined}
+			className={`${motion.className} ${presence.className}${className ? ` ${className}` : ""}`}
+			data-content-swap-state={active ? presence.phase : "outgoing"}
+			hidden={presence.phase === "closed"}
+			inert={inactive}
+		>
+			{children}
+		</div>
+	);
+}

--- a/packages/editor/src/decision-state.test.ts
+++ b/packages/editor/src/decision-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { advanceDecisionView, countUnanswered, visibleDecisionView } from ".";
+import { advanceDecisionView, countUnanswered, selectDecisionView, visibleDecisionView } from ".";
 
 import type { DecisionViewState } from ".";
 
@@ -67,4 +67,17 @@ describe("decision attention", () => {
 			expect(visibleDecisionView({ ...state, preferred: preference }, false, 1)).toBe(preference);
 		},
 	);
+
+	it("lets explicit Document navigation override a forced Decisions opening", () => {
+		let state = advanceDecisionView(
+			{ phase: "initial", preferred: "plan" },
+			false,
+			2,
+		);
+
+		state = selectDecisionView(state, "plan");
+
+		expect(state).toEqual({ phase: "complete", preferred: "plan" });
+		expect(visibleDecisionView(state, false, 2)).toBe("plan");
+	});
 });

--- a/packages/editor/src/decision-state.ts
+++ b/packages/editor/src/decision-state.ts
@@ -30,6 +30,13 @@ export function advanceDecisionView(
 	return unanswered > 0 ? { ...state, phase: "forced" } : state;
 }
 
+export function selectDecisionView(
+	state: DecisionViewState,
+	preferred: DecisionView,
+): DecisionViewState {
+	return { ...state, phase: "complete", preferred };
+}
+
 export function visibleDecisionView(
 	state: DecisionViewState,
 	hasPlanContent: boolean,

--- a/packages/editor/src/decisions.tsx
+++ b/packages/editor/src/decisions.tsx
@@ -16,11 +16,13 @@ import { QuestionnaireCard } from "./widgets/questionnaire";
 import type { Transport } from "@chopin/question/react";
 import type { MotionDisclosureContract } from "./disclosure-motion";
 import type { QuestionnaireEntry, QuestionnaireStore } from "./questionnaires";
+import type { QuestionStepMotion } from "./widget-options";
 
 export type DecisionsProps = {
 	store: QuestionnaireStore;
 	motion: MotionDisclosureContract;
 	motionImmediately?: () => boolean;
+	questionMotion?: QuestionStepMotion;
 	wire?: Transport;
 	connected?: boolean;
 	headingId?: string;
@@ -53,8 +55,17 @@ function useHistory() {
 }
 
 export function Decisions(
-	{ connected, headingId, motion, motionImmediately, onShowPlan, reveal, store, wire }:
-		DecisionsProps,
+	{
+		connected,
+		headingId,
+		motion,
+		motionImmediately,
+		onShowPlan,
+		questionMotion,
+		reveal,
+		store,
+		wire,
+	}: DecisionsProps,
 ) {
 	let entries = useQuestionnaires(store);
 	let content = useRef<HTMLDivElement>(null);
@@ -112,6 +123,7 @@ export function Decisions(
 		<QuestionnaireCard
 			connected={connected}
 			key={entry.id}
+			motion={questionMotion}
 			onQuestionEnter={question => store.highlight(entry.id, question)}
 			onQuestionLeave={() => store.clear()}
 			onQuestionSelect={question => {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -2,6 +2,8 @@ export { BackgroundWork } from "./background-work";
 export type { BackgroundWorkProps } from "./background-work";
 export { collaborationPlugin } from "./collaboration";
 export type { CollaborationOptions } from "./collaboration";
+export { ContentSwapLayer } from "./content-swap";
+export type { ContentSwapLayerProps, ContentSwapMotion } from "./content-swap";
 export { Count } from "./count";
 export { color, cursor } from "./cursor";
 export type { Cursor } from "./cursor";

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -7,7 +7,12 @@ export type { ContentSwapLayerProps, ContentSwapMotion } from "./content-swap";
 export { Count } from "./count";
 export { color, cursor } from "./cursor";
 export type { Cursor } from "./cursor";
-export { advanceDecisionView, countUnanswered, visibleDecisionView } from "./decision-state";
+export {
+	advanceDecisionView,
+	countUnanswered,
+	selectDecisionView,
+	visibleDecisionView,
+} from "./decision-state";
 export type { DecisionView, DecisionViewState, OpeningPhase } from "./decision-state";
 export { Decisions } from "./decisions";
 export type { DecisionsProps } from "./decisions";

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -40,5 +40,5 @@ export type { Draft, ThreadState, ThreadView } from "./threads";
 export { presenceClass, transitionPresence, useTransitionPresence } from "./transition-presence";
 export type { PresenceAction, PresencePhase, TransitionPresence } from "./transition-presence";
 export type { Connection, Transport, Unsubscribe } from "./transport";
-export type { CommentPresentation } from "./widget-options";
+export type { CommentPresentation, QuestionStepMotion } from "./widget-options";
 export { QuestionnaireCard, register as registerPlanWidgets } from "./widgets";

--- a/packages/editor/src/plan-editor.tsx
+++ b/packages/editor/src/plan-editor.tsx
@@ -28,7 +28,7 @@ import type { PlanProvider } from "./provider";
 import type { QuestionnaireStore } from "./questionnaires";
 import type { ThreadStore } from "./threads";
 import type { Connection, Transport } from "./transport";
-import type { CommentPresentation } from "./widget-options";
+import type { CommentPresentation, QuestionStepMotion } from "./widget-options";
 
 /**
  * Lexical paints remote cursors with inline styles unless the theme names a
@@ -64,6 +64,8 @@ export type PlanEditorProps = {
 	commentPresentation?: CommentPresentation;
 	/** App-owned input policy for interactions that should settle without motion. */
 	motionImmediately?: () => boolean;
+	/** Host presentation for moving between bounded questionnaire steps. */
+	questionMotion?: QuestionStepMotion;
 	/** Identity for this client's remote cursor. */
 	user: { name: string; color: string };
 	/** Read-only while an agent turn may be rewriting the plan. */
@@ -103,6 +105,7 @@ export function PlanEditor(
 		connection,
 		motionImmediately,
 		onScrollTop,
+		questionMotion,
 		questions,
 		readOnly,
 		scrollTop,
@@ -252,6 +255,7 @@ export function PlanEditor(
 					widgetsPlugin({
 						commentPresentation,
 						motionImmediately,
+						questionMotion,
 						questions,
 						threads,
 						changes,
@@ -272,6 +276,7 @@ export function PlanEditor(
 			questions,
 			commentPresentation,
 			motionImmediately,
+			questionMotion,
 			threads,
 			changes,
 			offline,

--- a/packages/editor/src/widget-options.ts
+++ b/packages/editor/src/widget-options.ts
@@ -1,15 +1,22 @@
 import { Cell } from "@mdxeditor/gurx";
 
 import type { ChangeStore } from "./changes";
+import type { ContentSwapMotion } from "./content-swap";
 import type { QuestionnaireStore } from "./questionnaires";
 import type { ThreadStore } from "./threads";
 import type { Transport } from "./transport";
 
 export type CommentPresentation = "popover" | "sheet";
 
+export type QuestionStepMotion = {
+	contract: ContentSwapMotion;
+	immediately: () => boolean;
+};
+
 export type WidgetOptions = {
 	commentPresentation?: CommentPresentation;
 	motionImmediately?: () => boolean;
+	questionMotion?: QuestionStepMotion;
 	questions?: QuestionnaireStore;
 	threads?: ThreadStore;
 	changes?: ChangeStore;

--- a/packages/editor/src/widgets/questionnaire.test.tsx
+++ b/packages/editor/src/widgets/questionnaire.test.tsx
@@ -89,7 +89,7 @@ test("a stored unanswered questionnaire keeps its compatibility view without a l
 	expect(markup).not.toContain("Cancel");
 });
 
-test("a host motion contract retains one inert question step beside the active step", () => {
+test("a host motion contract owns the active question step", () => {
 	let markup = renderToStaticMarkup(
 		createElement(QuestionnaireCard, {
 			canEdit: false,
@@ -120,10 +120,10 @@ test("a host motion contract retains one inert question step beside the active s
 		}),
 	);
 
-	expect(markup.match(/class="motion-content-swap/g)).toHaveLength(2);
+	expect(markup.match(/class="motion-content-swap/g)).toHaveLength(1);
 	expect(markup).toContain("question-step-swap content-swap-stack");
-	expect(markup).toContain('aria-hidden="true"');
-	expect(markup).toContain(' inert=""');
+	expect(markup).not.toContain('data-content-swap-state="outgoing"');
+	expect(markup).not.toContain(' inert=""');
 });
 
 test("a read-only decision remains linked but has no answer actions", () => {

--- a/packages/editor/src/widgets/questionnaire.test.tsx
+++ b/packages/editor/src/widgets/questionnaire.test.tsx
@@ -89,6 +89,43 @@ test("a stored unanswered questionnaire keeps its compatibility view without a l
 	expect(markup).not.toContain("Cancel");
 });
 
+test("a host motion contract retains one inert question step beside the active step", () => {
+	let markup = renderToStaticMarkup(
+		createElement(QuestionnaireCard, {
+			canEdit: false,
+			connected: true,
+			motion: {
+				contract: { className: "motion-content-swap", closeDuration: 250 },
+				immediately: () => true,
+			},
+			value: {
+				id: "01K0N4TR8K7JGM4R1J7PW4R8YJ",
+				questions: [
+					{
+						id: "storage",
+						header: "Storage",
+						prompt: "Where should room state live?",
+						multiple: false,
+						options: [{ id: "mdx", label: "MDX on disk" }],
+					},
+					{
+						id: "scope",
+						header: "Scope",
+						prompt: "What belongs in the first cut?",
+						multiple: true,
+						options: [{ id: "anchors", label: "Anchors" }],
+					},
+				],
+			},
+		}),
+	);
+
+	expect(markup.match(/class="motion-content-swap/g)).toHaveLength(2);
+	expect(markup).toContain("question-step-swap content-swap-stack");
+	expect(markup).toContain('aria-hidden="true"');
+	expect(markup).toContain(' inert=""');
+});
+
 test("a read-only decision remains linked but has no answer actions", () => {
 	let markup = renderToStaticMarkup(
 		createElement(QuestionnaireCard, {

--- a/packages/editor/src/widgets/questionnaire.tsx
+++ b/packages/editor/src/widgets/questionnaire.tsx
@@ -11,11 +11,13 @@ import { QuestionView, useQuestionnaire } from "@chopin/question/react";
 import { useCellValue } from "@mdxeditor/gurx";
 
 import { Provenance, SidecarCard } from "../card";
+import { ContentSwapLayer } from "../content-swap";
 import { widgets$ } from "../widget-options";
 
 import type { Transport } from "@chopin/question/react";
 import type { Answer } from "@chopin/question";
 import type { Questionnaire, QuestionnaireNode } from "@chopin/dialect";
+import type { QuestionStepMotion } from "../widget-options";
 
 /** The plan stores the chosen text; the shared view wants answer records. */
 function answers(value: Questionnaire): Answer[] | undefined {
@@ -55,6 +57,7 @@ export type QuestionnaireCardProps = {
 	onQuestionLeave?: (question: string) => void;
 	/** Take the reader to that prose. Without it the shared view's jump is inert. */
 	onQuestionSelect?: (question: string) => void;
+	motion?: QuestionStepMotion;
 };
 
 export function QuestionnaireCard(
@@ -64,6 +67,7 @@ export function QuestionnaireCard(
 		onQuestionEnter,
 		onQuestionLeave,
 		onQuestionSelect,
+		motion,
 		places,
 		value,
 		wire,
@@ -78,6 +82,7 @@ export function QuestionnaireCard(
 			<Undecided
 				canEdit={canEdit}
 				connected={connected}
+				motion={motion}
 				value={value}
 				wire={wire}
 				{...pointing}
@@ -93,8 +98,14 @@ type Pointing = {
 };
 
 function Undecided(
-	{ canEdit, connected, value, wire, ...pointing }:
-		& { canEdit: boolean; connected: boolean; value: Questionnaire; wire?: Transport }
+	{ canEdit, connected, motion, value, wire, ...pointing }:
+		& {
+			canEdit: boolean;
+			connected: boolean;
+			motion?: QuestionStepMotion;
+			value: Questionnaire;
+			wire?: Transport;
+		}
 		& Pointing,
 ) {
 	let state = useQuestionnaire({
@@ -124,6 +135,19 @@ function Undecided(
 				onCancel={editable ? state.cancel : undefined}
 				onChange={editable ? state.change : undefined}
 				onSubmit={editable ? state.submit : undefined}
+				renderStep={motion
+					? ({ active, children, question }) => (
+						<ContentSwapLayer
+							active={active}
+							className="question-step-layer"
+							immediately={motion.immediately()}
+							key={question}
+							motion={motion.contract}
+						>
+							{children}
+						</ContentSwapLayer>
+					)
+					: undefined}
 				status="open"
 				submitting={state.submitting}
 				{...pointing}
@@ -163,6 +187,7 @@ function InlineQuestionnaire({ value }: { value: Questionnaire }) {
 		<QuestionnaireCard
 			canEdit={options.canEdit}
 			connected={options.connected}
+			motion={options.questionMotion}
 			onQuestionEnter={question => options.questions?.highlight(value.id, question)}
 			onQuestionLeave={() => options.questions?.clear()}
 			onQuestionSelect={question => options.questions?.reveal(value.id, question)}

--- a/packages/editor/src/widgets/questionnaire.tsx
+++ b/packages/editor/src/widgets/questionnaire.tsx
@@ -124,7 +124,7 @@ function QuestionStepSwap(
 	}, [active, question]);
 
 	return (
-		<div className="question-step-swap content-swap-stack">
+		<div className="question-step-swap content-swap-stack" data-question-step-swap>
 			{outgoing && (
 				<ContentSwapLayer
 					active={false}

--- a/packages/editor/src/widgets/questionnaire.tsx
+++ b/packages/editor/src/widgets/questionnaire.tsx
@@ -7,6 +7,7 @@
  * the source reads correctly on its own.
  */
 
+import { useEffect, useRef, useState } from "react";
 import { QuestionView, useQuestionnaire } from "@chopin/question/react";
 import { useCellValue } from "@mdxeditor/gurx";
 
@@ -14,6 +15,7 @@ import { Provenance, SidecarCard } from "../card";
 import { ContentSwapLayer } from "../content-swap";
 import { widgets$ } from "../widget-options";
 
+import type { ReactNode } from "react";
 import type { Transport } from "@chopin/question/react";
 import type { Answer } from "@chopin/question";
 import type { Questionnaire, QuestionnaireNode } from "@chopin/dialect";
@@ -97,6 +99,58 @@ type Pointing = {
 	onQuestionSelect?: (question: string) => void;
 };
 
+type QuestionStep = { children: ReactNode; question: string };
+
+function QuestionStepSwap(
+	{ children, motion, question }: {
+		children: ReactNode;
+		motion: QuestionStepMotion;
+		question: string;
+	},
+) {
+	let current = useRef<QuestionStep>({ children, question });
+	let immediately = motion.immediately();
+	let [presented, setPresented] = useState(question);
+	let [active, setActive] = useState(question);
+	let [outgoing, setOutgoing] = useState<QuestionStep>();
+	if (presented !== question) {
+		setOutgoing(current.current);
+		setPresented(question);
+		if (immediately) setActive(question);
+	}
+	current.current = { children, question };
+	useEffect(() => {
+		if (active !== question) setActive(question);
+	}, [active, question]);
+
+	return (
+		<div className="question-step-swap content-swap-stack">
+			{outgoing && (
+				<ContentSwapLayer
+					active={false}
+					className="question-step-layer"
+					immediately={immediately}
+					key={outgoing.question}
+					motion={motion.contract}
+					onClosed={() =>
+						setOutgoing(step => step?.question === outgoing.question ? undefined : step)}
+				>
+					{outgoing.children}
+				</ContentSwapLayer>
+			)}
+			<ContentSwapLayer
+				active={active === presented}
+				className="question-step-layer"
+				immediately={immediately}
+				key={presented}
+				motion={motion.contract}
+			>
+				{children}
+			</ContentSwapLayer>
+		</div>
+	);
+}
+
 function Undecided(
 	{ canEdit, connected, motion, value, wire, ...pointing }:
 		& {
@@ -136,16 +190,10 @@ function Undecided(
 				onChange={editable ? state.change : undefined}
 				onSubmit={editable ? state.submit : undefined}
 				renderStep={motion
-					? ({ active, children, question }) => (
-						<ContentSwapLayer
-							active={active}
-							className="question-step-layer"
-							immediately={motion.immediately()}
-							key={question}
-							motion={motion.contract}
-						>
+					? ({ children, question }) => (
+						<QuestionStepSwap motion={motion} question={question}>
 							{children}
-						</ContentSwapLayer>
+						</QuestionStepSwap>
 					)
 					: undefined}
 				status="open"

--- a/packages/question/package.json
+++ b/packages/question/package.json
@@ -26,6 +26,8 @@
 	},
 	"devDependencies": {
 		"@types/bun": "catalog:bun",
-		"@types/react": "catalog:react"
+		"@types/react": "catalog:react",
+		"@types/react-dom": "catalog:react",
+		"react-dom": "catalog:react"
 	}
 }

--- a/packages/question/src/react/index.ts
+++ b/packages/question/src/react/index.ts
@@ -6,6 +6,6 @@
  */
 
 export { QuestionView } from "./question-view";
-export type { Collaborator, QuestionViewProps } from "./question-view";
+export type { Collaborator, QuestionStepRenderProps, QuestionViewProps } from "./question-view";
 export { forget, useQuestionnaire } from "./use-questionnaire";
 export type { QuestionnaireOptions, QuestionnaireState, Transport } from "./use-questionnaire";

--- a/packages/question/src/react/question-view.test.ts
+++ b/packages/question/src/react/question-view.test.ts
@@ -23,7 +23,7 @@ test("a replacement definition falls back before rendering when its active quest
 	expect(currentQuestion({ questions: [storage, scope] }, "removed")).toBe(storage);
 });
 
-test("a host renderer receives every stable question id with one active step", () => {
+test("a host renderer receives only the active question panel", () => {
 	let definition = {
 		questions: [
 			{
@@ -42,19 +42,17 @@ test("a host renderer receives every stable question id with one active step", (
 			},
 		],
 	};
-	let steps: { active: boolean; question: string }[] = [];
+	let steps: string[] = [];
 
-	renderToStaticMarkup(createElement(QuestionView, {
+	let markup = renderToStaticMarkup(createElement(QuestionView, {
 		definition,
 		drafts: {},
-		renderStep: ({ active, children, question }) => {
-			steps.push({ active, question });
+		renderStep: ({ children, question }) => {
+			steps.push(question);
 			return children;
 		},
 	}));
 
-	expect(steps).toEqual([
-		{ active: true, question: "storage" },
-		{ active: false, question: "scope" },
-	]);
+	expect(steps).toEqual(["storage"]);
+	expect(markup).not.toContain("content-swap-stack");
 });

--- a/packages/question/src/react/question-view.test.ts
+++ b/packages/question/src/react/question-view.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
-import { currentQuestion } from "./question-view";
+import { currentQuestion, QuestionView } from "./question-view";
 
 test("a replacement definition falls back before rendering when its active question disappears", () => {
 	let storage = {
@@ -19,4 +21,40 @@ test("a replacement definition falls back before rendering when its active quest
 	};
 
 	expect(currentQuestion({ questions: [storage, scope] }, "removed")).toBe(storage);
+});
+
+test("a host renderer receives every stable question id with one active step", () => {
+	let definition = {
+		questions: [
+			{
+				id: "storage",
+				header: "Storage",
+				question: "Where should room state live?",
+				multiple: false,
+				options: [],
+			},
+			{
+				id: "scope",
+				header: "Scope",
+				question: "What belongs in the first cut?",
+				multiple: false,
+				options: [],
+			},
+		],
+	};
+	let steps: { active: boolean; question: string }[] = [];
+
+	renderToStaticMarkup(createElement(QuestionView, {
+		definition,
+		drafts: {},
+		renderStep: ({ active, children, question }) => {
+			steps.push({ active, question });
+			return children;
+		},
+	}));
+
+	expect(steps).toEqual([
+		{ active: true, question: "storage" },
+		{ active: false, question: "scope" },
+	]);
 });

--- a/packages/question/src/react/question-view.tsx
+++ b/packages/question/src/react/question-view.tsx
@@ -9,7 +9,7 @@
  * as they arrive rather than tracking local state.
  */
 
-import { Fragment, useCallback, useEffect, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { CheckIcon, ShuffleSimpleIcon, XIcon } from "@phosphor-icons/react";
 
 import { answered } from "../draft";
@@ -26,7 +26,6 @@ export type Collaborator = {
 };
 
 export type QuestionStepRenderProps = {
-	active: boolean;
 	children: ReactNode;
 	question: string;
 };
@@ -515,73 +514,61 @@ export function QuestionView(props: QuestionViewProps) {
 
 			{aside}
 
-			<div className="question-step-swap content-swap-stack">
-				{definition.questions.map(question => {
-					let activeStep = question.id === active;
-					if (!activeStep && !renderStep) return null;
-					let panel = (
-						<section
-							data-ace-question-id={question.id}
-							id={activeStep ? `${base}-panel` : undefined}
-							role={multiple && activeStep ? "tabpanel" : undefined}
-							className="px-3 py-2.5"
-							onMouseEnter={() => onQuestionEnter?.(question.id)}
-							onMouseLeave={event =>
-								!event.currentTarget.contains(document.activeElement)
-								&& onQuestionLeave?.(question.id)}
-							onFocusCapture={() => onQuestionEnter?.(question.id)}
-							onBlurCapture={event =>
-								!event.currentTarget.contains(event.relatedTarget)
-								&& !event.currentTarget.matches(":hover")
-								&& onQuestionLeave?.(question.id)}
+			{(() => {
+				let panel = (
+					<section
+						data-ace-question-id={current.id}
+						id={`${base}-panel`}
+						role={multiple ? "tabpanel" : undefined}
+						className="px-3 py-2.5"
+						onMouseEnter={() => onQuestionEnter?.(current.id)}
+						onMouseLeave={event =>
+							!event.currentTarget.contains(document.activeElement)
+							&& onQuestionLeave?.(current.id)}
+						onFocusCapture={() => onQuestionEnter?.(current.id)}
+						onBlurCapture={event =>
+							!event.currentTarget.contains(event.relatedTarget)
+							&& !event.currentTarget.matches(":hover")
+							&& onQuestionLeave?.(current.id)}
+					>
+						<header className="flex min-w-0 flex-wrap items-baseline justify-between gap-2">
+							<h4 className="m-0 min-w-0 break-words text-sm font-semibold text-text-primary">
+								{current.header}
+							</h4>
+							<Badges people={collaborators.filter(person => person.question === current.id)} />
+						</header>
+
+						{/* Never the whole panel: below this is a form. */}
+						<Related
+							id={current.id}
+							count={places?.[current.id] ?? 0}
+							label={current.question}
+							className="mt-1 mb-2"
+							onSelect={onQuestionSelect}
 						>
-							<header className="flex min-w-0 flex-wrap items-baseline justify-between gap-2">
-								<h4 className="m-0 min-w-0 break-words text-sm font-semibold text-text-primary">
-									{question.header}
-								</h4>
-								<Badges
-									people={collaborators.filter(person => person.question === question.id)}
-								/>
-							</header>
+							<p className="m-0 text-sm text-text-secondary">{current.question}</p>
+						</Related>
 
-							{/* Never the whole panel: below this is a form. */}
-							<Related
-								id={question.id}
-								count={places?.[question.id] ?? 0}
-								label={question.question}
-								className="mt-1 mb-2"
-								onSelect={onQuestionSelect}
-							>
-								<p className="m-0 text-sm text-text-secondary">{question.question}</p>
-							</Related>
+						<Choices
+							question={current}
+							draft={drafts[current.id]}
+							disabled={disabled}
+							name={`${base}-${current.id}`}
+							onChange={change => onChange?.(current.id, change)}
+						/>
 
-							<Choices
-								question={question}
-								draft={drafts[question.id]}
-								disabled={disabled}
-								name={`${base}-${question.id}`}
-								onChange={change => onChange?.(question.id, change)}
-							/>
+						<Custom
+							question={current}
+							draft={drafts[current.id]}
+							disabled={disabled}
+							name={`${base}-${current.id}`}
+							onChange={change => onChange?.(current.id, change)}
+						/>
+					</section>
+				);
 
-							<Custom
-								question={question}
-								draft={drafts[question.id]}
-								disabled={disabled}
-								name={`${base}-${question.id}`}
-								onChange={change => onChange?.(question.id, change)}
-							/>
-						</section>
-					);
-					if (renderStep) {
-						return (
-							<Fragment key={question.id}>
-								{renderStep({ active: activeStep, children: panel, question: question.id })}
-							</Fragment>
-						);
-					}
-					return <Fragment key={question.id}>{panel}</Fragment>;
-				})}
-			</div>
+				return renderStep ? renderStep({ children: panel, question: current.id }) : panel;
+			})()}
 
 			{error && (
 				<p role="alert" className="px-3 pb-2 text-sm text-destructive-ink">

--- a/packages/question/src/react/question-view.tsx
+++ b/packages/question/src/react/question-view.tsx
@@ -376,6 +376,7 @@ export function QuestionView(props: QuestionViewProps) {
 	let [selected, setActive] = useState(() => definition.questions[0]?.id);
 	let current = currentQuestion(definition, selected);
 	let active = current.id;
+	let panelId = `${base}-panel-${active}`;
 	if (active !== selected) setActive(active);
 	// Cancelling cannot be undone and the agent is waiting, so it takes a
 	// second, deliberate click rather than a modal nobody reads.
@@ -475,7 +476,7 @@ export function QuestionView(props: QuestionViewProps) {
 								type="button"
 								role="tab"
 								aria-selected={question.id === active}
-								aria-controls={`${base}-panel`}
+								aria-controls={question.id === active ? `${base}-panel-${question.id}` : undefined}
 								aria-label={done ? `${question.header}, answered` : question.header}
 								tabIndex={question.id === active ? 0 : -1}
 								// Switching question, and only that. A tab used to ask to be
@@ -517,8 +518,9 @@ export function QuestionView(props: QuestionViewProps) {
 			{(() => {
 				let panel = (
 					<section
+						aria-labelledby={multiple ? `${base}-tab-${current.id}` : undefined}
 						data-ace-question-id={current.id}
-						id={`${base}-panel`}
+						id={panelId}
 						role={multiple ? "tabpanel" : undefined}
 						className="px-3 py-2.5"
 						onMouseEnter={() => onQuestionEnter?.(current.id)}

--- a/packages/question/src/react/question-view.tsx
+++ b/packages/question/src/react/question-view.tsx
@@ -9,7 +9,7 @@
  * as they arrive rather than tracking local state.
  */
 
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useId, useRef, useState } from "react";
 import { CheckIcon, ShuffleSimpleIcon, XIcon } from "@phosphor-icons/react";
 
 import { answered } from "../draft";
@@ -23,6 +23,12 @@ export type Collaborator = {
 	client: string;
 	handle: string;
 	question?: string;
+};
+
+export type QuestionStepRenderProps = {
+	active: boolean;
+	children: ReactNode;
+	question: string;
 };
 
 export type QuestionViewProps = {
@@ -55,6 +61,8 @@ export type QuestionViewProps = {
 	error?: string;
 	/** Rendered beside the heading; hosts use it for counts and provenance. */
 	aside?: ReactNode;
+	/** Lets a host retain bounded steps for presentation without owning question state. */
+	renderStep?: (props: QuestionStepRenderProps) => ReactNode;
 };
 
 export function currentQuestion(
@@ -361,6 +369,7 @@ export function QuestionView(props: QuestionViewProps) {
 		onQuestionEnter,
 		onQuestionLeave,
 		onQuestionSelect,
+		renderStep,
 	} = props;
 
 	let base = useId();
@@ -506,57 +515,73 @@ export function QuestionView(props: QuestionViewProps) {
 
 			{aside}
 
-			{current && (
-				<section
-					data-ace-question-id={current.id}
-					id={`${base}-panel`}
-					role={multiple ? "tabpanel" : undefined}
-					className="px-3 py-2.5"
-					onMouseEnter={() => onQuestionEnter?.(current.id)}
-					onMouseLeave={event =>
-						!event.currentTarget.contains(document.activeElement)
-						&& onQuestionLeave?.(current.id)}
-					onFocusCapture={() => onQuestionEnter?.(current.id)}
-					onBlurCapture={event =>
-						!event.currentTarget.contains(event.relatedTarget)
-						&& !event.currentTarget.matches(":hover")
-						&& onQuestionLeave?.(current.id)}
-				>
-					<header className="flex min-w-0 flex-wrap items-baseline justify-between gap-2">
-						<h4 className="m-0 min-w-0 break-words text-sm font-semibold text-text-primary">
-							{current.header}
-						</h4>
-						<Badges people={collaborators.filter(person => person.question === current.id)} />
-					</header>
+			<div className="question-step-swap content-swap-stack">
+				{definition.questions.map(question => {
+					let activeStep = question.id === active;
+					if (!activeStep && !renderStep) return null;
+					let panel = (
+						<section
+							data-ace-question-id={question.id}
+							id={activeStep ? `${base}-panel` : undefined}
+							role={multiple && activeStep ? "tabpanel" : undefined}
+							className="px-3 py-2.5"
+							onMouseEnter={() => onQuestionEnter?.(question.id)}
+							onMouseLeave={event =>
+								!event.currentTarget.contains(document.activeElement)
+								&& onQuestionLeave?.(question.id)}
+							onFocusCapture={() => onQuestionEnter?.(question.id)}
+							onBlurCapture={event =>
+								!event.currentTarget.contains(event.relatedTarget)
+								&& !event.currentTarget.matches(":hover")
+								&& onQuestionLeave?.(question.id)}
+						>
+							<header className="flex min-w-0 flex-wrap items-baseline justify-between gap-2">
+								<h4 className="m-0 min-w-0 break-words text-sm font-semibold text-text-primary">
+									{question.header}
+								</h4>
+								<Badges
+									people={collaborators.filter(person => person.question === question.id)}
+								/>
+							</header>
 
-					{/* Never the whole panel: below this is a form. */}
-					<Related
-						id={current.id}
-						count={places?.[current.id] ?? 0}
-						label={current.question}
-						className="mt-1 mb-2"
-						onSelect={onQuestionSelect}
-					>
-						<p className="m-0 text-sm text-text-secondary">{current.question}</p>
-					</Related>
+							{/* Never the whole panel: below this is a form. */}
+							<Related
+								id={question.id}
+								count={places?.[question.id] ?? 0}
+								label={question.question}
+								className="mt-1 mb-2"
+								onSelect={onQuestionSelect}
+							>
+								<p className="m-0 text-sm text-text-secondary">{question.question}</p>
+							</Related>
 
-					<Choices
-						question={current}
-						draft={drafts[current.id]}
-						disabled={disabled}
-						name={`${base}-${current.id}`}
-						onChange={change => onChange?.(current.id, change)}
-					/>
+							<Choices
+								question={question}
+								draft={drafts[question.id]}
+								disabled={disabled}
+								name={`${base}-${question.id}`}
+								onChange={change => onChange?.(question.id, change)}
+							/>
 
-					<Custom
-						question={current}
-						draft={drafts[current.id]}
-						disabled={disabled}
-						name={`${base}-${current.id}`}
-						onChange={change => onChange?.(current.id, change)}
-					/>
-				</section>
-			)}
+							<Custom
+								question={question}
+								draft={drafts[question.id]}
+								disabled={disabled}
+								name={`${base}-${question.id}`}
+								onChange={change => onChange?.(question.id, change)}
+							/>
+						</section>
+					);
+					if (renderStep) {
+						return (
+							<Fragment key={question.id}>
+								{renderStep({ active: activeStep, children: panel, question: question.id })}
+							</Fragment>
+						);
+					}
+					return <Fragment key={question.id}>{panel}</Fragment>;
+				})}
+			</div>
 
 			{error && (
 				<p role="alert" className="px-3 pb-2 text-sm text-destructive-ink">


### PR DESCRIPTION
## Summary
- add one accessible content-swap layer with immediate inert and accessibility-tree ownership
- animate pointer-owned Document, Decisions, Background Work, and questionnaire step swaps while keeping keyboard and reduced-motion paths immediate
- hold document-route swaps until destinations resolve, with stable input ownership and visit publication through interrupted navigation

## Verification
- bun run fix
- bun test (1232 passed, 2 PostgreSQL-only skips)
- bun run types
- bun run ci
- focused Playwright coverage for workspace, questionnaire, and document-route swaps (3 passed)