### PR TITLE
Add durable inline research requests

### DIFF
--- a/apps/server/src/research/request-view.ts
+++ b/apps/server/src/research/request-view.ts
@@ -11,7 +11,10 @@ export function projectRequestView(input: {
 	sources: ResearchEvidence["sources"];
 	child: Research.ReadyChild | undefined;
 }): Research.RequestView {
-	let state: Job.State = input.answer?.job.state ?? input.evidence?.job.state ?? "pending";
+	let unlinked = !input.turn.evidenceJobId && !input.turn.answerJobId;
+	let state: Job.State = unlinked
+		? "failed"
+		: input.answer?.job.state ?? input.evidence?.job.state ?? "pending";
 	let base: Research.RequestViewBase = {
 		id: input.workspace.id,
 		channelId: input.workspace.channelId,

--- a/apps/server/src/research/routes.test.ts
+++ b/apps/server/src/research/routes.test.ts
@@ -345,6 +345,42 @@ describe("research workspace routes", () => {
 		).toBe(409);
 	});
 
+	it("exposes a durably cleared request as retryable after reload", async () => {
+		let context = await setup();
+		let created = await create(context);
+		await failInitial(context);
+		let detail = await context.storage.research.get(context.channel.id, created.body.request.id);
+		let initial = detail!.turns[0]!;
+		await context.storage.research.resetInitialAttempt({
+			channelId: context.channel.id,
+			workspaceId: created.body.request.id,
+			expectedEvidenceJobId: initial.evidenceJobId,
+			expectedAnswerJobId: initial.answerJobId,
+			now: new Date(context.now.getTime() + 3),
+			lease: context.lease,
+		});
+		let path = `/api/channels/${context.channel.id}/research-workspaces/${created.body.request.id}`;
+
+		let observed = await context.router.handle(request(path, context.cookie));
+		expect(observed?.status).toBe(200);
+		expect(await observed!.json()).toMatchObject({
+			id: created.body.request.id,
+			state: "failed",
+			stage: "failed",
+			error: "Research could not be completed.",
+		});
+		let retried = await context.router.handle(request(
+			`${path}/retry`,
+			context.cookie,
+			retryMutation(),
+		));
+		expect(retried?.status).toBe(200);
+		expect(await retried!.json()).toMatchObject({
+			id: created.body.request.id,
+			stage: "queued",
+		});
+	});
+
 	it("enforces retry origin, authentication, write access, and archive state", async () => {
 		let context = await setup();
 		let created = await createInline(context);

--- a/apps/server/src/research/routes.test.ts
+++ b/apps/server/src/research/routes.test.ts
@@ -300,8 +300,7 @@ describe("research workspace routes", () => {
 		expect(context.owners).toEqual([context.channel.id]);
 		expect(await context.storage.research.list(context.channel.id, 100)).toHaveLength(2);
 
-		let path =
-			`/api/channels/${context.channel.id}/research-requests/${inline.body.request.id}`;
+		let path = `/api/channels/${context.channel.id}/research-requests/${inline.body.request.id}`;
 		let observed = await context.router.handle(request(path, context.cookie));
 		expect(observed?.status).toBe(200);
 		expect(await observed!.json()).toMatchObject({ id: inline.body.request.id });
@@ -347,7 +346,7 @@ describe("research workspace routes", () => {
 
 	it("exposes a durably cleared request as retryable after reload", async () => {
 		let context = await setup();
-		let created = await create(context);
+		let created = await createInline(context);
 		await failInitial(context);
 		let detail = await context.storage.research.get(context.channel.id, created.body.request.id);
 		let initial = detail!.turns[0]!;
@@ -359,7 +358,7 @@ describe("research workspace routes", () => {
 			now: new Date(context.now.getTime() + 3),
 			lease: context.lease,
 		});
-		let path = `/api/channels/${context.channel.id}/research-workspaces/${created.body.request.id}`;
+		let path = `/api/channels/${context.channel.id}/research-requests/${created.body.request.id}`;
 
 		let observed = await context.router.handle(request(path, context.cookie));
 		expect(observed?.status).toBe(200);

--- a/apps/server/src/research/routes.test.ts
+++ b/apps/server/src/research/routes.test.ts
@@ -155,6 +155,7 @@ async function setup() {
 		cookie: pair(issued.cookie),
 		owners,
 		now,
+		lease,
 	};
 }
 
@@ -180,6 +181,41 @@ async function create(context: Awaited<ReturnType<typeof setup>>) {
 	));
 	if (!response) throw new Error("research create route was not registered");
 	return { response, body: await response.json() };
+}
+
+async function createInline(context: Awaited<ReturnType<typeof setup>>) {
+	let response = await context.router.handle(request(
+		`/api/channels/${context.channel.id}/research-requests`,
+		context.cookie,
+		mutation({ question: "What changed?", requestId: requestId(11) }),
+	));
+	if (!response) throw new Error("inline research create route was not registered");
+	return { response, body: await response.json() };
+}
+
+async function failInitial(context: Awaited<ReturnType<typeof setup>>) {
+	let [claimed] = await context.storage.jobs.claim({
+		channelId: context.channel.id,
+		claimOwner: "route-failing-worker",
+		count: 1,
+		ttlMs: 30_000,
+		now: new Date(context.now.getTime() + 1),
+		lease: context.lease,
+	});
+	if (!claimed) throw new Error("route evidence job was not claimable");
+	await context.storage.jobs.fail({
+		channelId: context.channel.id,
+		jobId: claimed.id,
+		claimOwner: "route-failing-worker",
+		claimGeneration: claimed.claimGeneration,
+		reason: "private failure",
+		now: new Date(context.now.getTime() + 2),
+		lease: context.lease,
+	});
+}
+
+function retryMutation(origin = "https://chopin.test"): RequestInit {
+	return { method: "POST", headers: { origin } };
 }
 
 describe("research workspace routes", () => {
@@ -247,6 +283,111 @@ describe("research workspace routes", () => {
 			context.cookie,
 		));
 		expect(read?.status).toBe(200);
+	});
+
+	it("starts inline research without replacing private workspace creation", async () => {
+		let context = await setup();
+		let draft = await create(context);
+		expect(draft.body.workspace.origin).toBe("sidebar");
+		expect(context.owners).toEqual([]);
+
+		let inline = await createInline(context);
+		expect(inline.response.status).toBe(201);
+		expect(inline.body).toMatchObject({
+			repeated: false,
+			request: { question: "What changed?", stage: "queued" },
+		});
+		expect(context.owners).toEqual([context.channel.id]);
+		expect(await context.storage.research.list(context.channel.id, 100)).toHaveLength(2);
+
+		let path =
+			`/api/channels/${context.channel.id}/research-requests/${inline.body.request.id}`;
+		let observed = await context.router.handle(request(path, context.cookie));
+		expect(observed?.status).toBe(200);
+		expect(await observed!.json()).toMatchObject({ id: inline.body.request.id });
+
+		let cancelled = await context.router.handle(request(
+			`${path}/cancel`,
+			context.cookie,
+			mutation({}),
+		));
+		expect(cancelled?.status).toBe(200);
+		expect(await cancelled!.json()).toMatchObject({ stage: "cancelled" });
+	});
+
+	it("retries a failed request without minting another workspace", async () => {
+		let context = await setup();
+		let created = await createInline(context);
+		await failInitial(context);
+		let path =
+			`/api/channels/${context.channel.id}/research-requests/${created.body.request.id}/retry`;
+
+		let retried = await context.router.handle(request(
+			path,
+			context.cookie,
+			retryMutation(),
+		));
+
+		expect(retried?.status).toBe(200);
+		expect(await retried!.json()).toMatchObject({
+			id: created.body.request.id,
+			question: created.body.request.question,
+			stage: "queued",
+		});
+		expect(await context.storage.research.list(context.channel.id, 100)).toHaveLength(1);
+		expect(context.owners).toEqual([context.channel.id, context.channel.id]);
+		expect(
+			(await context.router.handle(request(
+				path,
+				context.cookie,
+				retryMutation(),
+			)))?.status,
+		).toBe(409);
+	});
+
+	it("enforces retry origin, authentication, write access, and archive state", async () => {
+		let context = await setup();
+		let created = await createInline(context);
+		await failInitial(context);
+		let path =
+			`/api/channels/${context.channel.id}/research-requests/${created.body.request.id}/retry`;
+
+		expect((await context.router.handle(request(path, undefined, retryMutation())))?.status)
+			.toBe(401);
+		expect(
+			(await context.router.handle(request(
+				path,
+				context.cookie,
+				retryMutation("https://evil.test"),
+			)))?.status,
+		).toBe(403);
+		context.access.repository = {
+			...context.access.repository,
+			permissions: { pull: true, push: false, admin: false },
+		};
+		expect(
+			(await context.router.handle(request(
+				path,
+				context.cookie,
+				retryMutation(),
+			)))?.status,
+		).toBe(403);
+		context.access.repository = {
+			...context.access.repository,
+			permissions: { pull: true, push: true, admin: false },
+		};
+		await context.storage.channels.archive({
+			id: context.channel.id,
+			now: new Date(context.now.getTime() + 3),
+		});
+		expect(
+			(await context.router.handle(request(
+				path,
+				context.cookie,
+				retryMutation(),
+			)))?.status,
+		).toBe(409);
+		expect(context.owners).toEqual([context.channel.id]);
 	});
 
 	it("returns inaccessible and cross-channel children as not found", async () => {

--- a/apps/server/src/research/routes.ts
+++ b/apps/server/src/research/routes.ts
@@ -295,6 +295,37 @@ export function registerResearchWorkspaceRoutes(
 	);
 
 	router.on(
+		"POST",
+		"/api/channels/:channelId/research-requests",
+		async (request, _url, params) => {
+			let denied = origin(request, auth);
+			if (denied) return denied;
+			try {
+				let session = await auth.sessions.authenticate(request);
+				if (!session) return json({ error: "authentication required" }, 401);
+				let access = await channelAccess(auth, session, params.channelId!);
+				if (!access) return json({ error: "channel not found" }, 404);
+				if (!canWrite(access.repository)) {
+					return json({ error: "repository write access is required" }, 403);
+				}
+				let input = await body(request, ["question", "requestId"]);
+				if (!input) return json({ error: "question and requestId are required" }, 400);
+				let created = await service.start({
+					channelId: access.channel.id,
+					question: input.question as string,
+					requestId: input.requestId as string,
+					requestedBy: session.user.id,
+					requestedByHandle: session.user.login,
+					beforeStart: () => options.ensureOwner(access.channel, access.session, access.repository),
+				});
+				return json(created, created.repeated ? 200 : 201);
+			} catch (err) {
+				return failure(err, auth);
+			}
+		},
+	);
+
+	router.on(
 		"GET",
 		"/api/channels/:channelId/research-workspaces/:workspaceId",
 		async (request, _url, params) => {
@@ -414,6 +445,82 @@ export function registerResearchWorkspaceRoutes(
 				return json(workspace, 200, {
 					location: location(access.channel, access.repository, workspace.workspace.id),
 				});
+			} catch (err) {
+				return failure(err, auth);
+			}
+		},
+	);
+
+	router.on(
+		"GET",
+		"/api/channels/:channelId/research-requests/:workspaceId",
+		async (request, _url, params) => {
+			try {
+				let session = await auth.sessions.authenticate(request);
+				if (!session) return json({ error: "authentication required" }, 401);
+				let access = await channelAccess(auth, session, params.channelId!);
+				if (!access) return json({ error: "research request not found" }, 404);
+				let researchRequest = await service.request(access.channel.id, params.workspaceId!);
+				return researchRequest
+					? json(researchRequest)
+					: json({ error: "research request not found" }, 404);
+			} catch (err) {
+				return failure(err, auth);
+			}
+		},
+	);
+
+	router.on(
+		"POST",
+		"/api/channels/:channelId/research-requests/:workspaceId/retry",
+		async (request, _url, params) => {
+			let denied = origin(request, auth);
+			if (denied) return denied;
+			try {
+				let session = await auth.sessions.authenticate(request);
+				if (!session) return json({ error: "authentication required" }, 401);
+				let access = await channelAccess(auth, session, params.channelId!);
+				if (!access) return json({ error: "research request not found" }, 404);
+				if (!canWrite(access.repository)) {
+					return json({ error: "repository write access is required" }, 403);
+				}
+				if (access.channel.archivedAt) {
+					return json({ error: "document is archived" }, 409);
+				}
+				let researchRequest = await service.retryRequest({
+					channelId: access.channel.id,
+					workspaceId: params.workspaceId!,
+					beforeStart: () => options.ensureOwner(access.channel, access.session, access.repository),
+				});
+				return json(researchRequest);
+			} catch (err) {
+				return failure(err, auth);
+			}
+		},
+	);
+
+	router.on(
+		"POST",
+		"/api/channels/:channelId/research-requests/:workspaceId/cancel",
+		async (request, _url, params) => {
+			let denied = origin(request, auth);
+			if (denied) return denied;
+			try {
+				let session = await auth.sessions.authenticate(request);
+				if (!session) return json({ error: "authentication required" }, 401);
+				let access = await channelAccess(auth, session, params.channelId!);
+				if (!access) return json({ error: "research request not found" }, 404);
+				if (!canWrite(access.repository)) {
+					return json({ error: "repository write access is required" }, 403);
+				}
+				if (access.channel.archivedAt) {
+					return json({ error: "document is archived" }, 409);
+				}
+				let researchRequest = await service.cancelRequest({
+					channelId: access.channel.id,
+					workspaceId: params.workspaceId!,
+				});
+				return json(researchRequest);
 			} catch (err) {
 				return failure(err, auth);
 			}

--- a/apps/server/src/research/service.test.ts
+++ b/apps/server/src/research/service.test.ts
@@ -258,14 +258,19 @@ describe("research workspace service", () => {
 		expect((await context.jobs.list(context.channelId, 100))?.jobs).toHaveLength(1);
 	});
 
-	it("relinks existing first evidence work during restart reconciliation", async () => {
+	it("adopts orphan first evidence only after an owner-checked exact retry", async () => {
 		let context = await setup();
-		await expect(context.service.start({
+		let owners = 0;
+		let input = {
 			channelId: context.channelId,
 			question: "Which API contracts changed?",
 			requestId: requestId(1),
 			requestedBy: context.userId,
+		};
+		await expect(context.service.start({
+			...input,
 			beforeStart: () => {
+				owners++;
 				throw new Error("simulate a crash before first enqueue");
 			},
 		})).rejects.toThrow("simulate a crash before first enqueue");
@@ -303,7 +308,21 @@ describe("research workspace service", () => {
 		expect(
 			(await context.storage.research.get(context.channelId, workspace.id))?.turns[0]
 				?.evidenceJobId,
+		).toBeUndefined();
+		expect((await context.jobs.list(context.channelId, 100))?.jobs).toHaveLength(1);
+
+		let recovered = await context.restart().start({
+			...input,
+			beforeStart: () => {
+				owners++;
+			},
+		});
+		expect(recovered.repeated).toBe(true);
+		expect(
+			(await context.storage.research.get(context.channelId, workspace.id))?.turns[0]
+				?.evidenceJobId,
 		).toBe(existing.job.id);
+		expect(owners).toBe(2);
 		expect((await context.jobs.list(context.channelId, 100))?.jobs).toHaveLength(1);
 	});
 

--- a/apps/server/src/research/service.test.ts
+++ b/apps/server/src/research/service.test.ts
@@ -260,9 +260,8 @@ describe("research workspace service", () => {
 		let [workspace] = await context.storage.research.list(context.channelId, 100);
 		if (!workspace) throw new Error("durable research request is unavailable");
 
-		let restarted = context.restart();
-		let observed = await reconciledRequest(restarted, context.channelId, workspace.id);
-		expect(observed).toMatchObject({ state: "pending", stage: "queued" });
+		let observed = await context.restart().request(context.channelId, workspace.id);
+		expect(observed).toMatchObject({ state: "failed", stage: "failed" });
 		expect(
 			(await context.storage.research.get(context.channelId, workspace.id))?.turns[0]
 				?.evidenceJobId,
@@ -316,7 +315,7 @@ describe("research workspace service", () => {
 
 		let reader = context.restart();
 		let before = await reader.request(context.channelId, workspace.id);
-		expect(before).toMatchObject({ state: "pending", stage: "queued" });
+		expect(before).toMatchObject({ state: "failed", stage: "failed" });
 		expect(
 			(await context.storage.research.get(context.channelId, workspace.id))?.turns[0]
 				?.evidenceJobId,
@@ -327,7 +326,7 @@ describe("research workspace service", () => {
 			context.channelId,
 			workspace.id,
 		);
-		expect(observed).toMatchObject({ state: "pending", stage: "queued" });
+		expect(observed).toMatchObject({ state: "failed", stage: "failed" });
 		expect(
 			(await context.storage.research.get(context.channelId, workspace.id))?.turns[0]
 				?.evidenceJobId,

--- a/apps/server/src/research/service.test.ts
+++ b/apps/server/src/research/service.test.ts
@@ -24,6 +24,28 @@ import {
 import type { ResearchReport } from "../jobs/research-workspace";
 import type { JsonValue } from "../storage/model";
 
+async function failInitialEvidence(context: Awaited<ReturnType<typeof setup>>) {
+	let [claimed] = await context.storage.jobs.claim({
+		channelId: context.channelId,
+		claimOwner: "failing-worker",
+		count: 1,
+		ttlMs: 30_000,
+		now: context.advance(),
+		lease: context.lease,
+	});
+	if (!claimed) throw new Error("initial evidence job was not claimable");
+	await context.storage.jobs.fail({
+		channelId: context.channelId,
+		jobId: claimed.id,
+		claimOwner: "failing-worker",
+		claimGeneration: claimed.claimGeneration,
+		reason: "internal-provider-detail",
+		now: context.advance(),
+		lease: context.lease,
+	});
+	return claimed.id;
+}
+
 describe("research workspace service", () => {
 	it("starts one inline request and schedules its initial turn immediately", async () => {
 		let context = await setup();
@@ -636,6 +658,141 @@ describe("research workspace service", () => {
 				cancelledRequest.request.id,
 			))?.workspace.publishedChannelId,
 		).toBeUndefined();
+	});
+
+	it("retries failed and cancelled work on the same immutable request", async () => {
+		for (let terminal of ["failed", "cancelled"] as const) {
+			let context = await setup();
+			let started = await context.service.start({
+				channelId: context.channelId,
+				question: `  Preserve the ${terminal} brief exactly.  `,
+				requestId: requestId(31),
+				requestedBy: context.userId,
+			});
+			let before = await context.storage.research.get(context.channelId, started.request.id);
+			let oldJobId = before!.turns[0]!.evidenceJobId!;
+			if (terminal === "failed") await failInitialEvidence(context);
+			else {
+				await context.service.cancelRequest({
+					channelId: context.channelId,
+					workspaceId: started.request.id,
+				});
+			}
+			let owners = 0;
+
+			let retried = await context.service.retryRequest({
+				channelId: context.channelId,
+				workspaceId: started.request.id,
+				beforeStart: () => {
+					owners++;
+				},
+			});
+
+			expect(retried).toMatchObject({
+				id: started.request.id,
+				question: started.request.question,
+				stage: "queued",
+			});
+			let after = await context.storage.research.get(context.channelId, started.request.id);
+			expect(after!.turns).toHaveLength(1);
+			expect(after!.turns[0]!.evidenceJobId).not.toBe(oldJobId);
+			expect(await context.storage.research.findTurnByJob(context.channelId, oldJobId))
+				.toBeUndefined();
+			expect(owners).toBe(1);
+		}
+	});
+
+	it("rejects retry for active and ready requests", async () => {
+		let active = await setup();
+		let activeRequest = await active.service.start({
+			channelId: active.channelId,
+			question: "Active request",
+			requestId: requestId(32),
+			requestedBy: active.userId,
+		});
+		await expect(active.service.retryRequest({
+			channelId: active.channelId,
+			workspaceId: activeRequest.request.id,
+		})).rejects.toMatchObject({ code: "active-turn" });
+
+		let ready = await setup();
+		let readyRequest = await ready.service.start({
+			channelId: ready.channelId,
+			question: "Ready request",
+			requestId: requestId(33),
+			requestedBy: ready.userId,
+		});
+		let evidence = await settle(ready, "research-evidence", evidenceArtifact);
+		await ready.service.jobChanged(evidence.job);
+		let answer = await settle(ready, "research-answer", answerArtifact);
+		await ready.service.jobChanged(answer.job);
+		expect((await ready.service.request(ready.channelId, readyRequest.request.id))?.stage)
+			.toBe("ready");
+		await expect(ready.service.retryRequest({
+			channelId: ready.channelId,
+			workspaceId: readyRequest.request.id,
+		})).rejects.toMatchObject({ code: "not-ready" });
+	});
+
+	it("creates at most one new evidence job across concurrent retries", async () => {
+		let context = await setup();
+		let started = await context.service.start({
+			channelId: context.channelId,
+			question: "Retry concurrently",
+			requestId: requestId(34),
+			requestedBy: context.userId,
+		});
+		await failInitialEvidence(context);
+		let owners = 0;
+		let retry = () =>
+			context.service.retryRequest({
+				channelId: context.channelId,
+				workspaceId: started.request.id,
+				beforeStart: () => {
+					owners++;
+				},
+			});
+
+		let results = await Promise.allSettled([retry(), retry()]);
+
+		expect(results.filter(result => result.status === "fulfilled")).toHaveLength(1);
+		expect(results.filter(result => result.status === "rejected")).toHaveLength(1);
+		let jobs = await context.storage.jobs.list(context.channelId, 100);
+		expect(jobs!.jobs.filter(job => job.type === "research-evidence")).toHaveLength(2);
+		expect(owners).toBe(1);
+	});
+
+	it("requires an explicit retry to recover after links were durably cleared", async () => {
+		let context = await setup();
+		let started = await context.service.start({
+			channelId: context.channelId,
+			question: "Recover a cleared retry",
+			requestId: requestId(35),
+			requestedBy: context.userId,
+		});
+		let oldJobId = await failInitialEvidence(context);
+		await context.storage.research.resetInitialAttempt({
+			channelId: context.channelId,
+			workspaceId: started.request.id,
+			expectedEvidenceJobId: oldJobId,
+			expectedAnswerJobId: undefined,
+			now: context.advance(),
+			lease: context.lease,
+		});
+		let beforeRead = await context.storage.jobs.list(context.channelId, 100);
+
+		let observed = await context.restart().request(context.channelId, started.request.id);
+
+		expect(observed).toMatchObject({ stage: "queued", question: started.request.question });
+		expect((await context.storage.jobs.list(context.channelId, 100))!.jobs)
+			.toHaveLength(beforeRead!.jobs.length);
+		await context.restart().retryRequest({
+			channelId: context.channelId,
+			workspaceId: started.request.id,
+		});
+		let recovered = await context.storage.research.get(context.channelId, started.request.id);
+		expect(recovered!.turns[0]!.evidenceJobId).toBeDefined();
+		expect(recovered!.turns[0]!.evidenceJobId).not.toBe(oldJobId);
 	});
 
 	it("publishes a deterministic available child title when the report title already exists", async () => {

--- a/apps/server/src/research/service.test.ts
+++ b/apps/server/src/research/service.test.ts
@@ -194,6 +194,7 @@ describe("research workspace service", () => {
 		expect(durable).toHaveLength(1);
 		expect((await recovery.storage.research.get(recovery.channelId, durable[0]!.id))?.turns[0])
 			.toMatchObject({ kind: "initial", evidenceJobId: undefined });
+		expect(recovery.publications).toEqual([]);
 		let recovered = await recovery.service.start({
 			...recoveryInput,
 			beforeStart: () => {
@@ -240,7 +241,7 @@ describe("research workspace service", () => {
 		expect(owners).toBe(1);
 	});
 
-	it("keeps reads observational until owner setup succeeds on an exact retry", async () => {
+	it("exposes owner setup recovery without starting work on read", async () => {
 		let context = await setup();
 		let owners = 0;
 		let input = {
@@ -702,6 +703,65 @@ describe("research workspace service", () => {
 		}
 	});
 
+	it("replaces terminal answer attempts before publishing the retried request", async () => {
+		for (let terminal of ["failed", "cancelled"] as const) {
+			let context = await setup();
+			let started = await context.service.start({
+				channelId: context.channelId,
+				question: `Retry a ${terminal} answer`,
+				requestId: requestId(36),
+				requestedBy: context.userId,
+			});
+			let firstEvidence = await settle(context, "research-evidence", evidenceArtifact);
+			await context.service.jobChanged(firstEvidence.job);
+			let before = await context.storage.research.get(context.channelId, started.request.id);
+			let oldAnswerId = before!.turns[0]!.answerJobId!;
+			if (terminal === "failed") {
+				let [answer] = await context.storage.jobs.claim({
+					channelId: context.channelId,
+					claimOwner: "failing-answer-worker",
+					count: 100,
+					ttlMs: 30_000,
+					now: context.advance(),
+					lease: context.lease,
+				});
+				await context.storage.jobs.fail({
+					channelId: context.channelId,
+					jobId: answer!.id,
+					claimOwner: "failing-answer-worker",
+					claimGeneration: answer!.claimGeneration,
+					reason: "answer failed",
+					now: context.advance(),
+					lease: context.lease,
+				});
+			} else {
+				await context.service.cancelRequest({
+					channelId: context.channelId,
+					workspaceId: started.request.id,
+				});
+			}
+
+			await context.service.retryRequest({
+				channelId: context.channelId,
+				workspaceId: started.request.id,
+			});
+			expect(await context.storage.research.findTurnByJob(context.channelId, oldAnswerId))
+				.toBeUndefined();
+			let nextEvidence = await settle(context, "research-evidence", evidenceArtifact);
+			await context.service.jobChanged(nextEvidence.job);
+			let retried = await context.storage.research.get(context.channelId, started.request.id);
+			let nextAnswerId = retried!.turns[0]!.answerJobId;
+			expect(nextAnswerId).toBeDefined();
+			if (!nextAnswerId) throw new Error("retried answer was not linked");
+			expect(nextAnswerId).not.toBe(oldAnswerId);
+			let nextAnswer = await settle(context, "research-answer", answerArtifact);
+			expect(nextAnswer.job.id).toBe(nextAnswerId);
+			await context.service.jobChanged(nextAnswer.job);
+			expect(await context.service.request(context.channelId, started.request.id))
+				.toMatchObject({ id: started.request.id, stage: "ready" });
+		}
+	});
+
 	it("rejects retry for active and ready requests", async () => {
 		let active = await setup();
 		let activeRequest = await active.service.start({
@@ -783,7 +843,12 @@ describe("research workspace service", () => {
 
 		let observed = await context.restart().request(context.channelId, started.request.id);
 
-		expect(observed).toMatchObject({ stage: "queued", question: started.request.question });
+		expect(observed).toMatchObject({
+			state: "failed",
+			stage: "failed",
+			error: "Research could not be completed.",
+			question: started.request.question,
+		});
 		expect((await context.storage.jobs.list(context.channelId, 100))!.jobs)
 			.toHaveLength(beforeRead!.jobs.length);
 		await context.restart().retryRequest({

--- a/apps/server/src/research/service.ts
+++ b/apps/server/src/research/service.ts
@@ -456,14 +456,7 @@ export class ResearchWorkspaceService {
 			if (!initial) {
 				throw new ResearchWorkspaceError("invalid-state", "Research request has no initial work.");
 			}
-			if (initial.evidenceJobId === undefined) {
-				let existing = await this.#targetJob(
-					current.workspace.channelId,
-					"research-evidence",
-					this.#target(current.workspace.id, initial.id, "evidence"),
-				);
-				if (!existing) await input.beforeStart?.();
-			}
+			if (initial.evidenceJobId === undefined) await input.beforeStart?.();
 			await this.#ensureEvidence(current.workspace, initial);
 		});
 		let request = await this.request(input.channelId, stored.workspace.id);
@@ -797,14 +790,6 @@ export class ResearchWorkspaceService {
 			}
 			let changed = false;
 			for (let savedTurn of detail.turns) {
-				if (
-					(savedTurn.kind === "initial" || savedTurn.kind === "search-more")
-					&& savedTurn.evidenceJobId === undefined
-					&& this.#hasDefinition("research-evidence")
-				) {
-					changed = await this.#ensureEvidence(detail.workspace, savedTurn, false);
-					if (changed) break;
-				}
 				if (savedTurn.evidenceJobId && savedTurn.answerJobId === undefined) {
 					let evidence = await this.#jobs.get(channelId, savedTurn.evidenceJobId);
 					if (evidence?.job.state === "completed" && this.#hasDefinition("research-answer")) {
@@ -871,16 +856,11 @@ export class ResearchWorkspaceService {
 		});
 	}
 
-	async #ensureEvidence(
-		workspace: ResearchWorkspace,
-		savedTurn: ResearchTurn,
-		enqueue = true,
-	): Promise<boolean> {
+	async #ensureEvidence(workspace: ResearchWorkspace, savedTurn: ResearchTurn): Promise<boolean> {
 		if (savedTurn.evidenceJobId !== undefined) return false;
 		this.#requireDefinition("research-evidence");
 		let targetKey = this.#target(workspace.id, savedTurn.id, "evidence");
 		let existing = await this.#targetJob(workspace.channelId, "research-evidence", targetKey);
-		if (!existing && !enqueue) return false;
 		let job = existing ?? (await this.#jobs.enqueueUser({
 			channelId: workspace.channelId,
 			type: "research-evidence",

--- a/apps/server/src/research/service.ts
+++ b/apps/server/src/research/service.ts
@@ -143,6 +143,10 @@ export type CancelResearchRequest = {
 	workspaceId: string;
 };
 
+export type RetryResearchRequest = CancelResearchRequest & {
+	beforeStart?: () => void | Promise<void>;
+};
+
 export type ResearchWorkspaceTurnView = Research.Turn & {
 	readonly evidence?: Job.Detail;
 	readonly answer?: Job.Detail;
@@ -729,6 +733,64 @@ export class ResearchWorkspaceService {
 		});
 	}
 
+	async retryRequest(input: RetryResearchRequest): Promise<Research.RequestView> {
+		let channelId = safeId(input.channelId, "Channel id");
+		let workspaceId = safeId(input.workspaceId, "Workspace id");
+		return this.#exclusive(channelId, workspaceId, async () => {
+			let detail = await this.#reconciled(channelId, workspaceId);
+			if (!detail) throw new ResearchWorkspaceError("not-found", "Research request not found.");
+			if (detail.workspace.publishedChannelId) {
+				throw new ResearchWorkspaceError("not-ready", "Research request is already ready.");
+			}
+			let initial = detail.turns.find(value => value.kind === "initial");
+			if (!initial) {
+				throw new ResearchWorkspaceError("invalid-state", "Research request has no initial work.");
+			}
+			let linked = [
+				...(initial.evidenceJobId
+					? [{ id: initial.evidenceJobId, role: "evidence" as const }]
+					: []),
+				...(initial.answerJobId
+					? [{ id: initial.answerJobId, role: "answer" as const }]
+					: []),
+			];
+			let terminal = linked.length === 0;
+			for (let candidate of linked) {
+				let current = await this.#jobs.get(channelId, candidate.id);
+				if (!current) {
+					throw new ResearchWorkspaceError("invalid-state", "Linked research work is missing.");
+				}
+				this.#assertLinkedJob(current, detail.workspace, initial, candidate.role);
+				if (ACTIVE_JOB_STATES.has(current.job.state)) {
+					throw new ResearchWorkspaceError("active-turn", "Research request is still active.");
+				}
+				if (["failed", "cancelled", "superseded"].includes(current.job.state)) terminal = true;
+			}
+			if (!terminal) {
+				throw new ResearchWorkspaceError("not-ready", "Research request cannot be retried.");
+			}
+			let reset = await this.#storage.research.resetInitialAttempt({
+				channelId,
+				workspaceId,
+				expectedEvidenceJobId: initial.evidenceJobId,
+				expectedAnswerJobId: initial.answerJobId,
+				now: this.#time(),
+				lease: this.#lease(),
+			});
+			if (!reset.repeated) await this.#published(reset.workspace);
+			await input.beforeStart?.();
+			let cleared = await this.#stored(channelId, workspaceId);
+			let clearedInitial = cleared.turns.find(value => value.kind === "initial");
+			if (!clearedInitial) {
+				throw new ResearchWorkspaceError("invalid-state", "Research request has no initial work.");
+			}
+			await this.#ensureEvidence(cleared.workspace, clearedInitial);
+			let refreshed = await this.#reconciled(channelId, workspaceId);
+			if (!refreshed) throw new ResearchWorkspaceError("not-found", "Research request not found.");
+			return this.#requestView(refreshed);
+		});
+	}
+
 	async #cancelActiveTurn(
 		detail: ResearchWorkspaceDetail,
 		found: ResearchTurn,
@@ -860,12 +922,13 @@ export class ResearchWorkspaceService {
 		if (savedTurn.evidenceJobId !== undefined) return false;
 		this.#requireDefinition("research-evidence");
 		let targetKey = this.#target(workspace.id, savedTurn.id, "evidence");
-		let existing = await this.#targetJob(workspace.channelId, "research-evidence", targetKey);
+		let found = await this.#targetJob(workspace.channelId, "research-evidence", targetKey);
+		let existing = found && ACTIVE_JOB_STATES.has(found.state) ? found : undefined;
 		let job = existing ?? (await this.#jobs.enqueueUser({
 			channelId: workspace.channelId,
 			type: "research-evidence",
 			targetKey,
-			idempotencyKey: `research-evidence:${savedTurn.id}`,
+			idempotencyKey: `research-evidence:${savedTurn.id}:${workspace.revision}`,
 			input: {
 				workspaceId: workspace.id,
 				turnId: savedTurn.id,

--- a/apps/server/src/research/service.ts
+++ b/apps/server/src/research/service.ts
@@ -6,7 +6,7 @@ import {
 	parseResearchAnswerInput,
 	parseResearchEvidenceArtifact,
 } from "../jobs/research-workspace";
-import { RESEARCH_REPOSITORY_WORKSPACE_LIMIT } from "../storage/model";
+import { RESEARCH_REPOSITORY_WORKSPACE_LIMIT, researchAttemptDisposition } from "../storage/model";
 import { MAX_TITLE_LENGTH } from "../channels/title";
 import { publishInitialResearchChild } from "./publication";
 import { projectRequestView } from "./request-view";
@@ -20,6 +20,7 @@ import type {
 import type { JobDetail, JobService, JobView } from "../jobs/service";
 import type { DocumentTarget } from "../plan/service";
 import type {
+	BackgroundJobState,
 	JsonValue,
 	Lease,
 	ResearchMessage,
@@ -753,19 +754,20 @@ export class ResearchWorkspaceService {
 					? [{ id: initial.answerJobId, role: "answer" as const }]
 					: []),
 			];
-			let terminal = linked.length === 0;
+			let states: BackgroundJobState[] = [];
 			for (let candidate of linked) {
 				let current = await this.#jobs.get(channelId, candidate.id);
 				if (!current) {
 					throw new ResearchWorkspaceError("invalid-state", "Linked research work is missing.");
 				}
 				this.#assertLinkedJob(current, detail.workspace, initial, candidate.role);
-				if (ACTIVE_JOB_STATES.has(current.job.state)) {
-					throw new ResearchWorkspaceError("active-turn", "Research request is still active.");
-				}
-				if (["failed", "cancelled", "superseded"].includes(current.job.state)) terminal = true;
+				states.push(current.job.state);
 			}
-			if (!terminal) {
+			let disposition = researchAttemptDisposition(states);
+			if (disposition === "active") {
+				throw new ResearchWorkspaceError("active-turn", "Research request is still active.");
+			}
+			if (disposition !== "retryable") {
 				throw new ResearchWorkspaceError("not-ready", "Research request cannot be retried.");
 			}
 			let reset = await this.#storage.research.resetInitialAttempt({

--- a/apps/server/src/research/service.ts
+++ b/apps/server/src/research/service.ts
@@ -453,7 +453,6 @@ export class ResearchWorkspaceService {
 			now: this.#time(),
 			lease: this.#lease(),
 		});
-		if (!stored.repeated) await this.#published(stored.workspace);
 		await this.#exclusive(input.channelId, stored.workspace.id, async () => {
 			let current = await this.#stored(input.channelId, stored.workspace.id);
 			let initial = current.turns.find(value => value.kind === "initial");
@@ -953,7 +952,8 @@ export class ResearchWorkspaceService {
 		this.#requireDefinition("research-answer");
 		let workspace = detail.workspace;
 		let targetKey = this.#target(workspace.id, savedTurn.id, "answer");
-		let existing = await this.#targetJob(workspace.channelId, "research-answer", targetKey);
+		let found = await this.#targetJob(workspace.channelId, "research-answer", targetKey);
+		let existing = found && ACTIVE_JOB_STATES.has(found.state) ? found : undefined;
 		let job: JobView;
 		if (existing) job = existing;
 		else {
@@ -962,7 +962,7 @@ export class ResearchWorkspaceService {
 				channelId: workspace.channelId,
 				type: "research-answer",
 				targetKey,
-				idempotencyKey: `research-answer:${savedTurn.id}`,
+				idempotencyKey: `research-answer:${savedTurn.id}:${workspace.revision}`,
 				input: input as JsonValue,
 			});
 			job = enqueued.job;

--- a/apps/server/src/storage/contract.ts
+++ b/apps/server/src/storage/contract.ts
@@ -2089,6 +2089,155 @@ export function storageContract(name: string, factory: Factory): void {
 			}
 		});
 
+		it("clears only terminal initial research links with concurrency guards", async () => {
+			let storage = await opened(factory);
+			try {
+				let { userId, channelId, lease } = await userAndChannel(storage);
+				let started = await storage.research.start({
+					id: id("retry-workspace"),
+					channelId,
+					title: "Retry research",
+					question: "Which contract failed?",
+					origin: "inline",
+					createdBy: userId,
+					turnId: id("retry-turn"),
+					messageId: id("retry-message"),
+					requestId: id("retry-request"),
+					idempotencyKey: id("retry-start"),
+					fingerprint: "sha256:retry-start",
+					now: new Date("2026-01-07T03:04:05.000Z"),
+					lease,
+				});
+				let targetKey =
+					`research-evidence:workspace:${started.workspace.id}:turn:${started.turn.id}:evidence`;
+				let evidence = await storage.jobs.enqueue(backgroundJob(channelId, lease, {
+					id: id("retry-evidence"),
+					idempotencyKey: id("retry-evidence-enqueue"),
+					type: "research-evidence",
+					targetKey,
+					now: new Date("2026-01-07T03:04:06.000Z"),
+				}));
+				await storage.research.linkJob({
+					channelId,
+					workspaceId: started.workspace.id,
+					turnId: started.turn.id,
+					role: "evidence",
+					jobId: evidence.job.id,
+					now: new Date("2026-01-07T03:04:06.000Z"),
+					lease,
+				});
+				await expect(storage.research.resetInitialAttempt({
+					channelId,
+					workspaceId: started.workspace.id,
+					expectedEvidenceJobId: evidence.job.id,
+					expectedAnswerJobId: undefined,
+					now: new Date("2026-01-07T03:04:07.000Z"),
+					lease,
+				})).rejects.toMatchObject({ failure: "conflict" });
+
+				let [claimed] = await storage.jobs.claim({
+					channelId,
+					claimOwner: "retry-worker",
+					count: 1,
+					ttlMs: 10_000,
+					now: new Date("2026-01-07T03:04:08.000Z"),
+					lease,
+				});
+				await storage.jobs.fail({
+					channelId,
+					jobId: claimed!.id,
+					claimOwner: "retry-worker",
+					claimGeneration: claimed!.claimGeneration,
+					reason: "safe-retry",
+					now: new Date("2026-01-07T03:04:09.000Z"),
+					lease,
+				});
+				let answer = await storage.jobs.enqueue(backgroundJob(channelId, lease, {
+					id: id("retry-answer"),
+					idempotencyKey: id("retry-answer-enqueue"),
+					type: "research-answer",
+					targetKey:
+						`research-answer:workspace:${started.workspace.id}:turn:${started.turn.id}:answer`,
+					now: new Date("2026-01-07T03:04:09.000Z"),
+				}));
+				await storage.research.linkJob({
+					channelId,
+					workspaceId: started.workspace.id,
+					turnId: started.turn.id,
+					role: "answer",
+					jobId: answer.job.id,
+					now: new Date("2026-01-07T03:04:09.000Z"),
+					lease,
+				});
+				await expect(storage.research.resetInitialAttempt({
+					channelId,
+					workspaceId: started.workspace.id,
+					expectedEvidenceJobId: evidence.job.id,
+					expectedAnswerJobId: answer.job.id,
+					now: new Date("2026-01-07T03:04:09.000Z"),
+					lease,
+				})).rejects.toMatchObject({ failure: "conflict" });
+				let [claimedAnswer] = await storage.jobs.claim({
+					channelId,
+					claimOwner: "retry-worker",
+					count: 1,
+					ttlMs: 10_000,
+					now: new Date("2026-01-07T03:04:09.000Z"),
+					lease,
+				});
+				await storage.jobs.fail({
+					channelId,
+					jobId: claimedAnswer!.id,
+					claimOwner: "retry-worker",
+					claimGeneration: claimedAnswer!.claimGeneration,
+					reason: "safe-retry",
+					now: new Date("2026-01-07T03:04:10.000Z"),
+					lease,
+				});
+				let reset = await storage.research.resetInitialAttempt({
+					channelId,
+					workspaceId: started.workspace.id,
+					expectedEvidenceJobId: evidence.job.id,
+					expectedAnswerJobId: answer.job.id,
+					now: new Date("2026-01-07T03:04:11.000Z"),
+					lease,
+				});
+
+				expect(reset).toMatchObject({
+					repeated: false,
+					turn: {
+						id: started.turn.id,
+						question: "Which contract failed?",
+						evidenceJobId: undefined,
+						answerJobId: undefined,
+					},
+				});
+				expect(await storage.research.findTurnByJob(channelId, evidence.job.id))
+					.toBeUndefined();
+				expect(await storage.research.findTurnByJob(channelId, answer.job.id))
+					.toBeUndefined();
+				let replay = await storage.research.resetInitialAttempt({
+					channelId,
+					workspaceId: started.workspace.id,
+					expectedEvidenceJobId: undefined,
+					expectedAnswerJobId: undefined,
+					now: new Date("2026-01-07T03:04:12.000Z"),
+					lease,
+				});
+				expect(replay).toMatchObject({ repeated: true, turn: { id: started.turn.id } });
+				await expect(storage.research.resetInitialAttempt({
+					channelId,
+					workspaceId: started.workspace.id,
+					expectedEvidenceJobId: evidence.job.id,
+					expectedAnswerJobId: undefined,
+					now: new Date("2026-01-07T03:04:13.000Z"),
+					lease,
+				})).rejects.toMatchObject({ failure: "conflict" });
+			} finally {
+				await storage.close();
+			}
+		});
+
 		it("enqueues background targets idempotently without collaboration side effects", async () => {
 			let storage = await opened(factory);
 			try {

--- a/apps/server/src/storage/memory/research.ts
+++ b/apps/server/src/storage/memory/research.ts
@@ -4,6 +4,7 @@ import {
 	RESEARCH_REPOSITORY_CHANNEL_LIMIT,
 	RESEARCH_REPOSITORY_CHANNEL_WORKSPACE_LIMIT,
 	RESEARCH_REPOSITORY_WORKSPACE_LIMIT,
+	researchAttemptDisposition,
 } from "../model";
 
 import type {
@@ -12,6 +13,7 @@ import type {
 	AppendResearchTurn,
 	AppendResearchTurnResult,
 	BackgroundJobDetail,
+	BackgroundJobState,
 	ChannelRecord,
 	ConfirmResearchWorkspace,
 	ConfirmResearchWorkspaceResult,
@@ -487,19 +489,22 @@ export class MemoryResearchWorkspaceStore implements ResearchWorkspaceStore {
 			if (!foundTurn.evidenceJobId && !foundTurn.answerJobId) {
 				return { workspace: workspace(found), turn: turn(foundTurn), repeated: true };
 			}
-			let terminal = false;
+			let states: BackgroundJobState[] = [];
 			for (let jobId of [foundTurn.evidenceJobId, foundTurn.answerJobId]) {
 				if (!jobId) continue;
 				let detail = await this.#options.job(input.channelId, jobId);
 				if (!detail) {
 					throw missing(`background job ${jobId} does not exist in channel ${input.channelId}`);
 				}
-				if (["pending", "paused", "running"].includes(detail.job.state)) {
-					throw conflict(`research workspace ${found.id} still has active initial work`);
-				}
-				if (["failed", "cancelled", "superseded"].includes(detail.job.state)) terminal = true;
+				states.push(detail.job.state);
 			}
-			if (!terminal) throw conflict(`research workspace ${found.id} has no terminal initial work`);
+			let disposition = researchAttemptDisposition(states);
+			if (disposition === "active") {
+				throw conflict(`research workspace ${found.id} still has active initial work`);
+			}
+			if (disposition !== "retryable") {
+				throw conflict(`research workspace ${found.id} has no terminal initial work`);
+			}
 			this.#assertActiveChannel(input.channelId, input.lease);
 			let now = timestamp(input.now, "retry time");
 			let savedTurn: ResearchTurn = {

--- a/apps/server/src/storage/memory/research.ts
+++ b/apps/server/src/storage/memory/research.ts
@@ -31,6 +31,8 @@ import type {
 	ResearchWorkspaceRepositoryGroup,
 	ResearchWorkspaceRepositoryList,
 	ResearchWorkspaceSummary,
+	ResetInitialResearchAttempt,
+	ResetInitialResearchAttemptResult,
 	StartResearchWorkspace,
 	StartResearchWorkspaceResult,
 } from "../model";
@@ -457,6 +459,58 @@ export class MemoryResearchWorkspaceStore implements ResearchWorkspaceStore {
 			};
 			this.#replaceTurn(savedTurn);
 			this.#linkedJobs.set(input.jobId, { turnId: savedTurn.id, role: input.role });
+			let savedWorkspace = this.#saveWorkspace(found, now);
+			return {
+				workspace: workspace(savedWorkspace),
+				turn: turn(savedTurn),
+				repeated: false,
+			};
+		});
+
+	readonly resetInitialAttempt = (
+		input: ResetInitialResearchAttempt,
+	): Promise<ResetInitialResearchAttemptResult> =>
+		this.#mutate(async () => {
+			this.#assertActiveChannel(input.channelId, input.lease);
+			let found = this.#requireWorkspace(input.channelId, input.workspaceId);
+			if (found.publishedChannelId) {
+				throw conflict(`research workspace ${found.id} is already published`);
+			}
+			let foundTurn = (this.#turns.get(found.id) ?? [])[0];
+			if (!foundTurn || foundTurn.kind !== "initial") {
+				throw conflict(`research workspace ${found.id} has no initial turn`);
+			}
+			if (
+				foundTurn.evidenceJobId !== input.expectedEvidenceJobId
+				|| foundTurn.answerJobId !== input.expectedAnswerJobId
+			) throw conflict(`research workspace ${found.id} changed before retry`);
+			if (!foundTurn.evidenceJobId && !foundTurn.answerJobId) {
+				return { workspace: workspace(found), turn: turn(foundTurn), repeated: true };
+			}
+			let terminal = false;
+			for (let jobId of [foundTurn.evidenceJobId, foundTurn.answerJobId]) {
+				if (!jobId) continue;
+				let detail = await this.#options.job(input.channelId, jobId);
+				if (!detail) {
+					throw missing(`background job ${jobId} does not exist in channel ${input.channelId}`);
+				}
+				if (["pending", "paused", "running"].includes(detail.job.state)) {
+					throw conflict(`research workspace ${found.id} still has active initial work`);
+				}
+				if (["failed", "cancelled", "superseded"].includes(detail.job.state)) terminal = true;
+			}
+			if (!terminal) throw conflict(`research workspace ${found.id} has no terminal initial work`);
+			this.#assertActiveChannel(input.channelId, input.lease);
+			let now = timestamp(input.now, "retry time");
+			let savedTurn: ResearchTurn = {
+				...foundTurn,
+				evidenceJobId: undefined,
+				answerJobId: undefined,
+				updatedAt: new Date(Math.max(foundTurn.updatedAt.getTime(), now.getTime())),
+			};
+			this.#replaceTurn(savedTurn);
+			if (foundTurn.evidenceJobId) this.#linkedJobs.delete(foundTurn.evidenceJobId);
+			if (foundTurn.answerJobId) this.#linkedJobs.delete(foundTurn.answerJobId);
 			let savedWorkspace = this.#saveWorkspace(found, now);
 			return {
 				workspace: workspace(savedWorkspace),

--- a/apps/server/src/storage/model.ts
+++ b/apps/server/src/storage/model.ts
@@ -622,6 +622,17 @@ export type LinkResearchTurnJobResult = {
 	repeated: boolean;
 };
 
+export type ResetInitialResearchAttempt = {
+	channelId: string;
+	workspaceId: string;
+	expectedEvidenceJobId: string | undefined;
+	expectedAnswerJobId: string | undefined;
+	now: Date;
+	lease: Lease;
+};
+
+export type ResetInitialResearchAttemptResult = LinkResearchTurnJobResult;
+
 export type AppendResearchAgentMessage = {
 	channelId: string;
 	workspaceId: string;

--- a/apps/server/src/storage/model.ts
+++ b/apps/server/src/storage/model.ts
@@ -303,6 +303,36 @@ export type BackgroundJobState =
 	| "cancelled"
 	| "superseded";
 
+const BACKGROUND_JOB_STATES = new Set<BackgroundJobState>([
+	"pending",
+	"paused",
+	"running",
+	"completed",
+	"failed",
+	"cancelled",
+	"superseded",
+]);
+
+export function isBackgroundJobState(value: unknown): value is BackgroundJobState {
+	return typeof value === "string" && BACKGROUND_JOB_STATES.has(value as BackgroundJobState);
+}
+
+export type ResearchAttemptDisposition = "active" | "retryable" | "settled";
+
+/** One canonical retry policy, rechecked by storage while its job rows are locked. */
+export function researchAttemptDisposition(
+	states: readonly BackgroundJobState[],
+): ResearchAttemptDisposition {
+	if (states.some(state => state === "pending" || state === "paused" || state === "running")) {
+		return "active";
+	}
+	if (
+		states.length === 0
+		|| states.some(state => state === "failed" || state === "cancelled" || state === "superseded")
+	) return "retryable";
+	return "settled";
+}
+
 export type BackgroundJob = {
 	id: string;
 	channelId: string;

--- a/apps/server/src/storage/port.ts
+++ b/apps/server/src/storage/port.ts
@@ -50,6 +50,8 @@ import type {
 	ResearchWorkspaceDetail,
 	ResearchWorkspaceRepositoryList,
 	ResearchWorkspaceSummary,
+	ResetInitialResearchAttempt,
+	ResetInitialResearchAttemptResult,
 	ResumeBackgroundJob,
 	SaveCheckpoint,
 	SettleBackgroundJob,
@@ -178,6 +180,9 @@ export interface ResearchWorkspaceStore {
 	confirm(input: ConfirmResearchWorkspace): Promise<ConfirmResearchWorkspaceResult>;
 	appendTurn(input: AppendResearchTurn): Promise<AppendResearchTurnResult>;
 	linkJob(input: LinkResearchTurnJob): Promise<LinkResearchTurnJobResult>;
+	resetInitialAttempt(
+		input: ResetInitialResearchAttempt,
+	): Promise<ResetInitialResearchAttemptResult>;
 	appendAgentMessage(
 		input: AppendResearchAgentMessage,
 	): Promise<AppendResearchAgentMessageResult>;

--- a/apps/server/src/storage/postgres/research.ts
+++ b/apps/server/src/storage/postgres/research.ts
@@ -1,9 +1,11 @@
 import { conflict, corrupt, missing } from "../errors";
 import { deterministicChannelId } from "../../channels/id";
 import {
+	isBackgroundJobState,
 	RESEARCH_REPOSITORY_CHANNEL_LIMIT,
 	RESEARCH_REPOSITORY_CHANNEL_WORKSPACE_LIMIT,
 	RESEARCH_REPOSITORY_WORKSPACE_LIMIT,
+	researchAttemptDisposition,
 } from "../model";
 
 import type { SQL, TransactionSQL } from "bun";
@@ -12,6 +14,7 @@ import type {
 	AppendResearchAgentMessageResult,
 	AppendResearchTurn,
 	AppendResearchTurnResult,
+	BackgroundJobState,
 	ChannelRecord,
 	ConfirmResearchWorkspace,
 	ConfirmResearchWorkspaceResult,
@@ -870,7 +873,7 @@ export class PostgresResearchWorkspaceStore implements ResearchWorkspaceStore {
 				if (!foundTurn.evidenceJobId && !foundTurn.answerJobId) {
 					return { workspace: locked.workspace, turn: foundTurn, repeated: true };
 				}
-				let terminal = false;
+				let states: BackgroundJobState[] = [];
 				for (let jobId of [foundTurn.evidenceJobId, foundTurn.answerJobId]) {
 					if (!jobId) continue;
 					let [job] = await transaction<RetryJobRow[]>`
@@ -882,14 +885,14 @@ export class PostgresResearchWorkspaceStore implements ResearchWorkspaceStore {
 						throw missing(`background job ${jobId} does not exist in channel ${channelId}`);
 					}
 					let state = text(job.state, "retry job state");
-					if (["pending", "paused", "running"].includes(state)) {
-						throw conflict(`research workspace ${workspaceId} still has active initial work`);
-					}
-					if (["failed", "cancelled", "superseded"].includes(state)) {
-						terminal = true;
-					}
+					if (!isBackgroundJobState(state)) throw corrupt("background job has an invalid state");
+					states.push(state);
 				}
-				if (!terminal) {
+				let disposition = researchAttemptDisposition(states);
+				if (disposition === "active") {
+					throw conflict(`research workspace ${workspaceId} still has active initial work`);
+				}
+				if (disposition !== "retryable") {
 					throw conflict(`research workspace ${workspaceId} has no terminal initial work`);
 				}
 				let now = inputDate(input.now, "retry time");

--- a/apps/server/src/storage/postgres/research.ts
+++ b/apps/server/src/storage/postgres/research.ts
@@ -34,6 +34,8 @@ import type {
 	ResearchWorkspaceRepositoryGroup,
 	ResearchWorkspaceRepositoryList,
 	ResearchWorkspaceSummary,
+	ResetInitialResearchAttempt,
+	ResetInitialResearchAttemptResult,
 	StartResearchWorkspace,
 	StartResearchWorkspaceResult,
 } from "../model";
@@ -145,6 +147,11 @@ type LinkedJobRow = {
 	targetKey: unknown;
 	targetGeneration: unknown;
 	currentGeneration: unknown;
+};
+
+type RetryJobRow = {
+	id: unknown;
+	state: unknown;
 };
 
 type LockedWorkspace = {
@@ -824,6 +831,77 @@ export class PostgresResearchWorkspaceStore implements ResearchWorkspaceStore {
 					`;
 				let savedTurnRow = rows[0];
 				if (!savedTurnRow) throw corrupt("linking a research job returned no turn");
+				let savedWorkspace = await this.#bumpWorkspace(transaction, workspaceId, now, 0, 0);
+				return {
+					workspace: savedWorkspace,
+					turn: turn(savedTurnRow),
+					repeated: false,
+				};
+			}));
+
+	readonly resetInitialAttempt = (
+		input: ResetInitialResearchAttempt,
+	): Promise<ResetInitialResearchAttemptResult> =>
+		this.#run("reset initial research attempt", () =>
+			this.#sql.begin(async transaction => {
+				await this.#fence(transaction, input.lease);
+				let channelId = required(input.channelId, "channel id");
+				let workspaceId = required(input.workspaceId, "workspace id");
+				let archived = await this.#lockChannelArchiveState(transaction, channelId);
+				let locked = await this.#lockWorkspace(transaction, channelId, workspaceId);
+				if (archived) throw conflict(`channel ${channelId} is archived`);
+				if (locked.workspace.publishedChannelId) {
+					throw conflict(`research workspace ${workspaceId} is already published`);
+				}
+				let [foundTurnRow] = await transaction<TurnRow[]>`
+					SELECT ${transaction.unsafe(TURN_COLUMNS)}
+					FROM research_turns
+					WHERE workspace_id = ${workspaceId} AND ordinal = 1
+					FOR UPDATE
+				`;
+				let foundTurn = foundTurnRow ? turn(foundTurnRow) : undefined;
+				if (!foundTurn || foundTurn.kind !== "initial") {
+					throw conflict(`research workspace ${workspaceId} has no initial turn`);
+				}
+				if (
+					foundTurn.evidenceJobId !== input.expectedEvidenceJobId
+					|| foundTurn.answerJobId !== input.expectedAnswerJobId
+				) throw conflict(`research workspace ${workspaceId} changed before retry`);
+				if (!foundTurn.evidenceJobId && !foundTurn.answerJobId) {
+					return { workspace: locked.workspace, turn: foundTurn, repeated: true };
+				}
+				let terminal = false;
+				for (let jobId of [foundTurn.evidenceJobId, foundTurn.answerJobId]) {
+					if (!jobId) continue;
+					let [job] = await transaction<RetryJobRow[]>`
+						SELECT id, state FROM background_jobs
+						WHERE id = ${jobId} AND channel_id = ${channelId}
+						FOR UPDATE
+					`;
+					if (!job) {
+						throw missing(`background job ${jobId} does not exist in channel ${channelId}`);
+					}
+					let state = text(job.state, "retry job state");
+					if (["pending", "paused", "running"].includes(state)) {
+						throw conflict(`research workspace ${workspaceId} still has active initial work`);
+					}
+					if (["failed", "cancelled", "superseded"].includes(state)) {
+						terminal = true;
+					}
+				}
+				if (!terminal) {
+					throw conflict(`research workspace ${workspaceId} has no terminal initial work`);
+				}
+				let now = inputDate(input.now, "retry time");
+				let [savedTurnRow] = await transaction<TurnRow[]>`
+					UPDATE research_turns SET
+						evidence_job_id = NULL,
+						answer_job_id = NULL,
+						updated_at = GREATEST(updated_at, ${now})
+					WHERE id = ${foundTurn.id} AND workspace_id = ${workspaceId}
+					RETURNING ${transaction.unsafe(TURN_COLUMNS)}
+				`;
+				if (!savedTurnRow) throw corrupt("resetting research work returned no turn");
 				let savedWorkspace = await this.#bumpWorkspace(transaction, workspaceId, now, 0, 0);
 				return {
 					workspace: savedWorkspace,

--- a/apps/web/src/api.test.ts
+++ b/apps/web/src/api.test.ts
@@ -1,6 +1,16 @@
 import { afterEach, describe, expect, it } from "bun:test";
 
-import { archiveChannel, channels, deleteChannel, restoreChannel } from "./api";
+import {
+	archiveChannel,
+	cancelResearchRequest,
+	channels,
+	createResearchRequest,
+	createResearchWorkspace,
+	deleteChannel,
+	researchRequest,
+	restoreChannel,
+	retryResearchRequest,
+} from "./api";
 
 let originalFetch = globalThis.fetch;
 
@@ -30,6 +40,11 @@ describe("document lifecycle API", () => {
 		await archiveChannel("channel/one");
 		await restoreChannel("channel/one");
 		await deleteChannel("channel/one");
+		await createResearchWorkspace("channel/one", "Private draft", "workspace/one");
+		await createResearchRequest("channel/one", "Inline request", "request/one");
+		await researchRequest("channel/one", "request/one");
+		await cancelResearchRequest("channel/one", "request/one");
+		await retryResearchRequest("channel/one", "request/one");
 
 		expect(requests).toEqual([{
 			method: "GET",
@@ -47,6 +62,21 @@ describe("document lifecycle API", () => {
 		}, {
 			method: "DELETE",
 			path: "/api/channels/channel%2Fone",
+		}, {
+			method: "POST",
+			path: "/api/channels/channel%2Fone/research-workspaces",
+		}, {
+			method: "POST",
+			path: "/api/channels/channel%2Fone/research-requests",
+		}, {
+			method: "GET",
+			path: "/api/channels/channel%2Fone/research-requests/request%2Fone",
+		}, {
+			method: "POST",
+			path: "/api/channels/channel%2Fone/research-requests/request%2Fone/cancel",
+		}, {
+			method: "POST",
+			path: "/api/channels/channel%2Fone/research-requests/request%2Fone/retry",
 		}]);
 	});
 });

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -312,12 +312,17 @@ export function createResearchWorkspace(
 	});
 }
 
+function researchRequestPath(channelId: string, requestId?: string): string {
+	let path = `/api/channels/${encodeURIComponent(channelId)}/research-requests`;
+	return requestId ? `${path}/${encodeURIComponent(requestId)}` : path;
+}
+
 export function createResearchRequest(
 	channelId: string,
 	question: string,
 	requestId: string,
 ): Promise<{ request: Research.RequestView; repeated: boolean }> {
-	return response(`/api/channels/${encodeURIComponent(channelId)}/research-requests`, {
+	return response(researchRequestPath(channelId), {
 		method: "POST",
 		headers: { "content-type": "application/json" },
 		body: JSON.stringify({ question, requestId }),
@@ -329,36 +334,21 @@ export function researchRequest(
 	requestId: string,
 	signal?: AbortSignal,
 ): Promise<Research.RequestView> {
-	return response(
-		`/api/channels/${encodeURIComponent(channelId)}/research-requests/${
-			encodeURIComponent(requestId)
-		}`,
-		{ signal },
-	);
+	return response(researchRequestPath(channelId, requestId), { signal });
 }
 
 export function cancelResearchRequest(
 	channelId: string,
 	requestId: string,
 ): Promise<Research.RequestView> {
-	return response(
-		`/api/channels/${encodeURIComponent(channelId)}/research-requests/${
-			encodeURIComponent(requestId)
-		}/cancel`,
-		{ method: "POST" },
-	);
+	return response(`${researchRequestPath(channelId, requestId)}/cancel`, { method: "POST" });
 }
 
 export function retryResearchRequest(
 	channelId: string,
 	requestId: string,
 ): Promise<Research.RequestView> {
-	return response(
-		`/api/channels/${encodeURIComponent(channelId)}/research-requests/${
-			encodeURIComponent(requestId)
-		}/retry`,
-		{ method: "POST" },
-	);
+	return response(`${researchRequestPath(channelId, requestId)}/retry`, { method: "POST" });
 }
 
 export function researchWorkspace(

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -312,6 +312,55 @@ export function createResearchWorkspace(
 	});
 }
 
+export function createResearchRequest(
+	channelId: string,
+	question: string,
+	requestId: string,
+): Promise<{ request: Research.RequestView; repeated: boolean }> {
+	return response(`/api/channels/${encodeURIComponent(channelId)}/research-requests`, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({ question, requestId }),
+	});
+}
+
+export function researchRequest(
+	channelId: string,
+	requestId: string,
+	signal?: AbortSignal,
+): Promise<Research.RequestView> {
+	return response(
+		`/api/channels/${encodeURIComponent(channelId)}/research-requests/${
+			encodeURIComponent(requestId)
+		}`,
+		{ signal },
+	);
+}
+
+export function cancelResearchRequest(
+	channelId: string,
+	requestId: string,
+): Promise<Research.RequestView> {
+	return response(
+		`/api/channels/${encodeURIComponent(channelId)}/research-requests/${
+			encodeURIComponent(requestId)
+		}/cancel`,
+		{ method: "POST" },
+	);
+}
+
+export function retryResearchRequest(
+	channelId: string,
+	requestId: string,
+): Promise<Research.RequestView> {
+	return response(
+		`/api/channels/${encodeURIComponent(channelId)}/research-requests/${
+			encodeURIComponent(requestId)
+		}/retry`,
+		{ method: "POST" },
+	);
+}
+
 export function researchWorkspace(
 	channelId: string,
 	workspaceId: string,

--- a/apps/web/src/navigation-model.test.ts
+++ b/apps/web/src/navigation-model.test.ts
@@ -8,6 +8,7 @@ import {
 	finishProjectCreation,
 	landingDocument,
 	navigationMode,
+	researchChildDestination,
 } from "./navigation-model";
 
 import type { ProjectDocuments } from "./document-actions";
@@ -127,6 +128,13 @@ describe("navigation model", () => {
 		);
 		expect(documentDestination(projects, "missing")).toBe("/channels/missing");
 		expect(documentDestination(projects, "channel-two", "/explicit")).toBe("/explicit");
+	});
+
+	it("opens a ready research child in its parent repository", () => {
+		expect(researchChildDestination(
+			{ repositoryOwner: "acme space", repositoryName: "docs/tools" },
+			{ slug: "rollout evidence" },
+		)).toBe("/documents/acme%20space/docs%2Ftools/rollout%20evidence");
 	});
 
 	it("keeps one Project creating while another creation settles", () => {

--- a/apps/web/src/navigation-model.ts
+++ b/apps/web/src/navigation-model.ts
@@ -1,6 +1,7 @@
 import { documentPath } from "@chopin/protocol/document-url";
 
-import type { NavigationProject } from "./api";
+import type { NavigationProject, ResearchParentChannel } from "./api";
+import type { Research } from "@chopin/protocol";
 import type { ProjectDocuments } from "./document-actions";
 
 export type NavigationMode = "drawer" | "inline";
@@ -45,6 +46,13 @@ export function documentDestination(
 		}
 	}
 	return `/channels/${encodeURIComponent(documentId)}`;
+}
+
+export function researchChildDestination(
+	parent: Pick<ResearchParentChannel, "repositoryOwner" | "repositoryName">,
+	child: Pick<Research.ReadyChild, "slug">,
+): string {
+	return documentPath(parent.repositoryOwner, parent.repositoryName, child.slug);
 }
 
 export function beginProjectCreation(

--- a/apps/web/src/navigation-shell.tsx
+++ b/apps/web/src/navigation-shell.tsx
@@ -32,6 +32,7 @@ import {
 	landingDocument,
 	NAVIGATION_MEDIA,
 	navigationMode,
+	researchChildDestination,
 } from "./navigation-model";
 import {
 	ProjectSidebarExpandButton,
@@ -707,7 +708,7 @@ export function NavigationShell(
 		setError(undefined);
 		setDialog(undefined);
 		setDrawerOpen(false);
-		navigate(documentPath(channel.repositoryOwner, channel.repositoryName, child.slug));
+		navigate(researchChildDestination(channel, child));
 	}, [navigate]);
 	let researchWorkspaceChanged = useCallback((
 		channel: Api.ResearchParentChannel,

--- a/apps/web/src/navigation-shell.tsx
+++ b/apps/web/src/navigation-shell.tsx
@@ -113,6 +113,7 @@ let NavigationDocument = createContext<{
 	onDocumentDeleted: (documentId: string) => void;
 	onDocumentLoaded: (channel: Api.Channel, routeKey: DocumentRouteIdentity) => Promise<void>;
 	onRepositoryAccessChanged: () => void;
+	onResearchChildOpen: (child: Research.ReadyChild) => void;
 	onResearchWorkspaceChanged: (
 		channel: Api.ResearchParentChannel,
 		workspaceId: string,
@@ -129,6 +130,7 @@ let NavigationDocument = createContext<{
 	onDocumentDeleted() {},
 	async onDocumentLoaded() {},
 	onRepositoryAccessChanged() {},
+	onResearchChildOpen() {},
 	onResearchWorkspaceChanged() {},
 	onResearchWorkspaceLoaded() {},
 	onResearchWorkspacesRefresh() {},
@@ -699,6 +701,14 @@ export function NavigationShell(
 		let channel = currentChannelRef.current;
 		if (channel) documentAction(channel, action);
 	}, [documentAction]);
+	let researchChildOpen = useCallback((child: Research.ReadyChild) => {
+		let channel = currentChannelRef.current;
+		if (!channel) return;
+		setError(undefined);
+		setDialog(undefined);
+		setDrawerOpen(false);
+		navigate(documentPath(channel.repositoryOwner, channel.repositoryName, child.slug));
+	}, [navigate]);
 	let researchWorkspaceChanged = useCallback((
 		channel: Api.ResearchParentChannel,
 		workspaceId: string,
@@ -722,6 +732,7 @@ export function NavigationShell(
 		onDocumentDeleted: documentDeleted,
 		onDocumentLoaded: documentLoaded,
 		onRepositoryAccessChanged: repositoryAccessChanged,
+		onResearchChildOpen: researchChildOpen,
 		onResearchWorkspaceChanged: researchWorkspaceChanged,
 		onResearchWorkspaceLoaded: researchWorkspaceLoaded,
 		onResearchWorkspacesRefresh: refreshResearchChannel,
@@ -732,6 +743,7 @@ export function NavigationShell(
 		documentDeleted,
 		documentLoaded,
 		repositoryAccessChanged,
+		researchChildOpen,
 		researchWorkspaceChanged,
 		researchWorkspaceLoaded,
 		refreshResearchChannel,

--- a/apps/web/src/research-requests.test.ts
+++ b/apps/web/src/research-requests.test.ts
@@ -124,12 +124,13 @@ describe("research request store", () => {
 
 		expect(store.get("restored")).toBeUndefined();
 		let release = store.retain("restored");
-		store.refresh("restored");
+		let releaseDuplicate = store.retain("restored");
 		expect(calls).toBe(1);
 
 		load.resolve(request("restored", "searching"));
 		await settle();
 		expect(store.get("restored")?.stage).toBe("searching");
+		releaseDuplicate();
 		release();
 		unsubscribe();
 		store.dispose();
@@ -157,7 +158,7 @@ describe("research request store", () => {
 			onOpen() {},
 		});
 
-		store.dispose();
+		store.reset();
 		let unsubscribe = store.subscribe(() => {});
 		let release = store.retain("request-one");
 		await settle();
@@ -176,11 +177,42 @@ describe("research request store", () => {
 			onOpen() {},
 		});
 
-		store.dispose();
+		store.reset();
 		let created = await store.create("Research this", "request-one");
 
 		expect(store.get("request-one")).toBe(created);
 		store.dispose();
+	});
+
+	it("keeps terminal disposal distinct from reversible Strict Mode cleanup", async () => {
+		let reads = 0;
+		let creates = 0;
+		let store = new ResearchRequestStore({
+			api: api({
+				get: async (_channelId, id) => {
+					reads++;
+					return request(id);
+				},
+				create: async (_channelId, question, id) => {
+					creates++;
+					return { repeated: false, request: request(id, "queued", { question }) };
+				},
+			}),
+			channelId: "channel-one",
+			onOpen() {},
+		});
+
+		store.dispose();
+		let unsubscribe = store.subscribe(() => {});
+		let release = store.retain("request-one");
+		await settle();
+
+		expect(reads).toBe(0);
+		expect(store.get("request-one")).toBeUndefined();
+		await expect(store.create("Research this", "request-one")).rejects.toThrow("disposed");
+		expect(creates).toBe(0);
+		release();
+		unsubscribe();
 	});
 
 	it("refreshes only a mounted request named by socket invalidation", async () => {
@@ -374,7 +406,7 @@ describe("research request store", () => {
 		let release = store.retain("request-one");
 		await settle();
 
-		let retried = await store.retry("request-one", "  Exact stored question.  ");
+		let retried = await store.retry("request-one");
 		expect(retries).toEqual(["request-one"]);
 		expect(store.get("request-one")).toBe(retried);
 

--- a/apps/web/src/research-requests.test.ts
+++ b/apps/web/src/research-requests.test.ts
@@ -123,13 +123,14 @@ describe("research request store", () => {
 		let unsubscribe = store.subscribe(() => {});
 
 		expect(store.get("restored")).toBeUndefined();
-		store.refresh("restored");
+		let release = store.retain("restored");
 		store.refresh("restored");
 		expect(calls).toBe(1);
 
 		load.resolve(request("restored", "searching"));
 		await settle();
 		expect(store.get("restored")?.stage).toBe("searching");
+		release();
 		unsubscribe();
 		store.dispose();
 	});
@@ -147,7 +148,7 @@ describe("research request store", () => {
 			onOpen() {},
 		});
 		let unsubscribe = store.subscribe(() => {});
-		store.refresh("mounted");
+		let release = store.retain("mounted");
 		await settle();
 
 		store.invalidate("not-mounted");
@@ -155,6 +156,7 @@ describe("research request store", () => {
 		await settle();
 
 		expect(calls).toEqual(["mounted", "mounted"]);
+		release();
 		unsubscribe();
 		store.dispose();
 	});
@@ -171,7 +173,7 @@ describe("research request store", () => {
 			onOpen() {},
 		});
 		let unsubscribe = store.subscribe(() => {});
-		store.refresh("request-one");
+		let release = store.retain("request-one");
 		store.invalidate("request-one");
 
 		second.resolve(request("request-one", "writing", {
@@ -183,6 +185,7 @@ describe("research request store", () => {
 
 		expect(calls).toBe(2);
 		expect(store.get("request-one")?.stage).toBe("writing");
+		release();
 		unsubscribe();
 		store.dispose();
 	});
@@ -200,7 +203,7 @@ describe("research request store", () => {
 		});
 		let unsubscribe = store.subscribe(() => {});
 
-		store.refresh("request-one");
+		let release = store.retain("request-one");
 		await settle();
 		expect(clock.pending).toBe(1);
 		clock.run();
@@ -212,11 +215,12 @@ describe("research request store", () => {
 		expect(store.get("request-one")?.stage).toBe("ready");
 		expect(clock.pending).toBe(0);
 
+		release();
 		unsubscribe();
 		store.dispose();
 	});
 
-	it("removing the final mounted reference cancels fallback polling", async () => {
+	it("releasing the final mounted reference cancels fallback polling", async () => {
 		let clock = scheduler();
 		let store = new ResearchRequestStore({
 			api: api(),
@@ -225,13 +229,55 @@ describe("research request store", () => {
 			schedule: clock.schedule,
 		});
 		let unsubscribe = store.subscribe(() => {});
-		store.refresh("request-one");
+		let release = store.retain("request-one");
 		await settle();
 		expect(clock.pending).toBe(1);
 
-		unsubscribe();
+		release();
 
 		expect(clock.pending).toBe(0);
+		unsubscribe();
+		store.dispose();
+	});
+
+	it("releases one unmounted request while another card keeps polling", async () => {
+		let clock = scheduler();
+		let calls: string[] = [];
+		let first = deferred<Research.RequestView>();
+		let firstSignal: AbortSignal | undefined;
+		let store = new ResearchRequestStore({
+			api: api({
+				get: async (_channelId, id, signal) => {
+					calls.push(id);
+					if (id === "request-one") {
+						firstSignal = signal;
+						return first.promise;
+					}
+					return request(id, "searching");
+				},
+			}),
+			channelId: "channel-one",
+			onOpen() {},
+			schedule: clock.schedule,
+		});
+		let unsubscribe = store.subscribe(() => {});
+		let releaseOne = store.retain("request-one");
+		let releaseTwo = store.retain("request-two");
+		await settle();
+
+		releaseOne();
+		expect(firstSignal?.aborted).toBe(true);
+		store.invalidate("request-one");
+		expect(store.get("request-one")).toBeUndefined();
+		clock.run();
+		await settle();
+
+		expect(calls.filter(id => id === "request-one")).toHaveLength(1);
+		expect(calls.filter(id => id === "request-two")).toHaveLength(2);
+		expect(clock.pending).toBe(1);
+		releaseTwo();
+		expect(clock.pending).toBe(0);
+		unsubscribe();
 		store.dispose();
 	});
 
@@ -258,7 +304,7 @@ describe("research request store", () => {
 		store.dispose();
 	});
 
-	it("publishes a successful cancellation and retries the same exact request", async () => {
+	it("restores a failed request and retries it by durable identity", async () => {
 		let retries: string[] = [];
 		let initial = request("request-one", "failed", {
 			error: "Research could not be completed.",
@@ -267,7 +313,6 @@ describe("research request store", () => {
 		});
 		let store = new ResearchRequestStore({
 			api: api({
-				cancel: async () => request("request-one", "cancelled", { state: "cancelled" }),
 				retry: async (_channelId, requestId) => {
 					retries.push(requestId);
 					return request(requestId, "queued", { question: initial.question });
@@ -278,16 +323,33 @@ describe("research request store", () => {
 			onOpen() {},
 		});
 		let unsubscribe = store.subscribe(() => {});
-		store.refresh("request-one");
+		let release = store.retain("request-one");
 		await settle();
 
 		let retried = await store.retry("request-one", "  Exact stored question.  ");
 		expect(retries).toEqual(["request-one"]);
 		expect(store.get("request-one")).toBe(retried);
+
+		release();
+		unsubscribe();
+		store.dispose();
+	});
+
+	it("publishes a successful cancellation", async () => {
+		let store = new ResearchRequestStore({
+			api: api(),
+			channelId: "channel-one",
+			onOpen() {},
+		});
+		let unsubscribe = store.subscribe(() => {});
+		let release = store.retain("request-one");
+		await settle();
+
 		let cancelled = await store.cancel("request-one");
+
 		expect(cancelled.stage).toBe("cancelled");
 		expect(store.get("request-one")).toBe(cancelled);
-
+		release();
 		unsubscribe();
 		store.dispose();
 	});
@@ -310,12 +372,13 @@ describe("research request store", () => {
 			onOpen() {},
 		});
 		let unsubscribe = store.subscribe(() => {});
-		store.refresh("request-one");
+		let release = store.retain("request-one");
 		await settle();
 
 		expect(store.get("request-one")).toBe(ready);
 		expect("summary" in store.get("request-one")!).toBe(false);
 
+		release();
 		unsubscribe();
 		store.dispose();
 	});

--- a/apps/web/src/research-requests.test.ts
+++ b/apps/web/src/research-requests.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it } from "bun:test";
+
+import { ResearchRequestStore } from "./research-requests";
+
+import type { Research } from "@chopin/protocol";
+import type { ResearchRequestApi, ResearchRequestSchedule } from "./research-requests";
+
+function request(
+	id: string,
+	stage: Research.RequestStage = "queued",
+	overrides: Partial<Research.RequestView> = {},
+): Research.RequestView {
+	return {
+		id,
+		channelId: "channel-one",
+		question: "  Keep this brief exact.  ",
+		state: stage === "ready" ? "completed" : stage === "failed" ? "failed" : "running",
+		stage,
+		sources: [],
+		createdAt: "2026-08-24T09:00:00.000Z",
+		updatedAt: "2026-08-24T09:01:00.000Z",
+		...overrides,
+	};
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason: unknown) => void;
+	let promise = new Promise<T>((accept, decline) => {
+		resolve = accept;
+		reject = decline;
+	});
+	return { promise, reject, resolve };
+}
+
+function api(
+	overrides: Partial<ResearchRequestApi> = {},
+): ResearchRequestApi {
+	return {
+		cancel: async (_channelId, id) => request(id, "cancelled", { state: "cancelled" }),
+		create: async (_channelId, question, id) => ({
+			repeated: false,
+			request: request(id, "queued", { question }),
+		}),
+		get: async (_channelId, id) => request(id),
+		retry: async (_channelId, id) => request(id),
+		...overrides,
+	};
+}
+
+function scheduler() {
+	let callbacks: Array<() => void> = [];
+	let schedule: ResearchRequestSchedule = callback => {
+		callbacks.push(callback);
+		return () => {
+			callbacks = callbacks.filter(candidate => candidate !== callback);
+		};
+	};
+	return {
+		get pending() {
+			return callbacks.length;
+		},
+		run() {
+			let callback = callbacks.shift();
+			if (!callback) throw new Error("no scheduled research poll");
+			callback();
+		},
+		schedule,
+	};
+}
+
+async function settle() {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe("research request store", () => {
+	it("starts one request with the exact brief and stable request identity", async () => {
+		let calls: Array<{ channelId: string; question: string; requestId: string }> = [];
+		let store = new ResearchRequestStore({
+			api: api({
+				create: async (channelId, question, requestId) => {
+					calls.push({ channelId, question, requestId });
+					return {
+						repeated: false,
+						request: request("durable-request", "queued", { question }),
+					};
+				},
+			}),
+			channelId: "channel-one",
+			onOpen() {},
+		});
+		let notifications = 0;
+		let unsubscribe = store.subscribe(() => notifications++);
+
+		let created = await store.create("  Keep this brief exact.  ", "request-stable");
+
+		expect(calls).toEqual([{
+			channelId: "channel-one",
+			question: "  Keep this brief exact.  ",
+			requestId: "request-stable",
+		}]);
+		expect(created.id).toBe("durable-request");
+		expect(store.get("durable-request")).toBe(created);
+		expect(notifications).toBe(1);
+		unsubscribe();
+		store.dispose();
+	});
+
+	it("restores an unknown durable reference and deduplicates concurrent refreshes", async () => {
+		let load = deferred<Research.RequestView>();
+		let calls = 0;
+		let store = new ResearchRequestStore({
+			api: api({
+				get: async () => {
+					calls++;
+					return load.promise;
+				},
+			}),
+			channelId: "channel-one",
+			onOpen() {},
+		});
+		let unsubscribe = store.subscribe(() => {});
+
+		expect(store.get("restored")).toBeUndefined();
+		store.refresh("restored");
+		store.refresh("restored");
+		expect(calls).toBe(1);
+
+		load.resolve(request("restored", "searching"));
+		await settle();
+		expect(store.get("restored")?.stage).toBe("searching");
+		unsubscribe();
+		store.dispose();
+	});
+
+	it("refreshes only a mounted request named by socket invalidation", async () => {
+		let calls: string[] = [];
+		let store = new ResearchRequestStore({
+			api: api({
+				get: async (_channelId, id) => {
+					calls.push(id);
+					return request(id, "searching");
+				},
+			}),
+			channelId: "channel-one",
+			onOpen() {},
+		});
+		let unsubscribe = store.subscribe(() => {});
+		store.refresh("mounted");
+		await settle();
+
+		store.invalidate("not-mounted");
+		store.invalidate("mounted");
+		await settle();
+
+		expect(calls).toEqual(["mounted", "mounted"]);
+		unsubscribe();
+		store.dispose();
+	});
+
+	it("ignores a stale refresh after a newer invalidation result", async () => {
+		let first = deferred<Research.RequestView>();
+		let second = deferred<Research.RequestView>();
+		let calls = 0;
+		let store = new ResearchRequestStore({
+			api: api({
+				get: async () => (++calls === 1 ? first.promise : second.promise),
+			}),
+			channelId: "channel-one",
+			onOpen() {},
+		});
+		let unsubscribe = store.subscribe(() => {});
+		store.refresh("request-one");
+		store.invalidate("request-one");
+
+		second.resolve(request("request-one", "writing", {
+			updatedAt: "2026-08-24T09:03:00.000Z",
+		}));
+		await settle();
+		first.resolve(request("request-one", "searching"));
+		await settle();
+
+		expect(calls).toBe(2);
+		expect(store.get("request-one")?.stage).toBe("writing");
+		unsubscribe();
+		store.dispose();
+	});
+
+	it("polls non-terminal mounted work and stops at ready", async () => {
+		let clock = scheduler();
+		let stages: Research.RequestStage[] = ["searching", "publishing", "ready"];
+		let store = new ResearchRequestStore({
+			api: api({
+				get: async (_channelId, id) => request(id, stages.shift()!),
+			}),
+			channelId: "channel-one",
+			onOpen() {},
+			schedule: clock.schedule,
+		});
+		let unsubscribe = store.subscribe(() => {});
+
+		store.refresh("request-one");
+		await settle();
+		expect(clock.pending).toBe(1);
+		clock.run();
+		await settle();
+		expect(store.get("request-one")?.stage).toBe("publishing");
+		expect(clock.pending).toBe(1);
+		clock.run();
+		await settle();
+		expect(store.get("request-one")?.stage).toBe("ready");
+		expect(clock.pending).toBe(0);
+
+		unsubscribe();
+		store.dispose();
+	});
+
+	it("removing the final mounted reference cancels fallback polling", async () => {
+		let clock = scheduler();
+		let store = new ResearchRequestStore({
+			api: api(),
+			channelId: "channel-one",
+			onOpen() {},
+			schedule: clock.schedule,
+		});
+		let unsubscribe = store.subscribe(() => {});
+		store.refresh("request-one");
+		await settle();
+		expect(clock.pending).toBe(1);
+
+		unsubscribe();
+
+		expect(clock.pending).toBe(0);
+		store.dispose();
+	});
+
+	it("keeps the durable snapshot visible when cancellation fails", async () => {
+		let failure = new Error("Try cancellation again.");
+		let store = new ResearchRequestStore({
+			api: api({
+				cancel: async () => {
+					throw failure;
+				},
+			}),
+			channelId: "channel-one",
+			onOpen() {},
+		});
+		let unsubscribe = store.subscribe(() => {});
+		await store.create("Question", "request-one");
+		let before = store.get("request-one");
+
+		expect(store.cancel("request-one")).rejects.toBe(failure);
+		await settle();
+		expect(store.get("request-one")).toBe(before);
+
+		unsubscribe();
+		store.dispose();
+	});
+
+	it("publishes a successful cancellation and retries the same exact request", async () => {
+		let retries: string[] = [];
+		let initial = request("request-one", "failed", {
+			error: "Research could not be completed.",
+			question: "  Exact stored question.  ",
+			state: "failed",
+		});
+		let store = new ResearchRequestStore({
+			api: api({
+				cancel: async () => request("request-one", "cancelled", { state: "cancelled" }),
+				retry: async (_channelId, requestId) => {
+					retries.push(requestId);
+					return request(requestId, "queued", { question: initial.question });
+				},
+				get: async () => initial,
+			}),
+			channelId: "channel-one",
+			onOpen() {},
+		});
+		let unsubscribe = store.subscribe(() => {});
+		store.refresh("request-one");
+		await settle();
+
+		let retried = await store.retry("request-one", "  Exact stored question.  ");
+		expect(retries).toEqual(["request-one"]);
+		expect(store.get("request-one")).toBe(retried);
+		let cancelled = await store.cancel("request-one");
+		expect(cancelled.stage).toBe("cancelled");
+		expect(store.get("request-one")).toBe(cancelled);
+
+		unsubscribe();
+		store.dispose();
+	});
+
+	it("keeps authoritative safe error, sources, and ready-child metadata unchanged", async () => {
+		let ready = request("request-one", "ready", {
+			child: {
+				id: "child-one",
+				slug: "source-report",
+				sourceCount: 1,
+				summary: "Validated report summary",
+				title: "Source report",
+			},
+			error: "Safe server error",
+			sources: [{ title: "Primary source", url: "https://example.com/source" }],
+		});
+		let store = new ResearchRequestStore({
+			api: api({ get: async () => ready }),
+			channelId: "channel-one",
+			onOpen() {},
+		});
+		let unsubscribe = store.subscribe(() => {});
+		store.refresh("request-one");
+		await settle();
+
+		expect(store.get("request-one")).toBe(ready);
+		expect("summary" in store.get("request-one")!).toBe(false);
+
+		unsubscribe();
+		store.dispose();
+	});
+
+	it("hands a ready child to app navigation", () => {
+		let opened: Research.ReadyChild[] = [];
+		let store = new ResearchRequestStore({
+			api: api(),
+			channelId: "channel-one",
+			onOpen: child => opened.push(child),
+		});
+		let child: Research.ReadyChild = {
+			id: "child-one",
+			slug: "source-report",
+			sourceCount: 3,
+			summary: "A complete report.",
+			title: "Source report",
+		};
+
+		store.open(child);
+
+		expect(opened).toEqual([child]);
+		store.dispose();
+	});
+});

--- a/apps/web/src/research-requests.test.ts
+++ b/apps/web/src/research-requests.test.ts
@@ -8,19 +8,31 @@ import type { ResearchRequestApi, ResearchRequestSchedule } from "./research-req
 function request(
 	id: string,
 	stage: Research.RequestStage = "queued",
-	overrides: Partial<Research.RequestView> = {},
+	overrides: Partial<Research.RequestViewBase> & { child?: Research.ReadyChild } = {},
 ): Research.RequestView {
-	return {
+	let base: Research.RequestViewBase = {
 		id,
 		channelId: "channel-one",
-		question: "  Keep this brief exact.  ",
-		state: stage === "ready" ? "completed" : stage === "failed" ? "failed" : "running",
-		stage,
-		sources: [],
-		createdAt: "2026-08-24T09:00:00.000Z",
-		updatedAt: "2026-08-24T09:01:00.000Z",
-		...overrides,
+		question: overrides.question ?? "  Keep this brief exact.  ",
+		sources: overrides.sources ?? [],
+		createdAt: overrides.createdAt ?? "2026-08-24T09:00:00.000Z",
+		updatedAt: overrides.updatedAt ?? "2026-08-24T09:01:00.000Z",
 	};
+	if (stage === "failed") {
+		return { ...base, state: "failed", stage, error: "Research could not be completed." };
+	}
+	if (stage === "cancelled") return { ...base, state: "cancelled", stage };
+	if (stage === "ready") {
+		let child = overrides.child ?? {
+			id: "child-one",
+			title: "Research report",
+			slug: "research-report",
+			summary: "Completed research.",
+			sourceCount: 0,
+		};
+		return { ...base, state: "completed", stage, child };
+	}
+	return { ...base, state: "running", stage };
 }
 
 function deferred<T>() {
@@ -37,7 +49,7 @@ function api(
 	overrides: Partial<ResearchRequestApi> = {},
 ): ResearchRequestApi {
 	return {
-		cancel: async (_channelId, id) => request(id, "cancelled", { state: "cancelled" }),
+		cancel: async (_channelId, id) => request(id, "cancelled"),
 		create: async (_channelId, question, id) => ({
 			repeated: false,
 			request: request(id, "queued", { question }),
@@ -387,9 +399,7 @@ describe("research request store", () => {
 	it("restores a failed request and retries it by durable identity", async () => {
 		let retries: string[] = [];
 		let initial = request("request-one", "failed", {
-			error: "Research could not be completed.",
 			question: "  Exact stored question.  ",
-			state: "failed",
 		});
 		let store = new ResearchRequestStore({
 			api: api({
@@ -434,7 +444,7 @@ describe("research request store", () => {
 		store.dispose();
 	});
 
-	it("keeps authoritative safe error, sources, and ready-child metadata unchanged", async () => {
+	it("keeps authoritative sources and ready-child metadata unchanged", async () => {
 		let ready = request("request-one", "ready", {
 			child: {
 				id: "child-one",
@@ -443,7 +453,6 @@ describe("research request store", () => {
 				summary: "Validated report summary",
 				title: "Source report",
 			},
-			error: "Safe server error",
 			sources: [{ title: "Primary source", url: "https://example.com/source" }],
 		});
 		let store = new ResearchRequestStore({

--- a/apps/web/src/research-requests.test.ts
+++ b/apps/web/src/research-requests.test.ts
@@ -135,6 +135,54 @@ describe("research request store", () => {
 		store.dispose();
 	});
 
+	it("restores mounted references after Strict Mode rehearses cleanup", async () => {
+		let calls = 0;
+		let ready = request("request-one", "ready", {
+			child: {
+				id: "child-one",
+				slug: "research-report",
+				sourceCount: 2,
+				summary: "Completed research.",
+				title: "Research report",
+			},
+		});
+		let store = new ResearchRequestStore({
+			api: api({
+				get: async () => {
+					calls++;
+					return ready;
+				},
+			}),
+			channelId: "channel-one",
+			onOpen() {},
+		});
+
+		store.dispose();
+		let unsubscribe = store.subscribe(() => {});
+		let release = store.retain("request-one");
+		await settle();
+
+		expect(calls).toBe(1);
+		expect(store.get("request-one")).toBe(ready);
+		release();
+		unsubscribe();
+		store.dispose();
+	});
+
+	it("keeps a newly created request after Strict Mode rehearses cleanup", async () => {
+		let store = new ResearchRequestStore({
+			api: api(),
+			channelId: "channel-one",
+			onOpen() {},
+		});
+
+		store.dispose();
+		let created = await store.create("Research this", "request-one");
+
+		expect(store.get("request-one")).toBe(created);
+		store.dispose();
+	});
+
 	it("refreshes only a mounted request named by socket invalidation", async () => {
 		let calls: string[] = [];
 		let store = new ResearchRequestStore({

--- a/apps/web/src/research-requests.ts
+++ b/apps/web/src/research-requests.ts
@@ -68,7 +68,7 @@ export class ResearchRequestStore implements ResearchStore {
 	}
 
 	subscribe(listener: () => void): () => void {
-		if (this.#disposed) return () => {};
+		this.#disposed = false;
 		this.#listeners.add(listener);
 		this.#schedulePolling();
 		return () => {
@@ -78,7 +78,7 @@ export class ResearchRequestStore implements ResearchStore {
 	}
 
 	retain(id: string): () => void {
-		if (this.#disposed) return () => {};
+		this.#disposed = false;
 		this.#references.set(id, (this.#references.get(id) ?? 0) + 1);
 		void this.#load(id);
 		let retained = true;
@@ -109,6 +109,7 @@ export class ResearchRequestStore implements ResearchStore {
 	}
 
 	async create(question: string, requestId: string): Promise<Research.RequestView> {
+		this.#disposed = false;
 		let result = await this.#api.create(this.#channelId, question, requestId);
 		return this.#accept(result.request.id, result.request);
 	}

--- a/apps/web/src/research-requests.ts
+++ b/apps/web/src/research-requests.ts
@@ -68,7 +68,7 @@ export class ResearchRequestStore implements ResearchStore {
 	}
 
 	subscribe(listener: () => void): () => void {
-		this.#disposed = false;
+		if (this.#disposed) return () => {};
 		this.#listeners.add(listener);
 		this.#schedulePolling();
 		return () => {
@@ -78,7 +78,7 @@ export class ResearchRequestStore implements ResearchStore {
 	}
 
 	retain(id: string): () => void {
-		this.#disposed = false;
+		if (this.#disposed) return () => {};
 		this.#references.set(id, (this.#references.get(id) ?? 0) + 1);
 		void this.#load(id);
 		let retained = true;
@@ -103,23 +103,20 @@ export class ResearchRequestStore implements ResearchStore {
 		return this.#snapshots.get(id);
 	}
 
-	refresh(id: string): void {
-		if (this.#disposed) return;
-		void this.#load(id);
-	}
-
 	async create(question: string, requestId: string): Promise<Research.RequestView> {
-		this.#disposed = false;
+		this.#assertAvailable();
 		let result = await this.#api.create(this.#channelId, question, requestId);
 		return this.#accept(result.request.id, result.request);
 	}
 
 	async cancel(id: string): Promise<Research.RequestView> {
+		this.#assertAvailable();
 		let result = await this.#api.cancel(this.#channelId, id);
 		return this.#accept(id, result);
 	}
 
-	async retry(id: string, _question: string): Promise<Research.RequestView> {
+	async retry(id: string): Promise<Research.RequestView> {
+		this.#assertAvailable();
 		let result = await this.#api.retry(this.#channelId, id);
 		return this.#accept(id, result);
 	}
@@ -133,14 +130,20 @@ export class ResearchRequestStore implements ResearchStore {
 		void this.#load(id, true);
 	}
 
-	dispose(): void {
+	/** Clears mounted observers and work while retaining the durable response cache. */
+	reset(): void {
 		if (this.#disposed) return;
-		this.#disposed = true;
 		this.#stopPolling();
 		for (let read of this.#reads.values()) read.controller.abort();
 		this.#reads.clear();
 		this.#references.clear();
 		this.#listeners.clear();
+	}
+
+	dispose(): void {
+		if (this.#disposed) return;
+		this.reset();
+		this.#disposed = true;
 	}
 
 	#accept(id: string, snapshot: Research.RequestView): Research.RequestView {
@@ -166,8 +169,7 @@ export class ResearchRequestStore implements ResearchStore {
 		try {
 			let snapshot = await this.#api.get(this.#channelId, id, controller.signal);
 			if (
-				this.#disposed || controller.signal.aborted
-				|| this.#reads.get(id)?.generation !== generation
+				controller.signal.aborted || this.#reads.get(id)?.generation !== generation
 			) return;
 			this.#accept(id, snapshot);
 		} catch {
@@ -181,7 +183,7 @@ export class ResearchRequestStore implements ResearchStore {
 
 	#schedulePolling(): void {
 		this.#stopPolling();
-		if (this.#disposed || this.#listeners.size === 0) return;
+		if (this.#listeners.size === 0) return;
 		let pending = [...this.#references.keys()].filter(id => {
 			let snapshot = this.#snapshots.get(id);
 			return !snapshot || !["ready", "failed", "cancelled"].includes(snapshot.stage);
@@ -198,5 +200,9 @@ export class ResearchRequestStore implements ResearchStore {
 	#stopPolling(): void {
 		this.#cancelPoll?.();
 		this.#cancelPoll = undefined;
+	}
+
+	#assertAvailable(): void {
+		if (this.#disposed) throw new Error("Research request store is disposed.");
 	}
 }

--- a/apps/web/src/research-requests.ts
+++ b/apps/web/src/research-requests.ts
@@ -56,7 +56,7 @@ export class ResearchRequestStore implements ResearchStore {
 	#listeners = new Set<() => void>();
 	#onOpen: (child: Research.ReadyChild) => void;
 	#reads = new Map<string, Read>();
-	#referenced = new Set<string>();
+	#references = new Map<string, number>();
 	#schedule: ResearchRequestSchedule;
 	#snapshots = new Map<string, Research.RequestView>();
 
@@ -70,13 +70,32 @@ export class ResearchRequestStore implements ResearchStore {
 	subscribe(listener: () => void): () => void {
 		if (this.#disposed) return () => {};
 		this.#listeners.add(listener);
+		this.#schedulePolling();
 		return () => {
 			this.#listeners.delete(listener);
-			if (this.#listeners.size > 0) return;
-			this.#referenced.clear();
-			this.#stopPolling();
-			for (let read of this.#reads.values()) read.controller.abort();
-			this.#reads.clear();
+			this.#schedulePolling();
+		};
+	}
+
+	retain(id: string): () => void {
+		if (this.#disposed) return () => {};
+		this.#references.set(id, (this.#references.get(id) ?? 0) + 1);
+		void this.#load(id);
+		let retained = true;
+		return () => {
+			if (!retained) return;
+			retained = false;
+			let remaining = (this.#references.get(id) ?? 1) - 1;
+			if (remaining > 0) {
+				this.#references.set(id, remaining);
+				return;
+			}
+			this.#references.delete(id);
+			this.#snapshots.delete(id);
+			this.#generations.delete(id);
+			this.#reads.get(id)?.controller.abort();
+			this.#reads.delete(id);
+			this.#schedulePolling();
 		};
 	}
 
@@ -86,7 +105,6 @@ export class ResearchRequestStore implements ResearchStore {
 
 	refresh(id: string): void {
 		if (this.#disposed) return;
-		this.#referenced.add(id);
 		void this.#load(id);
 	}
 
@@ -110,7 +128,7 @@ export class ResearchRequestStore implements ResearchStore {
 	}
 
 	invalidate(id: string): void {
-		if (this.#disposed || !this.#referenced.has(id)) return;
+		if (this.#disposed || !this.#references.has(id)) return;
 		void this.#load(id, true);
 	}
 
@@ -120,7 +138,7 @@ export class ResearchRequestStore implements ResearchStore {
 		this.#stopPolling();
 		for (let read of this.#reads.values()) read.controller.abort();
 		this.#reads.clear();
-		this.#referenced.clear();
+		this.#references.clear();
 		this.#listeners.clear();
 	}
 
@@ -163,7 +181,7 @@ export class ResearchRequestStore implements ResearchStore {
 	#schedulePolling(): void {
 		this.#stopPolling();
 		if (this.#disposed || this.#listeners.size === 0) return;
-		let pending = [...this.#referenced].filter(id => {
+		let pending = [...this.#references.keys()].filter(id => {
 			let snapshot = this.#snapshots.get(id);
 			return !snapshot || !["ready", "failed", "cancelled"].includes(snapshot.stage);
 		});
@@ -171,7 +189,7 @@ export class ResearchRequestStore implements ResearchStore {
 		this.#cancelPoll = this.#schedule(() => {
 			this.#cancelPoll = undefined;
 			for (let id of pending) {
-				if (this.#referenced.has(id)) void this.#load(id);
+				if (this.#references.has(id)) void this.#load(id);
 			}
 		}, POLL_INTERVAL);
 	}

--- a/apps/web/src/research-requests.ts
+++ b/apps/web/src/research-requests.ts
@@ -1,0 +1,183 @@
+import type { Research } from "@chopin/protocol";
+import type { ResearchStore } from "@chopin/editor";
+
+import {
+	cancelResearchRequest,
+	createResearchRequest,
+	researchRequest,
+	retryResearchRequest,
+} from "./api";
+
+const POLL_INTERVAL = 2_000;
+
+export type ResearchRequestApi = {
+	create(
+		channelId: string,
+		question: string,
+		requestId: string,
+	): Promise<{ request: Research.RequestView; repeated: boolean }>;
+	get(channelId: string, requestId: string, signal?: AbortSignal): Promise<Research.RequestView>;
+	cancel(channelId: string, requestId: string): Promise<Research.RequestView>;
+	retry(channelId: string, requestId: string): Promise<Research.RequestView>;
+};
+
+export type ResearchRequestSchedule = (callback: () => void, delay: number) => () => void;
+
+export type ResearchRequestStoreOptions = {
+	api?: ResearchRequestApi;
+	channelId: string;
+	onOpen: (child: Research.ReadyChild) => void;
+	schedule?: ResearchRequestSchedule;
+};
+
+let browserApi: ResearchRequestApi = {
+	cancel: cancelResearchRequest,
+	create: createResearchRequest,
+	get: researchRequest,
+	retry: retryResearchRequest,
+};
+
+let browserSchedule: ResearchRequestSchedule = (callback, delay) => {
+	let timer = setTimeout(callback, delay);
+	return () => clearTimeout(timer);
+};
+
+type Read = {
+	controller: AbortController;
+	generation: number;
+};
+
+export class ResearchRequestStore implements ResearchStore {
+	#api: ResearchRequestApi;
+	#channelId: string;
+	#cancelPoll?: () => void;
+	#disposed = false;
+	#generations = new Map<string, number>();
+	#listeners = new Set<() => void>();
+	#onOpen: (child: Research.ReadyChild) => void;
+	#reads = new Map<string, Read>();
+	#referenced = new Set<string>();
+	#schedule: ResearchRequestSchedule;
+	#snapshots = new Map<string, Research.RequestView>();
+
+	constructor(options: ResearchRequestStoreOptions) {
+		this.#api = options.api ?? browserApi;
+		this.#channelId = options.channelId;
+		this.#onOpen = options.onOpen;
+		this.#schedule = options.schedule ?? browserSchedule;
+	}
+
+	subscribe(listener: () => void): () => void {
+		if (this.#disposed) return () => {};
+		this.#listeners.add(listener);
+		return () => {
+			this.#listeners.delete(listener);
+			if (this.#listeners.size > 0) return;
+			this.#referenced.clear();
+			this.#stopPolling();
+			for (let read of this.#reads.values()) read.controller.abort();
+			this.#reads.clear();
+		};
+	}
+
+	get(id: string): Research.RequestView | undefined {
+		return this.#snapshots.get(id);
+	}
+
+	refresh(id: string): void {
+		if (this.#disposed) return;
+		this.#referenced.add(id);
+		void this.#load(id);
+	}
+
+	async create(question: string, requestId: string): Promise<Research.RequestView> {
+		let result = await this.#api.create(this.#channelId, question, requestId);
+		return this.#accept(result.request.id, result.request);
+	}
+
+	async cancel(id: string): Promise<Research.RequestView> {
+		let result = await this.#api.cancel(this.#channelId, id);
+		return this.#accept(id, result);
+	}
+
+	async retry(id: string, _question: string): Promise<Research.RequestView> {
+		let result = await this.#api.retry(this.#channelId, id);
+		return this.#accept(id, result);
+	}
+
+	open(child: Research.ReadyChild): void {
+		this.#onOpen(child);
+	}
+
+	invalidate(id: string): void {
+		if (this.#disposed || !this.#referenced.has(id)) return;
+		void this.#load(id, true);
+	}
+
+	dispose(): void {
+		if (this.#disposed) return;
+		this.#disposed = true;
+		this.#stopPolling();
+		for (let read of this.#reads.values()) read.controller.abort();
+		this.#reads.clear();
+		this.#referenced.clear();
+		this.#listeners.clear();
+	}
+
+	#accept(id: string, snapshot: Research.RequestView): Research.RequestView {
+		if (snapshot.id !== id || snapshot.channelId !== this.#channelId) {
+			throw new Error("Research request response did not match its document reference.");
+		}
+		if (this.#disposed) return snapshot;
+		this.#snapshots.set(id, snapshot);
+		for (let listener of this.#listeners) listener();
+		this.#schedulePolling();
+		return snapshot;
+	}
+
+	async #load(id: string, replace = false): Promise<void> {
+		let active = this.#reads.get(id);
+		if (active && !replace) return;
+		if (active) active.controller.abort();
+		let controller = new AbortController();
+		let generation = (this.#generations.get(id) ?? 0) + 1;
+		this.#generations.set(id, generation);
+		let read = { controller, generation };
+		this.#reads.set(id, read);
+		try {
+			let snapshot = await this.#api.get(this.#channelId, id, controller.signal);
+			if (
+				this.#disposed || controller.signal.aborted
+				|| this.#reads.get(id)?.generation !== generation
+			) return;
+			this.#accept(id, snapshot);
+		} catch {
+			// Refresh failures leave the last durable snapshot visible. Polling or
+			// the next socket invalidation can retry the observational read.
+		} finally {
+			if (this.#reads.get(id)?.generation === generation) this.#reads.delete(id);
+			this.#schedulePolling();
+		}
+	}
+
+	#schedulePolling(): void {
+		this.#stopPolling();
+		if (this.#disposed || this.#listeners.size === 0) return;
+		let pending = [...this.#referenced].filter(id => {
+			let snapshot = this.#snapshots.get(id);
+			return !snapshot || !["ready", "failed", "cancelled"].includes(snapshot.stage);
+		});
+		if (pending.length === 0) return;
+		this.#cancelPoll = this.#schedule(() => {
+			this.#cancelPoll = undefined;
+			for (let id of pending) {
+				if (this.#referenced.has(id)) void this.#load(id);
+			}
+		}, POLL_INTERVAL);
+	}
+
+	#stopPolling(): void {
+		this.#cancelPoll?.();
+		this.#cancelPoll = undefined;
+	}
+}

--- a/apps/web/src/room-workspace.tsx
+++ b/apps/web/src/room-workspace.tsx
@@ -153,6 +153,7 @@ export function RoomWorkspace(
 		onDocumentDeleted,
 		onRepositoryAccessChanged,
 		onResearchChildOpen,
+		onResearchWorkspaceChanged,
 		onResearchWorkspacesRefresh,
 	} = useNavigationDocument();
 	let [status, setStatus] = useState<Status>("connecting");
@@ -380,6 +381,18 @@ export function RoomWorkspace(
 				onRepositoryAccessChanged();
 			}),
 			socket.on<Research.Changed>("research:changed", frame => {
+				onResearchWorkspaceChanged(
+					{
+						id: room,
+						repositoryId: repository.id,
+						repositoryOwner: repository.owner,
+						repositoryName: repository.name,
+						title: metadataRef.current.title,
+						slug: metadataRef.current.slug,
+					},
+					frame.workspaceId,
+					frame.revision,
+				);
 				research.invalidate(frame.workspaceId);
 			}),
 			threads.listen(socket),
@@ -395,6 +408,7 @@ export function RoomWorkspace(
 		handle,
 		jobs,
 		onDocumentDeleted,
+		onResearchWorkspaceChanged,
 		onResearchWorkspacesRefresh,
 		onRepositoryAccessChanged,
 		research,

--- a/apps/web/src/room-workspace.tsx
+++ b/apps/web/src/room-workspace.tsx
@@ -313,7 +313,7 @@ export function RoomWorkspace(
 		setMetadata(next);
 	}, [archivedAt, description, descriptionRevision, label, room, slug, updatedAt]);
 
-	useEffect(() => () => research.dispose(), [research]);
+	useEffect(() => () => research.reset(), [research]);
 
 	useEffect(() => {
 		let socket = new Wire({

--- a/apps/web/src/room-workspace.tsx
+++ b/apps/web/src/room-workspace.tsx
@@ -31,6 +31,7 @@ import { motionImmediately } from "./motion-input";
 import { useNavigationDocument } from "./navigation-shell";
 import { NavigationIcon } from "./project-sidebar";
 import { peopleHere } from "./presence";
+import { ResearchRequestStore } from "./research-requests";
 import { Wire } from "./wire";
 import { useWorkspaceIds, useWorkspaceMode, useWorkspaceState, Workspace } from "./workspace";
 import { availableDocumentView, presentWorkspace, storedDocumentView } from "./workspace-model";
@@ -151,7 +152,7 @@ export function RoomWorkspace(
 		onDocumentChanged,
 		onDocumentDeleted,
 		onRepositoryAccessChanged,
-		onResearchWorkspaceChanged,
+		onResearchChildOpen,
 		onResearchWorkspacesRefresh,
 	} = useNavigationDocument();
 	let [status, setStatus] = useState<Status>("connecting");
@@ -182,6 +183,14 @@ export function RoomWorkspace(
 	let [questions] = useState(() => new QuestionnaireStore());
 	let [threads] = useState(() => new ThreadStore());
 	let [jobs] = useState(() => new JobStore());
+	let research = useMemo(
+		() =>
+			new ResearchRequestStore({
+				channelId: room,
+				onOpen: onResearchChildOpen,
+			}),
+		[onResearchChildOpen, room],
+	);
 	let [reveal, setReveal] = useState<{ widget: string; token: number }>();
 	let [planScrollTop, setPlanScrollTop] = useState(0);
 	let entries = useQuestionnaires(questions);
@@ -303,6 +312,8 @@ export function RoomWorkspace(
 		setMetadata(next);
 	}, [archivedAt, description, descriptionRevision, label, room, slug, updatedAt]);
 
+	useEffect(() => () => research.dispose(), [research]);
+
 	useEffect(() => {
 		let socket = new Wire({
 			channelId: room,
@@ -369,18 +380,7 @@ export function RoomWorkspace(
 				onRepositoryAccessChanged();
 			}),
 			socket.on<Research.Changed>("research:changed", frame => {
-				onResearchWorkspaceChanged(
-					{
-						id: room,
-						repositoryId: repository.id,
-						repositoryOwner: repository.owner,
-						repositoryName: repository.name,
-						title: metadataRef.current.title,
-						slug: metadataRef.current.slug,
-					},
-					frame.workspaceId,
-					frame.revision,
-				);
+				research.invalidate(frame.workspaceId);
 			}),
 			threads.listen(socket),
 			jobs.listen(socket),
@@ -395,9 +395,9 @@ export function RoomWorkspace(
 		handle,
 		jobs,
 		onDocumentDeleted,
-		onResearchWorkspaceChanged,
 		onResearchWorkspacesRefresh,
 		onRepositoryAccessChanged,
+		research,
 		repository,
 		room,
 		threads,
@@ -483,6 +483,7 @@ export function RoomWorkspace(
 					questionMotion={QUESTION_MOTION}
 					questions={questions}
 					readOnly={!workspaceCanEdit}
+					research={research}
 					scrollTop={planScrollTop}
 					threads={threads}
 					user={user}

--- a/packages/dialect/src/dialect.ts
+++ b/packages/dialect/src/dialect.ts
@@ -25,6 +25,8 @@ export type Content =
 export type Attribute =
 	/** ULID, minted when the component is created. */
 	| { type: "id"; required: true }
+	/** Safe opaque identifier owned by a record outside the document. */
+	| { type: "reference"; required: true; max: number }
 	/** Plain text, length-bounded. */
 	| { type: "text"; required: boolean; max: number }
 	/** One of a fixed set. */
@@ -203,6 +205,16 @@ export const COMPONENTS: Readonly<Record<string, Component>> = Object.freeze({
 		attributes: {
 			type: { type: "enum", required: true, values: CALLOUT_TYPES },
 			title: { type: "text", required: false, max: limits.MAX_CALLOUT_TITLE },
+		},
+	}),
+
+	/** A reference to authoritative Research Workspace state. */
+	Research: plain({
+		name: "Research",
+		kind: "flow",
+		content: { type: "empty" },
+		attributes: {
+			id: { type: "reference", required: true, max: 96 },
 		},
 	}),
 

--- a/packages/dialect/src/index.ts
+++ b/packages/dialect/src/index.ts
@@ -40,12 +40,15 @@ export type { Registry } from "./registry";
 
 export {
 	$createCalloutNode,
+	$createResearchNode,
 	$createTabNode,
 	$createTabsNode,
 	$isCalloutNode,
+	$isResearchNode,
 	$isTabNode,
 	$isTabsNode,
 	CalloutNode,
+	ResearchNode,
 	TabNode,
 	TabsNode,
 } from "./nodes/containers";

--- a/packages/dialect/src/index.ts
+++ b/packages/dialect/src/index.ts
@@ -40,15 +40,12 @@ export type { Registry } from "./registry";
 
 export {
 	$createCalloutNode,
-	$createResearchNode,
 	$createTabNode,
 	$createTabsNode,
 	$isCalloutNode,
-	$isResearchNode,
 	$isTabNode,
 	$isTabsNode,
 	CalloutNode,
-	ResearchNode,
 	TabNode,
 	TabsNode,
 } from "./nodes/containers";
@@ -70,6 +67,8 @@ export {
 	ImageNode,
 	MathNode,
 } from "./nodes/content";
+export { $createResearchNode, $isResearchNode, ResearchNode } from "./nodes/research";
+export type { SerializedResearch } from "./nodes/research";
 
 export {
 	$createQuestionnaireNode,

--- a/packages/dialect/src/nodes/container-visitors.ts
+++ b/packages/dialect/src/nodes/container-visitors.ts
@@ -9,18 +9,20 @@
 
 import {
 	$createCalloutNode,
+	$createResearchNode,
 	$createTabNode,
 	$createTabsNode,
 	$isCalloutNode,
+	$isResearchNode,
 	$isTabNode,
 	$isTabsNode,
 } from "./containers";
 import { attribute, identity, isFlow, PRIORITY } from "./shared";
 
 import type { LexicalExportVisitor, MdastImportVisitor } from "@mdxeditor/editor";
-import type { LexicalNode } from "lexical";
+import type { ElementNode, LexicalNode } from "lexical";
 import type { MdxJsxFlowElement } from "mdast-util-mdx-jsx";
-import type { CalloutNode, CalloutType, TabNode, TabsNode } from "./containers";
+import type { CalloutNode, CalloutType, ResearchNode, TabNode, TabsNode } from "./containers";
 
 type Importer = MdastImportVisitor<MdxJsxFlowElement>;
 type Exporter<T extends LexicalNode> = LexicalExportVisitor<T, MdxJsxFlowElement>;
@@ -68,6 +70,16 @@ export const MdastCalloutVisitor = importer("Callout", node =>
 		attribute(node, "title") ?? "",
 	));
 
+export const MdastResearchVisitor: Importer = {
+	testNode: isFlow("Research"),
+	visitNode({ mdastNode, lexicalParent }) {
+		(lexicalParent as ElementNode).append(
+			$createResearchNode(attribute(mdastNode, "id") ?? ""),
+		);
+	},
+	priority: PRIORITY,
+};
+
 export const LexicalTabsVisitor: Exporter<TabsNode> = exporter(
 	"Tabs",
 	$isTabsNode,
@@ -86,14 +98,29 @@ export const LexicalCalloutVisitor: Exporter<CalloutNode> = exporter(
 	node => identity(node.getId(), { type: node.getCalloutType(), title: node.getTitle() }),
 );
 
+export const LexicalResearchVisitor: Exporter<ResearchNode> = {
+	testLexicalNode: $isResearchNode,
+	visitLexicalNode({ lexicalNode, mdastParent, actions }) {
+		actions.appendToParent(mdastParent, {
+			type: "mdxJsxFlowElement",
+			name: "Research",
+			attributes: identity(lexicalNode.getId()),
+			children: [],
+		});
+	},
+	priority: PRIORITY,
+};
+
 export const CONTAINER_IMPORT_VISITORS = [
 	MdastTabsVisitor,
 	MdastTabVisitor,
 	MdastCalloutVisitor,
+	MdastResearchVisitor,
 ];
 
 export const CONTAINER_EXPORT_VISITORS = [
 	LexicalTabsVisitor,
 	LexicalTabVisitor,
 	LexicalCalloutVisitor,
+	LexicalResearchVisitor,
 ];

--- a/packages/dialect/src/nodes/container-visitors.ts
+++ b/packages/dialect/src/nodes/container-visitors.ts
@@ -9,20 +9,18 @@
 
 import {
 	$createCalloutNode,
-	$createResearchNode,
 	$createTabNode,
 	$createTabsNode,
 	$isCalloutNode,
-	$isResearchNode,
 	$isTabNode,
 	$isTabsNode,
 } from "./containers";
 import { attribute, identity, isFlow, PRIORITY } from "./shared";
 
 import type { LexicalExportVisitor, MdastImportVisitor } from "@mdxeditor/editor";
-import type { ElementNode, LexicalNode } from "lexical";
+import type { LexicalNode } from "lexical";
 import type { MdxJsxFlowElement } from "mdast-util-mdx-jsx";
-import type { CalloutNode, CalloutType, ResearchNode, TabNode, TabsNode } from "./containers";
+import type { CalloutNode, CalloutType, TabNode, TabsNode } from "./containers";
 
 type Importer = MdastImportVisitor<MdxJsxFlowElement>;
 type Exporter<T extends LexicalNode> = LexicalExportVisitor<T, MdxJsxFlowElement>;
@@ -70,16 +68,6 @@ export const MdastCalloutVisitor = importer("Callout", node =>
 		attribute(node, "title") ?? "",
 	));
 
-export const MdastResearchVisitor: Importer = {
-	testNode: isFlow("Research"),
-	visitNode({ mdastNode, lexicalParent }) {
-		(lexicalParent as ElementNode).append(
-			$createResearchNode(attribute(mdastNode, "id") ?? ""),
-		);
-	},
-	priority: PRIORITY,
-};
-
 export const LexicalTabsVisitor: Exporter<TabsNode> = exporter(
 	"Tabs",
 	$isTabsNode,
@@ -98,29 +86,14 @@ export const LexicalCalloutVisitor: Exporter<CalloutNode> = exporter(
 	node => identity(node.getId(), { type: node.getCalloutType(), title: node.getTitle() }),
 );
 
-export const LexicalResearchVisitor: Exporter<ResearchNode> = {
-	testLexicalNode: $isResearchNode,
-	visitLexicalNode({ lexicalNode, mdastParent, actions }) {
-		actions.appendToParent(mdastParent, {
-			type: "mdxJsxFlowElement",
-			name: "Research",
-			attributes: identity(lexicalNode.getId()),
-			children: [],
-		});
-	},
-	priority: PRIORITY,
-};
-
 export const CONTAINER_IMPORT_VISITORS = [
 	MdastTabsVisitor,
 	MdastTabVisitor,
 	MdastCalloutVisitor,
-	MdastResearchVisitor,
 ];
 
 export const CONTAINER_EXPORT_VISITORS = [
 	LexicalTabsVisitor,
 	LexicalTabVisitor,
 	LexicalCalloutVisitor,
-	LexicalResearchVisitor,
 ];

--- a/packages/dialect/src/nodes/containers.test.ts
+++ b/packages/dialect/src/nodes/containers.test.ts
@@ -9,6 +9,7 @@ import { parse } from "../parse";
 import { registry } from "../registry";
 import { validate } from "../validate";
 import * as Containers from "./containers";
+import { $isResearchNode } from "./research";
 
 import type { Binding, Provider } from "@lexical/yjs";
 import type { LexicalEditor, TextNode } from "lexical";
@@ -70,11 +71,6 @@ const TABS = `<Tabs id="${ID}">\n`
 
 describe("structural components", () => {
 	it("round-trips one externally owned research reference", () => {
-		let isResearch = (Containers as unknown as {
-			$isResearchNode?: (node: unknown) => boolean;
-		}).$isResearchNode;
-		expect(typeof isResearch).toBe("function");
-		if (!isResearch) return;
 		let source = `<Research id="${RESEARCH_ID}" />\n`;
 		expect(validate(parse(source))).toEqual({ ok: true });
 		expect(canonical(source)).toBe(source);
@@ -83,11 +79,10 @@ describe("structural components", () => {
 		importPlan(instance, source, { registry: REGISTRY });
 		instance.getEditorState().read(() => {
 			let research = $getRoot().getFirstChild();
-			expect(isResearch(research)).toBe(true);
-			if (!isResearch(research)) return;
-			let reference = research as unknown as { getId(): string; exportJSON(): unknown };
-			expect(reference.getId()).toBe(RESEARCH_ID);
-			expect(reference.exportJSON()).toMatchObject({ planId: RESEARCH_ID });
+			expect($isResearchNode(research)).toBe(true);
+			if (!$isResearchNode(research)) return;
+			expect(research.getId()).toBe(RESEARCH_ID);
+			expect(research.exportJSON()).toMatchObject({ planId: RESEARCH_ID });
 		});
 	});
 
@@ -333,8 +328,8 @@ describe("container collaboration", () => {
 
 		b.editor.getEditorState().read(() => {
 			let research = $getRoot().getFirstChild();
-			expect(Containers.$isResearchNode(research)).toBe(true);
-			if (Containers.$isResearchNode(research)) expect(research.getId()).toBe(RESEARCH_ID);
+			expect($isResearchNode(research)).toBe(true);
+			if ($isResearchNode(research)) expect(research.getId()).toBe(RESEARCH_ID);
 		});
 		expect(exportPlan(b.editor, { registry: REGISTRY })).toBe(
 			`<Research id="${RESEARCH_ID}" />\n`,

--- a/packages/dialect/src/nodes/containers.test.ts
+++ b/packages/dialect/src/nodes/containers.test.ts
@@ -5,8 +5,10 @@ import { $getRoot, $isElementNode } from "lexical";
 import * as Y from "yjs";
 
 import { exportPlan, importPlan } from "../convert";
+import { parse } from "../parse";
 import { registry } from "../registry";
-import { $isCalloutNode, $isTabNode, $isTabsNode } from "./containers";
+import { validate } from "../validate";
+import * as Containers from "./containers";
 
 import type { Binding, Provider } from "@lexical/yjs";
 import type { LexicalEditor, TextNode } from "lexical";
@@ -16,6 +18,7 @@ const REGISTRY = registry();
 const ID = "01K0N4TR8K7JGM4R1J7PW4R8YJ";
 const ID2 = "01K0N4V4E7Y6P4MJ5WD8XZF3B2";
 const ID3 = "01K0N4W3B7P27CBAEC7A8C8WEA";
+const RESEARCH_ID = "8f4d193b-2018-4977-b404-0092bb911676";
 
 function editor(): LexicalEditor {
 	return createHeadlessEditor({
@@ -66,6 +69,28 @@ const TABS = `<Tabs id="${ID}">\n`
 	+ `</Tabs>\n`;
 
 describe("structural components", () => {
+	it("round-trips one externally owned research reference", () => {
+		let isResearch = (Containers as unknown as {
+			$isResearchNode?: (node: unknown) => boolean;
+		}).$isResearchNode;
+		expect(typeof isResearch).toBe("function");
+		if (!isResearch) return;
+		let source = `<Research id="${RESEARCH_ID}" />\n`;
+		expect(validate(parse(source))).toEqual({ ok: true });
+		expect(canonical(source)).toBe(source);
+
+		let instance = editor();
+		importPlan(instance, source, { registry: REGISTRY });
+		instance.getEditorState().read(() => {
+			let research = $getRoot().getFirstChild();
+			expect(isResearch(research)).toBe(true);
+			if (!isResearch(research)) return;
+			let reference = research as unknown as { getId(): string; exportJSON(): unknown };
+			expect(reference.getId()).toBe(RESEARCH_ID);
+			expect(reference.exportJSON()).toMatchObject({ planId: RESEARCH_ID });
+		});
+	});
+
 	it("round-trips a callout with its attributes", () => {
 		let out = canonical(CALLOUT);
 		expect(out).toContain(`id="${ID}"`);
@@ -101,12 +126,12 @@ describe("structural components", () => {
 
 		instance.getEditorState().read(() => {
 			let tabs = $getRoot().getFirstChild();
-			expect($isTabsNode(tabs)).toBe(true);
+			expect(Containers.$isTabsNode(tabs)).toBe(true);
 			if (!$isElementNode(tabs)) return;
 
 			let children = tabs.getChildren();
 			expect(children).toHaveLength(2);
-			expect(children.every($isTabNode)).toBe(true);
+			expect(children.every(Containers.$isTabNode)).toBe(true);
 
 			let first = children[0];
 			expect($isElementNode(first) && first.getChildren()[0]?.getType()).toBe("paragraph");
@@ -122,8 +147,8 @@ describe("structural components", () => {
 			let tab = $isElementNode(tabs) ? tabs.getFirstChild() : null;
 			let callout = $getRoot().getLastChild();
 			return {
-				callout: $isCalloutNode(callout) ? callout : null,
-				tab: $isTabNode(tab) ? tab : null,
+				callout: Containers.$isCalloutNode(callout) ? callout : null,
+				tab: Containers.$isTabNode(tab) ? tab : null,
 			};
 		});
 		let tabDOM = attributes({ "aria-label": "macOS" });
@@ -134,8 +159,8 @@ describe("structural components", () => {
 				let tabs = $getRoot().getFirstChild();
 				let tab = $isElementNode(tabs) ? tabs.getFirstChild() : null;
 				let callout = $getRoot().getLastChild();
-				if ($isTabNode(tab)) tab.setLabel("Linux");
-				if ($isCalloutNode(callout)) callout.setCalloutType("tip").setTitle("");
+				if (Containers.$isTabNode(tab)) tab.setLabel("Linux");
+				if (Containers.$isCalloutNode(callout)) callout.setCalloutType("tip").setTitle("");
 			},
 			{ discrete: true },
 		);
@@ -144,10 +169,10 @@ describe("structural components", () => {
 			let tabs = $getRoot().getFirstChild();
 			let tab = $isElementNode(tabs) ? tabs.getFirstChild() : null;
 			let callout = $getRoot().getLastChild();
-			expect($isTabNode(tab)).toBe(true);
-			expect($isCalloutNode(callout)).toBe(true);
-			if (!$isTabNode(tab) || !previous.tab) return;
-			if (!$isCalloutNode(callout) || !previous.callout) return;
+			expect(Containers.$isTabNode(tab)).toBe(true);
+			expect(Containers.$isCalloutNode(callout)).toBe(true);
+			if (!Containers.$isTabNode(tab) || !previous.tab) return;
+			if (!Containers.$isCalloutNode(callout) || !previous.callout) return;
 
 			tab.updateDOM(previous.tab, tabDOM);
 			callout.updateDOM(previous.callout, calloutDOM);
@@ -288,8 +313,8 @@ describe("container collaboration", () => {
 
 		b.editor.getEditorState().read(() => {
 			let callout = $getRoot().getFirstChild();
-			expect($isCalloutNode(callout)).toBe(true);
-			if (!$isCalloutNode(callout)) return;
+			expect(Containers.$isCalloutNode(callout)).toBe(true);
+			if (!Containers.$isCalloutNode(callout)) return;
 			expect(callout.getId()).toBe(ID);
 			expect(callout.getCalloutType()).toBe("warning");
 			expect(callout.getTitle()).toBe("Careful");

--- a/packages/dialect/src/nodes/containers.test.ts
+++ b/packages/dialect/src/nodes/containers.test.ts
@@ -320,4 +320,24 @@ describe("container collaboration", () => {
 			expect(callout.getTitle()).toBe("Careful");
 		});
 	});
+
+	it("keeps an atomic research reference through a sync and export", async () => {
+		let a = peer();
+		let b = peer();
+		a.doc.on("update", (update: Uint8Array, origin: unknown) => {
+			if (origin !== "relay") Y.applyUpdate(b.doc, update, "relay");
+		});
+
+		importPlan(a.editor, `<Research id="${RESEARCH_ID}" />\n`, { registry: REGISTRY });
+		await settle();
+
+		b.editor.getEditorState().read(() => {
+			let research = $getRoot().getFirstChild();
+			expect(Containers.$isResearchNode(research)).toBe(true);
+			if (Containers.$isResearchNode(research)) expect(research.getId()).toBe(RESEARCH_ID);
+		});
+		expect(exportPlan(b.editor, { registry: REGISTRY })).toBe(
+			`<Research id="${RESEARCH_ID}" />\n`,
+		);
+	});
 });

--- a/packages/dialect/src/nodes/containers.ts
+++ b/packages/dialect/src/nodes/containers.ts
@@ -1,9 +1,8 @@
 /**
  * Structural plan components.
  *
- * Tabs and callouts are `ElementNode`s whose children are ordinary Lexical
- * blocks, so their content collaborates exactly like top-level prose. Research
- * is an atomic reference whose mutable state lives outside the document.
+ * Each is an `ElementNode` whose children are ordinary Lexical blocks, so their
+ * content collaborates exactly like top-level prose.
  *
  * The DOM produced here is deliberately plain and semantic. Presentation and
  * interaction (tab strips, callout chrome) belong to `@chopin/editor`, which
@@ -15,13 +14,12 @@ import {
 	$getState,
 	$setState,
 	createState,
-	DecoratorNode,
 	ElementNode,
 	setDOMUnmanaged,
 } from "lexical";
 
 import { CALLOUT_TYPES } from "../dialect";
-import { render } from "./render";
+import { idState } from "./identity";
 
 import type {
 	EditorConfig,
@@ -30,7 +28,6 @@ import type {
 	LexicalUpdateJSON,
 	NodeKey,
 	SerializedElementNode,
-	SerializedLexicalNode,
 	Spread,
 } from "lexical";
 
@@ -45,9 +42,6 @@ function syncDOMAttribute(dom: HTMLElement, name: string, value: string | undefi
 	if (value === undefined) dom.removeAttribute(name);
 	else dom.setAttribute(name, value);
 }
-
-/** Stable identity, minted when the component is created. */
-export const idState = createState("plan-id", { parse: text });
 
 /** Tab label. */
 export const labelState = createState("plan-label", { parse: text });
@@ -296,80 +290,6 @@ export function $isCalloutNode(node: LexicalNode | null | undefined): node is Ca
 	return node instanceof CalloutNode;
 }
 
-// -- Research --------------------------------------------------------------
+export const CONTAINER_NODES = [TabsNode, TabNode, CalloutNode];
 
-type SerializedResearch = Spread<{ planId: string }, SerializedLexicalNode>;
-
-/** Atomic reference to Research Workspace state owned outside the document. */
-export class ResearchNode extends DecoratorNode<unknown> {
-	static override getType(): string {
-		return "plan-research";
-	}
-
-	static override clone(node: ResearchNode): ResearchNode {
-		return new ResearchNode(node.__key);
-	}
-
-	static override importJSON(serialized: SerializedResearch): ResearchNode {
-		return $createResearchNode().updateFromJSON(serialized);
-	}
-
-	getId(): string {
-		return $getState(this, idState);
-	}
-
-	setId(value: string): this {
-		return $setState(this.getWritable(), idState, value);
-	}
-
-	override exportJSON(): SerializedResearch {
-		return { ...super.exportJSON(), planId: this.getId() };
-	}
-
-	override updateFromJSON(serialized: LexicalUpdateJSON<SerializedResearch>): this {
-		return super.updateFromJSON(serialized).setId(serialized.planId ?? "");
-	}
-
-	override createDOM(): HTMLElement {
-		let dom = document.createElement("div");
-		dom.dataset.planResearch = this.getId();
-		return dom;
-	}
-
-	override updateDOM(): boolean {
-		return false;
-	}
-
-	override isInline(): boolean {
-		return false;
-	}
-
-	override isKeyboardSelectable(): boolean {
-		return true;
-	}
-
-	override decorate(): unknown {
-		return render(this);
-	}
-}
-
-export function $createResearchNode(id = ""): ResearchNode {
-	return $applyNodeReplacement(new ResearchNode().setId(id));
-}
-
-export function $isResearchNode(
-	node: LexicalNode | null | undefined,
-): node is ResearchNode {
-	return node instanceof ResearchNode;
-}
-
-export const CONTAINER_NODES = [TabsNode, TabNode, CalloutNode, ResearchNode];
-
-export type {
-	CalloutType,
-	NodeKey,
-	SerializedCallout,
-	SerializedContainer,
-	SerializedResearch,
-	SerializedTab,
-};
+export type { CalloutType, NodeKey, SerializedCallout, SerializedContainer, SerializedTab };

--- a/packages/dialect/src/nodes/containers.ts
+++ b/packages/dialect/src/nodes/containers.ts
@@ -1,10 +1,9 @@
 /**
  * Structural plan components.
  *
- * Each is an `ElementNode` whose children are ordinary Lexical blocks, so their
- * content collaborates exactly like top-level prose. That is the whole point of
- * not using MDXEditor's nested-editor components, which snapshot their contents
- * into a parent property and lose concurrent edits.
+ * Tabs and callouts are `ElementNode`s whose children are ordinary Lexical
+ * blocks, so their content collaborates exactly like top-level prose. Research
+ * is an atomic reference whose mutable state lives outside the document.
  *
  * The DOM produced here is deliberately plain and semantic. Presentation and
  * interaction (tab strips, callout chrome) belong to `@chopin/editor`, which
@@ -16,11 +15,13 @@ import {
 	$getState,
 	$setState,
 	createState,
+	DecoratorNode,
 	ElementNode,
 	setDOMUnmanaged,
 } from "lexical";
 
 import { CALLOUT_TYPES } from "../dialect";
+import { render } from "./render";
 
 import type {
 	EditorConfig,
@@ -29,6 +30,7 @@ import type {
 	LexicalUpdateJSON,
 	NodeKey,
 	SerializedElementNode,
+	SerializedLexicalNode,
 	Spread,
 } from "lexical";
 
@@ -294,6 +296,80 @@ export function $isCalloutNode(node: LexicalNode | null | undefined): node is Ca
 	return node instanceof CalloutNode;
 }
 
-export const CONTAINER_NODES = [TabsNode, TabNode, CalloutNode];
+// -- Research --------------------------------------------------------------
 
-export type { CalloutType, NodeKey, SerializedCallout, SerializedContainer, SerializedTab };
+type SerializedResearch = Spread<{ planId: string }, SerializedLexicalNode>;
+
+/** Atomic reference to Research Workspace state owned outside the document. */
+export class ResearchNode extends DecoratorNode<unknown> {
+	static override getType(): string {
+		return "plan-research";
+	}
+
+	static override clone(node: ResearchNode): ResearchNode {
+		return new ResearchNode(node.__key);
+	}
+
+	static override importJSON(serialized: SerializedResearch): ResearchNode {
+		return $createResearchNode().updateFromJSON(serialized);
+	}
+
+	getId(): string {
+		return $getState(this, idState);
+	}
+
+	setId(value: string): this {
+		return $setState(this.getWritable(), idState, value);
+	}
+
+	override exportJSON(): SerializedResearch {
+		return { ...super.exportJSON(), planId: this.getId() };
+	}
+
+	override updateFromJSON(serialized: LexicalUpdateJSON<SerializedResearch>): this {
+		return super.updateFromJSON(serialized).setId(serialized.planId ?? "");
+	}
+
+	override createDOM(): HTMLElement {
+		let dom = document.createElement("div");
+		dom.dataset.planResearch = this.getId();
+		return dom;
+	}
+
+	override updateDOM(): boolean {
+		return false;
+	}
+
+	override isInline(): boolean {
+		return false;
+	}
+
+	override isKeyboardSelectable(): boolean {
+		return true;
+	}
+
+	override decorate(): unknown {
+		return render(this);
+	}
+}
+
+export function $createResearchNode(id = ""): ResearchNode {
+	return $applyNodeReplacement(new ResearchNode().setId(id));
+}
+
+export function $isResearchNode(
+	node: LexicalNode | null | undefined,
+): node is ResearchNode {
+	return node instanceof ResearchNode;
+}
+
+export const CONTAINER_NODES = [TabsNode, TabNode, CalloutNode, ResearchNode];
+
+export type {
+	CalloutType,
+	NodeKey,
+	SerializedCallout,
+	SerializedContainer,
+	SerializedResearch,
+	SerializedTab,
+};

--- a/packages/dialect/src/nodes/identity.ts
+++ b/packages/dialect/src/nodes/identity.ts
@@ -1,0 +1,8 @@
+import { createState } from "lexical";
+
+function text(value: unknown): string {
+	return typeof value === "string" ? value : "";
+}
+
+/** Stable identity shared by identified dialect nodes. */
+export const idState = createState("plan-id", { parse: text });

--- a/packages/dialect/src/nodes/research-visitors.ts
+++ b/packages/dialect/src/nodes/research-visitors.ts
@@ -1,0 +1,28 @@
+import { $createResearchNode, $isResearchNode } from "./research";
+import { attribute, identity, isFlow, PRIORITY } from "./shared";
+
+import type { LexicalExportVisitor, MdastImportVisitor } from "@mdxeditor/editor";
+import type { MdxJsxFlowElement } from "mdast-util-mdx-jsx";
+import type { ResearchNode } from "./research";
+
+export const MdastResearchVisitor: MdastImportVisitor<MdxJsxFlowElement> = {
+	testNode: isFlow("Research"),
+	visitNode({ mdastNode, actions }) {
+		actions.addAndStepInto($createResearchNode(attribute(mdastNode, "id") ?? ""));
+	},
+	priority: PRIORITY,
+};
+
+export const LexicalResearchVisitor: LexicalExportVisitor<
+	ResearchNode,
+	MdxJsxFlowElement
+> = {
+	testLexicalNode: $isResearchNode,
+	visitLexicalNode({ lexicalNode, actions }) {
+		actions.addAndStepInto("mdxJsxFlowElement", {
+			name: "Research",
+			attributes: identity(lexicalNode.getId()),
+		});
+	},
+	priority: PRIORITY,
+};

--- a/packages/dialect/src/nodes/research.ts
+++ b/packages/dialect/src/nodes/research.ts
@@ -1,0 +1,71 @@
+import { $applyNodeReplacement, $getState, $setState, DecoratorNode } from "lexical";
+
+import { idState } from "./identity";
+import { render } from "./render";
+
+import type { LexicalNode, LexicalUpdateJSON, SerializedLexicalNode, Spread } from "lexical";
+
+export type SerializedResearch = Spread<{ planId: string }, SerializedLexicalNode>;
+
+/** Atomic reference to Research Workspace state owned outside the document. */
+export class ResearchNode extends DecoratorNode<unknown> {
+	static override getType(): string {
+		return "plan-research";
+	}
+
+	static override clone(node: ResearchNode): ResearchNode {
+		return new ResearchNode(node.__key);
+	}
+
+	static override importJSON(serialized: SerializedResearch): ResearchNode {
+		return $createResearchNode().updateFromJSON(serialized);
+	}
+
+	getId(): string {
+		return $getState(this, idState);
+	}
+
+	setId(value: string): this {
+		return $setState(this.getWritable(), idState, value);
+	}
+
+	override exportJSON(): SerializedResearch {
+		return { ...super.exportJSON(), planId: this.getId() };
+	}
+
+	override updateFromJSON(serialized: LexicalUpdateJSON<SerializedResearch>): this {
+		return super.updateFromJSON(serialized).setId(serialized.planId ?? "");
+	}
+
+	override createDOM(): HTMLElement {
+		let dom = document.createElement("div");
+		dom.dataset.planResearch = this.getId();
+		return dom;
+	}
+
+	override updateDOM(): boolean {
+		return false;
+	}
+
+	override isInline(): boolean {
+		return false;
+	}
+
+	override isKeyboardSelectable(): boolean {
+		return true;
+	}
+
+	override decorate(): unknown {
+		return render(this);
+	}
+}
+
+export function $createResearchNode(id = ""): ResearchNode {
+	return $applyNodeReplacement(new ResearchNode().setId(id));
+}
+
+export function $isResearchNode(
+	node: LexicalNode | null | undefined,
+): node is ResearchNode {
+	return node instanceof ResearchNode;
+}

--- a/packages/dialect/src/registry.ts
+++ b/packages/dialect/src/registry.ts
@@ -44,6 +44,8 @@ import {
 	MdastQuestionnaireVisitor,
 	QuestionnaireNode,
 } from "./nodes/questionnaire";
+import { ResearchNode } from "./nodes/research";
+import { LexicalResearchVisitor, MdastResearchVisitor } from "./nodes/research-visitors";
 import { LexicalTableVisitor, MdastTableVisitor, TABLE_NODES } from "./nodes/table";
 import { MdastUnderlineVisitor } from "./nodes/underline";
 import { extensions } from "./serialize";
@@ -166,6 +168,17 @@ export const decisionPlugin = realmPlugin({
 	},
 });
 
+/** Atomic reference to authoritative Research Workspace state. */
+export const researchPlugin = realmPlugin({
+	init(realm) {
+		realm.pubIn({
+			[addLexicalNode$]: [ResearchNode],
+			[addImportVisitor$]: MdastResearchVisitor,
+			[addExportVisitor$]: LexicalResearchVisitor,
+		});
+	},
+});
+
 /** Underline, mapped to Lexical's native text format rather than a wrapper node. */
 export const underlinePlugin = realmPlugin({
 	init(realm) {
@@ -250,6 +263,7 @@ export function plugins({ core: withCore = true } = {}): RealmPlugin[] {
 		contentPlugin(),
 		questionnairePlugin(),
 		decisionPlugin(),
+		researchPlugin(),
 		underlinePlugin(),
 		markdownPlugin(),
 	];

--- a/packages/dialect/src/validate.ts
+++ b/packages/dialect/src/validate.ts
@@ -16,6 +16,8 @@ import { ULID } from "./ulid";
 import type { Nodes, Parent, Root } from "mdast";
 import type { MdxJsxAttribute, MdxJsxFlowElement, MdxJsxTextElement } from "mdast-util-mdx-jsx";
 
+const REFERENCE = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/;
+
 export type Issue = {
 	/** Machine-readable, stable across releases. */
 	code: string;
@@ -232,6 +234,17 @@ class Validator {
 				case "id":
 					if (!ULID.test(value)) {
 						this.add("bad-id", `\`${spec.name}.${name}\` must be a ULID`, path, node);
+					}
+					break;
+
+				case "reference":
+					if (value.length > attribute.max || !REFERENCE.test(value)) {
+						this.add(
+							"bad-reference",
+							`\`${spec.name}.${name}\` must be a safe external reference`,
+							path,
+							node,
+						);
 					}
 					break;
 

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -45,5 +45,11 @@ export type { Draft, ThreadState, ThreadView } from "./threads";
 export { presenceClass, transitionPresence, useTransitionPresence } from "./transition-presence";
 export type { PresenceAction, PresencePhase, TransitionPresence } from "./transition-presence";
 export type { Connection, Transport, Unsubscribe } from "./transport";
-export type { CommentPresentation, QuestionStepMotion } from "./widget-options";
-export { QuestionnaireCard, register as registerPlanWidgets } from "./widgets";
+export type { CommentPresentation, QuestionStepMotion, ResearchStore } from "./widget-options";
+export {
+	QuestionnaireCard,
+	register as registerPlanWidgets,
+	ResearchCard,
+	ResearchComposer,
+	ResearchReference,
+} from "./widgets";

--- a/packages/editor/src/plan-editor.tsx
+++ b/packages/editor/src/plan-editor.tsx
@@ -19,6 +19,7 @@ import { ChangeStore } from "./changes";
 import { PlanChanges } from "./changes-chip";
 import { collaborationPlugin } from "./collaboration";
 import { PlanStatus } from "./status";
+import { ResearchDraftStore } from "./research-draft";
 import { register } from "./widgets";
 import { widgetsPlugin } from "./widgets-plugin";
 
@@ -131,6 +132,8 @@ export function PlanEditor(
 	// Nothing outside the editor reads this one, unlike the questionnaires,
 	// so it is owned here rather than being handed down from the room.
 	let [changes] = useState(() => new ChangeStore());
+	// This survives the keyed MDXEditor remount used for collaboration epoch rotation.
+	let [researchDrafts] = useState(() => new ResearchDraftStore());
 
 	// A rotated epoch invalidates the whole local document, so the editor is
 	// rebuilt rather than reconciled — that is what "reset" means. The marks
@@ -265,6 +268,7 @@ export function PlanEditor(
 						questionMotion,
 						questions,
 						research,
+						researchDrafts,
 						threads,
 						changes,
 						wire,
@@ -284,6 +288,7 @@ export function PlanEditor(
 			binding,
 			questions,
 			research,
+			researchDrafts,
 			commentPresentation,
 			motionImmediately,
 			questionMotion,

--- a/packages/editor/src/plan-editor.tsx
+++ b/packages/editor/src/plan-editor.tsx
@@ -126,6 +126,7 @@ export function PlanEditor(
 	// Presence renders, so it needs the provider as state; edits need it
 	// synchronously during an event, so they keep reading the ref.
 	let [presence, setPresence] = useState<PlanProvider>();
+	let [binding, setBinding] = useState<Binding>();
 	let previousWire = useRef(wire);
 	// Nothing outside the editor reads this one, unlike the questionnaires,
 	// so it is owned here rather than being handed down from the room.
@@ -143,6 +144,7 @@ export function PlanEditor(
 	// The store resolves anchors itself, because a Lexical key is per-editor:
 	// the server's key for a block means nothing in this browser.
 	let onBinding = useCallback((value: Binding | undefined) => {
+		setBinding(value);
 		questions?.bind(value);
 		threads?.bind(value);
 		changes.bind(value);
@@ -257,6 +259,7 @@ export function PlanEditor(
 						onChanges,
 					}),
 					widgetsPlugin({
+						binding,
 						commentPresentation,
 						motionImmediately,
 						questionMotion,
@@ -278,6 +281,7 @@ export function PlanEditor(
 			onBinding,
 			onAnchors,
 			onChanges,
+			binding,
 			questions,
 			research,
 			commentPresentation,

--- a/packages/editor/src/plan-editor.tsx
+++ b/packages/editor/src/plan-editor.tsx
@@ -29,7 +29,7 @@ import type { PlanProvider } from "./provider";
 import type { QuestionnaireStore } from "./questionnaires";
 import type { ThreadStore } from "./threads";
 import type { Connection, Transport } from "./transport";
-import type { CommentPresentation, QuestionStepMotion } from "./widget-options";
+import type { CommentPresentation, QuestionStepMotion, ResearchStore } from "./widget-options";
 
 /**
  * Lexical paints remote cursors with inline styles unless the theme names a
@@ -80,6 +80,8 @@ export type PlanEditorProps = {
 	 * editor, while the observer that finds them has to run inside it.
 	 */
 	questions?: QuestionnaireStore;
+	/** Durable Research Workspace state and actions supplied by the host app. */
+	research?: ResearchStore;
 	/** The same arrangement for comment threads. */
 	threads?: ThreadStore;
 	/** Remembered by the document host while this surface is hidden. */
@@ -109,6 +111,7 @@ export function PlanEditor(
 		questionMotion,
 		questions,
 		readOnly,
+		research,
 		scrollTop,
 		threads,
 		user,
@@ -258,6 +261,7 @@ export function PlanEditor(
 						motionImmediately,
 						questionMotion,
 						questions,
+						research,
 						threads,
 						changes,
 						wire,
@@ -275,6 +279,7 @@ export function PlanEditor(
 			onAnchors,
 			onChanges,
 			questions,
+			research,
 			commentPresentation,
 			motionImmediately,
 			questionMotion,

--- a/packages/editor/src/research-draft.test.ts
+++ b/packages/editor/src/research-draft.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "bun:test";
+import * as Y from "yjs";
+
+import type { Research } from "@chopin/protocol";
+
+const REQUEST: Research.RequestView = {
+	id: "07aeae6d-073d-4560-a9f4-bb8e4d954a46",
+	channelId: "document-one",
+	question: "  Keep this brief exactly.  ",
+	state: "running",
+	stage: "queued",
+	sources: [],
+	createdAt: "2026-08-24T09:00:00.000Z",
+	updatedAt: "2026-08-24T09:00:00.000Z",
+};
+
+type DraftStore = {
+	attachPlacement(place: (position: Y.RelativePosition, id: string) => boolean): () => void;
+	cancelCreated(cancel: (id: string) => Promise<Research.RequestView>): Promise<boolean>;
+	change(question: string): void;
+	dismiss(): boolean;
+	get(): {
+		created?: Research.RequestView;
+		cancelling?: boolean;
+		error?: string;
+		position?: Y.RelativePosition;
+		question: string;
+		submitted?: { question: string; requestId: string };
+		submitting?: boolean;
+	} | undefined;
+	open(
+		anchor: {
+			top: number;
+			right: number;
+			bottom: number;
+			left: number;
+			width: number;
+			height: number;
+		},
+		position?: Y.RelativePosition,
+	): void;
+	place(position: Y.RelativePosition): boolean;
+	start(
+		create: (question: string, requestId: string) => Promise<Research.RequestView>,
+	): Promise<void>;
+};
+
+async function draftStore(): Promise<{ new(): DraftStore } | undefined> {
+	let module = await import("./research-draft").catch(() => ({}));
+	let Store = (module as { ResearchDraftStore?: { new(): DraftStore } }).ResearchDraftStore;
+	expect(typeof Store).toBe("function");
+	return Store;
+}
+
+function position(name: string): Y.RelativePosition {
+	let doc = new Y.Doc();
+	return Y.createRelativePositionFromTypeIndex(doc.getText(name), 0);
+}
+
+const ANCHOR = { top: 1, right: 2, bottom: 3, left: 4, width: 5, height: 6 };
+
+describe("research draft lifecycle", () => {
+	it("keeps an in-flight create through disconnect or read-only placement loss", async () => {
+		let Store = await draftStore();
+		if (!Store) return;
+		let store = new Store();
+		let original = position("original");
+		store.open(ANCHOR, original);
+		store.change(REQUEST.question);
+		let resolve!: (request: Research.RequestView) => void;
+		let create = new Promise<Research.RequestView>(done => resolve = done);
+		let detachedCalls = 0;
+		let detach = store.attachPlacement(() => {
+			detachedCalls++;
+			return true;
+		});
+		let running = store.start(() => create);
+		expect(store.get()?.submitting).toBe(true);
+		expect(store.dismiss()).toBe(false);
+		detach();
+		resolve(REQUEST);
+		await running;
+
+		expect(detachedCalls).toBe(0);
+		expect(store.get()?.created).toEqual(REQUEST);
+		let reconnected: [Y.RelativePosition, string] | undefined;
+		store.attachPlacement((saved, id) => {
+			reconnected = [saved, id];
+			return true;
+		});
+		expect(reconnected).toEqual([original, REQUEST.id]);
+		expect(store.get()).toBeUndefined();
+	});
+
+	it("keeps durable recovery through a keyed editor remount during the POST", async () => {
+		let Store = await draftStore();
+		if (!Store) return;
+		let store = new Store();
+		let oldPosition = position("old-epoch");
+		let newPosition = position("new-epoch");
+		store.open(ANCHOR, oldPosition);
+		store.change(REQUEST.question);
+		let resolve!: (request: Research.RequestView) => void;
+		let create = new Promise<Research.RequestView>(done => resolve = done);
+		let oldCalls = 0;
+		let detach = store.attachPlacement(() => {
+			oldCalls++;
+			return true;
+		});
+		let running = store.start(() => create);
+		detach();
+		let newCalls: Y.RelativePosition[] = [];
+		store.attachPlacement(saved => {
+			newCalls.push(saved);
+			return saved === newPosition;
+		});
+		resolve(REQUEST);
+		await running;
+
+		expect(oldCalls).toBe(0);
+		expect(newCalls).toEqual([oldPosition]);
+		expect(store.get()?.created?.id).toBe(REQUEST.id);
+		expect(store.place(newPosition)).toBe(true);
+		expect(store.get()).toBeUndefined();
+	});
+
+	it("retains one exact idempotency identity after a failed create and remount", async () => {
+		let Store = await draftStore();
+		if (!Store) return;
+		let store = new Store();
+		store.open(ANCHOR, position("brief"));
+		store.change(REQUEST.question);
+		let attempts: Array<[string, string]> = [];
+		await store.start(async (question, requestId) => {
+			attempts.push([question, requestId]);
+			throw new Error("offline");
+		});
+		let saved = store.get()?.submitted;
+		expect(saved?.question).toBe(REQUEST.question);
+
+		await store.start(async (question, requestId) => {
+			attempts.push([question, requestId]);
+			return REQUEST;
+		});
+		expect(attempts).toEqual([
+			[REQUEST.question, saved!.requestId],
+			[REQUEST.question, saved!.requestId],
+		]);
+	});
+
+	it("cannot dismiss created recovery and clears it only after durable cancellation", async () => {
+		let Store = await draftStore();
+		if (!Store) return;
+		let store = new Store();
+		store.open(ANCHOR, position("cancel"));
+		store.change(REQUEST.question);
+		await store.start(async () => REQUEST);
+		expect(store.dismiss()).toBe(false);
+		expect(store.get()?.created?.id).toBe(REQUEST.id);
+
+		let cancelled: string | undefined;
+		let finish!: (request: Research.RequestView) => void;
+		let waiting = new Promise<Research.RequestView>(done => finish = done);
+		let cancellation = store.cancelCreated(async id => {
+			cancelled = id;
+			return waiting;
+		});
+		expect(store.get()?.cancelling).toBe(true);
+		expect(store.dismiss()).toBe(false);
+		let placements = 0;
+		store.attachPlacement(() => {
+			placements++;
+			return true;
+		});
+		expect(placements).toBe(0);
+		finish({ ...REQUEST, state: "cancelled", stage: "cancelled" });
+		expect(await cancellation).toBe(true);
+		expect(cancelled).toBe(REQUEST.id);
+		expect(store.get()).toBeUndefined();
+	});
+});

--- a/packages/editor/src/research-draft.test.ts
+++ b/packages/editor/src/research-draft.test.ts
@@ -16,7 +16,11 @@ const REQUEST: Research.RequestView = {
 
 type DraftStore = {
 	attachPlacement(place: (position: Y.RelativePosition, id: string) => boolean): () => void;
-	cancelCreated(cancel: (id: string) => Promise<Research.RequestView>): Promise<boolean>;
+	canOpen(): boolean;
+	cancelCreated(
+		cancel: (id: string) => Promise<Research.RequestView>,
+		writable?: boolean,
+	): Promise<boolean>;
 	change(question: string): void;
 	dismiss(): boolean;
 	get(): {
@@ -38,8 +42,8 @@ type DraftStore = {
 			height: number;
 		},
 		position?: Y.RelativePosition,
-	): void;
-	place(position: Y.RelativePosition): boolean;
+	): boolean;
+	place(position: Y.RelativePosition, writable?: boolean): boolean;
 	start(
 		create: (question: string, requestId: string) => Promise<Research.RequestView>,
 	): Promise<void>;
@@ -60,6 +64,39 @@ function position(name: string): Y.RelativePosition {
 const ANCHOR = { top: 1, right: 2, bottom: 3, left: 4, width: 5, height: 6 };
 
 describe("research draft lifecycle", () => {
+	it("refuses a second research draft during submission and created recovery", async () => {
+		let Store = await draftStore();
+		if (!Store) return;
+		let store = new Store();
+		let original = position("original");
+		let replacement = position("replacement");
+		expect(store.open(ANCHOR, original)).toBe(true);
+		store.change(REQUEST.question);
+		let resolve!: (request: Research.RequestView) => void;
+		let create = new Promise<Research.RequestView>(done => resolve = done);
+		let submitted: [string, string] | undefined;
+		let running = store.start((question, requestId) => {
+			submitted = [question, requestId];
+			return create;
+		});
+		let requestId = store.get()?.submitted?.requestId;
+
+		expect(store.canOpen()).toBe(false);
+		expect(store.open({ ...ANCHOR, top: 20 }, replacement)).toBe(false);
+		expect(store.get()?.question).toBe(REQUEST.question);
+		expect(store.get()?.submitted?.requestId).toBe(requestId);
+		expect(store.get()?.position).toBe(original);
+
+		resolve(REQUEST);
+		await running;
+		expect(store.get()?.created).toEqual(REQUEST);
+		expect(store.open({ ...ANCHOR, top: 30 }, replacement)).toBe(false);
+		expect(store.get()?.created).toEqual(REQUEST);
+		expect(store.get()?.submitted?.requestId).toBe(requestId);
+		expect(store.get()?.position).toBe(original);
+		expect(submitted).toEqual([REQUEST.question, requestId!]);
+	});
+
 	it("keeps an in-flight create through disconnect or read-only placement loss", async () => {
 		let Store = await draftStore();
 		if (!Store) return;
@@ -177,5 +214,29 @@ describe("research draft lifecycle", () => {
 		expect(await cancellation).toBe(true);
 		expect(cancelled).toBe(REQUEST.id);
 		expect(store.get()).toBeUndefined();
+	});
+
+	it("preserves created recovery without mutation while read-only", async () => {
+		let Store = await draftStore();
+		if (!Store) return;
+		let store = new Store();
+		let original = position("read-only-original");
+		store.open(ANCHOR, original);
+		store.change(REQUEST.question);
+		await store.start(async () => REQUEST);
+		let snapshot = store.get();
+		let cancellations = 0;
+
+		expect(
+			await store.cancelCreated(async () => {
+				cancellations++;
+				return { ...REQUEST, state: "cancelled", stage: "cancelled" };
+			}, false),
+		).toBe(false);
+		expect(store.place(position("read-only-new"), false)).toBe(false);
+		expect(cancellations).toBe(0);
+		expect(store.get()).toBe(snapshot);
+		expect(store.get()?.created).toEqual(REQUEST);
+		expect(store.get()?.position).toBe(original);
 	});
 });

--- a/packages/editor/src/research-draft.ts
+++ b/packages/editor/src/research-draft.ts
@@ -1,0 +1,184 @@
+import type { Research } from "@chopin/protocol";
+import type { RelativePosition } from "yjs";
+import type { DOMRectLike } from "./toolbar/placement";
+
+export type ResearchDraft = {
+	anchor: DOMRectLike;
+	position?: RelativePosition;
+	question: string;
+	created?: Research.RequestView;
+	submitted?: { question: string; requestId: string };
+	submitting?: boolean;
+	cancelling?: boolean;
+	error?: string;
+};
+
+type Placement = (position: RelativePosition, id: string) => boolean;
+
+/**
+ * Owns the non-document research composer across keyed Lexical editor lifetimes.
+ * The current editor contributes only a replaceable placement function.
+ */
+export class ResearchDraftStore {
+	#draft: ResearchDraft | undefined;
+	#listeners = new Set<() => void>();
+	#placement: Placement | undefined;
+
+	subscribe(listener: () => void): () => void {
+		this.#listeners.add(listener);
+		return () => this.#listeners.delete(listener);
+	}
+
+	get(): ResearchDraft | undefined {
+		return this.#draft;
+	}
+
+	open(anchor: DOMRectLike, position?: RelativePosition): void {
+		this.#set({ anchor, position, question: "" });
+	}
+
+	change(question: string): void {
+		let draft = this.#draft;
+		if (!draft || draft.submitting || draft.cancelling || draft.created) return;
+		this.#set({
+			...draft,
+			question,
+			error: undefined,
+			submitted: draft.question === question ? draft.submitted : undefined,
+		});
+	}
+
+	async start(
+		create: (question: string, requestId: string) => Promise<Research.RequestView>,
+		fallbackPosition?: RelativePosition,
+	): Promise<void> {
+		let draft = this.#draft;
+		if (!draft || draft.submitting || draft.cancelling || draft.created || !draft.question.trim()) {
+			return;
+		}
+		let position = draft.position ?? fallbackPosition;
+		if (!position) {
+			this.#set({
+				...draft,
+				error: "Choose an insertion point in the document before starting research.",
+			});
+			return;
+		}
+		draft = { ...draft, position };
+		let submitted = draft.submitted?.question === draft.question
+			? draft.submitted
+			: { question: draft.question, requestId: crypto.randomUUID() };
+		this.#set({ ...draft, submitted, submitting: true, error: undefined });
+
+		let request: Research.RequestView;
+		try {
+			request = await create(submitted.question, submitted.requestId);
+		} catch {
+			let current = this.#current(submitted.requestId);
+			if (current) {
+				this.#set({
+					...current,
+					submitting: false,
+					error: "Research could not be started.",
+				});
+			}
+			return;
+		}
+
+		let current = this.#current(submitted.requestId);
+		if (!current) return;
+		if (current.position && this.#insert(current.position, request.id)) {
+			this.#set(undefined);
+			return;
+		}
+		this.#set({
+			...current,
+			created: request,
+			submitting: false,
+			error:
+				"Research started, but its reference could not be placed. Choose a new insertion point in the document.",
+		});
+	}
+
+	attachPlacement(place: Placement): () => void {
+		this.#placement = place;
+		let draft = this.#draft;
+		if (
+			draft?.created
+			&& !draft.cancelling
+			&& draft.position
+			&& this.#insert(draft.position, draft.created.id)
+		) {
+			this.#set(undefined);
+		}
+		return () => {
+			if (this.#placement === place) this.#placement = undefined;
+		};
+	}
+
+	place(position: RelativePosition): boolean {
+		let draft = this.#draft;
+		if (!draft?.created || draft.cancelling) return false;
+		if (this.#insert(position, draft.created.id)) {
+			this.#set(undefined);
+			return true;
+		}
+		this.#set({
+			...draft,
+			position,
+			error: "Choose a new insertion point in the document, then place the research again.",
+		});
+		return false;
+	}
+
+	dismiss(): boolean {
+		let draft = this.#draft;
+		if (!draft) return true;
+		if (draft.submitting || draft.cancelling || draft.created) return false;
+		this.#set(undefined);
+		return true;
+	}
+
+	async cancelCreated(
+		cancel: (id: string) => Promise<Research.RequestView>,
+	): Promise<boolean> {
+		let draft = this.#draft;
+		if (!draft?.created || draft.submitting || draft.cancelling) return false;
+		let id = draft.created.id;
+		this.#set({ ...draft, cancelling: true, error: undefined });
+		try {
+			await cancel(id);
+		} catch {
+			let current = this.#draft;
+			if (current?.created?.id === id) {
+				this.#set({
+					...current,
+					cancelling: false,
+					error: "Research could not be cancelled.",
+				});
+			}
+			return false;
+		}
+		if (this.#draft?.created?.id !== id) return false;
+		this.#set(undefined);
+		return true;
+	}
+
+	#current(requestId: string): ResearchDraft | undefined {
+		let draft = this.#draft;
+		return draft?.submitted?.requestId === requestId ? draft : undefined;
+	}
+
+	#insert(position: RelativePosition, id: string): boolean {
+		try {
+			return this.#placement?.(position, id) ?? false;
+		} catch {
+			return false;
+		}
+	}
+
+	#set(draft: ResearchDraft | undefined): void {
+		this.#draft = draft;
+		for (let listener of this.#listeners) listener();
+	}
+}

--- a/packages/editor/src/research-draft.ts
+++ b/packages/editor/src/research-draft.ts
@@ -33,8 +33,14 @@ export class ResearchDraftStore {
 		return this.#draft;
 	}
 
-	open(anchor: DOMRectLike, position?: RelativePosition): void {
+	canOpen(): boolean {
+		return this.#draft === undefined;
+	}
+
+	open(anchor: DOMRectLike, position?: RelativePosition): boolean {
+		if (!this.canOpen()) return false;
 		this.#set({ anchor, position, question: "" });
+		return true;
 	}
 
 	change(question: string): void {
@@ -116,9 +122,9 @@ export class ResearchDraftStore {
 		};
 	}
 
-	place(position: RelativePosition): boolean {
+	place(position: RelativePosition, writable = true): boolean {
 		let draft = this.#draft;
-		if (!draft?.created || draft.cancelling) return false;
+		if (!writable || !draft?.created || draft.cancelling) return false;
 		if (this.#insert(position, draft.created.id)) {
 			this.#set(undefined);
 			return true;
@@ -141,9 +147,10 @@ export class ResearchDraftStore {
 
 	async cancelCreated(
 		cancel: (id: string) => Promise<Research.RequestView>,
+		writable = true,
 	): Promise<boolean> {
 		let draft = this.#draft;
-		if (!draft?.created || draft.submitting || draft.cancelling) return false;
+		if (!writable || !draft?.created || draft.submitting || draft.cancelling) return false;
 		let id = draft.created.id;
 		this.#set({ ...draft, cancelling: true, error: undefined });
 		try {

--- a/packages/editor/src/research-draft.ts
+++ b/packages/editor/src/research-draft.ts
@@ -2,16 +2,47 @@ import type { Research } from "@chopin/protocol";
 import type { RelativePosition } from "yjs";
 import type { DOMRectLike } from "./toolbar/placement";
 
-export type ResearchDraft = {
+type ResearchDraftBase = {
 	anchor: DOMRectLike;
 	position?: RelativePosition;
 	question: string;
-	created?: Research.RequestView;
-	submitted?: { question: string; requestId: string };
-	submitting?: boolean;
-	cancelling?: boolean;
 	error?: string;
 };
+
+type Submission = { question: string; requestId: string };
+
+export type ResearchDraft =
+	& ResearchDraftBase
+	& (
+		| {
+			phase: "editing";
+			created?: never;
+			submitted?: Submission;
+			submitting?: false;
+			cancelling?: false;
+		}
+		| {
+			phase: "starting";
+			created?: never;
+			submitted: Submission;
+			submitting: true;
+			cancelling?: false;
+		}
+		| {
+			phase: "placement";
+			created: Research.RequestView;
+			submitted: Submission;
+			submitting?: false;
+			cancelling?: false;
+		}
+		| {
+			phase: "cancelling";
+			created: Research.RequestView;
+			submitted: Submission;
+			submitting?: false;
+			cancelling: true;
+		}
+	);
 
 type Placement = (position: RelativePosition, id: string) => boolean;
 
@@ -39,13 +70,13 @@ export class ResearchDraftStore {
 
 	open(anchor: DOMRectLike, position?: RelativePosition): boolean {
 		if (!this.canOpen()) return false;
-		this.#set({ anchor, position, question: "" });
+		this.#set({ phase: "editing", anchor, position, question: "" });
 		return true;
 	}
 
 	change(question: string): void {
 		let draft = this.#draft;
-		if (!draft || draft.submitting || draft.cancelling || draft.created) return;
+		if (draft?.phase !== "editing") return;
 		this.#set({
 			...draft,
 			question,
@@ -59,9 +90,7 @@ export class ResearchDraftStore {
 		fallbackPosition?: RelativePosition,
 	): Promise<void> {
 		let draft = this.#draft;
-		if (!draft || draft.submitting || draft.cancelling || draft.created || !draft.question.trim()) {
-			return;
-		}
+		if (draft?.phase !== "editing" || !draft.question.trim()) return;
 		let position = draft.position ?? fallbackPosition;
 		if (!position) {
 			this.#set({
@@ -74,7 +103,7 @@ export class ResearchDraftStore {
 		let submitted = draft.submitted?.question === draft.question
 			? draft.submitted
 			: { question: draft.question, requestId: crypto.randomUUID() };
-		this.#set({ ...draft, submitted, submitting: true, error: undefined });
+		this.#set({ ...draft, phase: "starting", submitted, submitting: true, error: undefined });
 
 		let request: Research.RequestView;
 		try {
@@ -84,7 +113,8 @@ export class ResearchDraftStore {
 			if (current) {
 				this.#set({
 					...current,
-					submitting: false,
+					phase: "editing",
+					submitting: undefined,
 					error: "Research could not be started.",
 				});
 			}
@@ -99,8 +129,9 @@ export class ResearchDraftStore {
 		}
 		this.#set({
 			...current,
+			phase: "placement",
 			created: request,
-			submitting: false,
+			submitting: undefined,
 			error:
 				"Research started, but its reference could not be placed. Choose a new insertion point in the document.",
 		});
@@ -110,8 +141,7 @@ export class ResearchDraftStore {
 		this.#placement = place;
 		let draft = this.#draft;
 		if (
-			draft?.created
-			&& !draft.cancelling
+			draft?.phase === "placement"
 			&& draft.position
 			&& this.#insert(draft.position, draft.created.id)
 		) {
@@ -124,7 +154,7 @@ export class ResearchDraftStore {
 
 	place(position: RelativePosition, writable = true): boolean {
 		let draft = this.#draft;
-		if (!writable || !draft?.created || draft.cancelling) return false;
+		if (!writable || draft?.phase !== "placement") return false;
 		if (this.#insert(position, draft.created.id)) {
 			this.#set(undefined);
 			return true;
@@ -140,7 +170,7 @@ export class ResearchDraftStore {
 	dismiss(): boolean {
 		let draft = this.#draft;
 		if (!draft) return true;
-		if (draft.submitting || draft.cancelling || draft.created) return false;
+		if (draft.phase !== "editing") return false;
 		this.#set(undefined);
 		return true;
 	}
@@ -150,30 +180,33 @@ export class ResearchDraftStore {
 		writable = true,
 	): Promise<boolean> {
 		let draft = this.#draft;
-		if (!writable || !draft?.created || draft.submitting || draft.cancelling) return false;
+		if (!writable || draft?.phase !== "placement") return false;
 		let id = draft.created.id;
-		this.#set({ ...draft, cancelling: true, error: undefined });
+		this.#set({ ...draft, phase: "cancelling", cancelling: true, error: undefined });
 		try {
 			await cancel(id);
 		} catch {
 			let current = this.#draft;
-			if (current?.created?.id === id) {
+			if (current?.phase === "cancelling" && current.created.id === id) {
 				this.#set({
 					...current,
-					cancelling: false,
+					phase: "placement",
+					cancelling: undefined,
 					error: "Research could not be cancelled.",
 				});
 			}
 			return false;
 		}
-		if (this.#draft?.created?.id !== id) return false;
+		if (this.#draft?.phase !== "cancelling" || this.#draft.created.id !== id) return false;
 		this.#set(undefined);
 		return true;
 	}
 
-	#current(requestId: string): ResearchDraft | undefined {
+	#current(requestId: string): Extract<ResearchDraft, { phase: "starting" }> | undefined {
 		let draft = this.#draft;
-		return draft?.submitted?.requestId === requestId ? draft : undefined;
+		return draft?.phase === "starting" && draft.submitted.requestId === requestId
+			? draft as Extract<ResearchDraft, { phase: "starting" }>
+			: undefined;
 	}
 
 	#insert(position: RelativePosition, id: string): boolean {

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -8,6 +8,72 @@
 
 @import "./callout.css";
 
+.plan-research-composer-surface {
+	width: min(22rem, calc(100vw - 1rem));
+	padding: 0.75rem;
+}
+
+.plan-research-composer {
+	display: grid;
+	gap: 0.625rem;
+}
+
+.plan-research-composer label,
+.plan-research-heading strong {
+	font-size: var(--text-sm);
+	font-weight: 600;
+	color: var(--color-text-primary);
+}
+
+.plan-research-composer textarea {
+	width: 100%;
+	min-height: 5rem;
+	resize: vertical;
+	border: var(--edge-width) solid var(--color-control-edge);
+	border-radius: var(--radius-md);
+	background: var(--color-control);
+	padding: 0.625rem;
+	color: var(--color-text-primary);
+	font: inherit;
+}
+
+.plan-research-heading {
+	display: grid;
+	gap: 0.25rem;
+}
+
+.plan-research-heading span,
+.plan-research-error,
+.plan-research-sources {
+	font-size: var(--text-sm);
+	color: var(--color-text-secondary);
+}
+
+.plan-research-error {
+	margin: 0;
+	color: var(--color-destructive-ink);
+}
+
+.plan-research-sources {
+	display: grid;
+	gap: 0.25rem;
+	margin: 0;
+	padding-inline-start: 1.125rem;
+}
+
+.plan-research-sources a {
+	color: var(--color-text-primary);
+	text-decoration: underline;
+	text-underline-offset: 0.125rem;
+}
+
+.plan-research-actions {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: flex-end;
+	gap: 0.5rem;
+}
+
 .plan-background-job-actions {
 	display: flex;
 	flex-wrap: wrap;

--- a/packages/editor/src/toolbar/index.tsx
+++ b/packages/editor/src/toolbar/index.tsx
@@ -62,7 +62,12 @@ export function Toolbar() {
 	return (
 		<>
 			<SelectionBubble disabled={disabled} onComment={comment} />
-			<SlashMenu binding={options.binding} disabled={disabled} research={options.research} />
+			<SlashMenu
+				binding={options.binding}
+				disabled={disabled}
+				drafts={options.researchDrafts}
+				research={options.research}
+			/>
 		</>
 	);
 }

--- a/packages/editor/src/toolbar/index.tsx
+++ b/packages/editor/src/toolbar/index.tsx
@@ -62,7 +62,7 @@ export function Toolbar() {
 	return (
 		<>
 			<SelectionBubble disabled={disabled} onComment={comment} />
-			<SlashMenu disabled={disabled} research={options.research} />
+			<SlashMenu binding={options.binding} disabled={disabled} research={options.research} />
 		</>
 	);
 }

--- a/packages/editor/src/toolbar/index.tsx
+++ b/packages/editor/src/toolbar/index.tsx
@@ -13,7 +13,10 @@ import { $getSelection } from "lexical";
 import { $describe } from "../passage";
 import { widgets$ } from "../widgets-plugin";
 import { SelectionBubble } from "./bubble";
+import { ResearchComposerSurface } from "./research";
 import { SlashMenu } from "./slash";
+
+const RESEARCH_ACTIONS = new Set(["research"]);
 
 /**
  * Reads what it needs from the realm so the surfaces below it stay ordinary
@@ -63,11 +66,17 @@ export function Toolbar() {
 		<>
 			<SelectionBubble disabled={disabled} onComment={comment} />
 			<SlashMenu
-				binding={options.binding}
+				actions={options.research && options.researchDrafts ? RESEARCH_ACTIONS : undefined}
 				disabled={disabled}
-				drafts={options.researchDrafts}
-				research={options.research}
 			/>
+			{options.research && options.researchDrafts && (
+				<ResearchComposerSurface
+					binding={options.binding}
+					disabled={disabled}
+					drafts={options.researchDrafts}
+					research={options.research}
+				/>
+			)}
 		</>
 	);
 }

--- a/packages/editor/src/toolbar/index.tsx
+++ b/packages/editor/src/toolbar/index.tsx
@@ -62,7 +62,7 @@ export function Toolbar() {
 	return (
 		<>
 			<SelectionBubble disabled={disabled} onComment={comment} />
-			<SlashMenu disabled={disabled} />
+			<SlashMenu disabled={disabled} research={options.research} />
 		</>
 	);
 }

--- a/packages/editor/src/toolbar/research.tsx
+++ b/packages/editor/src/toolbar/research.tsx
@@ -1,0 +1,277 @@
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+	useSyncExternalStore,
+} from "react";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $getAnchorAndFocusForUserState } from "@lexical/yjs";
+import {
+	$createRangeSelection,
+	$getNodeByKey,
+	$getSelection,
+	$insertNodes,
+	$isElementNode,
+	$isRangeSelection,
+	$isTextNode,
+	$setSelection,
+	COMMAND_PRIORITY_LOW,
+	createCommand,
+} from "lexical";
+import { $createResearchNode, $isResearchNode } from "@chopin/dialect";
+import * as Y from "yjs";
+
+import { ResearchComposer } from "../widgets/research";
+import { placeSurface } from "./placement";
+import { editorSurfaceViewport, listenToEditorGeometry, SHELL } from "./surface";
+
+import type { Binding } from "@lexical/yjs";
+import type { LexicalEditor } from "lexical";
+import type { ResearchDraftStore } from "../research-draft";
+import type { ResearchStore } from "../widget-options";
+import type { DOMRectLike, SurfacePlacement } from "./placement";
+
+export type OpenResearch = {
+	anchor: DOMRectLike;
+	consume: () => boolean;
+};
+
+export const OPEN_RESEARCH_COMMAND = createCommand<OpenResearch>("OPEN_RESEARCH_COMMAND");
+
+/** Capture a document-safe insertion point before an asynchronous request begins. */
+export function captureResearchPosition(binding: Binding): Y.RelativePosition | undefined {
+	let selection = $getSelection();
+	if (!$isRangeSelection(selection) || !selection.isCollapsed()) return;
+	let point = selection.anchor;
+	let node = point.getNode();
+	let collab = binding.collabNodeMap.get(point.key);
+	if (!collab) return;
+
+	let shared = collab.getSharedType();
+	let offset = point.offset;
+	if ($isTextNode(node)) {
+		let parent = node.getParent();
+		let parentCollab = parent && binding.collabNodeMap.get(parent.getKey());
+		let currentOffset = collab.getOffset();
+		if (!parentCollab || currentOffset < 0) return;
+		shared = parentCollab.getSharedType();
+		offset = currentOffset + 1 + point.offset;
+	} else if ($isElementNode(node) && point.type === "element") {
+		offset = 0;
+		for (let child of node.getChildren().slice(0, point.offset)) {
+			offset += $isTextNode(child) ? child.getTextContentSize() + 1 : 1;
+		}
+	}
+	return Y.createRelativePositionFromTypeIndex(shared, offset);
+}
+
+/** Insert only when the saved collaborative position still resolves, and verify the result. */
+export function insertResearchReference(
+	editor: LexicalEditor,
+	binding: Binding,
+	position: Y.RelativePosition,
+	id: string,
+): boolean {
+	let key: string | undefined;
+	try {
+		editor.update(() => {
+			let resolved = $getAnchorAndFocusForUserState(binding, {
+				anchorPos: position,
+				focusPos: position,
+				color: "",
+				focusing: false,
+				name: "",
+				awarenessData: {},
+			});
+			if (!resolved.anchorKey || !resolved.focusKey) return;
+			let anchor = $getNodeByKey(resolved.anchorKey);
+			let focus = $getNodeByKey(resolved.focusKey);
+			if (!anchor || !focus) return;
+			let selection = $createRangeSelection();
+			selection.anchor.set(
+				resolved.anchorKey,
+				resolved.anchorOffset,
+				$isElementNode(anchor) ? "element" : "text",
+			);
+			selection.focus.set(
+				resolved.focusKey,
+				resolved.focusOffset,
+				$isElementNode(focus) ? "element" : "text",
+			);
+			$setSelection(selection);
+			let reference = $createResearchNode(id);
+			$insertNodes([reference]);
+			key = reference.getKey();
+		}, { discrete: true });
+	} catch {
+		return false;
+	}
+	if (!key) return false;
+	let inserted = false;
+	editor.getEditorState().read(() => {
+		let reference = $getNodeByKey(key!);
+		inserted = $isResearchNode(reference) && reference.getId() === id && reference.isAttached();
+	});
+	return inserted;
+}
+
+export function dismissResearchComposer(
+	editor: Pick<LexicalEditor, "focus">,
+	dismiss: () => void,
+): void {
+	dismiss();
+	editor.focus();
+}
+
+export function beginResearchDraft(
+	drafts: ResearchDraftStore,
+	consume: () => { anchor: DOMRectLike; position?: Y.RelativePosition } | undefined,
+): boolean {
+	if (!drafts.canOpen()) return false;
+	let next = consume();
+	return next ? drafts.open(next.anchor, next.position) : false;
+}
+
+export type ResearchComposerSurfaceProps = {
+	binding?: Binding;
+	disabled?: boolean;
+	drafts: ResearchDraftStore;
+	research: ResearchStore;
+};
+
+export function ResearchComposerSurface(
+	{ binding, disabled, drafts, research }: ResearchComposerSurfaceProps,
+) {
+	let [editor] = useLexicalComposerContext();
+	let subscribe = useCallback((listener: () => void) => drafts.subscribe(listener), [drafts]);
+	let read = useCallback(() => drafts.get(), [drafts]);
+	let draft = useSyncExternalStore(subscribe, read, read);
+	let surface = useRef<HTMLDivElement>(null);
+	let [position, setPosition] = useState<SurfacePlacement>();
+
+	useEffect(() =>
+		editor.registerCommand(
+			OPEN_RESEARCH_COMMAND,
+			({ anchor, consume }) => {
+				if (disabled) return false;
+				return beginResearchDraft(drafts, () => {
+					if (!consume()) return;
+					let saved: Y.RelativePosition | undefined;
+					if (binding) {
+						editor.getEditorState().read(() => {
+							saved = captureResearchPosition(binding);
+						});
+					}
+					return { anchor, position: saved };
+				});
+			},
+			COMMAND_PRIORITY_LOW,
+		), [binding, disabled, drafts, editor]);
+
+	let place = useCallback(() => {
+		let element = surface.current;
+		if (!element || !draft) return;
+		let viewport = editorSurfaceViewport(editor);
+		element.style.maxWidth = `${Math.max(0, viewport.width - 16)}px`;
+		let next = placeSurface(
+			draft.anchor,
+			{ width: element.offsetWidth, height: element.scrollHeight },
+			viewport,
+		);
+		setPosition(current =>
+			current?.left === next.left && current.top === next.top
+				&& current.maxHeight === next.maxHeight
+				? current
+				: next
+		);
+	}, [draft, editor]);
+
+	useLayoutEffect(() => {
+		if (draft) place();
+	}, [draft, place]);
+
+	useEffect(() => {
+		if (!draft) return;
+		return listenToEditorGeometry(editor, place);
+	}, [draft, editor, place]);
+
+	useLayoutEffect(() => {
+		if (!binding || disabled) return;
+		return drafts.attachPlacement((saved, id) =>
+			insertResearchReference(editor, binding, saved, id)
+		);
+	}, [binding, disabled, drafts, editor]);
+
+	if (!draft) return null;
+	let dismiss = () => dismissResearchComposer(editor, () => drafts.dismiss());
+	let currentPosition = () => {
+		if (!binding) return;
+		let found: Y.RelativePosition | undefined;
+		editor.getEditorState().read(() => {
+			found = captureResearchPosition(binding);
+		});
+		return found;
+	};
+	let submit = () => {
+		if (!draft.question.trim() || !binding || disabled) return;
+		if (draft.phase === "placement") {
+			let saved = currentPosition();
+			if (saved) drafts.place(saved);
+			return;
+		}
+		if (draft.phase !== "editing") return;
+		void drafts.start(
+			(question, requestId) => research.create(question, requestId),
+			currentPosition(),
+		);
+	};
+	let cancel = () => {
+		if (draft.phase === "editing") return dismiss();
+		if (draft.phase !== "placement" || disabled) return;
+		void drafts.cancelCreated(id => research.cancel(id)).then(cancelled => {
+			if (cancelled) editor.focus();
+		});
+	};
+	let busy = draft.phase === "starting" || draft.phase === "cancelling";
+	let created = draft.phase === "placement" || draft.phase === "cancelling";
+	return (
+		<div
+			ref={surface}
+			aria-label="Start research"
+			role="dialog"
+			data-focus-boundary=""
+			contentEditable={false}
+			className={`${SHELL} plan-research-composer-surface`}
+			style={position
+				? { top: position.top, left: position.left, maxHeight: position.maxHeight }
+				: {
+					top: draft.anchor.bottom + 8,
+					left: draft.anchor.left,
+					visibility: "hidden",
+				}}
+		>
+			<ResearchComposer
+				blocked={disabled
+					? "Wait until the document is editable before placing research."
+					: binding
+					? undefined
+					: "Connect to the document before starting research."}
+				busyLabel={draft.phase === "cancelling" ? "Cancelling…" : undefined}
+				cancelDisabled={created && !!disabled}
+				cancelLabel={created ? "Cancel research" : undefined}
+				dismissible={draft.phase === "editing"}
+				error={draft.error}
+				onCancel={cancel}
+				onChange={question => drafts.change(question)}
+				onEscape={dismiss}
+				onSubmit={submit}
+				question={draft.question}
+				questionLocked={created}
+				submitLabel={created ? "Place research here" : undefined}
+				submitting={busy}
+			/>
+		</div>
+	);
+}

--- a/packages/editor/src/toolbar/slash.test.ts
+++ b/packages/editor/src/toolbar/slash.test.ts
@@ -216,26 +216,21 @@ describe("slash menu commands", () => {
 		expect(exportPlan(b.editor)).toBe(source);
 	});
 
-	it("reports an insertion failure and reuses the created request at a new cursor", async () => {
+	it("reports an insertion failure and places the same request at a new cursor", async () => {
 		let target = peer();
 		importPlan(target.editor, "Keep this\n");
 		await settle();
-		let module = await import("./slash");
-		let create = (module as unknown as {
-			createResearchReference?: (
+		let module = await import("./slash") as unknown as {
+			captureResearchPosition(binding: Binding): Y.RelativePosition | undefined;
+			insertResearchReference(
 				editor: LexicalEditor,
 				binding: Binding,
 				position: Y.RelativePosition,
-				question: string,
-				requestId: string,
-				persist: (question: string, requestId: string) => Promise<Research.RequestView>,
-			) => Promise<{ inserted: boolean; request: Research.RequestView }>;
-		}).createResearchReference;
-		expect(typeof create).toBe("function");
-		if (!create) return;
+				id: string,
+			): boolean;
+		};
 		let foreign = new Y.Doc();
 		let invalid = Y.createRelativePositionFromTypeIndex(foreign.getText("gone"), 0);
-		let calls = 0;
 		let request: Research.RequestView = {
 			id: "07aeae6d-073d-4560-a9f4-bb8e4d954a46",
 			channelId: "document-one",
@@ -246,36 +241,25 @@ describe("slash menu commands", () => {
 			createdAt: "2026-08-24T09:00:00.000Z",
 			updatedAt: "2026-08-24T09:00:00.000Z",
 		};
-		let result = await create(
+		expect(module.insertResearchReference(
 			target.editor,
 			target.binding,
 			invalid,
-			"  Keep this brief exactly.  ",
-			"request-one",
-			async () => {
-				calls++;
-				return request;
-			},
-		);
-		expect(result).toEqual({ inserted: false, request });
+			request.id,
+		)).toBe(false);
 		expect(exportPlan(target.editor)).toBe("Keep this\n");
 
 		let saved: Y.RelativePosition | undefined;
 		target.editor.update(() => {
 			$getRoot().selectEnd();
-			saved = (module as unknown as {
-				captureResearchPosition(binding: Binding): Y.RelativePosition | undefined;
-			}).captureResearchPosition(target.binding);
+			saved = module.captureResearchPosition(target.binding);
 		}, { discrete: true });
-		expect((module as unknown as {
-			insertResearchReference(
-				editor: LexicalEditor,
-				binding: Binding,
-				position: Y.RelativePosition,
-				id: string,
-			): boolean;
-		}).insertResearchReference(target.editor, target.binding, saved!, request.id)).toBe(true);
-		expect(calls).toBe(1);
+		expect(module.insertResearchReference(
+			target.editor,
+			target.binding,
+			saved!,
+			request.id,
+		)).toBe(true);
 		expect(exportPlan(target.editor)).toContain(`<Research id="${request.id}" />`);
 	});
 

--- a/packages/editor/src/toolbar/slash.test.ts
+++ b/packages/editor/src/toolbar/slash.test.ts
@@ -36,6 +36,18 @@ const PROVIDER = {
 	on() {},
 } as unknown as Provider;
 
+const ANCHOR = { top: 1, right: 2, bottom: 3, left: 4, width: 5, height: 6 };
+const REQUEST: Research.RequestView = {
+	id: "07aeae6d-073d-4560-a9f4-bb8e4d954a46",
+	channelId: "document-one",
+	question: "Keep this question",
+	state: "running",
+	stage: "queued",
+	sources: [],
+	createdAt: "2026-08-24T09:00:00.000Z",
+	updatedAt: "2026-08-24T09:00:00.000Z",
+};
+
 function peer(): { editor: LexicalEditor; doc: Y.Doc; binding: Binding } {
 	let editor = createHeadlessEditor({
 		nodes: registry().nodes,
@@ -145,6 +157,54 @@ describe("slash menu trigger", () => {
 });
 
 describe("slash menu commands", () => {
+	it("does not consume a second trigger during submission or created recovery", async () => {
+		let module = await import("./slash") as unknown as {
+			beginResearchDraft?: (
+				drafts: {
+					canOpen(): boolean;
+					open(anchor: typeof ANCHOR, position?: Y.RelativePosition): boolean;
+				},
+				consume: () => { anchor: typeof ANCHOR; position?: Y.RelativePosition } | undefined,
+			) => boolean;
+		};
+		let { ResearchDraftStore } = await import("../research-draft");
+		let drafts = new ResearchDraftStore();
+		let original = Y.createRelativePositionFromTypeIndex(new Y.Doc().getText("original"), 0);
+		expect(drafts.open(ANCHOR, original)).toBe(true);
+		drafts.change(REQUEST.question);
+		let resolve!: (request: Research.RequestView) => void;
+		let create = new Promise<Research.RequestView>(done => resolve = done);
+		let running = drafts.start(() => create);
+		let requestId = drafts.get()?.submitted?.requestId;
+		let consumed = 0;
+		let attempt = () =>
+			module.beginResearchDraft!(drafts, () => {
+				consumed++;
+				return {
+					anchor: { ...ANCHOR, top: 99 },
+					position: Y.createRelativePositionFromTypeIndex(
+						new Y.Doc().getText("replacement"),
+						0,
+					),
+				};
+			});
+
+		expect(typeof module.beginResearchDraft).toBe("function");
+		if (!module.beginResearchDraft) return;
+		expect(attempt()).toBe(false);
+		expect(consumed).toBe(0);
+		expect(drafts.get()?.submitted?.requestId).toBe(requestId);
+
+		resolve(REQUEST);
+		await running;
+		expect(drafts.get()?.created).toEqual(REQUEST);
+		expect(attempt()).toBe(false);
+		expect(consumed).toBe(0);
+		expect(drafts.get()?.question).toBe(REQUEST.question);
+		expect(drafts.get()?.submitted?.requestId).toBe(requestId);
+		expect(drafts.get()?.position).toBe(original);
+	});
+
 	it("discovers the research composer by research and web search", async () => {
 		let module = await import("./slash");
 		let available = (module as unknown as {

--- a/packages/editor/src/toolbar/slash.test.ts
+++ b/packages/editor/src/toolbar/slash.test.ts
@@ -1,4 +1,17 @@
 import { describe, expect, it } from "bun:test";
+import { createHeadlessEditor } from "@lexical/headless";
+import {
+	$createParagraphNode,
+	$createTextNode,
+	$getRoot,
+	$getSelection,
+	$isRangeSelection,
+} from "lexical";
+
+import { exportPlan, registry } from "@chopin/dialect";
+
+import type { LexicalEditor, RangeSelection } from "lexical";
+import type { Research } from "@chopin/protocol";
 
 import { decide, trigger } from "./slash";
 
@@ -58,6 +71,105 @@ describe("slash menu trigger", () => {
 	it("has nothing to offer without a slash", () => {
 		expect(at("Rollout plan|")).toBeUndefined();
 		expect(at("|")).toBeUndefined();
+	});
+});
+
+describe("slash menu commands", () => {
+	it("discovers the research composer by research and web search", async () => {
+		let module = await import("./slash");
+		let available = (module as unknown as {
+			availableCommands?: (query: string) => Array<{ id: string }>;
+		}).availableCommands;
+		expect(available?.("research").map(command => command.id)).toEqual(["research"]);
+		expect(available?.("web search").map(command => command.id)).toEqual(["research"]);
+	});
+
+	it("opens the local composer instead of inserting a document node immediately", async () => {
+		let module = await import("./slash");
+		let command = module.availableCommands("research")[0] as unknown as {
+			run(editor: LexicalEditor, actions: { research(): void }): void;
+		};
+		let opened = 0;
+		command.run({} as LexicalEditor, { research: () => opened++ });
+		expect(opened).toBe(1);
+	});
+
+	it("inserts a durable reference at the selection saved before the request", async () => {
+		let schema = registry();
+		let editor = createHeadlessEditor({
+			nodes: schema.nodes,
+			onError: error => {
+				throw error;
+			},
+		});
+		let saved: RangeSelection | undefined;
+		editor.update(() => {
+			let text = $createTextNode("Before after");
+			$getRoot().append($createParagraphNode().append(text));
+			text.select(7, 7);
+			let selection = $getSelection();
+			if ($isRangeSelection(selection)) saved = selection.clone();
+		}, { discrete: true });
+		editor.update(() => $getRoot().selectEnd(), { discrete: true });
+
+		let module = await import("./slash");
+		let insert = (module as unknown as {
+			insertResearchReference?: (
+				editor: LexicalEditor,
+				selection: RangeSelection,
+				id: string,
+			) => boolean;
+		}).insertResearchReference;
+		expect(typeof insert).toBe("function");
+		if (!insert || !saved) return;
+		expect(insert(editor, saved, "workspace-one")).toBe(true);
+
+		let source = exportPlan(editor, { registry: schema });
+		expect(source).toContain("Before");
+		expect(source).toContain('<Research id="workspace-one" />');
+		expect(source).toContain("after");
+		expect(source.indexOf("Before")).toBeLessThan(source.indexOf("<Research"));
+		expect(source.indexOf("<Research")).toBeLessThan(source.indexOf("after"));
+	});
+
+	it("does not insert a dead reference when durable creation fails", async () => {
+		let schema = registry();
+		let editor = createHeadlessEditor({
+			nodes: schema.nodes,
+			onError: error => {
+				throw error;
+			},
+		});
+		let saved: RangeSelection | undefined;
+		editor.update(() => {
+			let text = $createTextNode("Keep this");
+			$getRoot().append($createParagraphNode().append(text));
+			text.selectEnd();
+			let selection = $getSelection();
+			if ($isRangeSelection(selection)) saved = selection.clone();
+		}, { discrete: true });
+		let module = await import("./slash");
+		let create = (module as unknown as {
+			createResearchReference?: (
+				editor: LexicalEditor,
+				selection: RangeSelection,
+				question: string,
+				requestId: string,
+				persist: (question: string, requestId: string) => Promise<Research.RequestView>,
+			) => Promise<Research.RequestView>;
+		}).createResearchReference;
+		expect(typeof create).toBe("function");
+		if (!create || !saved) return;
+		await expect(create(
+			editor,
+			saved,
+			"  Keep this brief exactly.  ",
+			"request-one",
+			async () => {
+				throw new Error("offline");
+			},
+		)).rejects.toThrow("offline");
+		expect(exportPlan(editor, { registry: schema })).toBe("Keep this\n");
 	});
 });
 

--- a/packages/editor/src/toolbar/slash.test.ts
+++ b/packages/editor/src/toolbar/slash.test.ts
@@ -158,7 +158,7 @@ describe("slash menu trigger", () => {
 
 describe("slash menu commands", () => {
 	it("does not consume a second trigger during submission or created recovery", async () => {
-		let module = await import("./slash") as unknown as {
+		let module = await import("./research") as unknown as {
 			beginResearchDraft?: (
 				drafts: {
 					canOpen(): boolean;
@@ -216,11 +216,15 @@ describe("slash menu commands", () => {
 
 	it("opens the local composer instead of inserting a document node immediately", async () => {
 		let module = await import("./slash");
-		let command = module.availableCommands("research")[0] as unknown as {
-			run(editor: LexicalEditor, actions: { research(): void }): void;
-		};
+		let command = module.availableCommands("research")[0]!;
 		let opened = 0;
-		command.run({} as LexicalEditor, { research: () => opened++ });
+		if (command.kind !== "action") throw new Error("research must be an action command");
+		command.run({
+			dispatchCommand(_command, action: { consume(): boolean }) {
+				if (action.consume()) opened++;
+				return true;
+			},
+		} as LexicalEditor, { anchor: ANCHOR, consume: () => true });
 		expect(opened).toBe(1);
 	});
 
@@ -231,7 +235,7 @@ describe("slash menu commands", () => {
 		importPlan(a.editor, "Before after\n");
 		await settle();
 
-		let module = await import("./slash") as unknown as {
+		let module = await import("./research") as unknown as {
 			captureResearchPosition?: (binding: Binding) => Y.RelativePosition | undefined;
 			insertResearchReference?: (
 				editor: LexicalEditor,
@@ -280,7 +284,7 @@ describe("slash menu commands", () => {
 		let target = peer();
 		importPlan(target.editor, "Keep this\n");
 		await settle();
-		let module = await import("./slash") as unknown as {
+		let module = await import("./research") as unknown as {
 			captureResearchPosition(binding: Binding): Y.RelativePosition | undefined;
 			insertResearchReference(
 				editor: LexicalEditor,
@@ -324,7 +328,7 @@ describe("slash menu commands", () => {
 	});
 
 	it("restores editor focus when the research composer is dismissed", async () => {
-		let module = await import("./slash") as unknown as {
+		let module = await import("./research") as unknown as {
 			dismissResearchComposer?: (editor: Pick<LexicalEditor, "focus">, dismiss: () => void) => void;
 		};
 		expect(typeof module.dismissResearchComposer).toBe("function");

--- a/packages/editor/src/toolbar/slash.test.ts
+++ b/packages/editor/src/toolbar/slash.test.ts
@@ -1,19 +1,82 @@
 import { describe, expect, it } from "bun:test";
 import { createHeadlessEditor } from "@lexical/headless";
+import { createYjsBinding, syncLexicalUpdateToYjs, syncYjsChangesToLexical } from "@lexical/yjs";
 import {
 	$createParagraphNode,
 	$createTextNode,
 	$getRoot,
 	$getSelection,
+	$isElementNode,
 	$isRangeSelection,
+	$isTextNode,
 } from "lexical";
 
-import { exportPlan, registry } from "@chopin/dialect";
+import * as Y from "yjs";
 
-import type { LexicalEditor, RangeSelection } from "lexical";
+import { exportPlan, importPlan, registry } from "@chopin/dialect";
+
+import type { Binding, Provider } from "@lexical/yjs";
+import type { LexicalEditor } from "lexical";
 import type { Research } from "@chopin/protocol";
 
 import { decide, trigger } from "./slash";
+
+const PROVIDER = {
+	awareness: {
+		getLocalState: () => null,
+		getStates: () => new Map(),
+		off() {},
+		on() {},
+		setLocalState() {},
+		setLocalStateField() {},
+	},
+	connect() {},
+	disconnect() {},
+	off() {},
+	on() {},
+} as unknown as Provider;
+
+function peer(): { editor: LexicalEditor; doc: Y.Doc; binding: Binding } {
+	let editor = createHeadlessEditor({
+		nodes: registry().nodes,
+		onError: error => {
+			throw error;
+		},
+	});
+	let doc = new Y.Doc();
+	let binding = createYjsBinding({ editor, id: "plan", doc, docMap: new Map([["plan", doc]]) });
+	editor.registerUpdateListener(
+		({ dirtyElements, dirtyLeaves, editorState, normalizedNodes, prevEditorState, tags }) => {
+			syncLexicalUpdateToYjs(
+				binding,
+				PROVIDER,
+				prevEditorState,
+				editorState,
+				dirtyElements,
+				dirtyLeaves,
+				normalizedNodes,
+				tags,
+			);
+		},
+	);
+	binding.root.getSharedType().observeDeep((events, transaction) => {
+		if (transaction.origin !== binding) syncYjsChangesToLexical(binding, PROVIDER, events, false);
+	});
+	return { editor, doc, binding };
+}
+
+function connect(a: Y.Doc, b: Y.Doc) {
+	a.on("update", (update, origin) => {
+		if (origin !== b) Y.applyUpdate(b, update, a);
+	});
+	b.on("update", (update, origin) => {
+		if (origin !== a) Y.applyUpdate(a, update, b);
+	});
+}
+
+async function settle(): Promise<void> {
+	for (let i = 0; i < 5; i++) await new Promise(resolve => setTimeout(resolve, 0));
+}
 
 /** Defaults to a local, armed, settled keystroke; each case varies one thing. */
 function when(over: Partial<Parameters<typeof decide>[0]> = {}) {
@@ -57,6 +120,13 @@ describe("slash menu trigger", () => {
 		expect(at("/ |")).toBeUndefined();
 	});
 
+	it("keeps the multi-word web search alias reachable", () => {
+		expect(at("/web |")).toBe("web ");
+		expect(at("/web s|")).toBe("web s");
+		expect(at("/web search|")).toBe("web search");
+		expect(at("/web search more|")).toBeUndefined();
+	});
+
 	it("ignores slashes the caret has moved away from", () => {
 		// Editing earlier in a line that happens to contain a trigger.
 		expect(at("Deploy| /table")).toBeUndefined();
@@ -94,82 +164,133 @@ describe("slash menu commands", () => {
 		expect(opened).toBe(1);
 	});
 
-	it("inserts a durable reference at the selection saved before the request", async () => {
-		let schema = registry();
-		let editor = createHeadlessEditor({
-			nodes: schema.nodes,
-			onError: error => {
-				throw error;
-			},
-		});
-		let saved: RangeSelection | undefined;
-		editor.update(() => {
-			let text = $createTextNode("Before after");
-			$getRoot().append($createParagraphNode().append(text));
-			text.select(7, 7);
-			let selection = $getSelection();
-			if ($isRangeSelection(selection)) saved = selection.clone();
-		}, { discrete: true });
-		editor.update(() => $getRoot().selectEnd(), { discrete: true });
+	it("rebases the saved insertion point across preceding collaborative edits", async () => {
+		let a = peer();
+		let b = peer();
+		connect(a.doc, b.doc);
+		importPlan(a.editor, "Before after\n");
+		await settle();
 
-		let module = await import("./slash");
-		let insert = (module as unknown as {
+		let module = await import("./slash") as unknown as {
+			captureResearchPosition?: (binding: Binding) => Y.RelativePosition | undefined;
 			insertResearchReference?: (
 				editor: LexicalEditor,
-				selection: RangeSelection,
+				binding: Binding,
+				position: Y.RelativePosition,
 				id: string,
 			) => boolean;
-		}).insertResearchReference;
-		expect(typeof insert).toBe("function");
-		if (!insert || !saved) return;
-		expect(insert(editor, saved, "workspace-one")).toBe(true);
+		};
+		expect(typeof module.captureResearchPosition).toBe("function");
+		expect(typeof module.insertResearchReference).toBe("function");
+		if (!module.captureResearchPosition || !module.insertResearchReference) return;
+		let saved: Y.RelativePosition | undefined;
+		a.editor.update(() => {
+			let paragraph = $getRoot().getFirstChild();
+			let text = $isElementNode(paragraph) ? paragraph.getFirstChild() : undefined;
+			if (!$isTextNode(text)) return;
+			text.select(7, 7);
+			saved = module.captureResearchPosition?.(a.binding);
+		}, { discrete: true });
+		expect(saved).toBeDefined();
 
-		let source = exportPlan(editor, { registry: schema });
-		expect(source).toContain("Before");
-		expect(source).toContain('<Research id="workspace-one" />');
-		expect(source).toContain("after");
-		expect(source.indexOf("Before")).toBeLessThan(source.indexOf("<Research"));
-		expect(source.indexOf("<Research")).toBeLessThan(source.indexOf("after"));
+		b.editor.update(() => {
+			let paragraph = $getRoot().getFirstChild();
+			let text = $isElementNode(paragraph) ? paragraph.getFirstChild() : undefined;
+			if ($isRangeSelection($getSelection())) $getRoot().selectEnd();
+			if ($isTextNode(text)) text.setTextContent(`Earlier ${text.getTextContent()}`);
+			paragraph?.insertBefore($createParagraphNode().append($createTextNode("New block")));
+		}, { discrete: true });
+		await settle();
+
+		expect(module.insertResearchReference(
+			a.editor,
+			a.binding,
+			saved!,
+			"8f4d193b-2018-4977-b404-0092bb911676",
+		)).toBe(true);
+		await settle();
+		let source = exportPlan(a.editor);
+		expect(source).toBe(
+			'New block\n\nEarlier Before&#x20;\n\n<Research id="8f4d193b-2018-4977-b404-0092bb911676" />\n\nafter\n',
+		);
+		expect(exportPlan(b.editor)).toBe(source);
 	});
 
-	it("does not insert a dead reference when durable creation fails", async () => {
-		let schema = registry();
-		let editor = createHeadlessEditor({
-			nodes: schema.nodes,
-			onError: error => {
-				throw error;
-			},
-		});
-		let saved: RangeSelection | undefined;
-		editor.update(() => {
-			let text = $createTextNode("Keep this");
-			$getRoot().append($createParagraphNode().append(text));
-			text.selectEnd();
-			let selection = $getSelection();
-			if ($isRangeSelection(selection)) saved = selection.clone();
-		}, { discrete: true });
+	it("reports an insertion failure and reuses the created request at a new cursor", async () => {
+		let target = peer();
+		importPlan(target.editor, "Keep this\n");
+		await settle();
 		let module = await import("./slash");
 		let create = (module as unknown as {
 			createResearchReference?: (
 				editor: LexicalEditor,
-				selection: RangeSelection,
+				binding: Binding,
+				position: Y.RelativePosition,
 				question: string,
 				requestId: string,
 				persist: (question: string, requestId: string) => Promise<Research.RequestView>,
-			) => Promise<Research.RequestView>;
+			) => Promise<{ inserted: boolean; request: Research.RequestView }>;
 		}).createResearchReference;
 		expect(typeof create).toBe("function");
-		if (!create || !saved) return;
-		await expect(create(
-			editor,
-			saved,
+		if (!create) return;
+		let foreign = new Y.Doc();
+		let invalid = Y.createRelativePositionFromTypeIndex(foreign.getText("gone"), 0);
+		let calls = 0;
+		let request: Research.RequestView = {
+			id: "07aeae6d-073d-4560-a9f4-bb8e4d954a46",
+			channelId: "document-one",
+			question: "  Keep this brief exactly.  ",
+			state: "running",
+			stage: "queued",
+			sources: [],
+			createdAt: "2026-08-24T09:00:00.000Z",
+			updatedAt: "2026-08-24T09:00:00.000Z",
+		};
+		let result = await create(
+			target.editor,
+			target.binding,
+			invalid,
 			"  Keep this brief exactly.  ",
 			"request-one",
 			async () => {
-				throw new Error("offline");
+				calls++;
+				return request;
 			},
-		)).rejects.toThrow("offline");
-		expect(exportPlan(editor, { registry: schema })).toBe("Keep this\n");
+		);
+		expect(result).toEqual({ inserted: false, request });
+		expect(exportPlan(target.editor)).toBe("Keep this\n");
+
+		let saved: Y.RelativePosition | undefined;
+		target.editor.update(() => {
+			$getRoot().selectEnd();
+			saved = (module as unknown as {
+				captureResearchPosition(binding: Binding): Y.RelativePosition | undefined;
+			}).captureResearchPosition(target.binding);
+		}, { discrete: true });
+		expect((module as unknown as {
+			insertResearchReference(
+				editor: LexicalEditor,
+				binding: Binding,
+				position: Y.RelativePosition,
+				id: string,
+			): boolean;
+		}).insertResearchReference(target.editor, target.binding, saved!, request.id)).toBe(true);
+		expect(calls).toBe(1);
+		expect(exportPlan(target.editor)).toContain(`<Research id="${request.id}" />`);
+	});
+
+	it("restores editor focus when the research composer is dismissed", async () => {
+		let module = await import("./slash") as unknown as {
+			dismissResearchComposer?: (editor: Pick<LexicalEditor, "focus">, dismiss: () => void) => void;
+		};
+		expect(typeof module.dismissResearchComposer).toBe("function");
+		if (!module.dismissResearchComposer) return;
+		let calls: string[] = [];
+		module.dismissResearchComposer(
+			{ focus: () => calls.push("focus") },
+			() => calls.push("dismiss"),
+		);
+		expect(calls).toEqual(["dismiss", "focus"]);
 	});
 });
 

--- a/packages/editor/src/toolbar/slash.tsx
+++ b/packages/editor/src/toolbar/slash.tsx
@@ -15,6 +15,7 @@ import {
 	useMemo,
 	useRef,
 	useState,
+	useSyncExternalStore,
 } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $copyBlockFormatIndent, $setBlocksType } from "@lexical/selection";
@@ -52,6 +53,7 @@ import { $createParagraphNode, $createTextNode, $insertNodes } from "lexical";
 import * as Y from "yjs";
 
 import { askForUrl } from "./url";
+import { ResearchDraftStore } from "../research-draft";
 import { ResearchComposer } from "../widgets/research";
 import { placeSurface } from "./placement";
 import {
@@ -65,7 +67,6 @@ import {
 
 import type { Binding } from "@lexical/yjs";
 import type { ElementNode, LexicalEditor, LexicalNode } from "lexical";
-import type { Research } from "@chopin/protocol";
 import type { ResearchStore } from "../widget-options";
 import type { DOMRectLike, SurfacePlacement } from "./placement";
 
@@ -313,18 +314,6 @@ export function insertResearchReference(
 	return inserted;
 }
 
-export async function createResearchReference(
-	editor: LexicalEditor,
-	binding: Binding,
-	position: Y.RelativePosition,
-	question: string,
-	requestId: string,
-	persist: (question: string, requestId: string) => Promise<Research.RequestView>,
-): Promise<{ inserted: boolean; request: Research.RequestView }> {
-	let request = await persist(question, requestId);
-	return { inserted: insertResearchReference(editor, binding, position, request.id), request };
-}
-
 export function dismissResearchComposer(
 	editor: Pick<LexicalEditor, "focus">,
 	dismiss: () => void,
@@ -401,32 +390,31 @@ export function decide(
 export type SlashMenuProps = {
 	binding?: Binding;
 	disabled?: boolean;
+	drafts?: ResearchDraftStore;
 	research?: ResearchStore;
 };
 
-type ResearchDraft = {
-	anchor: DOMRectLike;
-	position?: Y.RelativePosition;
-	question: string;
-	created?: Research.RequestView;
-	submitted?: { question: string; requestId: string };
-	submitting?: boolean;
-	error?: string;
-};
-
-export function SlashMenu({ binding, disabled, research }: SlashMenuProps) {
+export function SlashMenu({ binding, disabled, drafts, research }: SlashMenuProps) {
 	let [editor] = useLexicalComposerContext();
 	let [query, setQuery] = useState<string>();
 	let [anchor, setAnchor] = useState<DOMRectLike>();
 	let [position, setPosition] = useState<SurfacePlacement>();
 	let [index, setIndex] = useState(0);
-	let [draft, setDraft] = useState<ResearchDraft>();
+	let subscribeDraft = useCallback(
+		(listener: () => void) => drafts?.subscribe(listener) ?? (() => {}),
+		[drafts],
+	);
+	let readDraft = useCallback(() => drafts?.get(), [drafts]);
+	let draft = useSyncExternalStore(subscribeDraft, readDraft, readDraft);
 	let surface = useRef<HTMLDivElement>(null);
 	let open = query !== undefined && !disabled;
 
 	let matches = useMemo(
-		() => availableCommands(query ?? "").filter(command => command.id !== "research" || research),
-		[query, research],
+		() =>
+			availableCommands(query ?? "").filter(command =>
+				command.id !== "research" || (research && drafts)
+			),
+		[query, research, drafts],
 	);
 	// Groups now place dividers while options remain direct listbox children.
 	let grouped = useMemo(() => {
@@ -494,14 +482,14 @@ export function SlashMenu({ binding, disabled, research }: SlashMenuProps) {
 		let placement = anchor;
 		close();
 		command.run(editor, {
-			research: research && consumed && placement
+			research: research && drafts && consumed && placement
 				? () => {
 					setPosition(undefined);
-					setDraft({ anchor: placement, position: consumed.position, question: "" });
+					drafts.open(placement, consumed.position);
 				}
 				: undefined,
 		});
-	}, [anchor, consume, close, editor, research]);
+	}, [anchor, consume, close, drafts, editor, research]);
 
 	// Arming is what separates a slash the author typed from one that arrived
 	// with someone else's edit. Registered whether or not the menu is showing,
@@ -522,7 +510,6 @@ export function SlashMenu({ binding, disabled, research }: SlashMenuProps) {
 		// Clears any query left behind by the lock, which would otherwise spring
 		// the menu open the moment an agent turn ends.
 		if (disabled) {
-			setDraft(current => current?.created ? current : undefined);
 			close();
 			return;
 		}
@@ -589,6 +576,13 @@ export function SlashMenu({ binding, disabled, research }: SlashMenuProps) {
 		return listenToEditorGeometry(editor, place);
 	}, [editor, open, draft, place]);
 
+	useLayoutEffect(() => {
+		if (!drafts || !binding || disabled) return;
+		return drafts.attachPlacement((saved, id) =>
+			insertResearchReference(editor, binding, saved, id)
+		);
+	}, [binding, disabled, drafts, editor]);
+
 	let selected = useRef(matches[0]);
 	selected.current = matches[index];
 
@@ -617,8 +611,8 @@ export function SlashMenu({ binding, disabled, research }: SlashMenuProps) {
 		);
 	}, [editor, open, matches.length, close, choose]);
 
-	if (draft && research) {
-		let dismiss = () => dismissResearchComposer(editor, () => setDraft(undefined));
+	if (draft && drafts && research) {
+		let dismiss = () => dismissResearchComposer(editor, () => drafts.dismiss());
 		let currentPosition = () => {
 			if (!binding) return;
 			let found: Y.RelativePosition | undefined;
@@ -628,74 +622,26 @@ export function SlashMenu({ binding, disabled, research }: SlashMenuProps) {
 			return found;
 		};
 		let submit = () => {
-			if (draft.submitting || !draft.question.trim()) return;
+			if (draft.submitting || draft.cancelling || !draft.question.trim()) return;
 			if (!binding) return;
 			if (draft.created) {
 				let position = currentPosition();
-				if (position && insertResearchReference(editor, binding, position, draft.created.id)) {
-					setDraft(undefined);
-					return;
-				}
-				setDraft(current =>
-					current && {
-						...current,
-						error: "Choose a new insertion point in the document, then place the research again.",
-					}
-				);
+				if (position) drafts.place(position);
 				return;
 			}
-			let saved = draft.position ?? currentPosition();
-			if (!saved) {
-				setDraft(current =>
-					current && {
-						...current,
-						error: "Choose an insertion point in the document before starting research.",
-					}
-				);
-				return;
-			}
-			let submitted = draft.submitted?.question === draft.question
-				? draft.submitted
-				: { question: draft.question, requestId: crypto.randomUUID() };
-			setDraft(current =>
-				current && {
-					...current,
-					submitted,
-					submitting: true,
-					error: undefined,
-				}
-			);
-			void createResearchReference(
-				editor,
-				binding,
-				saved,
-				submitted.question,
-				submitted.requestId,
+			void drafts.start(
 				(question, requestId) => research.create(question, requestId),
-			).then(result => {
-				if (result.inserted) {
-					setDraft(undefined);
-					return;
-				}
-				setDraft(current =>
-					current && {
-						...current,
-						created: result.request,
-						submitting: false,
-						error:
-							"Research started, but its reference could not be placed. Choose a new insertion point in the document.",
-					}
-				);
-			}).catch(() =>
-				setDraft(current =>
-					current && {
-						...current,
-						submitting: false,
-						error: "Research could not be started.",
-					}
-				)
+				currentPosition(),
 			);
 		};
+		let cancel = () => {
+			if (!draft.created) return dismiss();
+			void drafts.cancelCreated(id => research.cancel(id)).then(cancelled => {
+				if (cancelled) editor.focus();
+			});
+		};
+		let busy = !!draft.submitting || !!draft.cancelling;
+		let dismissible = !busy && !draft.created;
 		return (
 			<div
 				ref={surface}
@@ -718,23 +664,18 @@ export function SlashMenu({ binding, disabled, research }: SlashMenuProps) {
 						: binding
 						? undefined
 						: "Connect to the document before starting research."}
+					busyLabel={draft.cancelling ? "Cancelling…" : undefined}
+					cancelLabel={draft.created ? "Cancel research" : undefined}
+					dismissible={dismissible}
 					error={draft.error}
-					onCancel={dismiss}
-					onChange={question =>
-						setDraft(current =>
-							current && {
-								...current,
-								question,
-								error: undefined,
-								submitted: current.question === question ? current.submitted : undefined,
-							}
-						)}
+					onCancel={cancel}
+					onChange={question => drafts.change(question)}
 					onEscape={dismiss}
 					onSubmit={submit}
 					question={draft.question}
 					questionLocked={!!draft.created}
 					submitLabel={draft.created ? "Place research here" : undefined}
-					submitting={draft.submitting}
+					submitting={busy}
 				/>
 			</div>
 		);

--- a/packages/editor/src/toolbar/slash.tsx
+++ b/packages/editor/src/toolbar/slash.tsx
@@ -18,8 +18,12 @@ import {
 } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $copyBlockFormatIndent, $setBlocksType } from "@lexical/selection";
+import { $getAnchorAndFocusForUserState } from "@lexical/yjs";
 import {
+	$createRangeSelection,
+	$getNodeByKey,
 	$getSelection,
+	$isElementNode,
 	$isRangeSelection,
 	$isTextNode,
 	$setSelection,
@@ -36,6 +40,7 @@ import {
 	$createResearchNode,
 	$createTabNode,
 	$createTabsNode,
+	$isResearchNode,
 	DIFF_LANGUAGE,
 	IMAGE_PROTOCOLS,
 	MERMAID_LANGUAGE,
@@ -44,6 +49,7 @@ import {
 
 import { $createTableNodeWithDimensions } from "@lexical/table";
 import { $createParagraphNode, $createTextNode, $insertNodes } from "lexical";
+import * as Y from "yjs";
 
 import { askForUrl } from "./url";
 import { ResearchComposer } from "../widgets/research";
@@ -57,10 +63,13 @@ import {
 	SHELL,
 } from "./surface";
 
-import type { ElementNode, LexicalEditor, LexicalNode, RangeSelection } from "lexical";
+import type { Binding } from "@lexical/yjs";
+import type { ElementNode, LexicalEditor, LexicalNode } from "lexical";
 import type { Research } from "@chopin/protocol";
 import type { ResearchStore } from "../widget-options";
 import type { DOMRectLike, SurfacePlacement } from "./placement";
+
+const MULTI_WORD_COMMANDS = ["web search"];
 
 export type SlashCommand = {
 	id: string;
@@ -227,31 +236,101 @@ export function availableCommands(query: string): SlashCommand[] {
 	return COMMANDS.filter(command => match(command, query));
 }
 
-/** Insert after an async request using the document selection captured before it began. */
+/** Capture a document-safe insertion point before an asynchronous request begins. */
+export function captureResearchPosition(binding: Binding): Y.RelativePosition | undefined {
+	let selection = $getSelection();
+	if (!$isRangeSelection(selection) || !selection.isCollapsed()) return;
+	let point = selection.anchor;
+	let node = point.getNode();
+	let collab = binding.collabNodeMap.get(point.key);
+	if (!collab) return;
+
+	let shared = collab.getSharedType();
+	let offset = point.offset;
+	if ($isTextNode(node)) {
+		let parent = node.getParent();
+		let parentCollab = parent && binding.collabNodeMap.get(parent.getKey());
+		let currentOffset = collab.getOffset();
+		if (!parentCollab || currentOffset < 0) return;
+		shared = parentCollab.getSharedType();
+		offset = currentOffset + 1 + point.offset;
+	} else if ($isElementNode(node) && point.type === "element") {
+		offset = 0;
+		for (let child of node.getChildren().slice(0, point.offset)) {
+			offset += $isTextNode(child) ? child.getTextContentSize() + 1 : 1;
+		}
+	}
+	return Y.createRelativePositionFromTypeIndex(shared, offset);
+}
+
+/** Insert only when the saved collaborative position still resolves, and verify the result. */
 export function insertResearchReference(
 	editor: LexicalEditor,
-	selection: RangeSelection,
+	binding: Binding,
+	position: Y.RelativePosition,
 	id: string,
 ): boolean {
+	let key: string | undefined;
+	try {
+		editor.update(() => {
+			let resolved = $getAnchorAndFocusForUserState(binding, {
+				anchorPos: position,
+				focusPos: position,
+				color: "",
+				focusing: false,
+				name: "",
+				awarenessData: {},
+			});
+			if (!resolved.anchorKey || !resolved.focusKey) return;
+			let anchor = $getNodeByKey(resolved.anchorKey);
+			let focus = $getNodeByKey(resolved.focusKey);
+			if (!anchor || !focus) return;
+			let selection = $createRangeSelection();
+			selection.anchor.set(
+				resolved.anchorKey,
+				resolved.anchorOffset,
+				$isElementNode(anchor) ? "element" : "text",
+			);
+			selection.focus.set(
+				resolved.focusKey,
+				resolved.focusOffset,
+				$isElementNode(focus) ? "element" : "text",
+			);
+			$setSelection(selection);
+			let reference = $createResearchNode(id);
+			$insertNodes([reference]);
+			key = reference.getKey();
+		}, { discrete: true });
+	} catch {
+		return false;
+	}
+	if (!key) return false;
 	let inserted = false;
-	editor.update(() => {
-		$setSelection(selection.clone());
-		$insertNodes([$createResearchNode(id)]);
-		inserted = true;
-	}, { discrete: true });
+	editor.getEditorState().read(() => {
+		let reference = $getNodeByKey(key!);
+		inserted = $isResearchNode(reference) && reference.getId() === id && reference.isAttached();
+	});
 	return inserted;
 }
 
 export async function createResearchReference(
 	editor: LexicalEditor,
-	selection: RangeSelection,
+	binding: Binding,
+	position: Y.RelativePosition,
 	question: string,
 	requestId: string,
 	persist: (question: string, requestId: string) => Promise<Research.RequestView>,
-): Promise<Research.RequestView> {
+): Promise<{ inserted: boolean; request: Research.RequestView }> {
 	let request = await persist(question, requestId);
-	insertResearchReference(editor, selection, request.id);
-	return request;
+	return { inserted: insertResearchReference(editor, binding, position, request.id), request };
+}
+
+export function dismissResearchComposer(
+	editor: Pick<LexicalEditor, "focus">,
+	dismiss: () => void,
+) {
+	dismiss();
+	editor.focus();
 }
 
 /**
@@ -275,8 +354,12 @@ export function trigger(text: string, offset: number): string | undefined {
 	if (preceding !== undefined && !/\s/.test(preceding)) return undefined;
 
 	let query = before.slice(slash + 1);
-	// A space ends the trigger: the user moved on and is writing prose.
-	if (/\s/.test(query)) return undefined;
+	// Spaces continue only a known multi-word command. Ordinary prose still
+	// closes immediately, rather than leaving a menu over the sentence.
+	if (
+		/\s/.test(query)
+		&& !MULTI_WORD_COMMANDS.some(command => command.startsWith(query.toLowerCase()))
+	) return undefined;
 
 	return query;
 }
@@ -316,20 +399,22 @@ export function decide(
 }
 
 export type SlashMenuProps = {
+	binding?: Binding;
 	disabled?: boolean;
 	research?: ResearchStore;
 };
 
 type ResearchDraft = {
 	anchor: DOMRectLike;
-	selection: RangeSelection;
+	position?: Y.RelativePosition;
 	question: string;
+	created?: Research.RequestView;
 	submitted?: { question: string; requestId: string };
 	submitting?: boolean;
 	error?: string;
 };
 
-export function SlashMenu({ disabled, research }: SlashMenuProps) {
+export function SlashMenu({ binding, disabled, research }: SlashMenuProps) {
 	let [editor] = useLexicalComposerContext();
 	let [query, setQuery] = useState<string>();
 	let [anchor, setAnchor] = useState<DOMRectLike>();
@@ -382,8 +467,8 @@ export function SlashMenu({ disabled, research }: SlashMenuProps) {
 	 * Only that span: anything the user had already written after the caret
 	 * belongs to them, and truncating the line to the slash would eat it.
 	 */
-	let consume = useCallback((): RangeSelection | undefined => {
-		let saved: RangeSelection | undefined;
+	let consume = useCallback((): { position?: Y.RelativePosition } | undefined => {
+		let consumed: { position?: Y.RelativePosition } | undefined;
 		editor.update(() => {
 			let selection = $getSelection();
 			if (!$isRangeSelection(selection)) return;
@@ -398,20 +483,21 @@ export function SlashMenu({ disabled, research }: SlashMenuProps) {
 
 			let start = offset - typed.length - 1;
 			node.setTextContent(text.slice(0, start) + text.slice(offset));
-			saved = node.select(start, start).clone();
+			node.select(start, start);
+			consumed = { position: binding ? captureResearchPosition(binding) : undefined };
 		}, { discrete: true });
-		return saved;
-	}, [editor]);
+		return consumed;
+	}, [binding, editor]);
 
 	let choose = useCallback((command: SlashCommand) => {
-		let selection = consume();
+		let consumed = consume();
 		let placement = anchor;
 		close();
 		command.run(editor, {
-			research: research && selection && placement
+			research: research && consumed && placement
 				? () => {
 					setPosition(undefined);
-					setDraft({ anchor: placement, selection, question: "" });
+					setDraft({ anchor: placement, position: consumed.position, question: "" });
 				}
 				: undefined,
 		});
@@ -436,7 +522,7 @@ export function SlashMenu({ disabled, research }: SlashMenuProps) {
 		// Clears any query left behind by the lock, which would otherwise spring
 		// the menu open the moment an agent turn ends.
 		if (disabled) {
-			setDraft(undefined);
+			setDraft(current => current?.created ? current : undefined);
 			close();
 			return;
 		}
@@ -532,8 +618,42 @@ export function SlashMenu({ disabled, research }: SlashMenuProps) {
 	}, [editor, open, matches.length, close, choose]);
 
 	if (draft && research) {
+		let dismiss = () => dismissResearchComposer(editor, () => setDraft(undefined));
+		let currentPosition = () => {
+			if (!binding) return;
+			let found: Y.RelativePosition | undefined;
+			editor.getEditorState().read(() => {
+				found = captureResearchPosition(binding);
+			});
+			return found;
+		};
 		let submit = () => {
 			if (draft.submitting || !draft.question.trim()) return;
+			if (!binding) return;
+			if (draft.created) {
+				let position = currentPosition();
+				if (position && insertResearchReference(editor, binding, position, draft.created.id)) {
+					setDraft(undefined);
+					return;
+				}
+				setDraft(current =>
+					current && {
+						...current,
+						error: "Choose a new insertion point in the document, then place the research again.",
+					}
+				);
+				return;
+			}
+			let saved = draft.position ?? currentPosition();
+			if (!saved) {
+				setDraft(current =>
+					current && {
+						...current,
+						error: "Choose an insertion point in the document before starting research.",
+					}
+				);
+				return;
+			}
 			let submitted = draft.submitted?.question === draft.question
 				? draft.submitted
 				: { question: draft.question, requestId: crypto.randomUUID() };
@@ -547,11 +667,26 @@ export function SlashMenu({ disabled, research }: SlashMenuProps) {
 			);
 			void createResearchReference(
 				editor,
-				draft.selection,
+				binding,
+				saved,
 				submitted.question,
 				submitted.requestId,
 				(question, requestId) => research.create(question, requestId),
-			).then(() => setDraft(undefined)).catch(() =>
+			).then(result => {
+				if (result.inserted) {
+					setDraft(undefined);
+					return;
+				}
+				setDraft(current =>
+					current && {
+						...current,
+						created: result.request,
+						submitting: false,
+						error:
+							"Research started, but its reference could not be placed. Choose a new insertion point in the document.",
+					}
+				);
+			}).catch(() =>
 				setDraft(current =>
 					current && {
 						...current,
@@ -578,8 +713,13 @@ export function SlashMenu({ disabled, research }: SlashMenuProps) {
 					}}
 			>
 				<ResearchComposer
+					blocked={disabled
+						? "Wait until the document is editable before placing research."
+						: binding
+						? undefined
+						: "Connect to the document before starting research."}
 					error={draft.error}
-					onCancel={() => setDraft(undefined)}
+					onCancel={dismiss}
 					onChange={question =>
 						setDraft(current =>
 							current && {
@@ -589,8 +729,11 @@ export function SlashMenu({ disabled, research }: SlashMenuProps) {
 								submitted: current.question === question ? current.submitted : undefined,
 							}
 						)}
+					onEscape={dismiss}
 					onSubmit={submit}
 					question={draft.question}
+					questionLocked={!!draft.created}
+					submitLabel={draft.created ? "Place research here" : undefined}
 					submitting={draft.submitting}
 				/>
 			</div>

--- a/packages/editor/src/toolbar/slash.tsx
+++ b/packages/editor/src/toolbar/slash.tsx
@@ -15,19 +15,13 @@ import {
 	useMemo,
 	useRef,
 	useState,
-	useSyncExternalStore,
 } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $copyBlockFormatIndent, $setBlocksType } from "@lexical/selection";
-import { $getAnchorAndFocusForUserState } from "@lexical/yjs";
 import {
-	$createRangeSelection,
-	$getNodeByKey,
 	$getSelection,
-	$isElementNode,
 	$isRangeSelection,
 	$isTextNode,
-	$setSelection,
 	COLLABORATION_TAG,
 	COMMAND_PRIORITY_LOW,
 	HISTORIC_TAG,
@@ -38,10 +32,8 @@ import {
 	$createCodeBlockNode,
 	$createImageNode,
 	$createMathNode,
-	$createResearchNode,
 	$createTabNode,
 	$createTabsNode,
-	$isResearchNode,
 	DIFF_LANGUAGE,
 	IMAGE_PROTOCOLS,
 	MERMAID_LANGUAGE,
@@ -50,12 +42,10 @@ import {
 
 import { $createTableNodeWithDimensions } from "@lexical/table";
 import { $createParagraphNode, $createTextNode, $insertNodes } from "lexical";
-import * as Y from "yjs";
 
 import { askForUrl } from "./url";
-import { ResearchDraftStore } from "../research-draft";
-import { ResearchComposer } from "../widgets/research";
 import { placeSurface } from "./placement";
+import { OPEN_RESEARCH_COMMAND } from "./research";
 import {
 	DIVIDER,
 	editorSurfaceViewport,
@@ -65,20 +55,25 @@ import {
 	SHELL,
 } from "./surface";
 
-import type { Binding } from "@lexical/yjs";
 import type { ElementNode, LexicalEditor, LexicalNode } from "lexical";
-import type { ResearchStore } from "../widget-options";
 import type { DOMRectLike, SurfacePlacement } from "./placement";
+import type { OpenResearch } from "./research";
 
 const MULTI_WORD_COMMANDS = ["web search"];
 
-export type SlashCommand = {
+type SlashCommandBase = {
 	id: string;
 	label: string;
 	group: string;
 	keywords: string[];
-	run: (editor: LexicalEditor, actions?: { research?: () => void }) => void;
 };
+
+export type SlashCommand =
+	& SlashCommandBase
+	& (
+		| { kind: "insert"; run: (editor: LexicalEditor) => void }
+		| { kind: "action"; run: (editor: LexicalEditor, action: OpenResearch) => boolean }
+	);
 
 /** Replace the current block, dropping the `/query` the user typed. */
 function replace(editor: LexicalEditor, build: () => ElementNode) {
@@ -137,13 +132,15 @@ const COMMANDS: SlashCommand[] = [
 		label: "Research",
 		group: "Research",
 		keywords: ["research", "web search"],
-		run: (_editor, actions) => actions?.research?.(),
+		kind: "action",
+		run: (editor, action) => editor.dispatchCommand(OPEN_RESEARCH_COMMAND, action),
 	},
 	{
 		id: "code",
 		label: "Code block",
 		group: "Technical",
 		keywords: ["code", "snippet", "fence"],
+		kind: "insert",
 		run: editor => replace(editor, () => $createCodeBlockNode("")),
 	},
 	{
@@ -151,6 +148,7 @@ const COMMANDS: SlashCommand[] = [
 		label: "Diff",
 		group: "Technical",
 		keywords: ["diff", "patch", "change"],
+		kind: "insert",
 		run: editor => replace(editor, () => $createCodeBlockNode(DIFF_LANGUAGE)),
 	},
 	{
@@ -158,6 +156,7 @@ const COMMANDS: SlashCommand[] = [
 		label: "Diagram",
 		group: "Technical",
 		keywords: ["mermaid", "diagram", "flowchart", "graph"],
+		kind: "insert",
 		run: editor => replace(editor, () => $createCodeBlockNode(MERMAID_LANGUAGE)),
 	},
 	{
@@ -165,6 +164,7 @@ const COMMANDS: SlashCommand[] = [
 		label: "Formula",
 		group: "Technical",
 		keywords: ["math", "latex", "katex", "equation"],
+		kind: "insert",
 		run: editor => replace(editor, () => $createMathNode(false)),
 	},
 	{
@@ -172,6 +172,7 @@ const COMMANDS: SlashCommand[] = [
 		label: "Image",
 		group: "Technical",
 		keywords: ["image", "picture", "figure", "screenshot"],
+		kind: "insert",
 		run: editor => {
 			let src = askForUrl("Image URL", { protocols: IMAGE_PROTOCOLS, relative: false });
 			if (!src) return;
@@ -185,6 +186,7 @@ const COMMANDS: SlashCommand[] = [
 		label: "Callout",
 		group: "Layout",
 		keywords: ["note", "warning", "aside", "admonition"],
+		kind: "insert",
 		run: editor => insertContainer(editor, () => $createCalloutNode(ulid())),
 	},
 	{
@@ -192,6 +194,7 @@ const COMMANDS: SlashCommand[] = [
 		label: "Table",
 		group: "Layout",
 		keywords: ["table", "grid", "row", "column", "spreadsheet"],
+		kind: "insert",
 		run: editor =>
 			editor.update(() => {
 				/*
@@ -210,6 +213,7 @@ const COMMANDS: SlashCommand[] = [
 		label: "Tabs",
 		group: "Layout",
 		keywords: ["tab", "switch", "panel"],
+		kind: "insert",
 		run: editor =>
 			editor.update(() => {
 				let tabs = $createTabsNode();
@@ -235,100 +239,6 @@ function match(command: SlashCommand, query: string): boolean {
 
 export function availableCommands(query: string): SlashCommand[] {
 	return COMMANDS.filter(command => match(command, query));
-}
-
-/** Capture a document-safe insertion point before an asynchronous request begins. */
-export function captureResearchPosition(binding: Binding): Y.RelativePosition | undefined {
-	let selection = $getSelection();
-	if (!$isRangeSelection(selection) || !selection.isCollapsed()) return;
-	let point = selection.anchor;
-	let node = point.getNode();
-	let collab = binding.collabNodeMap.get(point.key);
-	if (!collab) return;
-
-	let shared = collab.getSharedType();
-	let offset = point.offset;
-	if ($isTextNode(node)) {
-		let parent = node.getParent();
-		let parentCollab = parent && binding.collabNodeMap.get(parent.getKey());
-		let currentOffset = collab.getOffset();
-		if (!parentCollab || currentOffset < 0) return;
-		shared = parentCollab.getSharedType();
-		offset = currentOffset + 1 + point.offset;
-	} else if ($isElementNode(node) && point.type === "element") {
-		offset = 0;
-		for (let child of node.getChildren().slice(0, point.offset)) {
-			offset += $isTextNode(child) ? child.getTextContentSize() + 1 : 1;
-		}
-	}
-	return Y.createRelativePositionFromTypeIndex(shared, offset);
-}
-
-/** Insert only when the saved collaborative position still resolves, and verify the result. */
-export function insertResearchReference(
-	editor: LexicalEditor,
-	binding: Binding,
-	position: Y.RelativePosition,
-	id: string,
-): boolean {
-	let key: string | undefined;
-	try {
-		editor.update(() => {
-			let resolved = $getAnchorAndFocusForUserState(binding, {
-				anchorPos: position,
-				focusPos: position,
-				color: "",
-				focusing: false,
-				name: "",
-				awarenessData: {},
-			});
-			if (!resolved.anchorKey || !resolved.focusKey) return;
-			let anchor = $getNodeByKey(resolved.anchorKey);
-			let focus = $getNodeByKey(resolved.focusKey);
-			if (!anchor || !focus) return;
-			let selection = $createRangeSelection();
-			selection.anchor.set(
-				resolved.anchorKey,
-				resolved.anchorOffset,
-				$isElementNode(anchor) ? "element" : "text",
-			);
-			selection.focus.set(
-				resolved.focusKey,
-				resolved.focusOffset,
-				$isElementNode(focus) ? "element" : "text",
-			);
-			$setSelection(selection);
-			let reference = $createResearchNode(id);
-			$insertNodes([reference]);
-			key = reference.getKey();
-		}, { discrete: true });
-	} catch {
-		return false;
-	}
-	if (!key) return false;
-	let inserted = false;
-	editor.getEditorState().read(() => {
-		let reference = $getNodeByKey(key!);
-		inserted = $isResearchNode(reference) && reference.getId() === id && reference.isAttached();
-	});
-	return inserted;
-}
-
-export function dismissResearchComposer(
-	editor: Pick<LexicalEditor, "focus">,
-	dismiss: () => void,
-) {
-	dismiss();
-	editor.focus();
-}
-
-export function beginResearchDraft(
-	drafts: ResearchDraftStore,
-	consume: () => { anchor: DOMRectLike; position?: Y.RelativePosition } | undefined,
-): boolean {
-	if (!drafts.canOpen()) return false;
-	let next = consume();
-	return next ? drafts.open(next.anchor, next.position) : false;
 }
 
 /**
@@ -397,33 +307,27 @@ export function decide(
 }
 
 export type SlashMenuProps = {
-	binding?: Binding;
+	actions?: ReadonlySet<string>;
 	disabled?: boolean;
-	drafts?: ResearchDraftStore;
-	research?: ResearchStore;
 };
 
-export function SlashMenu({ binding, disabled, drafts, research }: SlashMenuProps) {
+const NO_ACTIONS = new Set<string>();
+
+export function SlashMenu({ actions = NO_ACTIONS, disabled }: SlashMenuProps) {
 	let [editor] = useLexicalComposerContext();
 	let [query, setQuery] = useState<string>();
 	let [anchor, setAnchor] = useState<DOMRectLike>();
 	let [position, setPosition] = useState<SurfacePlacement>();
 	let [index, setIndex] = useState(0);
-	let subscribeDraft = useCallback(
-		(listener: () => void) => drafts?.subscribe(listener) ?? (() => {}),
-		[drafts],
-	);
-	let readDraft = useCallback(() => drafts?.get(), [drafts]);
-	let draft = useSyncExternalStore(subscribeDraft, readDraft, readDraft);
 	let surface = useRef<HTMLDivElement>(null);
 	let open = query !== undefined && !disabled;
 
 	let matches = useMemo(
 		() =>
 			availableCommands(query ?? "").filter(command =>
-				command.id !== "research" || (research && drafts?.canOpen())
+				command.kind === "insert" || actions.has(command.id)
 			),
-		[query, research, drafts, draft],
+		[actions, query],
 	);
 	// Groups now place dividers while options remain direct listbox children.
 	let grouped = useMemo(() => {
@@ -464,8 +368,8 @@ export function SlashMenu({ binding, disabled, drafts, research }: SlashMenuProp
 	 * Only that span: anything the user had already written after the caret
 	 * belongs to them, and truncating the line to the slash would eat it.
 	 */
-	let consume = useCallback((): { position?: Y.RelativePosition } | undefined => {
-		let consumed: { position?: Y.RelativePosition } | undefined;
+	let consume = useCallback((): boolean => {
+		let consumed = false;
 		editor.update(() => {
 			let selection = $getSelection();
 			if (!$isRangeSelection(selection)) return;
@@ -481,32 +385,20 @@ export function SlashMenu({ binding, disabled, drafts, research }: SlashMenuProp
 			let start = offset - typed.length - 1;
 			node.setTextContent(text.slice(0, start) + text.slice(offset));
 			node.select(start, start);
-			consumed = { position: binding ? captureResearchPosition(binding) : undefined };
+			consumed = true;
 		}, { discrete: true });
 		return consumed;
-	}, [binding, editor]);
+	}, [editor]);
 
 	let choose = useCallback((command: SlashCommand) => {
-		let placement = anchor;
-		if (command.id === "research") {
-			command.run(editor, {
-				research: research && drafts && placement
-					? () => {
-						beginResearchDraft(drafts, () => {
-							let consumed = consume();
-							return consumed ? { anchor: placement, position: consumed.position } : undefined;
-						});
-						setPosition(undefined);
-					}
-					: undefined,
-			});
-			close();
+		if (command.kind === "action") {
+			if (anchor && command.run(editor, { anchor, consume })) close();
 			return;
 		}
 		consume();
 		close();
 		command.run(editor);
-	}, [anchor, consume, close, drafts, editor, research]);
+	}, [anchor, consume, close, editor]);
 
 	// Arming is what separates a slash the author typed from one that arrived
 	// with someone else's edit. Registered whether or not the menu is showing,
@@ -563,9 +455,8 @@ export function SlashMenu({ binding, disabled, drafts, research }: SlashMenuProp
 
 	let place = useCallback(() => {
 		let element = surface.current;
-		let placement = draft?.anchor ?? anchor;
-		if (!element || !placement) return;
-		let liveAnchor = draft ? draft.anchor : nativeSelectionRect();
+		if (!element || !anchor) return;
+		let liveAnchor = nativeSelectionRect();
 		if (!liveAnchor) {
 			setPosition(undefined);
 			return;
@@ -583,22 +474,15 @@ export function SlashMenu({ binding, disabled, drafts, research }: SlashMenuProp
 				? current
 				: next
 		);
-	}, [anchor, draft]);
+	}, [anchor]);
 	useLayoutEffect(() => {
-		if (open || draft) place();
-	}, [open, draft, grouped, place]);
+		if (open) place();
+	}, [open, grouped, place]);
 
 	useEffect(() => {
-		if (!open && !draft) return;
+		if (!open) return;
 		return listenToEditorGeometry(editor, place);
-	}, [editor, open, draft, place]);
-
-	useLayoutEffect(() => {
-		if (!drafts || !binding || disabled) return;
-		return drafts.attachPlacement((saved, id) =>
-			insertResearchReference(editor, binding, saved, id)
-		);
-	}, [binding, disabled, drafts, editor]);
+	}, [editor, open, place]);
 
 	let selected = useRef(matches[0]);
 	selected.current = matches[index];
@@ -627,78 +511,6 @@ export function SlashMenu({ binding, disabled, drafts, research }: SlashMenuProp
 			COMMAND_PRIORITY_LOW,
 		);
 	}, [editor, open, matches.length, close, choose]);
-
-	if (draft && drafts && research) {
-		let dismiss = () => dismissResearchComposer(editor, () => drafts.dismiss());
-		let currentPosition = () => {
-			if (!binding) return;
-			let found: Y.RelativePosition | undefined;
-			editor.getEditorState().read(() => {
-				found = captureResearchPosition(binding);
-			});
-			return found;
-		};
-		let submit = () => {
-			if (draft.submitting || draft.cancelling || !draft.question.trim()) return;
-			if (!binding || disabled) return;
-			if (draft.created) {
-				let position = currentPosition();
-				if (position) drafts.place(position, !disabled);
-				return;
-			}
-			void drafts.start(
-				(question, requestId) => research.create(question, requestId),
-				currentPosition(),
-			);
-		};
-		let cancel = () => {
-			if (!draft.created) return dismiss();
-			if (disabled) return;
-			void drafts.cancelCreated(id => research.cancel(id), !disabled).then(cancelled => {
-				if (cancelled) editor.focus();
-			});
-		};
-		let busy = !!draft.submitting || !!draft.cancelling;
-		let dismissible = !busy && !draft.created;
-		return (
-			<div
-				ref={surface}
-				aria-label="Start research"
-				role="dialog"
-				data-focus-boundary=""
-				contentEditable={false}
-				className={`${SHELL} plan-research-composer-surface`}
-				style={position
-					? { top: position.top, left: position.left, maxHeight: position.maxHeight }
-					: {
-						top: draft.anchor.bottom + 8,
-						left: draft.anchor.left,
-						visibility: "hidden",
-					}}
-			>
-				<ResearchComposer
-					blocked={disabled
-						? "Wait until the document is editable before placing research."
-						: binding
-						? undefined
-						: "Connect to the document before starting research."}
-					busyLabel={draft.cancelling ? "Cancelling…" : undefined}
-					cancelDisabled={!!draft.created && !!disabled}
-					cancelLabel={draft.created ? "Cancel research" : undefined}
-					dismissible={dismissible}
-					error={draft.error}
-					onCancel={cancel}
-					onChange={question => drafts.change(question)}
-					onEscape={dismiss}
-					onSubmit={submit}
-					question={draft.question}
-					questionLocked={!!draft.created}
-					submitLabel={draft.created ? "Place research here" : undefined}
-					submitting={busy}
-				/>
-			</div>
-		);
-	}
 
 	if (!open || !anchor || matches.length === 0) return null;
 

--- a/packages/editor/src/toolbar/slash.tsx
+++ b/packages/editor/src/toolbar/slash.tsx
@@ -322,6 +322,15 @@ export function dismissResearchComposer(
 	editor.focus();
 }
 
+export function beginResearchDraft(
+	drafts: ResearchDraftStore,
+	consume: () => { anchor: DOMRectLike; position?: Y.RelativePosition } | undefined,
+): boolean {
+	if (!drafts.canOpen()) return false;
+	let next = consume();
+	return next ? drafts.open(next.anchor, next.position) : false;
+}
+
 /**
  * What the caret is asking to insert, if anything.
  *
@@ -412,9 +421,9 @@ export function SlashMenu({ binding, disabled, drafts, research }: SlashMenuProp
 	let matches = useMemo(
 		() =>
 			availableCommands(query ?? "").filter(command =>
-				command.id !== "research" || (research && drafts)
+				command.id !== "research" || (research && drafts?.canOpen())
 			),
-		[query, research, drafts],
+		[query, research, drafts, draft],
 	);
 	// Groups now place dividers while options remain direct listbox children.
 	let grouped = useMemo(() => {
@@ -478,17 +487,25 @@ export function SlashMenu({ binding, disabled, drafts, research }: SlashMenuProp
 	}, [binding, editor]);
 
 	let choose = useCallback((command: SlashCommand) => {
-		let consumed = consume();
 		let placement = anchor;
+		if (command.id === "research") {
+			command.run(editor, {
+				research: research && drafts && placement
+					? () => {
+						beginResearchDraft(drafts, () => {
+							let consumed = consume();
+							return consumed ? { anchor: placement, position: consumed.position } : undefined;
+						});
+						setPosition(undefined);
+					}
+					: undefined,
+			});
+			close();
+			return;
+		}
+		consume();
 		close();
-		command.run(editor, {
-			research: research && drafts && consumed && placement
-				? () => {
-					setPosition(undefined);
-					drafts.open(placement, consumed.position);
-				}
-				: undefined,
-		});
+		command.run(editor);
 	}, [anchor, consume, close, drafts, editor, research]);
 
 	// Arming is what separates a slash the author typed from one that arrived
@@ -623,10 +640,10 @@ export function SlashMenu({ binding, disabled, drafts, research }: SlashMenuProp
 		};
 		let submit = () => {
 			if (draft.submitting || draft.cancelling || !draft.question.trim()) return;
-			if (!binding) return;
+			if (!binding || disabled) return;
 			if (draft.created) {
 				let position = currentPosition();
-				if (position) drafts.place(position);
+				if (position) drafts.place(position, !disabled);
 				return;
 			}
 			void drafts.start(
@@ -636,7 +653,8 @@ export function SlashMenu({ binding, disabled, drafts, research }: SlashMenuProp
 		};
 		let cancel = () => {
 			if (!draft.created) return dismiss();
-			void drafts.cancelCreated(id => research.cancel(id)).then(cancelled => {
+			if (disabled) return;
+			void drafts.cancelCreated(id => research.cancel(id), !disabled).then(cancelled => {
 				if (cancelled) editor.focus();
 			});
 		};
@@ -665,6 +683,7 @@ export function SlashMenu({ binding, disabled, drafts, research }: SlashMenuProp
 						? undefined
 						: "Connect to the document before starting research."}
 					busyLabel={draft.cancelling ? "Cancelling…" : undefined}
+					cancelDisabled={!!draft.created && !!disabled}
 					cancelLabel={draft.created ? "Cancel research" : undefined}
 					dismissible={dismissible}
 					error={draft.error}

--- a/packages/editor/src/toolbar/slash.tsx
+++ b/packages/editor/src/toolbar/slash.tsx
@@ -22,6 +22,7 @@ import {
 	$getSelection,
 	$isRangeSelection,
 	$isTextNode,
+	$setSelection,
 	COLLABORATION_TAG,
 	COMMAND_PRIORITY_LOW,
 	HISTORIC_TAG,
@@ -32,6 +33,7 @@ import {
 	$createCodeBlockNode,
 	$createImageNode,
 	$createMathNode,
+	$createResearchNode,
 	$createTabNode,
 	$createTabsNode,
 	DIFF_LANGUAGE,
@@ -44,6 +46,7 @@ import { $createTableNodeWithDimensions } from "@lexical/table";
 import { $createParagraphNode, $createTextNode, $insertNodes } from "lexical";
 
 import { askForUrl } from "./url";
+import { ResearchComposer } from "../widgets/research";
 import { placeSurface } from "./placement";
 import {
 	DIVIDER,
@@ -54,7 +57,9 @@ import {
 	SHELL,
 } from "./surface";
 
-import type { ElementNode, LexicalEditor, LexicalNode } from "lexical";
+import type { ElementNode, LexicalEditor, LexicalNode, RangeSelection } from "lexical";
+import type { Research } from "@chopin/protocol";
+import type { ResearchStore } from "../widget-options";
 import type { DOMRectLike, SurfacePlacement } from "./placement";
 
 export type SlashCommand = {
@@ -62,7 +67,7 @@ export type SlashCommand = {
 	label: string;
 	group: string;
 	keywords: string[];
-	run: (editor: LexicalEditor) => void;
+	run: (editor: LexicalEditor, actions?: { research?: () => void }) => void;
 };
 
 /** Replace the current block, dropping the `/query` the user typed. */
@@ -117,6 +122,13 @@ function insertContainer(
  * MDXEditor's transformer builds its own code node rather than the dialect's.
  */
 const COMMANDS: SlashCommand[] = [
+	{
+		id: "research",
+		label: "Research",
+		group: "Research",
+		keywords: ["research", "web search"],
+		run: (_editor, actions) => actions?.research?.(),
+	},
 	{
 		id: "code",
 		label: "Code block",
@@ -211,6 +223,37 @@ function match(command: SlashCommand, query: string): boolean {
 		|| command.keywords.some(word => word.includes(needle));
 }
 
+export function availableCommands(query: string): SlashCommand[] {
+	return COMMANDS.filter(command => match(command, query));
+}
+
+/** Insert after an async request using the document selection captured before it began. */
+export function insertResearchReference(
+	editor: LexicalEditor,
+	selection: RangeSelection,
+	id: string,
+): boolean {
+	let inserted = false;
+	editor.update(() => {
+		$setSelection(selection.clone());
+		$insertNodes([$createResearchNode(id)]);
+		inserted = true;
+	}, { discrete: true });
+	return inserted;
+}
+
+export async function createResearchReference(
+	editor: LexicalEditor,
+	selection: RangeSelection,
+	question: string,
+	requestId: string,
+	persist: (question: string, requestId: string) => Promise<Research.RequestView>,
+): Promise<Research.RequestView> {
+	let request = await persist(question, requestId);
+	insertResearchReference(editor, selection, request.id);
+	return request;
+}
+
 /**
  * What the caret is asking to insert, if anything.
  *
@@ -274,18 +317,32 @@ export function decide(
 
 export type SlashMenuProps = {
 	disabled?: boolean;
+	research?: ResearchStore;
 };
 
-export function SlashMenu({ disabled }: SlashMenuProps) {
+type ResearchDraft = {
+	anchor: DOMRectLike;
+	selection: RangeSelection;
+	question: string;
+	submitted?: { question: string; requestId: string };
+	submitting?: boolean;
+	error?: string;
+};
+
+export function SlashMenu({ disabled, research }: SlashMenuProps) {
 	let [editor] = useLexicalComposerContext();
 	let [query, setQuery] = useState<string>();
 	let [anchor, setAnchor] = useState<DOMRectLike>();
 	let [position, setPosition] = useState<SurfacePlacement>();
 	let [index, setIndex] = useState(0);
+	let [draft, setDraft] = useState<ResearchDraft>();
 	let surface = useRef<HTMLDivElement>(null);
 	let open = query !== undefined && !disabled;
 
-	let matches = useMemo(() => COMMANDS.filter(item => match(item, query ?? "")), [query]);
+	let matches = useMemo(
+		() => availableCommands(query ?? "").filter(command => command.id !== "research" || research),
+		[query, research],
+	);
 	// Groups now place dividers while options remain direct listbox children.
 	let grouped = useMemo(() => {
 		let out = new Map<string, SlashCommand[]>();
@@ -325,7 +382,8 @@ export function SlashMenu({ disabled }: SlashMenuProps) {
 	 * Only that span: anything the user had already written after the caret
 	 * belongs to them, and truncating the line to the slash would eat it.
 	 */
-	let consume = useCallback(() => {
+	let consume = useCallback((): RangeSelection | undefined => {
+		let saved: RangeSelection | undefined;
 		editor.update(() => {
 			let selection = $getSelection();
 			if (!$isRangeSelection(selection)) return;
@@ -340,15 +398,24 @@ export function SlashMenu({ disabled }: SlashMenuProps) {
 
 			let start = offset - typed.length - 1;
 			node.setTextContent(text.slice(0, start) + text.slice(offset));
-			node.select(start, start);
-		});
+			saved = node.select(start, start).clone();
+		}, { discrete: true });
+		return saved;
 	}, [editor]);
 
 	let choose = useCallback((command: SlashCommand) => {
-		consume();
+		let selection = consume();
+		let placement = anchor;
 		close();
-		command.run(editor);
-	}, [consume, close, editor]);
+		command.run(editor, {
+			research: research && selection && placement
+				? () => {
+					setPosition(undefined);
+					setDraft({ anchor: placement, selection, question: "" });
+				}
+				: undefined,
+		});
+	}, [anchor, consume, close, editor, research]);
 
 	// Arming is what separates a slash the author typed from one that arrived
 	// with someone else's edit. Registered whether or not the menu is showing,
@@ -369,6 +436,7 @@ export function SlashMenu({ disabled }: SlashMenuProps) {
 		// Clears any query left behind by the lock, which would otherwise spring
 		// the menu open the moment an agent turn ends.
 		if (disabled) {
+			setDraft(undefined);
 			close();
 			return;
 		}
@@ -405,8 +473,9 @@ export function SlashMenu({ disabled }: SlashMenuProps) {
 
 	let place = useCallback(() => {
 		let element = surface.current;
-		if (!element || !anchor) return;
-		let liveAnchor = nativeSelectionRect();
+		let placement = draft?.anchor ?? anchor;
+		if (!element || !placement) return;
+		let liveAnchor = draft ? draft.anchor : nativeSelectionRect();
 		if (!liveAnchor) {
 			setPosition(undefined);
 			return;
@@ -424,15 +493,15 @@ export function SlashMenu({ disabled }: SlashMenuProps) {
 				? current
 				: next
 		);
-	}, [anchor]);
+	}, [anchor, draft]);
 	useLayoutEffect(() => {
-		if (open) place();
-	}, [open, grouped, place]);
+		if (open || draft) place();
+	}, [open, draft, grouped, place]);
 
 	useEffect(() => {
-		if (!open) return;
+		if (!open && !draft) return;
 		return listenToEditorGeometry(editor, place);
-	}, [editor, open, place]);
+	}, [editor, open, draft, place]);
 
 	let selected = useRef(matches[0]);
 	selected.current = matches[index];
@@ -461,6 +530,72 @@ export function SlashMenu({ disabled }: SlashMenuProps) {
 			COMMAND_PRIORITY_LOW,
 		);
 	}, [editor, open, matches.length, close, choose]);
+
+	if (draft && research) {
+		let submit = () => {
+			if (draft.submitting || !draft.question.trim()) return;
+			let submitted = draft.submitted?.question === draft.question
+				? draft.submitted
+				: { question: draft.question, requestId: crypto.randomUUID() };
+			setDraft(current =>
+				current && {
+					...current,
+					submitted,
+					submitting: true,
+					error: undefined,
+				}
+			);
+			void createResearchReference(
+				editor,
+				draft.selection,
+				submitted.question,
+				submitted.requestId,
+				(question, requestId) => research.create(question, requestId),
+			).then(() => setDraft(undefined)).catch(() =>
+				setDraft(current =>
+					current && {
+						...current,
+						submitting: false,
+						error: "Research could not be started.",
+					}
+				)
+			);
+		};
+		return (
+			<div
+				ref={surface}
+				aria-label="Start research"
+				role="dialog"
+				data-focus-boundary=""
+				contentEditable={false}
+				className={`${SHELL} plan-research-composer-surface`}
+				style={position
+					? { top: position.top, left: position.left, maxHeight: position.maxHeight }
+					: {
+						top: draft.anchor.bottom + 8,
+						left: draft.anchor.left,
+						visibility: "hidden",
+					}}
+			>
+				<ResearchComposer
+					error={draft.error}
+					onCancel={() => setDraft(undefined)}
+					onChange={question =>
+						setDraft(current =>
+							current && {
+								...current,
+								question,
+								error: undefined,
+								submitted: current.question === question ? current.submitted : undefined,
+							}
+						)}
+					onSubmit={submit}
+					question={draft.question}
+					submitting={draft.submitting}
+				/>
+			</div>
+		);
+	}
 
 	if (!open || !anchor || matches.length === 0) return null;
 

--- a/packages/editor/src/widget-options.ts
+++ b/packages/editor/src/widget-options.ts
@@ -4,6 +4,7 @@ import type { Binding } from "@lexical/yjs";
 import type { ChangeStore } from "./changes";
 import type { ContentSwapMotion } from "./content-swap";
 import type { Research } from "@chopin/protocol";
+import type { ResearchDraftStore } from "./research-draft";
 import type { QuestionnaireStore } from "./questionnaires";
 import type { ThreadStore } from "./threads";
 import type { Transport } from "./transport";
@@ -33,6 +34,7 @@ export type WidgetOptions = {
 	questionMotion?: QuestionStepMotion;
 	questions?: QuestionnaireStore;
 	research?: ResearchStore;
+	researchDrafts?: ResearchDraftStore;
 	threads?: ThreadStore;
 	changes?: ChangeStore;
 	wire?: Transport;

--- a/packages/editor/src/widget-options.ts
+++ b/packages/editor/src/widget-options.ts
@@ -1,5 +1,6 @@
 import { Cell } from "@mdxeditor/gurx";
 
+import type { Binding } from "@lexical/yjs";
 import type { ChangeStore } from "./changes";
 import type { ContentSwapMotion } from "./content-swap";
 import type { Research } from "@chopin/protocol";
@@ -26,6 +27,7 @@ export type ResearchStore = {
 };
 
 export type WidgetOptions = {
+	binding?: Binding;
 	commentPresentation?: CommentPresentation;
 	motionImmediately?: () => boolean;
 	questionMotion?: QuestionStepMotion;

--- a/packages/editor/src/widget-options.ts
+++ b/packages/editor/src/widget-options.ts
@@ -21,10 +21,9 @@ export type ResearchStore = {
 	subscribe(listener: () => void): () => void;
 	retain(id: string): () => void;
 	get(id: string): Research.RequestView | undefined;
-	refresh(id: string): void;
 	create(question: string, requestId: string): Promise<Research.RequestView>;
 	cancel(id: string): Promise<Research.RequestView>;
-	retry(id: string, question: string): Promise<Research.RequestView>;
+	retry(id: string): Promise<Research.RequestView>;
 	open(child: Research.ReadyChild): void;
 };
 

--- a/packages/editor/src/widget-options.ts
+++ b/packages/editor/src/widget-options.ts
@@ -19,6 +19,7 @@ export type QuestionStepMotion = {
 /** App-owned HTTP state and actions for durable Research Workspace references. */
 export type ResearchStore = {
 	subscribe(listener: () => void): () => void;
+	retain(id: string): () => void;
 	get(id: string): Research.RequestView | undefined;
 	refresh(id: string): void;
 	create(question: string, requestId: string): Promise<Research.RequestView>;

--- a/packages/editor/src/widget-options.ts
+++ b/packages/editor/src/widget-options.ts
@@ -2,6 +2,7 @@ import { Cell } from "@mdxeditor/gurx";
 
 import type { ChangeStore } from "./changes";
 import type { ContentSwapMotion } from "./content-swap";
+import type { Research } from "@chopin/protocol";
 import type { QuestionnaireStore } from "./questionnaires";
 import type { ThreadStore } from "./threads";
 import type { Transport } from "./transport";
@@ -13,11 +14,23 @@ export type QuestionStepMotion = {
 	immediately: () => boolean;
 };
 
+/** App-owned HTTP state and actions for durable Research Workspace references. */
+export type ResearchStore = {
+	subscribe(listener: () => void): () => void;
+	get(id: string): Research.RequestView | undefined;
+	refresh(id: string): void;
+	create(question: string, requestId: string): Promise<Research.RequestView>;
+	cancel(id: string): Promise<Research.RequestView>;
+	retry(id: string, question: string): Promise<Research.RequestView>;
+	open(child: Research.ReadyChild): void;
+};
+
 export type WidgetOptions = {
 	commentPresentation?: CommentPresentation;
 	motionImmediately?: () => boolean;
 	questionMotion?: QuestionStepMotion;
 	questions?: QuestionnaireStore;
+	research?: ResearchStore;
 	threads?: ThreadStore;
 	changes?: ChangeStore;
 	wire?: Transport;

--- a/packages/editor/src/widgets/index.ts
+++ b/packages/editor/src/widgets/index.ts
@@ -11,8 +11,9 @@ import { setRenderer } from "@chopin/dialect";
 import { renderDecision } from "./decision";
 import { renderImage } from "./image";
 import { renderQuestionnaire } from "./questionnaire";
+import { renderResearch } from "./research";
 
-import type { DecisionNode, ImageNode, QuestionnaireNode } from "@chopin/dialect";
+import type { DecisionNode, ImageNode, QuestionnaireNode, ResearchNode } from "@chopin/dialect";
 
 let registered = false;
 
@@ -24,6 +25,7 @@ export function register(): void {
 	setRenderer<ImageNode>("plan-image", renderImage);
 	setRenderer<QuestionnaireNode>("plan-questionnaire", renderQuestionnaire);
 	setRenderer<DecisionNode>("plan-decision", renderDecision);
+	setRenderer<ResearchNode>("plan-research", renderResearch);
 }
 
 export { CalloutPlugin } from "./callout";
@@ -31,4 +33,5 @@ export { EnterPlugin } from "./enter";
 export { QuestionnaireCard } from "./questionnaire";
 export type { QuestionnaireCardProps } from "./questionnaire";
 export { PreviewPlugin } from "./render-blocks";
+export { ResearchCard, ResearchComposer, ResearchReference } from "./research";
 export { TabsPlugin } from "./tabs";

--- a/packages/editor/src/widgets/research.test.tsx
+++ b/packages/editor/src/widgets/research.test.tsx
@@ -10,16 +10,38 @@ import { register } from "./index";
 import type { ComponentType } from "react";
 import type { Research } from "@chopin/protocol";
 
-const BASE: Research.RequestView = {
+const REQUEST_BASE: Research.RequestViewBase = {
 	id: "workspace-one",
 	channelId: "document-one",
 	question: "Which evidence supports the rollout date?",
-	state: "running",
-	stage: "searching",
 	sources: [{ title: "Release notes", url: "https://example.com/releases" }],
 	createdAt: "2026-08-24T09:00:00.000Z",
 	updatedAt: "2026-08-24T09:01:00.000Z",
 };
+
+const BASE: Research.RequestView = { ...REQUEST_BASE, state: "running", stage: "searching" };
+
+function atStage(stage: Research.RequestStage): Research.RequestView {
+	if (stage === "failed") {
+		return { ...REQUEST_BASE, state: "failed", stage, error: "Research could not be completed." };
+	}
+	if (stage === "cancelled") return { ...REQUEST_BASE, state: "cancelled", stage };
+	if (stage === "ready") {
+		return {
+			...REQUEST_BASE,
+			state: "completed",
+			stage,
+			child: {
+				id: "child-one",
+				title: "Rollout evidence",
+				slug: "rollout-evidence",
+				summary: "Validated report summary",
+				sourceCount: 1,
+			},
+		};
+	}
+	return { ...REQUEST_BASE, state: "running", stage };
+}
 
 type CardProps = {
 	request: Research.RequestView;
@@ -247,16 +269,16 @@ describe("research reference", () => {
 			["ready", { cancel: false, open: true, remove: true, retry: false }],
 		];
 		for (let [stage, want] of expected) {
-			let request = stage === "loading" ? undefined : { ...BASE, stage };
+			let request = stage === "loading" ? undefined : atStage(stage);
 			expect(actions(request, true)).toEqual(want);
 		}
-		expect(actions({ ...BASE, stage: "ready" }, false)).toEqual({
+		expect(actions(atStage("ready"), false)).toEqual({
 			cancel: false,
 			open: true,
 			remove: false,
 			retry: false,
 		});
-		expect(actions({ ...BASE, stage: "failed" }, false)).toEqual({
+		expect(actions(atStage("failed"), false)).toEqual({
 			cancel: false,
 			open: false,
 			remove: false,

--- a/packages/editor/src/widgets/research.test.tsx
+++ b/packages/editor/src/widgets/research.test.tsx
@@ -31,6 +31,7 @@ type CardProps = {
 
 type ComposerProps = {
 	blocked?: string;
+	cancelDisabled?: boolean;
 	error?: string;
 	onCancel: () => void;
 	onChange: (value: string) => void;
@@ -93,6 +94,23 @@ describe("research composer", () => {
 
 		expect(markup).toContain("Connect to the document before starting research.");
 		expect(markup).toMatch(/<button[^>]*disabled=""[^>]*type="submit"/);
+	});
+
+	it("exposes no placement or cancellation mutation for read-only created recovery", async () => {
+		let { composer: Composer } = await components();
+		if (!Composer) return;
+		let markup = renderToStaticMarkup(createElement(Composer, {
+			question: BASE.question,
+			blocked: "Reconnect with edit access to place this research.",
+			cancelDisabled: true,
+			submitLabel: "Place research",
+			onCancel() {},
+			onChange() {},
+			onSubmit() {},
+		}));
+
+		expect(markup).toContain("Place research");
+		expect((markup.match(/disabled=""/g) ?? []).length).toBe(2);
 	});
 
 	it("turns Escape into a composer dismissal", async () => {

--- a/packages/editor/src/widgets/research.test.tsx
+++ b/packages/editor/src/widgets/research.test.tsx
@@ -44,6 +44,7 @@ type ComposerProps = {
 
 type Store = {
 	subscribe(listener: () => void): () => void;
+	retain(id: string): () => void;
 	get(id: string): Research.RequestView | undefined;
 	refresh(id: string): void;
 	create(question: string, requestId: string): Promise<Research.RequestView>;
@@ -291,6 +292,7 @@ describe("research reference", () => {
 		if (!Reference) return;
 		let store: Store = {
 			subscribe: () => () => {},
+			retain: () => () => {},
 			get: id => id === BASE.id ? BASE : undefined,
 			refresh() {},
 			create: async () => BASE,
@@ -320,12 +322,17 @@ describe("research reference", () => {
 		if (!Reference || !subscribe) return;
 		class ClassStore implements Store {
 			listeners = new Set<() => void>();
+			retained: string[] = [];
 			subscribe(listener: () => void) {
 				this.listeners.add(listener);
 				return () => this.listeners.delete(listener);
 			}
 			get() {
 				return BASE;
+			}
+			retain(id: string) {
+				this.retained.push(id);
+				return () => this.retained.splice(this.retained.indexOf(id), 1);
 			}
 			refresh() {}
 			async create() {
@@ -352,6 +359,34 @@ describe("research reference", () => {
 		expect(markup).toContain(BASE.question);
 	});
 
+	it("retains and releases the reference id through the store contract", async () => {
+		let module = await import("./research");
+		let retain = (module as unknown as {
+			retainResearch?: (store: Store, id: string) => () => void;
+		}).retainResearch;
+		expect(typeof retain).toBe("function");
+		if (!retain) return;
+		let retained = new Set<string>();
+		let store = {
+			subscribe: () => () => {},
+			retain: (id: string) => {
+				retained.add(id);
+				return () => retained.delete(id);
+			},
+			get: () => BASE,
+			refresh() {},
+			create: async () => BASE,
+			cancel: async () => BASE,
+			retry: async () => BASE,
+			open() {},
+		};
+
+		let release = retain(store, BASE.id);
+		expect(retained).toEqual(new Set([BASE.id]));
+		release();
+		expect(retained).toEqual(new Set());
+	});
+
 	it("retries the same authoritative request with its exact question", async () => {
 		let module = await import("./research");
 		let retry = (module as unknown as {
@@ -365,6 +400,7 @@ describe("research reference", () => {
 		let received: [string, string] | undefined;
 		let store: Store = {
 			subscribe: () => () => {},
+			retain: () => () => {},
 			get: () => BASE,
 			refresh() {},
 			create: async () => BASE,

--- a/packages/editor/src/widgets/research.test.tsx
+++ b/packages/editor/src/widgets/research.test.tsx
@@ -112,6 +112,29 @@ describe("research composer", () => {
 		}, () => calls.push("escape"));
 		expect(calls).toEqual(["prevent", "stop", "escape"]);
 	});
+
+	it("does not dismiss an in-flight composer on Escape", async () => {
+		let module = await import("./research") as unknown as {
+			handleResearchComposerKey?: (
+				event: { key: string; preventDefault(): void; stopPropagation(): void },
+				onEscape: () => void,
+				dismissible?: boolean,
+			) => void;
+		};
+		expect(typeof module.handleResearchComposerKey).toBe("function");
+		if (!module.handleResearchComposerKey) return;
+		let calls: string[] = [];
+		module.handleResearchComposerKey(
+			{
+				key: "Escape",
+				preventDefault: () => calls.push("prevent"),
+				stopPropagation: () => calls.push("stop"),
+			},
+			() => calls.push("escape"),
+			false,
+		);
+		expect(calls).toEqual(["prevent", "stop"]);
+	});
 });
 
 describe("research card", () => {

--- a/packages/editor/src/widgets/research.test.tsx
+++ b/packages/editor/src/widgets/research.test.tsx
@@ -46,10 +46,9 @@ type Store = {
 	subscribe(listener: () => void): () => void;
 	retain(id: string): () => void;
 	get(id: string): Research.RequestView | undefined;
-	refresh(id: string): void;
 	create(question: string, requestId: string): Promise<Research.RequestView>;
 	cancel(id: string): Promise<Research.RequestView>;
-	retry(id: string, question: string): Promise<Research.RequestView>;
+	retry(id: string): Promise<Research.RequestView>;
 	open(child: Research.ReadyChild): void;
 };
 
@@ -294,7 +293,6 @@ describe("research reference", () => {
 			subscribe: () => () => {},
 			retain: () => () => {},
 			get: id => id === BASE.id ? BASE : undefined,
-			refresh() {},
 			create: async () => BASE,
 			cancel: async () => BASE,
 			retry: async () => BASE,
@@ -307,111 +305,5 @@ describe("research reference", () => {
 		}));
 		expect(markup).toContain(BASE.question);
 		expect(markup).toContain("Searching");
-	});
-
-	it("subscribes safely to a class store whose method depends on this", async () => {
-		let module = await import("./research");
-		let subscribe = (module as unknown as {
-			subscribeResearch?: (store: Store, listener: () => void) => () => void;
-		}).subscribeResearch;
-		let Reference = (module as unknown as {
-			ResearchReference?: ComponentType<{ id: string; onRemove: () => void; store: Store }>;
-		}).ResearchReference;
-		expect(typeof subscribe).toBe("function");
-		expect(typeof Reference).toBe("function");
-		if (!Reference || !subscribe) return;
-		class ClassStore implements Store {
-			listeners = new Set<() => void>();
-			retained: string[] = [];
-			subscribe(listener: () => void) {
-				this.listeners.add(listener);
-				return () => this.listeners.delete(listener);
-			}
-			get() {
-				return BASE;
-			}
-			retain(id: string) {
-				this.retained.push(id);
-				return () => this.retained.splice(this.retained.indexOf(id), 1);
-			}
-			refresh() {}
-			async create() {
-				return BASE;
-			}
-			async cancel() {
-				return BASE;
-			}
-			async retry() {
-				return BASE;
-			}
-			open() {}
-		}
-		let store = new ClassStore();
-		let off = subscribe(store, () => {});
-		expect(store.listeners.size).toBe(1);
-		off();
-		expect(store.listeners.size).toBe(0);
-		let markup = renderToStaticMarkup(createElement(Reference, {
-			id: BASE.id,
-			onRemove() {},
-			store,
-		}));
-		expect(markup).toContain(BASE.question);
-	});
-
-	it("retains and releases the reference id through the store contract", async () => {
-		let module = await import("./research");
-		let retain = (module as unknown as {
-			retainResearch?: (store: Store, id: string) => () => void;
-		}).retainResearch;
-		expect(typeof retain).toBe("function");
-		if (!retain) return;
-		let retained = new Set<string>();
-		let store = {
-			subscribe: () => () => {},
-			retain: (id: string) => {
-				retained.add(id);
-				return () => retained.delete(id);
-			},
-			get: () => BASE,
-			refresh() {},
-			create: async () => BASE,
-			cancel: async () => BASE,
-			retry: async () => BASE,
-			open() {},
-		};
-
-		let release = retain(store, BASE.id);
-		expect(retained).toEqual(new Set([BASE.id]));
-		release();
-		expect(retained).toEqual(new Set());
-	});
-
-	it("retries the same authoritative request with its exact question", async () => {
-		let module = await import("./research");
-		let retry = (module as unknown as {
-			retryResearch?: (
-				store: Store,
-				request: Research.RequestView,
-			) => Promise<Research.RequestView>;
-		}).retryResearch;
-		expect(typeof retry).toBe("function");
-		if (!retry) return;
-		let received: [string, string] | undefined;
-		let store: Store = {
-			subscribe: () => () => {},
-			retain: () => () => {},
-			get: () => BASE,
-			refresh() {},
-			create: async () => BASE,
-			cancel: async () => BASE,
-			retry: async (id, question) => {
-				received = [id, question];
-				return BASE;
-			},
-			open() {},
-		};
-		await retry(store, BASE);
-		expect(received).toEqual([BASE.id, BASE.question]);
 	});
 });

--- a/packages/editor/src/widgets/research.test.tsx
+++ b/packages/editor/src/widgets/research.test.tsx
@@ -25,16 +25,19 @@ type CardProps = {
 	request: Research.RequestView;
 	onCancel?: () => void;
 	onOpen?: () => void;
-	onRemove: () => void;
+	onRemove?: () => void;
 	onRetry?: () => void;
 };
 
 type ComposerProps = {
+	blocked?: string;
 	error?: string;
 	onCancel: () => void;
 	onChange: (value: string) => void;
+	onEscape?: () => void;
 	onSubmit: () => void;
 	question: string;
+	submitLabel?: string;
 	submitting?: boolean;
 };
 
@@ -76,6 +79,39 @@ describe("research composer", () => {
 		expect(markup).toContain("Cancel");
 		expect((markup.match(/textarea/g) ?? []).length).toBe(2);
 	});
+
+	it("explains why submission is unavailable without a collaboration anchor", async () => {
+		let { composer: Composer } = await components();
+		if (!Composer) return;
+		let markup = renderToStaticMarkup(createElement(Composer, {
+			question: BASE.question,
+			blocked: "Connect to the document before starting research.",
+			onCancel() {},
+			onChange() {},
+			onSubmit() {},
+		}));
+
+		expect(markup).toContain("Connect to the document before starting research.");
+		expect(markup).toMatch(/<button[^>]*disabled=""[^>]*type="submit"/);
+	});
+
+	it("turns Escape into a composer dismissal", async () => {
+		let module = await import("./research") as unknown as {
+			handleResearchComposerKey?: (
+				event: { key: string; preventDefault(): void; stopPropagation(): void },
+				onEscape: () => void,
+			) => void;
+		};
+		expect(typeof module.handleResearchComposerKey).toBe("function");
+		if (!module.handleResearchComposerKey) return;
+		let calls: string[] = [];
+		module.handleResearchComposerKey({
+			key: "Escape",
+			preventDefault: () => calls.push("prevent"),
+			stopPropagation: () => calls.push("stop"),
+		}, () => calls.push("escape"));
+		expect(calls).toEqual(["prevent", "stop", "escape"]);
+	});
 });
 
 describe("research card", () => {
@@ -93,7 +129,7 @@ describe("research card", () => {
 		expect(markup).toContain("Release notes");
 		expect(markup).toContain("https://example.com/releases");
 		expect(markup).toContain("Cancel research");
-		expect(markup).toContain("Remove research reference");
+		expect(markup).not.toContain("Remove research reference");
 		expect(markup).not.toContain("summary");
 	});
 
@@ -145,6 +181,48 @@ describe("research card", () => {
 });
 
 describe("research reference", () => {
+	it("defines one explicit state-to-actions policy", async () => {
+		let module = await import("./research");
+		let actions = (module as unknown as {
+			researchActions?: (
+				request: Research.RequestView | undefined,
+				canEdit: boolean,
+			) => { cancel: boolean; open: boolean; remove: boolean; retry: boolean };
+		}).researchActions;
+		expect(typeof actions).toBe("function");
+		if (!actions) return;
+		let expected: Array<[
+			Research.RequestStage | "loading",
+			{ cancel: boolean; open: boolean; remove: boolean; retry: boolean },
+		]> = [
+			["loading", { cancel: false, open: false, remove: false, retry: false }],
+			["queued", { cancel: true, open: false, remove: false, retry: false }],
+			["searching", { cancel: true, open: false, remove: false, retry: false }],
+			["analyzing", { cancel: true, open: false, remove: false, retry: false }],
+			["writing", { cancel: true, open: false, remove: false, retry: false }],
+			["publishing", { cancel: false, open: false, remove: false, retry: false }],
+			["failed", { cancel: false, open: false, remove: true, retry: true }],
+			["cancelled", { cancel: false, open: false, remove: true, retry: true }],
+			["ready", { cancel: false, open: true, remove: true, retry: false }],
+		];
+		for (let [stage, want] of expected) {
+			let request = stage === "loading" ? undefined : { ...BASE, stage };
+			expect(actions(request, true)).toEqual(want);
+		}
+		expect(actions({ ...BASE, stage: "ready" }, false)).toEqual({
+			cancel: false,
+			open: true,
+			remove: false,
+			retry: false,
+		});
+		expect(actions({ ...BASE, stage: "failed" }, false)).toEqual({
+			cancel: false,
+			open: false,
+			remove: false,
+			retry: false,
+		});
+	});
+
 	it("registers the dialect node renderer", async () => {
 		register();
 		let schema = registry();
@@ -186,6 +264,51 @@ describe("research reference", () => {
 		}));
 		expect(markup).toContain(BASE.question);
 		expect(markup).toContain("Searching");
+	});
+
+	it("subscribes safely to a class store whose method depends on this", async () => {
+		let module = await import("./research");
+		let subscribe = (module as unknown as {
+			subscribeResearch?: (store: Store, listener: () => void) => () => void;
+		}).subscribeResearch;
+		let Reference = (module as unknown as {
+			ResearchReference?: ComponentType<{ id: string; onRemove: () => void; store: Store }>;
+		}).ResearchReference;
+		expect(typeof subscribe).toBe("function");
+		expect(typeof Reference).toBe("function");
+		if (!Reference || !subscribe) return;
+		class ClassStore implements Store {
+			listeners = new Set<() => void>();
+			subscribe(listener: () => void) {
+				this.listeners.add(listener);
+				return () => this.listeners.delete(listener);
+			}
+			get() {
+				return BASE;
+			}
+			refresh() {}
+			async create() {
+				return BASE;
+			}
+			async cancel() {
+				return BASE;
+			}
+			async retry() {
+				return BASE;
+			}
+			open() {}
+		}
+		let store = new ClassStore();
+		let off = subscribe(store, () => {});
+		expect(store.listeners.size).toBe(1);
+		off();
+		expect(store.listeners.size).toBe(0);
+		let markup = renderToStaticMarkup(createElement(Reference, {
+			id: BASE.id,
+			onRemove() {},
+			store,
+		}));
+		expect(markup).toContain(BASE.question);
 	});
 
 	it("retries the same authoritative request with its exact question", async () => {

--- a/packages/editor/src/widgets/research.test.tsx
+++ b/packages/editor/src/widgets/research.test.tsx
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createHeadlessEditor } from "@lexical/headless";
+import { $getRoot } from "lexical";
+
+import { $createResearchNode, registry } from "@chopin/dialect";
+import { register } from "./index";
+
+import type { ComponentType } from "react";
+import type { Research } from "@chopin/protocol";
+
+const BASE: Research.RequestView = {
+	id: "workspace-one",
+	channelId: "document-one",
+	question: "Which evidence supports the rollout date?",
+	state: "running",
+	stage: "searching",
+	sources: [{ title: "Release notes", url: "https://example.com/releases" }],
+	createdAt: "2026-08-24T09:00:00.000Z",
+	updatedAt: "2026-08-24T09:01:00.000Z",
+};
+
+type CardProps = {
+	request: Research.RequestView;
+	onCancel?: () => void;
+	onOpen?: () => void;
+	onRemove: () => void;
+	onRetry?: () => void;
+};
+
+type ComposerProps = {
+	error?: string;
+	onCancel: () => void;
+	onChange: (value: string) => void;
+	onSubmit: () => void;
+	question: string;
+	submitting?: boolean;
+};
+
+type Store = {
+	subscribe(listener: () => void): () => void;
+	get(id: string): Research.RequestView | undefined;
+	refresh(id: string): void;
+	create(question: string, requestId: string): Promise<Research.RequestView>;
+	cancel(id: string): Promise<Research.RequestView>;
+	retry(id: string, question: string): Promise<Research.RequestView>;
+	open(child: Research.ReadyChild): void;
+};
+
+async function components() {
+	let module = await import("./research").catch(() => ({}));
+	let card = (module as { ResearchCard?: ComponentType<CardProps> }).ResearchCard;
+	let composer = (module as { ResearchComposer?: ComponentType<ComposerProps> }).ResearchComposer;
+	expect(typeof card).toBe("function");
+	expect(typeof composer).toBe("function");
+	return { card, composer };
+}
+
+describe("research composer", () => {
+	it("keeps one exact brief actionable after a failed create", async () => {
+		let { composer: Composer } = await components();
+		if (!Composer) return;
+		let markup = renderToStaticMarkup(createElement(Composer, {
+			question: BASE.question,
+			error: "Research could not be started.",
+			onCancel() {},
+			onChange() {},
+			onSubmit() {},
+		}));
+
+		expect(markup).toContain("Research question");
+		expect(markup).toContain(BASE.question);
+		expect(markup).toContain("Research could not be started.");
+		expect(markup).toContain("Start research");
+		expect(markup).toContain("Cancel");
+		expect((markup.match(/textarea/g) ?? []).length).toBe(2);
+	});
+});
+
+describe("research card", () => {
+	it("shows pending stage and discovered sources without a partial summary", async () => {
+		let { card: Card } = await components();
+		if (!Card) return;
+		let markup = renderToStaticMarkup(createElement(Card, {
+			request: BASE,
+			onCancel() {},
+			onRemove() {},
+		}));
+
+		expect(markup).toContain(BASE.question);
+		expect(markup).toContain("Searching");
+		expect(markup).toContain("Release notes");
+		expect(markup).toContain("https://example.com/releases");
+		expect(markup).toContain("Cancel research");
+		expect(markup).toContain("Remove research reference");
+		expect(markup).not.toContain("summary");
+	});
+
+	it("shows only the safe failure and retry action after failure", async () => {
+		let { card: Card } = await components();
+		if (!Card) return;
+		let markup = renderToStaticMarkup(createElement(Card, {
+			request: {
+				...BASE,
+				state: "failed",
+				stage: "failed",
+				error: "Research could not be completed.",
+			},
+			onRemove() {},
+			onRetry() {},
+		}));
+
+		expect(markup).toContain("Research failed");
+		expect(markup).toContain("Research could not be completed.");
+		expect(markup).toContain("Retry research");
+		expect(markup).not.toContain("Cancel research");
+	});
+
+	it("opens the ready child without an expand action or report summary", async () => {
+		let { card: Card } = await components();
+		if (!Card) return;
+		let markup = renderToStaticMarkup(createElement(Card, {
+			request: {
+				...BASE,
+				state: "completed",
+				stage: "ready",
+				child: {
+					id: "child-one",
+					title: "Rollout evidence",
+					slug: "rollout-evidence",
+					summary: "This must stay out of the inline card.",
+					sourceCount: 1,
+				},
+			},
+			onOpen() {},
+			onRemove() {},
+		}));
+
+		expect(markup).toContain("Research ready");
+		expect(markup).toContain("Open Rollout evidence");
+		expect(markup).not.toContain("This must stay out of the inline card.");
+		expect(markup).not.toContain("Expand");
+	});
+});
+
+describe("research reference", () => {
+	it("registers the dialect node renderer", async () => {
+		register();
+		let schema = registry();
+		let editor = createHeadlessEditor({
+			nodes: schema.nodes,
+			onError: error => {
+				throw error;
+			},
+		});
+		let decorated: unknown;
+		editor.update(() => {
+			let node = $createResearchNode(BASE.id);
+			$getRoot().append(node);
+			decorated = node.decorate();
+		}, { discrete: true });
+		expect(decorated).not.toBeNull();
+	});
+
+	it("derives mutable state from the injected store", async () => {
+		let module = await import("./research");
+		let Reference = (module as unknown as {
+			ResearchReference?: ComponentType<{ id: string; onRemove: () => void; store: Store }>;
+		}).ResearchReference;
+		expect(typeof Reference).toBe("function");
+		if (!Reference) return;
+		let store: Store = {
+			subscribe: () => () => {},
+			get: id => id === BASE.id ? BASE : undefined,
+			refresh() {},
+			create: async () => BASE,
+			cancel: async () => BASE,
+			retry: async () => BASE,
+			open() {},
+		};
+		let markup = renderToStaticMarkup(createElement(Reference, {
+			id: BASE.id,
+			onRemove() {},
+			store,
+		}));
+		expect(markup).toContain(BASE.question);
+		expect(markup).toContain("Searching");
+	});
+
+	it("retries the same authoritative request with its exact question", async () => {
+		let module = await import("./research");
+		let retry = (module as unknown as {
+			retryResearch?: (
+				store: Store,
+				request: Research.RequestView,
+			) => Promise<Research.RequestView>;
+		}).retryResearch;
+		expect(typeof retry).toBe("function");
+		if (!retry) return;
+		let received: [string, string] | undefined;
+		let store: Store = {
+			subscribe: () => () => {},
+			get: () => BASE,
+			refresh() {},
+			create: async () => BASE,
+			cancel: async () => BASE,
+			retry: async (id, question) => {
+				received = [id, question];
+				return BASE;
+			},
+			open() {},
+		};
+		await retry(store, BASE);
+		expect(received).toEqual([BASE.id, BASE.question]);
+	});
+});

--- a/packages/editor/src/widgets/research.tsx
+++ b/packages/editor/src/widgets/research.tsx
@@ -23,6 +23,9 @@ const STAGES: Record<Research.RequestStage, string> = {
 
 export type ResearchComposerProps = {
 	blocked?: string;
+	busyLabel?: string;
+	cancelLabel?: string;
+	dismissible?: boolean;
 	error?: string;
 	onCancel: () => void;
 	onChange: (value: string) => void;
@@ -37,16 +40,20 @@ export type ResearchComposerProps = {
 export function handleResearchComposerKey(
 	event: Pick<KeyboardEvent, "key" | "preventDefault" | "stopPropagation">,
 	onEscape: () => void,
+	dismissible = true,
 ) {
 	if (event.key !== "Escape") return;
 	event.preventDefault();
 	event.stopPropagation();
-	onEscape();
+	if (dismissible) onEscape();
 }
 
 export function ResearchComposer(
 	{
 		blocked,
+		busyLabel = "Starting…",
+		cancelLabel = "Cancel",
+		dismissible = true,
 		error,
 		onCancel,
 		onChange,
@@ -66,7 +73,9 @@ export function ResearchComposer(
 	return (
 		<form
 			className="plan-research-composer"
-			onKeyDown={onEscape ? event => handleResearchComposerKey(event, onEscape) : undefined}
+			onKeyDown={onEscape
+				? event => handleResearchComposerKey(event, onEscape, dismissible)
+				: undefined}
 			onSubmit={submit}
 		>
 			<label htmlFor={id}>Research question</label>
@@ -89,14 +98,14 @@ export function ResearchComposer(
 					onClick={onCancel}
 					type="button"
 				>
-					Cancel
+					{cancelLabel}
 				</button>
 				<button
 					className="btn btn-sm btn-primary"
 					disabled={submitting || !!blocked || !question.trim()}
 					type="submit"
 				>
-					{submitting ? "Starting…" : submitLabel}
+					{submitting ? busyLabel : submitLabel}
 				</button>
 			</div>
 		</form>

--- a/packages/editor/src/widgets/research.tsx
+++ b/packages/editor/src/widgets/research.tsx
@@ -1,0 +1,253 @@
+import { useEffect, useId, useState, useSyncExternalStore } from "react";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { useCellValue } from "@mdxeditor/gurx";
+
+import { SidecarCard } from "../card";
+import { widgets$ } from "../widget-options";
+
+import type { FormEvent } from "react";
+import type { Research } from "@chopin/protocol";
+import type { ResearchNode } from "@chopin/dialect";
+import type { ResearchStore } from "../widget-options";
+
+const STAGES: Record<Research.RequestStage, string> = {
+	queued: "Queued",
+	searching: "Searching",
+	analyzing: "Analyzing",
+	writing: "Writing",
+	publishing: "Publishing",
+	ready: "Research ready",
+	failed: "Research failed",
+	cancelled: "Research cancelled",
+};
+
+export type ResearchComposerProps = {
+	error?: string;
+	onCancel: () => void;
+	onChange: (value: string) => void;
+	onSubmit: () => void;
+	question: string;
+	submitting?: boolean;
+};
+
+export function ResearchComposer(
+	{ error, onCancel, onChange, onSubmit, question, submitting }: ResearchComposerProps,
+) {
+	let id = useId();
+	let submit = (event: FormEvent) => {
+		event.preventDefault();
+		onSubmit();
+	};
+	return (
+		<form className="plan-research-composer" onSubmit={submit}>
+			<label htmlFor={id}>Research question</label>
+			<textarea
+				autoFocus
+				disabled={submitting}
+				id={id}
+				maxLength={4096}
+				onChange={event => onChange(event.target.value)}
+				rows={3}
+				value={question}
+			/>
+			{error && <p role="alert">{error}</p>}
+			<div className="plan-research-actions">
+				<button
+					className="btn btn-sm btn-secondary"
+					disabled={submitting}
+					onClick={onCancel}
+					type="button"
+				>
+					Cancel
+				</button>
+				<button
+					className="btn btn-sm btn-primary"
+					disabled={submitting || !question.trim()}
+					type="submit"
+				>
+					{submitting ? "Starting…" : "Start research"}
+				</button>
+			</div>
+		</form>
+	);
+}
+
+export type ResearchCardProps = {
+	actionError?: string;
+	busy?: boolean;
+	canEdit?: boolean;
+	request: Research.RequestView;
+	onCancel?: () => void;
+	onOpen?: () => void;
+	onRemove: () => void;
+	onRetry?: () => void;
+};
+
+export function ResearchCard(
+	{ actionError, busy, canEdit = true, onCancel, onOpen, onRemove, onRetry, request }:
+		ResearchCardProps,
+) {
+	let ready = request.stage === "ready" && request.child;
+	return (
+		<SidecarCard label="Research">
+			<div className="plan-research-heading">
+				<strong>{STAGES[request.stage]}</strong>
+				<span>{request.question}</span>
+			</div>
+			{request.error && <p className="plan-research-error" role="status">{request.error}</p>}
+			{request.sources.length > 0 && (
+				<ul aria-label="Research sources" className="plan-research-sources">
+					{request.sources.map(source => (
+						<li key={source.url}>
+							<a href={source.url} rel="noreferrer" target="_blank">{source.title}</a>
+						</li>
+					))}
+				</ul>
+			)}
+			{actionError && <p className="plan-research-error" role="status">{actionError}</p>}
+			<div className="plan-research-actions">
+				{onCancel && (
+					<button
+						aria-label="Cancel research"
+						className="btn btn-sm btn-secondary"
+						disabled={busy || !canEdit}
+						onClick={onCancel}
+						type="button"
+					>
+						Cancel
+					</button>
+				)}
+				{onRetry && (
+					<button
+						aria-label="Retry research"
+						className="btn btn-sm btn-secondary"
+						disabled={busy || !canEdit}
+						onClick={onRetry}
+						type="button"
+					>
+						Retry
+					</button>
+				)}
+				{ready && onOpen && (
+					<button className="btn btn-sm btn-primary" disabled={busy} onClick={onOpen} type="button">
+						Open {ready.title}
+					</button>
+				)}
+				<button
+					aria-label="Remove research reference"
+					className="btn btn-sm btn-ghost"
+					disabled={busy || !canEdit}
+					onClick={onRemove}
+					type="button"
+				>
+					Remove
+				</button>
+			</div>
+		</SidecarCard>
+	);
+}
+
+export function retryResearch(
+	store: ResearchStore,
+	request: Research.RequestView,
+): Promise<Research.RequestView> {
+	return store.retry(request.id, request.question);
+}
+
+export type ResearchReferenceProps = {
+	canEdit?: boolean;
+	id: string;
+	onRemove: () => void;
+	store: ResearchStore;
+};
+
+export function ResearchReference({ canEdit = true, id, onRemove, store }: ResearchReferenceProps) {
+	let request = useSyncExternalStore(
+		store.subscribe,
+		() => store.get(id),
+		() => store.get(id),
+	);
+	let [busy, setBusy] = useState(false);
+	let [actionError, setActionError] = useState<string>();
+
+	useEffect(() => store.refresh(id), [id, store]);
+
+	if (!request) {
+		return (
+			<SidecarCard label="Research">
+				<strong>Loading research…</strong>
+				<div className="plan-research-actions">
+					<button
+						aria-label="Remove research reference"
+						className="btn btn-sm btn-ghost"
+						disabled={!canEdit}
+						onClick={onRemove}
+						type="button"
+					>
+						Remove
+					</button>
+				</div>
+			</SidecarCard>
+		);
+	}
+
+	let action = (run: () => Promise<Research.RequestView>) => {
+		setBusy(true);
+		setActionError(undefined);
+		void run().catch(() => setActionError("Research could not be updated.")).finally(() =>
+			setBusy(false)
+		);
+	};
+	let active = request.stage !== "ready" && request.stage !== "failed"
+		&& request.stage !== "cancelled";
+	let retryable = request.stage === "failed" || request.stage === "cancelled";
+
+	return (
+		<ResearchCard
+			actionError={actionError}
+			busy={busy}
+			canEdit={canEdit}
+			request={request}
+			onCancel={canEdit && active ? () => action(() => store.cancel(request.id)) : undefined}
+			onOpen={request.child ? () => store.open(request.child!) : undefined}
+			onRemove={onRemove}
+			onRetry={canEdit && retryable ? () => action(() => retryResearch(store, request)) : undefined}
+		/>
+	);
+}
+
+function InlineResearch({ id, node }: { id: string; node: ResearchNode }) {
+	let [editor] = useLexicalComposerContext();
+	let options = useCellValue(widgets$);
+	let store = options.research;
+	let remove = () => editor.update(() => node.getLatest().remove());
+	return store
+		? (
+			<ResearchReference
+				canEdit={options.canEdit}
+				id={id}
+				onRemove={remove}
+				store={store}
+			/>
+		)
+		: (
+			<SidecarCard label="Research">
+				<strong>Research unavailable</strong>
+				<div className="plan-research-actions">
+					<button
+						aria-label="Remove research reference"
+						className="btn btn-sm btn-ghost"
+						disabled={!options.canEdit}
+						onClick={remove}
+						type="button"
+					>
+						Remove
+					</button>
+				</div>
+			</SidecarCard>
+		);
+}
+
+export function renderResearch(node: ResearchNode) {
+	return <InlineResearch id={node.getId()} node={node} />;
+}

--- a/packages/editor/src/widgets/research.tsx
+++ b/packages/editor/src/widgets/research.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useId, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useId, useState, useSyncExternalStore } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { useCellValue } from "@mdxeditor/gurx";
 
 import { SidecarCard } from "../card";
 import { widgets$ } from "../widget-options";
 
-import type { FormEvent } from "react";
+import type { FormEvent, KeyboardEvent } from "react";
 import type { Research } from "@chopin/protocol";
 import type { ResearchNode } from "@chopin/dialect";
 import type { ResearchStore } from "../widget-options";
@@ -22,16 +22,41 @@ const STAGES: Record<Research.RequestStage, string> = {
 };
 
 export type ResearchComposerProps = {
+	blocked?: string;
 	error?: string;
 	onCancel: () => void;
 	onChange: (value: string) => void;
+	onEscape?: () => void;
 	onSubmit: () => void;
 	question: string;
+	questionLocked?: boolean;
+	submitLabel?: string;
 	submitting?: boolean;
 };
 
+export function handleResearchComposerKey(
+	event: Pick<KeyboardEvent, "key" | "preventDefault" | "stopPropagation">,
+	onEscape: () => void,
+) {
+	if (event.key !== "Escape") return;
+	event.preventDefault();
+	event.stopPropagation();
+	onEscape();
+}
+
 export function ResearchComposer(
-	{ error, onCancel, onChange, onSubmit, question, submitting }: ResearchComposerProps,
+	{
+		blocked,
+		error,
+		onCancel,
+		onChange,
+		onEscape,
+		onSubmit,
+		question,
+		questionLocked,
+		submitLabel = "Start research",
+		submitting,
+	}: ResearchComposerProps,
 ) {
 	let id = useId();
 	let submit = (event: FormEvent) => {
@@ -39,7 +64,11 @@ export function ResearchComposer(
 		onSubmit();
 	};
 	return (
-		<form className="plan-research-composer" onSubmit={submit}>
+		<form
+			className="plan-research-composer"
+			onKeyDown={onEscape ? event => handleResearchComposerKey(event, onEscape) : undefined}
+			onSubmit={submit}
+		>
 			<label htmlFor={id}>Research question</label>
 			<textarea
 				autoFocus
@@ -47,9 +76,11 @@ export function ResearchComposer(
 				id={id}
 				maxLength={4096}
 				onChange={event => onChange(event.target.value)}
+				readOnly={questionLocked}
 				rows={3}
 				value={question}
 			/>
+			{blocked && <p role="status">{blocked}</p>}
 			{error && <p role="alert">{error}</p>}
 			<div className="plan-research-actions">
 				<button
@@ -62,10 +93,10 @@ export function ResearchComposer(
 				</button>
 				<button
 					className="btn btn-sm btn-primary"
-					disabled={submitting || !question.trim()}
+					disabled={submitting || !!blocked || !question.trim()}
 					type="submit"
 				>
-					{submitting ? "Starting…" : "Start research"}
+					{submitting ? "Starting…" : submitLabel}
 				</button>
 			</div>
 		</form>
@@ -79,7 +110,7 @@ export type ResearchCardProps = {
 	request: Research.RequestView;
 	onCancel?: () => void;
 	onOpen?: () => void;
-	onRemove: () => void;
+	onRemove?: () => void;
 	onRetry?: () => void;
 };
 
@@ -88,6 +119,7 @@ export function ResearchCard(
 		ResearchCardProps,
 ) {
 	let ready = request.stage === "ready" && request.child;
+	let actions = researchActions(request, canEdit);
 	return (
 		<SidecarCard label="Research">
 			<div className="plan-research-heading">
@@ -106,7 +138,7 @@ export function ResearchCard(
 			)}
 			{actionError && <p className="plan-research-error" role="status">{actionError}</p>}
 			<div className="plan-research-actions">
-				{onCancel && (
+				{actions.cancel && onCancel && (
 					<button
 						aria-label="Cancel research"
 						className="btn btn-sm btn-secondary"
@@ -117,7 +149,7 @@ export function ResearchCard(
 						Cancel
 					</button>
 				)}
-				{onRetry && (
+				{actions.retry && onRetry && (
 					<button
 						aria-label="Retry research"
 						className="btn btn-sm btn-secondary"
@@ -128,20 +160,22 @@ export function ResearchCard(
 						Retry
 					</button>
 				)}
-				{ready && onOpen && (
+				{actions.open && ready && onOpen && (
 					<button className="btn btn-sm btn-primary" disabled={busy} onClick={onOpen} type="button">
 						Open {ready.title}
 					</button>
 				)}
-				<button
-					aria-label="Remove research reference"
-					className="btn btn-sm btn-ghost"
-					disabled={busy || !canEdit}
-					onClick={onRemove}
-					type="button"
-				>
-					Remove
-				</button>
+				{actions.remove && onRemove && (
+					<button
+						aria-label="Remove research reference"
+						className="btn btn-sm btn-ghost"
+						disabled={busy || !canEdit}
+						onClick={onRemove}
+						type="button"
+					>
+						Remove
+					</button>
+				)}
 			</div>
 		</SidecarCard>
 	);
@@ -154,6 +188,35 @@ export function retryResearch(
 	return store.retry(request.id, request.question);
 }
 
+export type ResearchActions = {
+	cancel: boolean;
+	open: boolean;
+	remove: boolean;
+	retry: boolean;
+};
+
+const NONE: ResearchActions = { cancel: false, open: false, remove: false, retry: false };
+
+export function researchActions(
+	request: Research.RequestView | undefined,
+	canEdit: boolean,
+): ResearchActions {
+	if (!request) return NONE;
+	if (request.stage === "ready") return { ...NONE, open: true, remove: canEdit };
+	if (!canEdit) return NONE;
+	if (["queued", "searching", "analyzing", "writing"].includes(request.stage)) {
+		return { ...NONE, cancel: true };
+	}
+	if (request.stage === "failed" || request.stage === "cancelled") {
+		return { ...NONE, remove: true, retry: true };
+	}
+	return NONE;
+}
+
+export function subscribeResearch(store: ResearchStore, listener: () => void): () => void {
+	return store.subscribe(listener);
+}
+
 export type ResearchReferenceProps = {
 	canEdit?: boolean;
 	id: string;
@@ -162,8 +225,12 @@ export type ResearchReferenceProps = {
 };
 
 export function ResearchReference({ canEdit = true, id, onRemove, store }: ResearchReferenceProps) {
+	let subscribe = useCallback(
+		(listener: () => void) => subscribeResearch(store, listener),
+		[store],
+	);
 	let request = useSyncExternalStore(
-		store.subscribe,
+		subscribe,
 		() => store.get(id),
 		() => store.get(id),
 	);
@@ -176,17 +243,6 @@ export function ResearchReference({ canEdit = true, id, onRemove, store }: Resea
 		return (
 			<SidecarCard label="Research">
 				<strong>Loading research…</strong>
-				<div className="plan-research-actions">
-					<button
-						aria-label="Remove research reference"
-						className="btn btn-sm btn-ghost"
-						disabled={!canEdit}
-						onClick={onRemove}
-						type="button"
-					>
-						Remove
-					</button>
-				</div>
 			</SidecarCard>
 		);
 	}
@@ -198,9 +254,7 @@ export function ResearchReference({ canEdit = true, id, onRemove, store }: Resea
 			setBusy(false)
 		);
 	};
-	let active = request.stage !== "ready" && request.stage !== "failed"
-		&& request.stage !== "cancelled";
-	let retryable = request.stage === "failed" || request.stage === "cancelled";
+	let actions = researchActions(request, canEdit);
 
 	return (
 		<ResearchCard
@@ -208,10 +262,10 @@ export function ResearchReference({ canEdit = true, id, onRemove, store }: Resea
 			busy={busy}
 			canEdit={canEdit}
 			request={request}
-			onCancel={canEdit && active ? () => action(() => store.cancel(request.id)) : undefined}
-			onOpen={request.child ? () => store.open(request.child!) : undefined}
-			onRemove={onRemove}
-			onRetry={canEdit && retryable ? () => action(() => retryResearch(store, request)) : undefined}
+			onCancel={actions.cancel ? () => action(() => store.cancel(request.id)) : undefined}
+			onOpen={actions.open && request.child ? () => store.open(request.child!) : undefined}
+			onRemove={actions.remove ? onRemove : undefined}
+			onRetry={actions.retry ? () => action(() => retryResearch(store, request)) : undefined}
 		/>
 	);
 }
@@ -233,17 +287,6 @@ function InlineResearch({ id, node }: { id: string; node: ResearchNode }) {
 		: (
 			<SidecarCard label="Research">
 				<strong>Research unavailable</strong>
-				<div className="plan-research-actions">
-					<button
-						aria-label="Remove research reference"
-						className="btn btn-sm btn-ghost"
-						disabled={!options.canEdit}
-						onClick={remove}
-						type="button"
-					>
-						Remove
-					</button>
-				</div>
 			</SidecarCard>
 		);
 }

--- a/packages/editor/src/widgets/research.tsx
+++ b/packages/editor/src/widgets/research.tsx
@@ -192,13 +192,6 @@ export function ResearchCard(
 	);
 }
 
-export function retryResearch(
-	store: ResearchStore,
-	request: Research.RequestView,
-): Promise<Research.RequestView> {
-	return store.retry(request.id, request.question);
-}
-
 export type ResearchActions = {
 	cancel: boolean;
 	open: boolean;
@@ -224,14 +217,6 @@ export function researchActions(
 	return NONE;
 }
 
-export function subscribeResearch(store: ResearchStore, listener: () => void): () => void {
-	return store.subscribe(listener);
-}
-
-export function retainResearch(store: ResearchStore, id: string): () => void {
-	return store.retain(id);
-}
-
 export type ResearchReferenceProps = {
 	canEdit?: boolean;
 	id: string;
@@ -241,7 +226,7 @@ export type ResearchReferenceProps = {
 
 export function ResearchReference({ canEdit = true, id, onRemove, store }: ResearchReferenceProps) {
 	let subscribe = useCallback(
-		(listener: () => void) => subscribeResearch(store, listener),
+		(listener: () => void) => store.subscribe(listener),
 		[store],
 	);
 	let request = useSyncExternalStore(
@@ -252,7 +237,7 @@ export function ResearchReference({ canEdit = true, id, onRemove, store }: Resea
 	let [busy, setBusy] = useState(false);
 	let [actionError, setActionError] = useState<string>();
 
-	useEffect(() => retainResearch(store, id), [id, store]);
+	useEffect(() => store.retain(id), [id, store]);
 
 	if (!request) {
 		return (
@@ -280,7 +265,7 @@ export function ResearchReference({ canEdit = true, id, onRemove, store }: Resea
 			onCancel={actions.cancel ? () => action(() => store.cancel(request.id)) : undefined}
 			onOpen={actions.open && request.child ? () => store.open(request.child!) : undefined}
 			onRemove={actions.remove ? onRemove : undefined}
-			onRetry={actions.retry ? () => action(() => retryResearch(store, request)) : undefined}
+			onRetry={actions.retry ? () => action(() => store.retry(request.id)) : undefined}
 		/>
 	);
 }

--- a/packages/editor/src/widgets/research.tsx
+++ b/packages/editor/src/widgets/research.tsx
@@ -24,6 +24,7 @@ const STAGES: Record<Research.RequestStage, string> = {
 export type ResearchComposerProps = {
 	blocked?: string;
 	busyLabel?: string;
+	cancelDisabled?: boolean;
 	cancelLabel?: string;
 	dismissible?: boolean;
 	error?: string;
@@ -52,6 +53,7 @@ export function ResearchComposer(
 	{
 		blocked,
 		busyLabel = "Starting…",
+		cancelDisabled,
 		cancelLabel = "Cancel",
 		dismissible = true,
 		error,
@@ -94,7 +96,7 @@ export function ResearchComposer(
 			<div className="plan-research-actions">
 				<button
 					className="btn btn-sm btn-secondary"
-					disabled={submitting}
+					disabled={submitting || cancelDisabled}
 					onClick={onCancel}
 					type="button"
 				>

--- a/packages/editor/src/widgets/research.tsx
+++ b/packages/editor/src/widgets/research.tsx
@@ -228,6 +228,10 @@ export function subscribeResearch(store: ResearchStore, listener: () => void): (
 	return store.subscribe(listener);
 }
 
+export function retainResearch(store: ResearchStore, id: string): () => void {
+	return store.retain(id);
+}
+
 export type ResearchReferenceProps = {
 	canEdit?: boolean;
 	id: string;
@@ -248,7 +252,7 @@ export function ResearchReference({ canEdit = true, id, onRemove, store }: Resea
 	let [busy, setBusy] = useState(false);
 	let [actionError, setActionError] = useState<string>();
 
-	useEffect(() => store.refresh(id), [id, store]);
+	useEffect(() => retainResearch(store, id), [id, store]);
 
 	if (!request) {
 		return (


### PR DESCRIPTION
Stack 2 of 7 for the research child-document redesign. Builds on #128.

Adds the restricted-dialect research reference, editor slash-command composer and inline status card, durable request creation/retry/cancellation storage and routes, and the browser request store that restores polling and exact request identity across remounts. This includes the preserved React Strict Mode cleanup recovery fix.

This layer preserves the stack-1 private Research Workspace flow alongside inline requests. It does not include child-document navigation UI or later research workspace redesign work.

Verification:
- bun run fix: 0 warnings, 0 errors
- Focused research, navigation, dialect, and editor tests: 110 passed
- Research Workspace E2E: 6 passed
- PostgreSQL contract: 58 passed against the disposable db-e2e service
- bun test: 1,331 passed; 2 PostgreSQL skips
- bun run types
- bun run ci
- git diff --check

Environment-only reruns:
- The full bun test command was run outside the managed bind sandbox because its socket tests require ephemeral loopback listeners; 1,331 passed and 2 PostgreSQL tests skipped.
- PostgreSQL contracts were run outside the network sandbox against the disposable db-e2e service on port 5433; 58 passed.
- The focused E2E suite was run outside the sandbox because it requires Docker and local application ports; 6 passed.
