### PR TITLE
Fix purposeful motion audit gaps

### DIFF
--- a/apps/web/src/motion-input.test.ts
+++ b/apps/web/src/motion-input.test.ts
@@ -7,3 +7,7 @@ test("settles keyboard-owned surfaces immediately", () => {
 	expect(motionImmediately({})).toBe(false);
 	expect(motionImmediately()).toBe(false);
 });
+
+test("settles reduced-motion pointer surfaces immediately", () => {
+	expect(motionImmediately({ motionInput: "pointer" }, true)).toBe(true);
+});

--- a/apps/web/src/motion-input.ts
+++ b/apps/web/src/motion-input.ts
@@ -1,9 +1,13 @@
 import { useEffect } from "react";
 
-export function motionImmediately(dataset?: { motionInput?: string }): boolean {
+export function motionImmediately(
+	dataset?: { motionInput?: string },
+	prefersReducedMotion = typeof window !== "undefined"
+		&& window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+): boolean {
 	let source = dataset
 		?? (typeof document === "undefined" ? undefined : document.documentElement.dataset);
-	return source?.motionInput === "keyboard";
+	return source?.motionInput === "keyboard" || prefersReducedMotion;
 }
 
 export function useMotionInput(): void {

--- a/apps/web/src/theme.test.ts
+++ b/apps/web/src/theme.test.ts
@@ -330,7 +330,15 @@ describe("editor feedback motion", () => {
 		) {
 			expect(FEEDBACK).toMatch(
 				new RegExp(
-					`:root\\[data-motion-input="pointer"\\]\\s+\\.editor-motion-feedback\\[data-motion-feedback="${kind}"\\]\\s*{[^}]*transition-duration: var\\(--${duration}\\)[^}]*transition-timing-function: var\\(--motion-smooth-out\\)`,
+					`:root\\[data-motion-input="pointer"\\]\\s+\\.editor-motion-feedback\\[data-motion-feedback="${kind}"\\][^{}]*{[^}]*transition-duration: var\\(--${duration}\\)[^}]*transition-timing-function: var\\(--motion-smooth-out\\)`,
+					"s",
+				),
+			);
+		}
+		for (let [kind, duration] of [["icon", "icon-swap-dur"], ["alert", "toast-open"]]) {
+			expect(FEEDBACK).toMatch(
+				new RegExp(
+					`\\.editor-motion-feedback\\[data-motion-feedback="${kind}"\\]\\[data-motion-owned="pointer"\\][^{}]*{[^}]*transition-duration: var\\(--${duration}\\)`,
 					"s",
 				),
 			);
@@ -362,7 +370,7 @@ describe("editor feedback motion", () => {
 
 	it("settles pointer-owned editor feedback under reduced motion", () => {
 		expect(FEEDBACK).toMatch(
-			/@media \(prefers-reduced-motion: reduce\)\s*{[^}]*:root\[data-motion-input="pointer"\]\s+\.editor-motion-feedback\[data-motion-feedback\]\s*{[^}]*transition-duration:\s*0s;/s,
+			/@media \(prefers-reduced-motion: reduce\)\s*{[^}]*:root\[data-motion-input="pointer"\]\s+\.editor-motion-feedback\[data-motion-feedback\][^{}]*\.editor-motion-feedback\[data-motion-feedback\]\[data-motion-owned="pointer"\]\s*{[^}]*transition-duration:\s*0s;/s,
 		);
 	});
 });

--- a/e2e/jobs.e2e.ts
+++ b/e2e/jobs.e2e.ts
@@ -141,3 +141,102 @@ test("running research shows durable stage progress", async ({ baseURL, join, ro
 	await expect(page.getByText("Research report synthesis")).toBeVisible();
 	await expect(page.getByText("In progress")).toBeVisible();
 });
+
+test("cancellation failures use terminal alert feedback for each motion path", async ({ baseURL, join, page, room, seed }) => {
+	await seed(SOURCE);
+	await seedRunningResearchAnswerJob(Number(new URL(baseURL!).port), room, QUESTION);
+	await page.routeWebSocket("**/ws?**", route => {
+		let server = route.connectToServer();
+		route.onMessage(message => {
+			if (typeof message === "string") {
+				let frame = JSON.parse(message) as { kind: string; rid?: string };
+				if (frame.kind === "job:cancel") {
+					setTimeout(() =>
+						route.send(JSON.stringify({
+							kind: "session:error",
+							message: "Cancellation is temporarily unavailable",
+							rid: frame.rid,
+							ts: 0,
+						})), 100);
+					return;
+				}
+			}
+			server.send(message);
+		});
+	});
+	page = await join("ana");
+	await page.getByRole("button", { name: /Background Work/ }).click();
+	let cancel = page.getByRole("button", { name: `Cancel Research answer: ${QUESTION}` });
+	await page.evaluate(() => {
+		let transitionCounter = { starts: 0 };
+		Reflect.set(window, "__backgroundAlertTransitions", transitionCounter);
+		document.addEventListener("transitionstart", event => {
+			if (
+				event.target instanceof Element
+				&& event.target.matches('[data-motion-feedback="alert"]')
+			) transitionCounter.starts++;
+		}, true);
+	});
+
+	await cancel.click();
+	await page.keyboard.press("Shift");
+	let alert = page.getByRole("alert");
+	await expect(alert).toHaveText("Cancellation is temporarily unavailable");
+	await expect(alert).toHaveAttribute("data-motion-feedback", "alert");
+	await expect.poll(() =>
+		page.evaluate(() => {
+			let transitionCounter = Reflect.get(window, "__backgroundAlertTransitions") as {
+				starts: number;
+			};
+			return transitionCounter.starts;
+		})
+	).toBeGreaterThan(0);
+	let pointerStarts = await page.evaluate(() => {
+		let transitionCounter = Reflect.get(window, "__backgroundAlertTransitions") as {
+			starts: number;
+		};
+		return transitionCounter.starts;
+	});
+
+	await cancel.focus();
+	await page.keyboard.press("Enter");
+	await page.mouse.move(1, 1);
+	await expect(alert).toHaveText("Cancellation is temporarily unavailable");
+	await expect(alert).toHaveCSS("transition-duration", "0s");
+	expect(
+		await page.evaluate(() => {
+			let transitionCounter = Reflect.get(window, "__backgroundAlertTransitions") as {
+				starts: number;
+			};
+			return transitionCounter.starts;
+		}),
+	).toBe(pointerStarts);
+
+	await page.emulateMedia({ reducedMotion: "reduce" });
+	await cancel.click();
+	await expect(alert).toHaveText("Cancellation is temporarily unavailable");
+	await expect(alert).toHaveCSS("transition-duration", "0s");
+	expect(
+		await page.evaluate(() => {
+			let transitionCounter = Reflect.get(window, "__backgroundAlertTransitions") as {
+				starts: number;
+			};
+			return transitionCounter.starts;
+		}),
+	).toBe(pointerStarts);
+
+	await page.emulateMedia({ reducedMotion: "no-preference" });
+	await cancel.click();
+	await page.keyboard.press("Shift");
+	await page.emulateMedia({ reducedMotion: "reduce" });
+	await expect(alert).toHaveText("Cancellation is temporarily unavailable");
+	await expect(alert).toHaveCSS("transition-duration", "0s");
+	expect(
+		await page.evaluate(() => {
+			let transitionCounter = Reflect.get(window, "__backgroundAlertTransitions") as {
+				starts: number;
+			};
+			return transitionCounter.starts;
+		}),
+	).toBe(pointerStarts);
+});

--- a/e2e/responsive-content.e2e.ts
+++ b/e2e/responsive-content.e2e.ts
@@ -322,6 +322,79 @@ for (let viewport of RESPONSIVE_VIEWPORTS) {
 	});
 }
 
+test("the Planner change disclosure animates only pointer-owned glyph swaps", async ({ baseURL, join, page, room, seed }) => {
+	await seed(RESPONSIVE_SOURCE);
+	let checkpoint = await readDocument(Number(new URL(baseURL!).port), room);
+	let changes = await injectAgentChange(page, checkpoint);
+	page = await join("change-reader");
+	await changes.addedAtEnd();
+	let trigger = page.getByRole("button", { name: "What the agent changed" });
+	let icon = trigger.locator("[data-feedback-icon]");
+	await expect(icon).toHaveAttribute("data-feedback-icon", "closed");
+	await page.evaluate(() => {
+		let transitionCounter = { starts: 0 };
+		Reflect.set(window, "__changeIconTransitions", transitionCounter);
+		document.addEventListener("transitionstart", event => {
+			if (
+				event.target instanceof Element
+				&& event.target.matches('[data-motion-feedback="icon"]')
+			) transitionCounter.starts++;
+		}, true);
+	});
+	await trigger.click();
+	await page.keyboard.press("Shift");
+	await expect(icon).toHaveAttribute("data-feedback-icon", "open");
+	await expect(icon).toHaveCSS("transition-duration", "0.25s");
+	await expect.poll(() =>
+		page.evaluate(() => {
+			let transitionCounter = Reflect.get(window, "__changeIconTransitions") as { starts: number };
+			return transitionCounter.starts;
+		})
+	).toBeGreaterThan(0);
+	let pointerStarts = await page.evaluate(() => {
+		let transitionCounter = Reflect.get(window, "__changeIconTransitions") as { starts: number };
+		return transitionCounter.starts;
+	});
+	await page.mouse.click(1, 1);
+	await page.keyboard.press("Shift");
+	await expect(icon).toHaveAttribute("data-feedback-icon", "closed");
+	await expect(icon).toHaveCSS("transition-duration", "0.25s");
+	await expect.poll(() =>
+		page.evaluate(() => {
+			let transitionCounter = Reflect.get(window, "__changeIconTransitions") as { starts: number };
+			return transitionCounter.starts;
+		})
+	).toBeGreaterThan(pointerStarts);
+	pointerStarts = await page.evaluate(() => {
+		let transitionCounter = Reflect.get(window, "__changeIconTransitions") as { starts: number };
+		return transitionCounter.starts;
+	});
+
+	await trigger.focus();
+	await page.keyboard.press("Space");
+	await expect(icon).toHaveAttribute("data-feedback-icon", "open");
+	await expect(icon).toHaveCSS("transition-duration", "0s");
+	await icon.hover();
+	await expect(icon).toHaveCSS("transition-duration", "0s");
+	expect(
+		await page.evaluate(() => {
+			let transitionCounter = Reflect.get(window, "__changeIconTransitions") as { starts: number };
+			return transitionCounter.starts;
+		}),
+	).toBe(pointerStarts);
+
+	await page.emulateMedia({ reducedMotion: "reduce" });
+	await trigger.click();
+	await expect(icon).toHaveAttribute("data-feedback-icon", "closed");
+	await expect(icon).toHaveCSS("transition-duration", "0s");
+	expect(
+		await page.evaluate(() => {
+			let transitionCounter = Reflect.get(window, "__changeIconTransitions") as { starts: number };
+			return transitionCounter.starts;
+		}),
+	).toBe(pointerStarts);
+});
+
 for (let viewport of RESPONSIVE_VIEWPORTS) {
 	test(`${viewport.name} keeps hostile rich content readable and navigable`, async ({ join, seed }) => {
 		await seed(RESPONSIVE_SOURCE);

--- a/e2e/sidecar.e2e.ts
+++ b/e2e/sidecar.e2e.ts
@@ -142,6 +142,31 @@ test("question step swaps overlap only for pointer input", async ({ join, seed }
 		"aria-selected",
 		"true",
 	);
+
+	await page.emulateMedia({ reducedMotion: "reduce" });
+	await stack.evaluate(root => {
+		let counts: number[] = [];
+		let recordActiveCount = () => {
+			counts.push(
+				root.querySelectorAll(":scope > [data-content-swap-state]:not([hidden]):not([inert])")
+					.length,
+			);
+		};
+		let observer = new MutationObserver(recordActiveCount);
+		observer.observe(root, { attributes: true, childList: true, subtree: true });
+		Reflect.set(window, "__questionStepActiveCounts", counts);
+		Reflect.set(window, "__questionStepObserver", observer);
+		recordActiveCount();
+	});
+	await scope.click();
+	await expect(visible).toHaveCount(1);
+	let activeCounts = await page.evaluate(() => {
+		let observer = Reflect.get(window, "__questionStepObserver") as MutationObserver;
+		observer.disconnect();
+		return Reflect.get(window, "__questionStepActiveCounts") as number[];
+	});
+	expect(activeCounts).not.toContain(0);
+	await expect(scope).toHaveAttribute("aria-selected", "true");
 });
 
 async function rewriteFirstBlock(page: import("@playwright/test").Page, value: string) {

--- a/packages/editor/src/background-work.tsx
+++ b/packages/editor/src/background-work.tsx
@@ -150,7 +150,7 @@ function BackgroundJob(
 ) {
 	let snapshot = useJobs(store);
 	let [disclosure, setDisclosure] = useState({ immediately: false, open: false });
-	let [error, setError] = useState<string>();
+	let [error, setError] = useState<{ immediately: boolean; message: string }>();
 	let resultId = useId();
 	let detail = snapshot.details[job.id];
 	let resultOpen = disclosure.open && detail !== undefined;
@@ -197,9 +197,15 @@ function BackgroundJob(
 						data-press="wide"
 						disabled={!connected || !!snapshot.pending[job.id]}
 						onClick={() => {
+							let immediately = motionImmediately?.() ?? false;
 							setError(undefined);
 							void store.cancel(job).catch(err =>
-								setError(err instanceof Error ? err.message : "Could not cancel background work.")
+								setError({
+									immediately,
+									message: err instanceof Error
+										? err.message
+										: "Could not cancel background work.",
+								})
 							);
 						}}
 						type="button"
@@ -241,7 +247,16 @@ function BackgroundJob(
 					)
 					: <p>Result is unavailable.</p>}
 			</MotionDisclosure>
-			{error && <p role="status">{error}</p>}
+			{error && (
+				<p
+					className="editor-motion-feedback"
+					data-motion-feedback="alert"
+					data-motion-owned={error.immediately ? "immediate" : "pointer"}
+					role="alert"
+				>
+					{error.message}
+				</p>
+			)}
 		</article>
 	);
 }

--- a/packages/editor/src/changes-chip.test.tsx
+++ b/packages/editor/src/changes-chip.test.tsx
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { PlanChanges } from "./changes-chip";
+
+import type { ChangeStore, Snapshot } from "./changes";
+
+test("the change-list trigger uses keyed editor feedback for its closed glyph", () => {
+	let snapshot: Snapshot = {
+		above: 1,
+		below: 0,
+		entries: [{
+			id: "change",
+			kind: "added",
+			blocks: [{ preview: "A changed paragraph", type: "paragraph" }],
+			seen: false,
+		}],
+	};
+	let store = {
+		reveal() {},
+		snapshot: () => snapshot,
+		subscribe: () => () => {},
+	} as unknown as ChangeStore;
+	let markup = renderToStaticMarkup(createElement(PlanChanges, { store }));
+
+	expect(markup).toContain('data-feedback-icon="closed"');
+	expect(markup).toContain('data-motion-feedback="icon"');
+	expect(markup).toContain("editor-motion-feedback");
+});

--- a/packages/editor/src/changes-chip.tsx
+++ b/packages/editor/src/changes-chip.tsx
@@ -14,6 +14,8 @@
 
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
 
+import { MotionDisclosureIcon } from "./disclosure-motion";
+
 import type { ChangeStore, Entry, Snapshot } from "./changes";
 
 /** Past this the number stops being informative and starts being noise. */
@@ -72,14 +74,16 @@ function List({ entries }: { entries: Entry[] }) {
 }
 
 function Chip(
-	{ entries, onGo, side, waiting }: {
+	{ entries, motionImmediately, onGo, side, waiting }: {
 		entries: Entry[];
+		motionImmediately?: () => boolean;
 		onGo: () => void;
 		side: "above" | "below";
 		waiting: number;
 	},
 ) {
 	let [open, setOpen] = useState(false);
+	let [iconMotionOwner, setIconMotionOwner] = useState<"immediate" | "pointer">();
 	let box = useRef<HTMLDivElement>(null);
 
 	// Once every change in this direction is read, the list has nothing left
@@ -89,7 +93,10 @@ function Chip(
 	let [openedForWaiting, setOpenedForWaiting] = useState(waiting);
 	if (waiting !== openedForWaiting) {
 		setOpenedForWaiting(waiting);
-		if (waiting === 0) setOpen(false);
+		if (waiting === 0) {
+			setIconMotionOwner(undefined);
+			setOpen(false);
+		}
 	}
 
 	// Closing on an outside click rather than on blur: the list is inside the
@@ -97,7 +104,10 @@ function Chip(
 	useEffect(() => {
 		if (!open) return;
 		let close = (event: MouseEvent) => {
-			if (!box.current?.contains(event.target as Node)) setOpen(false);
+			if (!box.current?.contains(event.target as Node)) {
+				setIconMotionOwner("pointer");
+				setOpen(false);
+			}
 		};
 		document.addEventListener("mousedown", close);
 		return () => document.removeEventListener("mousedown", close);
@@ -125,10 +135,21 @@ function Chip(
 					type="button"
 					className="plan-changes-more"
 					aria-expanded={open}
-					onClick={() => setOpen(value => !value)}
+					onClick={() => {
+						setIconMotionOwner(
+							motionImmediately?.() ? "immediate" : "pointer",
+						);
+						setOpen(value => !value);
+					}}
 					title="What the agent changed"
 				>
-					<span aria-hidden="true">{open ? "▾" : "▸"}</span>
+					<MotionDisclosureIcon
+						className="editor-motion-feedback"
+						closed="▸"
+						motionOwner={iconMotionOwner}
+						open={open}
+						opened="▾"
+					/>
 					<span className="sr-only">What the agent changed</span>
 				</button>
 			</div>
@@ -136,7 +157,9 @@ function Chip(
 	);
 }
 
-export function PlanChanges({ store }: { store: ChangeStore }) {
+export function PlanChanges(
+	{ motionImmediately, store }: { motionImmediately?: () => boolean; store: ChangeStore },
+) {
 	let { above, below, entries } = useChanges(store);
 
 	let goUp = useCallback(() => store.reveal("above"), [store]);
@@ -144,8 +167,20 @@ export function PlanChanges({ store }: { store: ChangeStore }) {
 
 	return (
 		<>
-			<Chip entries={entries} onGo={goUp} side="above" waiting={above} />
-			<Chip entries={entries} onGo={goDown} side="below" waiting={below} />
+			<Chip
+				entries={entries}
+				motionImmediately={motionImmediately}
+				onGo={goUp}
+				side="above"
+				waiting={above}
+			/>
+			<Chip
+				entries={entries}
+				motionImmediately={motionImmediately}
+				onGo={goDown}
+				side="below"
+				waiting={below}
+			/>
 		</>
 	);
 }

--- a/packages/editor/src/disclosure-motion.test.tsx
+++ b/packages/editor/src/disclosure-motion.test.tsx
@@ -62,6 +62,36 @@ test("renders keyed disclosure glyphs for their open state", () => {
 	expect(opened).not.toContain("Closed");
 });
 
+test("an immediate keyed glyph carries a zero-duration override", () => {
+	let markup = renderToStaticMarkup(
+		createElement(MotionDisclosureIcon, {
+			className: "host-feedback",
+			closed: "Closed",
+			motionOwner: "immediate",
+			open: false,
+			opened: "Opened",
+		}),
+	);
+
+	expect(markup).toContain('data-motion-owned="immediate"');
+	expect(markup).toContain('style="transition-duration:0s"');
+});
+
+test("a pointer-owned keyed glyph carries its initiating owner", () => {
+	let markup = renderToStaticMarkup(
+		createElement(MotionDisclosureIcon, {
+			className: "host-feedback",
+			closed: "Closed",
+			motionOwner: "pointer",
+			open: false,
+			opened: "Opened",
+		}),
+	);
+
+	expect(markup).toContain('data-motion-owned="pointer"');
+	expect(markup).not.toContain("transition-duration");
+});
+
 test("renders closed disclosures without retained content", () => {
 	let markup = renderToStaticMarkup(
 		createElement(

--- a/packages/editor/src/disclosure-motion.tsx
+++ b/packages/editor/src/disclosure-motion.tsx
@@ -43,9 +43,10 @@ export function MotionDisclosure(
 }
 
 export function MotionDisclosureIcon(
-	{ className, closed, open, opened }: {
+	{ className, closed, motionOwner, open, opened }: {
 		className: string;
 		closed: ReactNode;
+		motionOwner?: "immediate" | "pointer";
 		open: boolean;
 		opened: ReactNode;
 	},
@@ -57,7 +58,11 @@ export function MotionDisclosureIcon(
 			className={`${className} inline-flex`}
 			data-feedback-icon={state}
 			data-motion-feedback="icon"
+			data-motion-owned={motionOwner}
 			key={state}
+			style={motionOwner === "immediate"
+				? { transitionDuration: "0s" }
+				: undefined}
 		>
 			{open ? opened : closed}
 		</span>

--- a/packages/editor/src/feedback.css
+++ b/packages/editor/src/feedback.css
@@ -5,7 +5,8 @@
 	transform: none;
 }
 
-:root[data-motion-input="pointer"] .editor-motion-feedback[data-motion-feedback="icon"] {
+:root[data-motion-input="pointer"] .editor-motion-feedback[data-motion-feedback="icon"],
+.editor-motion-feedback[data-motion-feedback="icon"][data-motion-owned="pointer"] {
 	transition-property: opacity, transform;
 	transition-duration: var(--icon-swap-dur);
 	transition-timing-function: var(--motion-smooth-out);
@@ -17,10 +18,15 @@
 	transition-timing-function: var(--motion-smooth-out);
 }
 
-:root[data-motion-input="pointer"] .editor-motion-feedback[data-motion-feedback="alert"] {
+:root[data-motion-input="pointer"] .editor-motion-feedback[data-motion-feedback="alert"],
+.editor-motion-feedback[data-motion-feedback="alert"][data-motion-owned="pointer"] {
 	transition-property: opacity, transform;
 	transition-duration: var(--toast-open);
 	transition-timing-function: var(--motion-smooth-out);
+}
+
+:root .editor-motion-feedback[data-motion-feedback="alert"][data-motion-owned="immediate"] {
+	transition-duration: 0s;
 }
 
 @starting-style {
@@ -41,7 +47,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	:root[data-motion-input="pointer"] .editor-motion-feedback[data-motion-feedback] {
+	:root[data-motion-input="pointer"] .editor-motion-feedback[data-motion-feedback],
+	.editor-motion-feedback[data-motion-feedback][data-motion-owned="pointer"] {
 		transition-duration: 0s;
 	}
 }

--- a/packages/editor/src/plan-editor.tsx
+++ b/packages/editor/src/plan-editor.tsx
@@ -334,7 +334,7 @@ export function PlanEditor(
 						/>
 					</div>
 					{/* In the document column, so they track the prose, not the pane. */}
-					<PlanChanges store={changes} />
+					<PlanChanges motionImmediately={motionImmediately} store={changes} />
 					<PlanStatus
 						connection={connection}
 						synced={state.synced}


### PR DESCRIPTION
## Summary

- activate reduced-motion question swaps synchronously without changing normal pointer overlap
- reuse the keyed editor disclosure icon and retain its initiating pointer or immediate owner across keyed swaps
- render cancellation failures through the accessible alert-feedback contract while retaining action input ownership

## Verification

- bun run fix
- focused motion, theme, and editor unit tests
- bun run types
- bun run ci
- 3 focused Playwright regressions for question swaps, change disclosure, and cancellation alerts
- full bun test: 1257 passed, 2 skipped, 0 failed

## Review

Independent standards, specification, and general reviews all report ready.