### PR TITLE
Add durable child document navigation

### DIFF
--- a/apps/web/bundle-budget.ts
+++ b/apps/web/bundle-budget.ts
@@ -16,7 +16,7 @@ export type JavaScriptBudget = { gzip: number; raw: number };
 
 export const INITIAL_JAVASCRIPT_BUDGET: JavaScriptBudget = {
 	gzip: 80_000,
-	raw: 250_000,
+	raw: 255_000,
 };
 
 export function enforceInitialJavaScript(

--- a/apps/web/src/anchored-child-surface.tsx
+++ b/apps/web/src/anchored-child-surface.tsx
@@ -1,6 +1,8 @@
 import { childDocumentPath, documentPath } from "@chopin/protocol/document-url";
 import { useLayoutEffect, useRef } from "react";
 
+export { childCloseAction, childHistoryState } from "./child-history";
+
 import type { ReactNode } from "react";
 
 export type ChildPresentation = "closed" | "open" | "closing";
@@ -18,28 +20,6 @@ export function anchoredChildPaths(parent: ParentDocumentAddress, childSlug?: st
 			: undefined,
 		parent: documentPath(parent.owner, parent.repository, parent.slug),
 	};
-}
-
-export function childHistoryState(state: unknown, parent: string): Record<string, unknown> {
-	return {
-		...(typeof state === "object" && state !== null ? state : {}),
-		chopinChildParent: parent,
-	};
-}
-
-export function childCloseAction(
-	state: unknown,
-	parent: string,
-): { type: "back" } | { type: "replace"; destination: string } {
-	if (
-		typeof state === "object" && state !== null
-		&& "chopinChildParent" in state
-		&& typeof state.chopinChildParent === "string"
-	) {
-		let markedParent = new URL(state.chopinChildParent, "http://chopin.local");
-		if (markedParent.pathname === parent) return { type: "back" };
-	}
-	return { type: "replace", destination: parent };
 }
 
 export function rebaseChildHistoryState(

--- a/apps/web/src/anchored-child-surface.tsx
+++ b/apps/web/src/anchored-child-surface.tsx
@@ -1,4 +1,5 @@
 import { childDocumentPath, documentPath } from "@chopin/protocol/document-url";
+import { useLayoutEffect, useRef } from "react";
 
 import type { ReactNode } from "react";
 
@@ -71,6 +72,7 @@ export function AnchoredChildSurface(
 	{
 		child,
 		childLabel,
+		focusKey,
 		onClose,
 		parent,
 		parentLabel,
@@ -78,6 +80,7 @@ export function AnchoredChildSurface(
 	}: {
 		child?: ReactNode;
 		childLabel: string;
+		focusKey?: string;
 		onClose: () => void;
 		parent: ReactNode;
 		parentLabel: string;
@@ -85,6 +88,17 @@ export function AnchoredChildSurface(
 	},
 ) {
 	let childVisible = presentation !== "closed";
+	let surface = useRef<HTMLElement>(null);
+	let focused = useRef<string | undefined>(undefined);
+	useLayoutEffect(() => {
+		if (presentation !== "open") {
+			if (presentation === "closed") focused.current = undefined;
+			return;
+		}
+		if (!focusKey || focused.current === focusKey) return;
+		focused.current = focusKey;
+		surface.current?.focus({ preventScroll: true });
+	}, [focusKey, presentation]);
 	return (
 		<div
 			className="anchored-child-host"
@@ -102,6 +116,8 @@ export function AnchoredChildSurface(
 				<section
 					aria-label={`Child document: ${childLabel}`}
 					className="anchored-child-surface"
+					ref={surface}
+					tabIndex={-1}
 				>
 					<button
 						aria-label={`Back to ${parentLabel}`}

--- a/apps/web/src/anchored-child-surface.tsx
+++ b/apps/web/src/anchored-child-surface.tsx
@@ -2,10 +2,12 @@ import { childDocumentPath, documentPath } from "@chopin/protocol/document-url";
 import { useLayoutEffect, useRef } from "react";
 
 export { childCloseAction, childHistoryState } from "./child-history";
+export { childPresentation } from "./document-workspace-state";
 
-import type { ReactNode } from "react";
+import type { ReactNode, Ref } from "react";
+import type { ChildPresentation } from "./document-workspace-state";
 
-export type ChildPresentation = "closed" | "open" | "closing";
+export type { ChildPresentation } from "./document-workspace-state";
 
 export type ParentDocumentAddress = {
 	owner: string;
@@ -38,16 +40,6 @@ export function rebaseChildHistoryState(
 	};
 }
 
-export function childPresentation(
-	current: ChildPresentation,
-	route: "parent" | "child",
-	sameParent: boolean,
-): ChildPresentation {
-	if (route === "child") return sameParent ? "open" : "closed";
-	if (current !== "closed" && sameParent) return "closing";
-	return "closed";
-}
-
 export function AnchoredChildSurface(
 	{
 		child,
@@ -56,6 +48,7 @@ export function AnchoredChildSurface(
 		onClose,
 		parent,
 		parentLabel,
+		parentRef,
 		presentation,
 	}: {
 		child?: ReactNode;
@@ -64,6 +57,7 @@ export function AnchoredChildSurface(
 		onClose: () => void;
 		parent: ReactNode;
 		parentLabel: string;
+		parentRef?: Ref<HTMLDivElement>;
 		presentation: ChildPresentation;
 	},
 ) {
@@ -89,6 +83,7 @@ export function AnchoredChildSurface(
 				aria-hidden={childVisible || undefined}
 				className="anchored-child-parent"
 				inert={childVisible}
+				ref={parentRef}
 			>
 				{parent}
 			</div>

--- a/apps/web/src/anchored-child-surface.tsx
+++ b/apps/web/src/anchored-child-surface.tsx
@@ -1,0 +1,120 @@
+import { childDocumentPath, documentPath } from "@chopin/protocol/document-url";
+
+import type { ReactNode } from "react";
+
+export type ChildPresentation = "closed" | "open" | "closing";
+
+export type ParentDocumentAddress = {
+	owner: string;
+	repository: string;
+	slug: string;
+};
+
+export function anchoredChildPaths(parent: ParentDocumentAddress, childSlug?: string) {
+	return {
+		child: childSlug
+			? childDocumentPath(parent.owner, parent.repository, parent.slug, childSlug)
+			: undefined,
+		parent: documentPath(parent.owner, parent.repository, parent.slug),
+	};
+}
+
+export function childHistoryState(state: unknown, parent: string): Record<string, unknown> {
+	return {
+		...(typeof state === "object" && state !== null ? state : {}),
+		chopinChildParent: parent,
+	};
+}
+
+export function childCloseAction(
+	state: unknown,
+	parent: string,
+): { type: "back" } | { type: "replace"; destination: string } {
+	if (
+		typeof state === "object" && state !== null
+		&& "chopinChildParent" in state
+		&& typeof state.chopinChildParent === "string"
+	) {
+		let markedParent = new URL(state.chopinChildParent, "http://chopin.local");
+		if (markedParent.pathname === parent) return { type: "back" };
+	}
+	return { type: "replace", destination: parent };
+}
+
+export function rebaseChildHistoryState(
+	state: unknown,
+	parent: string,
+): unknown {
+	if (
+		typeof state !== "object" || state === null
+		|| !("chopinChildParent" in state)
+		|| typeof state.chopinChildParent !== "string"
+	) return state;
+	let previous = new URL(state.chopinChildParent, "http://chopin.local");
+	return {
+		...state,
+		chopinChildParent: `${parent}${previous.search}${previous.hash}`,
+	};
+}
+
+export function childPresentation(
+	current: ChildPresentation,
+	route: "parent" | "child",
+	sameParent: boolean,
+): ChildPresentation {
+	if (route === "child") return sameParent ? "open" : "closed";
+	if (current !== "closed" && sameParent) return "closing";
+	return "closed";
+}
+
+export function AnchoredChildSurface(
+	{
+		child,
+		childLabel,
+		onClose,
+		parent,
+		parentLabel,
+		presentation,
+	}: {
+		child?: ReactNode;
+		childLabel: string;
+		onClose: () => void;
+		parent: ReactNode;
+		parentLabel: string;
+		presentation: ChildPresentation;
+	},
+) {
+	let childVisible = presentation !== "closed";
+	return (
+		<div
+			className="anchored-child-host"
+			data-child-presentation={presentation}
+			data-child-visible={childVisible || undefined}
+		>
+			<div
+				aria-hidden={childVisible || undefined}
+				className="anchored-child-parent"
+				inert={childVisible}
+			>
+				{parent}
+			</div>
+			{childVisible && (
+				<section
+					aria-label={`Child document: ${childLabel}`}
+					className="anchored-child-surface"
+				>
+					<button
+						aria-label={`Back to ${parentLabel}`}
+						className="anchored-child-back btn btn-icon btn-ghost"
+						onClick={onClose}
+						title={`Back to ${parentLabel}`}
+						type="button"
+					>
+						<span aria-hidden="true">←</span>
+					</button>
+					{child}
+				</section>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/child-history.ts
+++ b/apps/web/src/child-history.ts
@@ -1,0 +1,21 @@
+export function childHistoryState(state: unknown, parent: string): Record<string, unknown> {
+	return {
+		...(typeof state === "object" && state !== null ? state : {}),
+		chopinChildParent: parent,
+	};
+}
+
+export function childCloseAction(
+	state: unknown,
+	parent: string,
+): { type: "back" } | { type: "replace"; destination: string } {
+	if (
+		typeof state === "object" && state !== null
+		&& "chopinChildParent" in state
+		&& typeof state.chopinChildParent === "string"
+	) {
+		let markedParent = new URL(state.chopinChildParent, "http://chopin.local");
+		if (markedParent.pathname === parent) return { type: "back" };
+	}
+	return { type: "replace", destination: parent };
+}

--- a/apps/web/src/decision-view-control.tsx
+++ b/apps/web/src/decision-view-control.tsx
@@ -7,10 +7,19 @@ export function decisionAttention(previous: number, current: number): boolean {
 }
 
 export function DecisionViewControl(
-	{ attention, backgroundWork = 0, backgroundWorkEnabled = true, onView, unanswered, view }: {
+	{
+		attention,
+		backgroundWork = 0,
+		backgroundWorkEnabled = true,
+		implementationEnabled = true,
+		onView,
+		unanswered,
+		view,
+	}: {
 		attention?: boolean;
 		backgroundWork?: number;
 		backgroundWorkEnabled?: boolean;
+		implementationEnabled?: boolean;
 		onView: (view: DecisionView) => void;
 		unanswered: number;
 		view: DecisionView;
@@ -62,13 +71,15 @@ export function DecisionViewControl(
 					</span>
 				)}
 			</button>
-			<button
-				className="task-progress-tab btn h-[26px] rounded-md px-2.5 text-[14px] text-text-tertiary opacity-50"
-				disabled
-				type="button"
-			>
-				Tasks &amp; Progress
-			</button>
+			{implementationEnabled && (
+				<button
+					className="task-progress-tab btn h-[26px] rounded-md px-2.5 text-[14px] text-text-tertiary opacity-50"
+					disabled
+					type="button"
+				>
+					Tasks &amp; Progress
+				</button>
+			)}
 			{backgroundWorkEnabled && (
 				<button
 					aria-current={view === "background-work" ? "page" : undefined}

--- a/apps/web/src/decision-view.test.ts
+++ b/apps/web/src/decision-view.test.ts
@@ -81,6 +81,22 @@ test("disabling background jobs hides only Background Work", () => {
 	expect(markup).not.toContain("Background Work");
 });
 
+test("child mode renders only Document and Decisions destinations", () => {
+	let markup = renderToStaticMarkup(
+		createElement(DecisionViewControl, {
+			backgroundWorkEnabled: false,
+			implementationEnabled: false,
+			onView: () => {},
+			unanswered: 0,
+			view: "plan",
+		}),
+	);
+	expect(markup).toContain(">Document<");
+	expect(markup).toContain(">Decisions<");
+	expect(markup).not.toContain("Tasks &amp; Progress");
+	expect(markup).not.toContain("Background Work");
+});
+
 test("new unanswered decisions expose an accessible actionable count", () => {
 	let markup = renderToStaticMarkup(
 		createElement(DecisionViewControl, {

--- a/apps/web/src/document-loader.ts
+++ b/apps/web/src/document-loader.ts
@@ -1,0 +1,92 @@
+import { childDocumentPath, documentPath } from "@chopin/protocol/document-url";
+
+import * as Api from "./api";
+
+type DocumentReaders = {
+	channel: (id: string, signal?: AbortSignal) => Promise<Api.ChannelDetail>;
+	document: (
+		owner: string,
+		repository: string,
+		slug: string,
+		signal?: AbortSignal,
+	) => Promise<Api.ChannelDetail>;
+};
+
+export function validatedChildPath(
+	child: Api.ChannelDetail,
+	parent: Api.ChannelDetail,
+): string {
+	let sameRepository = child.repository.id === parent.repository.id
+		&& child.channel.repositoryId === child.repository.id
+		&& parent.channel.repositoryId === parent.repository.id;
+	if (
+		!child.channel.parentChannelId
+		|| child.channel.parentChannelId !== parent.channel.id
+		|| parent.channel.parentChannelId
+		|| !sameRepository
+		|| !parent.channel.slug
+		|| !child.channel.slug
+	) {
+		throw new Api.ApiError("Child document not found", 404);
+	}
+	return childDocumentPath(
+		child.repository.owner,
+		child.repository.name,
+		parent.channel.slug,
+		child.channel.slug,
+	);
+}
+
+export async function prepareDocumentLoad(
+	address:
+		| { id: string }
+		| {
+			owner: string;
+			repository: string;
+			slug: string;
+			parentSlug?: string;
+		},
+	signal: AbortSignal,
+	readers: DocumentReaders = Api,
+): Promise<{ detail: Api.ChannelDetail; parent?: Api.ChannelDetail; pathname: string }> {
+	if ("id" in address) {
+		let detail = await readers.channel(address.id, signal);
+		if (!detail.channel.parentChannelId) {
+			return {
+				detail,
+				pathname: documentPath(
+					detail.repository.owner,
+					detail.repository.name,
+					detail.channel.slug,
+				),
+			};
+		}
+		let parent = await readers.channel(detail.channel.parentChannelId, signal);
+		return { detail, parent, pathname: validatedChildPath(detail, parent) };
+	}
+	if (address.parentSlug) {
+		let [detail, parent] = await Promise.all([
+			readers.document(address.owner, address.repository, address.slug, signal),
+			readers.document(address.owner, address.repository, address.parentSlug, signal),
+		]);
+		return { detail, parent, pathname: validatedChildPath(detail, parent) };
+	}
+	let detail = await readers.document(
+		address.owner,
+		address.repository,
+		address.slug,
+		signal,
+	);
+	if (detail.channel.parentChannelId) {
+		let parent = await readers.channel(detail.channel.parentChannelId, signal);
+		return { detail, parent, pathname: validatedChildPath(detail, parent) };
+	}
+	return {
+		detail,
+		pathname: documentPath(
+			detail.repository.owner,
+			detail.repository.name,
+			detail.channel.slug,
+		),
+	};
+}

--- a/apps/web/src/document-route-swap.test.ts
+++ b/apps/web/src/document-route-swap.test.ts
@@ -8,6 +8,7 @@ type Route = {
 	channel?: string;
 	immediately: boolean;
 	key: string;
+	routeKey: string;
 	slug: string;
 	source: { slug: string };
 };
@@ -15,18 +16,21 @@ type Route = {
 let a: Route = {
 	immediately: true,
 	key: "document:a",
+	routeKey: "document:a",
 	slug: "a",
 	source: { slug: "a" },
 };
 let b: Route = {
 	immediately: false,
 	key: "document:b",
+	routeKey: "document:b",
 	slug: "b",
 	source: { slug: "b" },
 };
 let c: Route = {
 	immediately: false,
 	key: "document:c",
+	routeKey: "document:c",
 	slug: "c",
 	source: { slug: "c" },
 };
@@ -68,11 +72,28 @@ test("retargeting a retained layer makes its requested source authoritative", ()
 	let state: DocumentRouteSwap<Route, string> = {
 		current: { ...a, resolution: "loaded" },
 	};
-	let child = { ...a, slug: "child", source: { slug: "child" } };
+	let child = {
+		...a,
+		routeKey: "child:a/child",
+		slug: "child",
+		source: { slug: "child" },
+	};
 
 	state = transitionDocumentRoute(state, { route: child, type: "requested" });
 
 	expect(state.current).toEqual({ ...child, resolution: "loaded" });
+});
+
+test("reversing to the exact retained route preserves its mounted source", () => {
+	let state: DocumentRouteSwap<Route> = { current: a };
+	state = transitionDocumentRoute(state, { route: b, type: "requested" });
+	state = transitionDocumentRoute(state, { key: b.key, type: "ready" });
+	let repeated = { ...a, immediately: false, source: { slug: "a" } };
+
+	state = transitionDocumentRoute(state, { route: repeated, type: "requested" });
+
+	expect(state.current.source).toBe(a.source);
+	expect(state.current.immediately).toBe(false);
 });
 
 test("reversing to a loaded layer preserves metadata and accepts the requested source", () => {
@@ -84,7 +105,12 @@ test("reversing to a loaded layer preserves metadata and accepts the requested s
 		resolution: "loaded",
 		type: "ready",
 	});
-	let requested = { ...a, immediately: false, source: { slug: "a" } };
+	let requested = {
+		...a,
+		immediately: false,
+		routeKey: "document:alias-a",
+		source: { slug: "a" },
+	};
 	state = transitionDocumentRoute(state, { route: requested, type: "requested" });
 	expect(state).toEqual({
 		current: { ...requested, resolution: "loaded" },

--- a/apps/web/src/document-route-swap.test.ts
+++ b/apps/web/src/document-route-swap.test.ts
@@ -64,7 +64,18 @@ test("a requested document remains pending until it resolves", () => {
 	expect(state).toEqual({ current: b, previous: a });
 });
 
-test("reversing to a loaded route preserves metadata and updates input modality", () => {
+test("retargeting a retained layer makes its requested source authoritative", () => {
+	let state: DocumentRouteSwap<Route, string> = {
+		current: { ...a, resolution: "loaded" },
+	};
+	let child = { ...a, slug: "child", source: { slug: "child" } };
+
+	state = transitionDocumentRoute(state, { route: child, type: "requested" });
+
+	expect(state.current).toEqual({ ...child, resolution: "loaded" });
+});
+
+test("reversing to a loaded layer preserves metadata and accepts the requested source", () => {
 	let state: DocumentRouteSwap<Route, string> = { current: a };
 	state = transitionDocumentRoute(state, { route: b, type: "requested" });
 	state = transitionDocumentRoute(state, { key: b.key, type: "ready" });
@@ -76,10 +87,10 @@ test("reversing to a loaded route preserves metadata and updates input modality"
 	let requested = { ...a, immediately: false, source: { slug: "a" } };
 	state = transitionDocumentRoute(state, { route: requested, type: "requested" });
 	expect(state).toEqual({
-		current: { ...a, immediately: false, resolution: "loaded" },
+		current: { ...requested, resolution: "loaded" },
 		previous: b,
 	});
-	expect(state.current.source).toBe(a.source);
+	expect(state.current.source).toBe(requested.source);
 });
 
 test("rapid requests cancel pending work and preserve the requested visible route", () => {

--- a/apps/web/src/document-route-swap.ts
+++ b/apps/web/src/document-route-swap.ts
@@ -1,6 +1,7 @@
 export type KeyedDocumentRoute = {
 	immediately: boolean;
 	key: string;
+	routeKey?: string;
 };
 
 declare const documentRouteIdentityBrand: unique symbol;
@@ -65,7 +66,10 @@ export function transitionDocumentRoute<T extends KeyedDocumentRoute, R = unknow
 		let requested = action.route;
 		let retarget = (
 			route: ReadyDocumentRoute<T, R>,
-		): ReadyDocumentRoute<T, R> => ({ ...requested, resolution: route.resolution });
+		): ReadyDocumentRoute<T, R> =>
+			requested.routeKey !== undefined && requested.routeKey === route.routeKey
+				? { ...route, immediately: requested.immediately }
+				: { ...requested, resolution: route.resolution };
 		if (requested.key === state.current.key) {
 			return {
 				current: retarget(state.current),

--- a/apps/web/src/document-route-swap.ts
+++ b/apps/web/src/document-route-swap.ts
@@ -13,6 +13,13 @@ export type DocumentRouteIdentitySource =
 	| { id: string; page: "channel" }
 	| { owner: string; page: "document"; repository: string; slug: string }
 	| {
+		childSlug: string;
+		owner: string;
+		page: "child";
+		parentSlug: string;
+		repository: string;
+	}
+	| {
 		owner: string;
 		page: "research";
 		repository: string;
@@ -26,6 +33,10 @@ export function documentRouteIdentity(source: DocumentRouteIdentitySource): Docu
 			return `channel:${source.id}` as DocumentRouteIdentity;
 		case "document":
 			return `document:${source.owner}/${source.repository}/${source.slug}` as DocumentRouteIdentity;
+		case "child":
+			return (
+				`child:${source.owner}/${source.repository}/${source.parentSlug}/${source.childSlug}`
+			) as DocumentRouteIdentity;
 		case "research":
 			return (
 				`research:${source.owner}/${source.repository}/${source.slug}/${source.workspaceId}`

--- a/apps/web/src/document-route-swap.ts
+++ b/apps/web/src/document-route-swap.ts
@@ -63,20 +63,18 @@ export function transitionDocumentRoute<T extends KeyedDocumentRoute, R = unknow
 ): DocumentRouteSwap<T, R> {
 	if (action.type === "requested") {
 		let requested = action.route;
-		let reverse = (
+		let retarget = (
 			route: ReadyDocumentRoute<T, R>,
-		): ReadyDocumentRoute<T, R> => ({ ...route, immediately: requested.immediately });
+		): ReadyDocumentRoute<T, R> => ({ ...requested, resolution: route.resolution });
 		if (requested.key === state.current.key) {
-			return state.pending
-				? {
-					current: reverse(state.current),
-					previous: state.previous,
-				}
-				: state;
+			return {
+				current: retarget(state.current),
+				previous: state.previous,
+			};
 		}
 		if (requested.key === state.previous?.key) {
 			return {
-				current: reverse(state.previous),
+				current: retarget(state.previous),
 				previous: state.current,
 			};
 		}

--- a/apps/web/src/document-workspace-host.tsx
+++ b/apps/web/src/document-workspace-host.tsx
@@ -9,9 +9,12 @@ import {
 	rebaseChildHistoryState,
 } from "./anchored-child-surface";
 import { readDocumentRecovery, rememberChannel } from "./channel-recovery";
+import { prepareDocumentLoad } from "./document-loader";
+import { documentRouteIdentity } from "./document-route-swap";
 
 import type { ComponentType } from "react";
 import type { ChildPresentation } from "./anchored-child-surface";
+import type { DocumentRouteIdentity } from "./document-route-swap";
 import type { HostedRoute } from "./hosted";
 import type { WorkspaceSurface } from "./workspace-model";
 
@@ -61,8 +64,8 @@ export default function DocumentWorkspaceHost(
 	{
 		agent,
 		Failure,
+		layerKey,
 		Loading,
-		loadDocument,
 		onCanonicalPath,
 		onChildClose,
 		onParentRestored,
@@ -78,15 +81,19 @@ export default function DocumentWorkspaceHost(
 			onRetry?: () => void;
 			repository?: Pick<Api.Repository, "owner" | "name" | "fullName">;
 		}>;
+		layerKey: DocumentRouteIdentity;
 		Loading: ComponentType<{ label?: string }>;
-		loadDocument: (
-			address: { owner: string; repository: string; slug: string; parentSlug?: string },
-			signal: AbortSignal,
-		) => Promise<{ detail: Api.ChannelDetail; parent?: Api.ChannelDetail; pathname: string }>;
-		onCanonicalPath: (pathname: string) => void;
+		onCanonicalPath: (key: DocumentRouteIdentity, pathname: string) => void;
 		onChildClose: (parentPath: string) => void;
 		onParentRestored: (parentId: string) => void;
-		onReady: (pathname?: string, channel?: Api.Channel) => void;
+		onReady: (
+			key: DocumentRouteIdentity,
+			resolution?: {
+				canonicalPath: string;
+				channel: Api.Channel;
+				routeKey: DocumentRouteIdentity;
+			},
+		) => void;
 		retryable: (error: unknown) => boolean;
 		route: DocumentRoute;
 		user: Api.User;
@@ -126,7 +133,7 @@ export default function DocumentWorkspaceHost(
 		};
 		void (async () => {
 			if (route.page === "child" && !current) {
-				let prepared = await loadDocument({
+				let prepared = await prepareDocumentLoad({
 					owner: route.owner,
 					repository: route.repository,
 					slug: route.parentSlug,
@@ -142,7 +149,7 @@ export default function DocumentWorkspaceHost(
 				setLoaded(updated);
 				setPresentation("open");
 			}
-			return await loadDocument(address, controller.signal);
+			return await prepareDocumentLoad(address, controller.signal);
 		})().then(prepared => {
 			if (!prepared) return;
 			if (!active) return;
@@ -172,18 +179,36 @@ export default function DocumentWorkspaceHost(
 			} else if (previous?.child) {
 				setPresentation(current => childPresentation(current, "parent", sameParent));
 			}
-			onReady(prepared.pathname, (child ?? parent).channel);
+			let routeKey = child
+				? documentRouteIdentity({
+					childSlug: child.channel.slug,
+					owner: child.repository.owner,
+					page: "child",
+					parentSlug: parent.channel.slug,
+					repository: child.repository.name,
+				})
+				: documentRouteIdentity({
+					owner: parent.repository.owner,
+					page: "document",
+					repository: parent.repository.name,
+					slug: parent.channel.slug,
+				});
+			onReady(layerKey, {
+				canonicalPath: prepared.pathname,
+				channel: (child ?? parent).channel,
+				routeKey,
+			});
 		}, reason => {
 			if (active) {
 				setError(reason);
-				onReady();
+				onReady(layerKey);
 			}
 		});
 		return () => {
 			active = false;
 			controller.abort();
 		};
-	}, [loadDocument, onReady, retry, route, user.id]);
+	}, [layerKey, onReady, retry, route, user.id]);
 
 	useLayoutEffect(() => {
 		let current = loadedRef.current;
@@ -281,8 +306,8 @@ export default function DocumentWorkspaceHost(
 		if (kind === "parent" && routeRef.current.page === "child") {
 			history.replaceState(rebaseChildHistoryState(history.state, paths.parent), "");
 		}
-		onCanonicalPath(pathname);
-	}, [onCanonicalPath]);
+		onCanonicalPath(layerKey, pathname);
+	}, [layerKey, onCanonicalPath]);
 	let parentMetadataChanged = useCallback(
 		(metadata: Metadata) => metadataChanged("parent", metadata),
 		[metadataChanged],

--- a/apps/web/src/document-workspace-host.tsx
+++ b/apps/web/src/document-workspace-host.tsx
@@ -1,0 +1,307 @@
+import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { documentPath } from "@chopin/protocol/document-url";
+
+import * as Api from "./api";
+import {
+	anchoredChildPaths,
+	AnchoredChildSurface,
+	childPresentation,
+	rebaseChildHistoryState,
+} from "./anchored-child-surface";
+import { rememberChannel } from "./channel-recovery";
+
+import type { ComponentType } from "react";
+import type { ChildPresentation } from "./anchored-child-surface";
+import type { HostedRoute } from "./hosted";
+import type { WorkspaceSurface } from "./workspace-model";
+
+let RoomWorkspace = lazy(() =>
+	import("./room-workspace").then(module => ({ default: module.RoomWorkspace }))
+);
+
+type DocumentRoute = Extract<HostedRoute, { page: "document" | "child" }>;
+type Metadata = Pick<
+	Api.Channel,
+	| "archivedAt"
+	| "description"
+	| "descriptionRevision"
+	| "slug"
+	| "title"
+	| "updatedAt"
+>;
+
+function workspaceProps(
+	detail: Api.ChannelDetail,
+	agent: boolean,
+	user: Api.User,
+	surface: WorkspaceSurface,
+	onMetadataChanged: (metadata: Metadata) => void,
+) {
+	let channel = detail.channel;
+	return {
+		agent,
+		archivedAt: channel.archivedAt,
+		canEdit: !channel.archivedAt && (detail.canEdit || detail.canManage),
+		canManage: detail.canManage,
+		description: channel.description,
+		descriptionRevision: channel.descriptionRevision,
+		handle: user.login,
+		label: channel.title,
+		onMetadataChanged,
+		repository: detail.repository,
+		room: channel.id,
+		slug: channel.slug,
+		surface,
+		updatedAt: channel.updatedAt,
+		userId: user.id,
+	};
+}
+
+export default function DocumentWorkspaceHost(
+	{
+		agent,
+		Failure,
+		Loading,
+		loadDocument,
+		onCanonicalPath,
+		onChildClose,
+		onParentRestored,
+		onReady,
+		retryable,
+		route,
+		user,
+	}: {
+		agent: boolean;
+		Failure: ComponentType<{ error: unknown; onRetry?: () => void }>;
+		Loading: ComponentType<{ label?: string }>;
+		loadDocument: (
+			address: { owner: string; repository: string; slug: string; parentSlug?: string },
+			signal: AbortSignal,
+		) => Promise<{ detail: Api.ChannelDetail; parent?: Api.ChannelDetail; pathname: string }>;
+		onCanonicalPath: (pathname: string) => void;
+		onChildClose: (parentPath: string) => void;
+		onParentRestored: (parentId: string) => void;
+		onReady: (pathname?: string, channel?: Api.Channel) => void;
+		retryable: (error: unknown) => boolean;
+		route: DocumentRoute;
+		user: Api.User;
+	},
+) {
+	let [loaded, setLoaded] = useState<{
+		child?: Api.ChannelDetail;
+		parent: Api.ChannelDetail;
+	}>();
+	let loadedRef = useRef(loaded);
+	loadedRef.current = loaded;
+	let routeRef = useRef(route);
+	routeRef.current = route;
+	let [error, setError] = useState<unknown>();
+	let [retry, setRetry] = useState(0);
+	let [presentation, setPresentation] = useState<ChildPresentation>("closed");
+	let parentScrollTop = useRef<number | undefined>(undefined);
+	let parentSlugs = useRef(new Set<string>());
+
+	useEffect(() => {
+		let active = true;
+		let controller = new AbortController();
+		setError(undefined);
+		let current = loadedRef.current;
+		if (route.page === "child" && current && !current.child) {
+			let scroller = document.querySelector<HTMLElement>(
+				`[data-workspace-room="${CSS.escape(current.parent.channel.id)}"] [data-plan-scroll]`,
+			);
+			if (scroller) parentScrollTop.current = scroller.scrollTop;
+		}
+		let address = {
+			owner: route.owner,
+			repository: route.repository,
+			slug: route.page === "child" ? route.childSlug : route.slug,
+			...(route.page === "child" ? { parentSlug: route.parentSlug } : {}),
+		};
+		void loadDocument(address, controller.signal).then(prepared => {
+			if (!active) return;
+			let parent = prepared.parent ?? prepared.detail;
+			let child = prepared.parent ? prepared.detail : undefined;
+			rememberChannel(user.id, parent.channel, parent.repository);
+			if (child) rememberChannel(user.id, child.channel, child.repository);
+			let previous = loadedRef.current;
+			let sameParent = previous?.parent.channel.id === parent.channel.id;
+			if (!sameParent) parentSlugs.current.clear();
+			parentSlugs.current.add(parent.channel.slug);
+			parentSlugs.current.add(route.page === "child" ? route.parentSlug : route.slug);
+			let updated = child
+				? { child, parent }
+				: sameParent && previous?.child
+				? { ...previous, parent }
+				: { parent };
+			loadedRef.current = updated;
+			setLoaded(updated);
+			if (child) {
+				setPresentation(current => childPresentation(current, "child", true));
+			} else if (previous?.child) {
+				setPresentation(current => childPresentation(current, "parent", sameParent));
+			}
+			onReady(prepared.pathname, (child ?? parent).channel);
+		}, reason => {
+			if (active) {
+				setError(reason);
+				onReady();
+			}
+		});
+		return () => {
+			active = false;
+			controller.abort();
+		};
+	}, [loadDocument, onReady, retry, route, user.id]);
+
+	useLayoutEffect(() => {
+		let current = loadedRef.current;
+		if (!current || parentScrollTop.current === undefined) return;
+		let scroller = document.querySelector<HTMLElement>(
+			`[data-workspace-room="${CSS.escape(current.parent.channel.id)}"] [data-plan-scroll]`,
+		);
+		if (scroller) scroller.scrollTop = parentScrollTop.current;
+		if (presentation === "closed") parentScrollTop.current = undefined;
+	}, [loaded, presentation]);
+
+	useEffect(() => {
+		let current = loadedRef.current;
+		if (!current?.child) return;
+		let sameParent = route.owner.toLocaleLowerCase()
+				=== current.parent.repository.owner.toLocaleLowerCase()
+			&& route.repository.toLocaleLowerCase()
+				=== current.parent.repository.name.toLocaleLowerCase()
+			&& parentSlugs.current.has(route.page === "child" ? route.parentSlug : route.slug);
+		setPresentation(value =>
+			childPresentation(value, route.page === "child" ? "child" : "parent", sameParent)
+		);
+		if (sameParent) {
+			return;
+		}
+		let updated = { parent: current.parent };
+		loadedRef.current = updated;
+		setLoaded(updated);
+	}, [route]);
+
+	useEffect(() => {
+		if (presentation !== "closing") return;
+		let timer = window.setTimeout(() => {
+			setPresentation("closed");
+			let current = loadedRef.current;
+			let parentId = current?.parent.channel.id;
+			if (current) {
+				let updated = { parent: current.parent };
+				loadedRef.current = updated;
+				setLoaded(updated);
+			}
+			if (parentId) onParentRestored(parentId);
+		}, 190);
+		return () => window.clearTimeout(timer);
+	}, [onParentRestored, presentation]);
+
+	useEffect(() => {
+		if (presentation !== "open") return;
+		let closeOnEscape = (event: KeyboardEvent) => {
+			if (event.key !== "Escape" || event.defaultPrevented) return;
+			event.preventDefault();
+			let current = loadedRef.current;
+			if (current?.child) {
+				onChildClose(documentPath(
+					current.parent.repository.owner,
+					current.parent.repository.name,
+					current.parent.channel.slug,
+				));
+			}
+		};
+		window.addEventListener("keydown", closeOnEscape);
+		return () => window.removeEventListener("keydown", closeOnEscape);
+	}, [onChildClose, presentation]);
+
+	let metadataChanged = useCallback((kind: "parent" | "child", metadata: Metadata) => {
+		let current = loadedRef.current;
+		if (!current) return;
+		let target = kind === "parent" ? current.parent : current.child;
+		if (!target) return;
+		let next = { ...target, channel: { ...target.channel, ...metadata } };
+		let updated = kind === "parent" ? { ...current, parent: next } : { ...current, child: next };
+		if (kind === "parent") parentSlugs.current.add(metadata.slug);
+		loadedRef.current = updated;
+		setLoaded(updated);
+		let paths = anchoredChildPaths(
+			{
+				owner: updated.parent.repository.owner,
+				repository: updated.parent.repository.name,
+				slug: updated.parent.channel.slug,
+			},
+			updated.child?.channel.slug,
+		);
+		let pathname = routeRef.current.page === "child" && updated.child
+			? paths.child!
+			: paths.parent;
+		if (kind === "parent" && routeRef.current.page === "child") {
+			history.replaceState(rebaseChildHistoryState(history.state, paths.parent), "");
+		}
+		onCanonicalPath(pathname);
+	}, [onCanonicalPath]);
+	let parentMetadataChanged = useCallback(
+		(metadata: Metadata) => metadataChanged("parent", metadata),
+		[metadataChanged],
+	);
+	let childMetadataChanged = useCallback(
+		(metadata: Metadata) => metadataChanged("child", metadata),
+		[metadataChanged],
+	);
+
+	if (error) {
+		return (
+			<Failure
+				error={error}
+				onRetry={retryable(error)
+					? () => {
+						setError(undefined);
+						setRetry(value => value + 1);
+					}
+					: undefined}
+			/>
+		);
+	}
+	if (!loaded) return <Loading label="Opening document..." />;
+
+	let parentPath = anchoredChildPaths(
+		{
+			owner: loaded.parent.repository.owner,
+			repository: loaded.parent.repository.name,
+			slug: loaded.parent.channel.slug,
+		},
+		loaded.child?.channel.slug,
+	).parent;
+	let parent = (
+		<Suspense fallback={<Loading label="Opening parent document..." />}>
+			<RoomWorkspace
+				{...workspaceProps(loaded.parent, agent, user, "document", parentMetadataChanged)}
+				key={loaded.parent.channel.id}
+			/>
+		</Suspense>
+	);
+	let child = loaded.child
+		? (
+			<Suspense fallback={<Loading label="Opening child document..." />}>
+				<RoomWorkspace
+					{...workspaceProps(loaded.child, agent, user, "child", childMetadataChanged)}
+					key={loaded.child.channel.id}
+				/>
+			</Suspense>
+		)
+		: undefined;
+	return (
+		<AnchoredChildSurface
+			child={child}
+			childLabel={loaded.child?.channel.title ?? ""}
+			onClose={() => onChildClose(parentPath)}
+			parent={parent}
+			parentLabel={loaded.parent.channel.title}
+			presentation={presentation}
+			key={loaded.parent.channel.id}
+		/>
+	);
+}

--- a/apps/web/src/document-workspace-host.tsx
+++ b/apps/web/src/document-workspace-host.tsx
@@ -8,7 +8,7 @@ import {
 	childPresentation,
 	rebaseChildHistoryState,
 } from "./anchored-child-surface";
-import { rememberChannel } from "./channel-recovery";
+import { readDocumentRecovery, rememberChannel } from "./channel-recovery";
 
 import type { ComponentType } from "react";
 import type { ChildPresentation } from "./anchored-child-surface";
@@ -72,7 +72,12 @@ export default function DocumentWorkspaceHost(
 		user,
 	}: {
 		agent: boolean;
-		Failure: ComponentType<{ error: unknown; onRetry?: () => void }>;
+		Failure: ComponentType<{
+			channel?: { title?: string; slug?: string };
+			error: unknown;
+			onRetry?: () => void;
+			repository?: Pick<Api.Repository, "owner" | "name" | "fullName">;
+		}>;
 		Loading: ComponentType<{ label?: string }>;
 		loadDocument: (
 			address: { owner: string; repository: string; slug: string; parentSlug?: string },
@@ -100,6 +105,7 @@ export default function DocumentWorkspaceHost(
 	let [presentation, setPresentation] = useState<ChildPresentation>("closed");
 	let parentScrollTop = useRef<number | undefined>(undefined);
 	let parentSlugs = useRef(new Set<string>());
+	let childSlugs = useRef(new Set<string>());
 
 	useEffect(() => {
 		let active = true;
@@ -118,7 +124,27 @@ export default function DocumentWorkspaceHost(
 			slug: route.page === "child" ? route.childSlug : route.slug,
 			...(route.page === "child" ? { parentSlug: route.parentSlug } : {}),
 		};
-		void loadDocument(address, controller.signal).then(prepared => {
+		void (async () => {
+			if (route.page === "child" && !current) {
+				let prepared = await loadDocument({
+					owner: route.owner,
+					repository: route.repository,
+					slug: route.parentSlug,
+				}, controller.signal);
+				if (!active) return;
+				let parent = prepared.parent ?? prepared.detail;
+				rememberChannel(user.id, parent.channel, parent.repository);
+				parentSlugs.current.clear();
+				parentSlugs.current.add(parent.channel.slug);
+				parentSlugs.current.add(route.parentSlug);
+				let updated = { parent };
+				loadedRef.current = updated;
+				setLoaded(updated);
+				setPresentation("open");
+			}
+			return await loadDocument(address, controller.signal);
+		})().then(prepared => {
+			if (!prepared) return;
 			if (!active) return;
 			let parent = prepared.parent ?? prepared.detail;
 			let child = prepared.parent ? prepared.detail : undefined;
@@ -129,6 +155,11 @@ export default function DocumentWorkspaceHost(
 			if (!sameParent) parentSlugs.current.clear();
 			parentSlugs.current.add(parent.channel.slug);
 			parentSlugs.current.add(route.page === "child" ? route.parentSlug : route.slug);
+			if (child) {
+				if (previous?.child?.channel.id !== child.channel.id) childSlugs.current.clear();
+				childSlugs.current.add(child.channel.slug);
+				if (route.page === "child") childSlugs.current.add(route.childSlug);
+			}
 			let updated = child
 				? { child, parent }
 				: sameParent && previous?.child
@@ -166,16 +197,24 @@ export default function DocumentWorkspaceHost(
 
 	useEffect(() => {
 		let current = loadedRef.current;
-		if (!current?.child) return;
+		if (!current) return;
 		let sameParent = route.owner.toLocaleLowerCase()
 				=== current.parent.repository.owner.toLocaleLowerCase()
 			&& route.repository.toLocaleLowerCase()
 				=== current.parent.repository.name.toLocaleLowerCase()
 			&& parentSlugs.current.has(route.page === "child" ? route.parentSlug : route.slug);
-		setPresentation(value =>
-			childPresentation(value, route.page === "child" ? "child" : "parent", sameParent)
-		);
-		if (sameParent) {
+		if (route.page === "child") {
+			let sameChild = sameParent && current.child
+				&& childSlugs.current.has(route.childSlug);
+			setPresentation(value => childPresentation(value, "child", sameParent));
+			if (sameChild || (!current.child && sameParent)) return;
+		} else {
+			setPresentation(value => childPresentation(value, "parent", sameParent));
+			if (sameParent) return;
+		}
+		if (!sameParent) {
+			loadedRef.current = undefined;
+			setLoaded(undefined);
 			return;
 		}
 		let updated = { parent: current.parent };
@@ -205,7 +244,7 @@ export default function DocumentWorkspaceHost(
 			if (event.key !== "Escape" || event.defaultPrevented) return;
 			event.preventDefault();
 			let current = loadedRef.current;
-			if (current?.child) {
+			if (current) {
 				onChildClose(documentPath(
 					current.parent.repository.owner,
 					current.parent.repository.name,
@@ -225,6 +264,7 @@ export default function DocumentWorkspaceHost(
 		let next = { ...target, channel: { ...target.channel, ...metadata } };
 		let updated = kind === "parent" ? { ...current, parent: next } : { ...current, child: next };
 		if (kind === "parent") parentSlugs.current.add(metadata.slug);
+		else childSlugs.current.add(metadata.slug);
 		loadedRef.current = updated;
 		setLoaded(updated);
 		let paths = anchoredChildPaths(
@@ -252,20 +292,34 @@ export default function DocumentWorkspaceHost(
 		[metadataChanged],
 	);
 
-	if (error) {
+	let retryFailure = error && retryable(error)
+		? () => {
+			setError(undefined);
+			setRetry(value => value + 1);
+		}
+		: undefined;
+	let requestedSlug = route.page === "child" ? route.childSlug : route.slug;
+	let recovery = readDocumentRecovery(user.id, route.owner, route.repository, requestedSlug);
+	let requestedRepository = {
+		fullName: `${route.owner}/${route.repository}`,
+		name: route.repository,
+		owner: route.owner,
+	};
+	if (error && !loaded) {
 		return (
 			<Failure
+				channel={recovery?.channel ?? { slug: requestedSlug }}
 				error={error}
-				onRetry={retryable(error)
-					? () => {
-						setError(undefined);
-						setRetry(value => value + 1);
-					}
-					: undefined}
+				onRetry={retryFailure}
+				repository={recovery?.repository ?? requestedRepository}
 			/>
 		);
 	}
-	if (!loaded) return <Loading label="Opening document..." />;
+	if (!loaded) {
+		return (
+			<Loading label={route.page === "document" ? "Opening channel..." : "Opening document..."} />
+		);
+	}
 
 	let parentPath = anchoredChildPaths(
 		{
@@ -292,11 +346,20 @@ export default function DocumentWorkspaceHost(
 				/>
 			</Suspense>
 		)
+		: route.page === "child" && presentation === "open"
+		? error
+			? <Failure error={error} onRetry={retryFailure} />
+			: <Loading label="Opening child document..." />
 		: undefined;
 	return (
 		<AnchoredChildSurface
 			child={child}
-			childLabel={loaded.child?.channel.title ?? ""}
+			childLabel={loaded.child?.channel.title ?? (route.page === "child"
+				? route.childSlug
+				: "")}
+			focusKey={loaded.child?.channel.id ?? (route.page === "child"
+				? `${route.parentSlug}/${route.childSlug}`
+				: undefined)}
 			onClose={() => onChildClose(parentPath)}
 			parent={parent}
 			parentLabel={loaded.parent.channel.title}

--- a/apps/web/src/document-workspace-host.tsx
+++ b/apps/web/src/document-workspace-host.tsx
@@ -86,7 +86,11 @@ export default function DocumentWorkspaceHost(
 		}>;
 		layerKey: DocumentRouteIdentity;
 		Loading: ComponentType<{ label?: string }>;
-		onCanonicalPath: (key: DocumentRouteIdentity, pathname: string) => void;
+		onCanonicalPath: (
+			key: DocumentRouteIdentity,
+			routeKey: DocumentRouteIdentity,
+			pathname: string,
+		) => void;
 		onChildClose: (parentPath: string) => void;
 		onParentRestored: (parentId: string) => void;
 		onReady: (
@@ -249,7 +253,7 @@ export default function DocumentWorkspaceHost(
 		if (kind === "parent" && routeRef.current.page === "child") {
 			history.replaceState(rebaseChildHistoryState(history.state, paths.parent), "");
 		}
-		onCanonicalPath(layerKey, pathname);
+		onCanonicalPath(layerKey, documentRouteIdentity(routeRef.current), pathname);
 	}, [layerKey, onCanonicalPath, send]);
 	let parentMetadataChanged = useCallback(
 		(metadata: Metadata) => metadataChanged("parent", metadata),

--- a/apps/web/src/document-workspace-host.tsx
+++ b/apps/web/src/document-workspace-host.tsx
@@ -5,15 +5,18 @@ import * as Api from "./api";
 import {
 	anchoredChildPaths,
 	AnchoredChildSurface,
-	childPresentation,
 	rebaseChildHistoryState,
 } from "./anchored-child-surface";
 import { readDocumentRecovery, rememberChannel } from "./channel-recovery";
 import { prepareDocumentLoad } from "./document-loader";
 import { documentRouteIdentity } from "./document-route-swap";
+import {
+	initialDocumentWorkspaceState,
+	transitionDocumentWorkspace,
+} from "./document-workspace-state";
 
 import type { ComponentType } from "react";
-import type { ChildPresentation } from "./anchored-child-surface";
+import type { DocumentWorkspaceAction } from "./document-workspace-state";
 import type { DocumentRouteIdentity } from "./document-route-swap";
 import type { HostedRoute } from "./hosted";
 import type { WorkspaceSurface } from "./workspace-model";
@@ -99,30 +102,31 @@ export default function DocumentWorkspaceHost(
 		user: Api.User;
 	},
 ) {
-	let [loaded, setLoaded] = useState<{
-		child?: Api.ChannelDetail;
-		parent: Api.ChannelDetail;
-	}>();
-	let loadedRef = useRef(loaded);
-	loadedRef.current = loaded;
+	let [state, setState] = useState(initialDocumentWorkspaceState);
+	let stateRef = useRef(state);
+	stateRef.current = state;
+	let send = useCallback((action: DocumentWorkspaceAction) => {
+		let next = transitionDocumentWorkspace(stateRef.current, action);
+		stateRef.current = next;
+		setState(next);
+		return next;
+	}, []);
+	let loaded = state.status === "ready" ? state.loaded : undefined;
 	let routeRef = useRef(route);
 	routeRef.current = route;
-	let [error, setError] = useState<unknown>();
-	let [retry, setRetry] = useState(0);
-	let [presentation, setPresentation] = useState<ChildPresentation>("closed");
+	let error = state.error;
+	let presentation = state.presentation;
 	let parentScrollTop = useRef<number | undefined>(undefined);
-	let parentSlugs = useRef(new Set<string>());
-	let childSlugs = useRef(new Set<string>());
+	let parentSurface = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		let active = true;
 		let controller = new AbortController();
-		setError(undefined);
-		let current = loadedRef.current;
+		send({ type: "loading" });
+		let currentState = stateRef.current;
+		let current = currentState.status === "ready" ? currentState.loaded : undefined;
 		if (route.page === "child" && current && !current.child) {
-			let scroller = document.querySelector<HTMLElement>(
-				`[data-workspace-room="${CSS.escape(current.parent.channel.id)}"] [data-plan-scroll]`,
-			);
+			let scroller = parentSurface.current?.querySelector<HTMLElement>("[data-plan-scroll]");
 			if (scroller) parentScrollTop.current = scroller.scrollTop;
 		}
 		let address = {
@@ -141,13 +145,7 @@ export default function DocumentWorkspaceHost(
 				if (!active) return;
 				let parent = prepared.parent ?? prepared.detail;
 				rememberChannel(user.id, parent.channel, parent.repository);
-				parentSlugs.current.clear();
-				parentSlugs.current.add(parent.channel.slug);
-				parentSlugs.current.add(route.parentSlug);
-				let updated = { parent };
-				loadedRef.current = updated;
-				setLoaded(updated);
-				setPresentation("open");
+				send({ parent, route, type: "parent-ready" });
 			}
 			return await prepareDocumentLoad(address, controller.signal);
 		})().then(prepared => {
@@ -157,28 +155,7 @@ export default function DocumentWorkspaceHost(
 			let child = prepared.parent ? prepared.detail : undefined;
 			rememberChannel(user.id, parent.channel, parent.repository);
 			if (child) rememberChannel(user.id, child.channel, child.repository);
-			let previous = loadedRef.current;
-			let sameParent = previous?.parent.channel.id === parent.channel.id;
-			if (!sameParent) parentSlugs.current.clear();
-			parentSlugs.current.add(parent.channel.slug);
-			parentSlugs.current.add(route.page === "child" ? route.parentSlug : route.slug);
-			if (child) {
-				if (previous?.child?.channel.id !== child.channel.id) childSlugs.current.clear();
-				childSlugs.current.add(child.channel.slug);
-				if (route.page === "child") childSlugs.current.add(route.childSlug);
-			}
-			let updated = child
-				? { child, parent }
-				: sameParent && previous?.child
-				? { ...previous, parent }
-				: { parent };
-			loadedRef.current = updated;
-			setLoaded(updated);
-			if (child) {
-				setPresentation(current => childPresentation(current, "child", true));
-			} else if (previous?.child) {
-				setPresentation(current => childPresentation(current, "parent", sameParent));
-			}
+			send({ child, parent, route, type: "ready" });
 			let routeKey = child
 				? documentRouteIdentity({
 					childSlug: child.channel.slug,
@@ -200,7 +177,7 @@ export default function DocumentWorkspaceHost(
 			});
 		}, reason => {
 			if (active) {
-				setError(reason);
+				send({ error: reason, type: "failed" });
 				onReady(layerKey);
 			}
 		});
@@ -208,72 +185,41 @@ export default function DocumentWorkspaceHost(
 			active = false;
 			controller.abort();
 		};
-	}, [layerKey, onReady, retry, route, user.id]);
+	}, [layerKey, onReady, route, send, state.retry, user.id]);
 
 	useLayoutEffect(() => {
-		let current = loadedRef.current;
-		if (!current || parentScrollTop.current === undefined) return;
-		let scroller = document.querySelector<HTMLElement>(
-			`[data-workspace-room="${CSS.escape(current.parent.channel.id)}"] [data-plan-scroll]`,
-		);
+		if (!loaded || parentScrollTop.current === undefined) return;
+		let scroller = parentSurface.current?.querySelector<HTMLElement>("[data-plan-scroll]");
 		if (scroller) scroller.scrollTop = parentScrollTop.current;
 		if (presentation === "closed") parentScrollTop.current = undefined;
 	}, [loaded, presentation]);
 
 	useEffect(() => {
-		let current = loadedRef.current;
-		if (!current) return;
-		let sameParent = route.owner.toLocaleLowerCase()
-				=== current.parent.repository.owner.toLocaleLowerCase()
-			&& route.repository.toLocaleLowerCase()
-				=== current.parent.repository.name.toLocaleLowerCase()
-			&& parentSlugs.current.has(route.page === "child" ? route.parentSlug : route.slug);
-		if (route.page === "child") {
-			let sameChild = sameParent && current.child
-				&& childSlugs.current.has(route.childSlug);
-			setPresentation(value => childPresentation(value, "child", sameParent));
-			if (sameChild || (!current.child && sameParent)) return;
-		} else {
-			setPresentation(value => childPresentation(value, "parent", sameParent));
-			if (sameParent) return;
-		}
-		if (!sameParent) {
-			loadedRef.current = undefined;
-			setLoaded(undefined);
-			return;
-		}
-		let updated = { parent: current.parent };
-		loadedRef.current = updated;
-		setLoaded(updated);
-	}, [route]);
+		send({ route, type: "route" });
+	}, [route, send]);
 
 	useEffect(() => {
 		if (presentation !== "closing") return;
 		let timer = window.setTimeout(() => {
-			setPresentation("closed");
-			let current = loadedRef.current;
-			let parentId = current?.parent.channel.id;
-			if (current) {
-				let updated = { parent: current.parent };
-				loadedRef.current = updated;
-				setLoaded(updated);
-			}
+			let current = stateRef.current;
+			let parentId = current.status === "ready" ? current.loaded.parent.channel.id : undefined;
+			send({ type: "closed" });
 			if (parentId) onParentRestored(parentId);
 		}, 190);
 		return () => window.clearTimeout(timer);
-	}, [onParentRestored, presentation]);
+	}, [onParentRestored, presentation, send]);
 
 	useEffect(() => {
 		if (presentation !== "open") return;
 		let closeOnEscape = (event: KeyboardEvent) => {
 			if (event.key !== "Escape" || event.defaultPrevented) return;
 			event.preventDefault();
-			let current = loadedRef.current;
-			if (current) {
+			let current = stateRef.current;
+			if (current.status === "ready") {
 				onChildClose(documentPath(
-					current.parent.repository.owner,
-					current.parent.repository.name,
-					current.parent.channel.slug,
+					current.loaded.parent.repository.owner,
+					current.loaded.parent.repository.name,
+					current.loaded.parent.channel.slug,
 				));
 			}
 		};
@@ -282,16 +228,13 @@ export default function DocumentWorkspaceHost(
 	}, [onChildClose, presentation]);
 
 	let metadataChanged = useCallback((kind: "parent" | "child", metadata: Metadata) => {
-		let current = loadedRef.current;
-		if (!current) return;
-		let target = kind === "parent" ? current.parent : current.child;
+		let current = stateRef.current;
+		if (current.status === "empty") return;
+		let target = kind === "parent" ? current.loaded.parent : current.loaded.child;
 		if (!target) return;
-		let next = { ...target, channel: { ...target.channel, ...metadata } };
-		let updated = kind === "parent" ? { ...current, parent: next } : { ...current, child: next };
-		if (kind === "parent") parentSlugs.current.add(metadata.slug);
-		else childSlugs.current.add(metadata.slug);
-		loadedRef.current = updated;
-		setLoaded(updated);
+		let updatedState = send({ kind, metadata, type: "metadata" });
+		if (updatedState.status === "empty") return;
+		let updated = updatedState.loaded;
 		let paths = anchoredChildPaths(
 			{
 				owner: updated.parent.repository.owner,
@@ -307,7 +250,7 @@ export default function DocumentWorkspaceHost(
 			history.replaceState(rebaseChildHistoryState(history.state, paths.parent), "");
 		}
 		onCanonicalPath(layerKey, pathname);
-	}, [layerKey, onCanonicalPath]);
+	}, [layerKey, onCanonicalPath, send]);
 	let parentMetadataChanged = useCallback(
 		(metadata: Metadata) => metadataChanged("parent", metadata),
 		[metadataChanged],
@@ -318,10 +261,7 @@ export default function DocumentWorkspaceHost(
 	);
 
 	let retryFailure = error && retryable(error)
-		? () => {
-			setError(undefined);
-			setRetry(value => value + 1);
-		}
+		? () => send({ type: "retry" })
 		: undefined;
 	let requestedSlug = route.page === "child" ? route.childSlug : route.slug;
 	let recovery = readDocumentRecovery(user.id, route.owner, route.repository, requestedSlug);
@@ -388,6 +328,7 @@ export default function DocumentWorkspaceHost(
 			onClose={() => onChildClose(parentPath)}
 			parent={parent}
 			parentLabel={loaded.parent.channel.title}
+			parentRef={parentSurface}
 			presentation={presentation}
 			key={loaded.parent.channel.id}
 		/>

--- a/apps/web/src/document-workspace-state.test.ts
+++ b/apps/web/src/document-workspace-state.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test";
+
+import {
+	initialDocumentWorkspaceState,
+	transitionDocumentWorkspace,
+} from "./document-workspace-state";
+
+import type { ChannelDetail } from "./api";
+
+function detail(id: string, slug: string, parentChannelId?: string): ChannelDetail {
+	return {
+		canEdit: true,
+		canManage: true,
+		channel: {
+			createdAt: "2026-08-27T00:00:00.000Z",
+			createdBy: "user-one",
+			descriptionRevision: 0,
+			id,
+			...(parentChannelId ? { parentChannelId } : {}),
+			repositoryId: "R_score",
+			repositoryName: "score",
+			repositoryOwner: "octo-org",
+			revision: 0,
+			slug,
+			title: slug,
+			updatedAt: "2026-08-27T00:00:00.000Z",
+		},
+		repository: {
+			defaultBranch: "main",
+			fullName: "octo-org/score",
+			id: "R_score",
+			name: "score",
+			owner: "octo-org",
+			permissions: { admin: false, pull: true, push: true },
+			private: false,
+			url: "https://github.com/octo-org/score",
+		},
+	};
+}
+
+test("one state transition owns parent retention across the child lifecycle", () => {
+	let parent = detail("parent-one", "canonical-parent");
+	let child = detail("child-one", "canonical-child", parent.channel.id);
+	let route = {
+		childSlug: "requested-child",
+		owner: "octo-org",
+		page: "child" as const,
+		parentSlug: "requested-parent",
+		repository: "score",
+	};
+	let state = transitionDocumentWorkspace(initialDocumentWorkspaceState(), {
+		parent,
+		route,
+		type: "parent-ready",
+	});
+	expect(state).toMatchObject({
+		loaded: { parent },
+		presentation: "open",
+		status: "ready",
+	});
+
+	state = transitionDocumentWorkspace(state, { child, parent, route, type: "ready" });
+	expect(state).toMatchObject({
+		loaded: { child, parent },
+		presentation: "open",
+		status: "ready",
+	});
+
+	state = transitionDocumentWorkspace(state, {
+		route: {
+			owner: "octo-org",
+			page: "document",
+			repository: "score",
+			slug: "canonical-parent",
+		},
+		type: "route",
+	});
+	expect(state).toMatchObject({
+		loaded: { child, parent },
+		presentation: "closing",
+		status: "ready",
+	});
+
+	state = transitionDocumentWorkspace(state, { type: "closed" });
+	expect(state).toMatchObject({
+		loaded: { parent },
+		presentation: "closed",
+		status: "ready",
+	});
+	expect(state.status === "ready" && state.loaded.child).toBeUndefined();
+});

--- a/apps/web/src/document-workspace-state.test.ts
+++ b/apps/web/src/document-workspace-state.test.ts
@@ -89,3 +89,41 @@ test("one state transition owns parent retention across the child lifecycle", ()
 	});
 	expect(state.status === "ready" && state.loaded.child).toBeUndefined();
 });
+
+test("restoring a document removes archived metadata from the retained workspace", () => {
+	let parent = detail("parent-one", "parent");
+	let route = {
+		owner: "octo-org",
+		page: "document" as const,
+		repository: "score",
+		slug: "parent",
+	};
+	let state = transitionDocumentWorkspace(initialDocumentWorkspaceState(), {
+		parent,
+		route,
+		type: "ready",
+	});
+	state = transitionDocumentWorkspace(state, {
+		kind: "parent",
+		metadata: {
+			archivedAt: "2026-08-27T01:00:00.000Z",
+			descriptionRevision: 0,
+			slug: "parent",
+			title: "parent",
+			updatedAt: "2026-08-27T01:00:00.000Z",
+		},
+		type: "metadata",
+	});
+	state = transitionDocumentWorkspace(state, {
+		kind: "parent",
+		metadata: {
+			descriptionRevision: 0,
+			slug: "parent",
+			title: "parent",
+			updatedAt: "2026-08-27T02:00:00.000Z",
+		},
+		type: "metadata",
+	});
+
+	expect(state.status === "ready" && state.loaded.parent.channel.archivedAt).toBeUndefined();
+});

--- a/apps/web/src/document-workspace-state.ts
+++ b/apps/web/src/document-workspace-state.ts
@@ -1,3 +1,5 @@
+import { updateDocumentMetadata } from "./document-actions";
+
 import type { ChannelDetail } from "./api";
 import type { DocumentMetadata } from "./document-actions";
 import type { DocumentRouteIdentitySource } from "./document-route-swap";
@@ -142,7 +144,7 @@ export function transitionDocumentWorkspace(
 		if (state.status === "empty") return state;
 		let target = action.kind === "parent" ? state.loaded.parent : state.loaded.child;
 		if (!target) return state;
-		let detail = { ...target, channel: { ...target.channel, ...action.metadata } };
+		let detail = { ...target, channel: updateDocumentMetadata(target.channel, action.metadata) };
 		let loaded = action.kind === "parent"
 			? { ...state.loaded, parent: detail }
 			: { ...state.loaded, child: detail };

--- a/apps/web/src/document-workspace-state.ts
+++ b/apps/web/src/document-workspace-state.ts
@@ -1,0 +1,164 @@
+import type { ChannelDetail } from "./api";
+import type { DocumentMetadata } from "./document-actions";
+import type { DocumentRouteIdentitySource } from "./document-route-swap";
+
+export type ChildPresentation = "closed" | "open" | "closing";
+
+type DocumentRoute = Extract<DocumentRouteIdentitySource, { page: "document" | "child" }>;
+
+type EmptyDocumentWorkspace = {
+	error?: unknown;
+	presentation: "closed";
+	retry: number;
+	status: "empty";
+};
+
+export type ReadyDocumentWorkspace = {
+	childSlugs: ReadonlySet<string>;
+	error?: unknown;
+	loaded: { child?: ChannelDetail; parent: ChannelDetail };
+	parentSlugs: ReadonlySet<string>;
+	presentation: ChildPresentation;
+	retry: number;
+	status: "ready";
+};
+
+export type DocumentWorkspaceState = EmptyDocumentWorkspace | ReadyDocumentWorkspace;
+
+export type DocumentWorkspaceAction =
+	| { type: "loading" }
+	| { error: unknown; type: "failed" }
+	| {
+		parent: ChannelDetail;
+		route: Extract<DocumentRoute, { page: "child" }>;
+		type: "parent-ready";
+	}
+	| { child?: ChannelDetail; parent: ChannelDetail; route: DocumentRoute; type: "ready" }
+	| { route: DocumentRoute; type: "route" }
+	| { kind: "parent" | "child"; metadata: DocumentMetadata; type: "metadata" }
+	| { type: "retry" }
+	| { type: "closed" };
+
+export function initialDocumentWorkspaceState(retry = 0): DocumentWorkspaceState {
+	return { presentation: "closed", retry, status: "empty" };
+}
+
+export function childPresentation(
+	current: ChildPresentation,
+	route: "parent" | "child",
+	sameParent: boolean,
+): ChildPresentation {
+	if (route === "child") return sameParent ? "open" : "closed";
+	if (current !== "closed" && sameParent) return "closing";
+	return "closed";
+}
+
+function sameRepository(route: DocumentRoute, detail: ChannelDetail): boolean {
+	return route.owner.toLocaleLowerCase() === detail.repository.owner.toLocaleLowerCase()
+		&& route.repository.toLocaleLowerCase() === detail.repository.name.toLocaleLowerCase();
+}
+
+function routeMatchesParent(
+	state: ReadyDocumentWorkspace,
+	route: DocumentRoute,
+): boolean {
+	let slug = route.page === "child" ? route.parentSlug : route.slug;
+	return sameRepository(route, state.loaded.parent) && state.parentSlugs.has(slug);
+}
+
+export function transitionDocumentWorkspace(
+	state: DocumentWorkspaceState,
+	action: DocumentWorkspaceAction,
+): DocumentWorkspaceState {
+	if (action.type === "loading") return { ...state, error: undefined };
+	if (action.type === "failed") return { ...state, error: action.error };
+	if (action.type === "retry") return { ...state, error: undefined, retry: state.retry + 1 };
+	if (action.type === "parent-ready") {
+		return {
+			childSlugs: new Set(),
+			loaded: { parent: action.parent },
+			parentSlugs: new Set([action.parent.channel.slug, action.route.parentSlug]),
+			presentation: "open",
+			retry: state.retry,
+			status: "ready",
+		};
+	}
+	if (action.type === "ready") {
+		let previous = state.status === "ready" ? state : undefined;
+		let sameParent = previous?.loaded.parent.channel.id === action.parent.channel.id;
+		let parentSlugs = previous && sameParent
+			? new Set(previous.parentSlugs)
+			: new Set<string>();
+		parentSlugs.add(action.parent.channel.slug);
+		parentSlugs.add(action.route.page === "child" ? action.route.parentSlug : action.route.slug);
+		let childSlugs = action.child && previous?.loaded.child?.channel.id === action.child.channel.id
+			? new Set(previous.childSlugs)
+			: new Set<string>();
+		if (action.child) {
+			childSlugs.add(action.child.channel.slug);
+			if (action.route.page === "child") childSlugs.add(action.route.childSlug);
+		}
+		let loaded = action.child
+			? { child: action.child, parent: action.parent }
+			: sameParent && previous?.loaded.child
+			? { ...previous.loaded, parent: action.parent }
+			: { parent: action.parent };
+		let presentation = action.child
+			? childPresentation(previous?.presentation ?? "closed", "child", true)
+			: previous?.loaded.child
+			? childPresentation(previous.presentation, "parent", !!sameParent)
+			: previous?.presentation ?? "closed";
+		return {
+			childSlugs,
+			loaded,
+			parentSlugs,
+			presentation,
+			retry: state.retry,
+			status: "ready",
+		};
+	}
+	if (action.type === "route") {
+		if (state.status === "empty") return state;
+		let sameParent = routeMatchesParent(state, action.route);
+		if (action.route.page === "child") {
+			let sameChild = sameParent && state.loaded.child
+				&& state.childSlugs.has(action.route.childSlug);
+			let presentation = childPresentation(state.presentation, "child", sameParent);
+			if (sameChild || (!state.loaded.child && sameParent)) return { ...state, presentation };
+			if (!sameParent) return initialDocumentWorkspaceState(state.retry);
+			return {
+				...state,
+				childSlugs: new Set(),
+				loaded: { parent: state.loaded.parent },
+				presentation,
+			};
+		}
+		let presentation = childPresentation(state.presentation, "parent", sameParent);
+		return sameParent
+			? { ...state, presentation }
+			: initialDocumentWorkspaceState(state.retry);
+	}
+	if (action.type === "metadata") {
+		if (state.status === "empty") return state;
+		let target = action.kind === "parent" ? state.loaded.parent : state.loaded.child;
+		if (!target) return state;
+		let detail = { ...target, channel: { ...target.channel, ...action.metadata } };
+		let loaded = action.kind === "parent"
+			? { ...state.loaded, parent: detail }
+			: { ...state.loaded, child: detail };
+		let slugs = new Set(action.kind === "parent" ? state.parentSlugs : state.childSlugs);
+		slugs.add(action.metadata.slug);
+		return {
+			...state,
+			loaded,
+			...(action.kind === "parent" ? { parentSlugs: slugs } : { childSlugs: slugs }),
+		};
+	}
+	if (state.status === "empty") return state;
+	return {
+		...state,
+		childSlugs: new Set(),
+		loaded: { parent: state.loaded.parent },
+		presentation: "closed",
+	};
+}

--- a/apps/web/src/hosted.test.ts
+++ b/apps/web/src/hosted.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
 import { ApiError } from "./api";
+import {
+	anchoredChildPaths,
+	AnchoredChildSurface,
+	childCloseAction,
+	childHistoryState,
+	childPresentation,
+	rebaseChildHistoryState,
+} from "./anchored-child-surface";
 import {
 	githubLoginHref,
 	hostedRoute,
@@ -31,6 +41,7 @@ function detail(
 		canEdit: true,
 		canManage: true,
 		channel: {
+			descriptionRevision: 0,
 			id,
 			repositoryId,
 			repositoryOwner: "octo-org",
@@ -131,6 +142,76 @@ describe("hosted routes", () => {
 	});
 });
 
+describe("anchored child lifecycle", () => {
+	it("renders one parent-aware close control over an inert parent with separate rooms", () => {
+		let markup = renderToStaticMarkup(createElement(AnchoredChildSurface, {
+			child: createElement("div", { "data-workspace-room": "child-room" }),
+			childLabel: "Source review",
+			onClose() {},
+			parent: createElement("div", { "data-workspace-room": "parent-room" }),
+			parentLabel: "Release plan",
+			presentation: "open",
+		}));
+
+		expect(markup).toContain('aria-hidden="true"');
+		expect(markup).toContain('inert=""');
+		expect(markup).toContain('aria-label="Back to Release plan"');
+		expect(markup.match(/<button/g)).toHaveLength(1);
+		expect(markup).toContain('data-workspace-room="parent-room"');
+		expect(markup).toContain('data-workspace-room="child-room"');
+		expect(markup).not.toContain("Expand");
+	});
+
+	it("marks an in-app child push without discarding existing history state", () => {
+		expect(childHistoryState({ navigation: 4 }, "/documents/octo-org/score/parent?view=plan#note"))
+			.toEqual({
+				navigation: 4,
+				chopinChildParent: "/documents/octo-org/score/parent?view=plan#note",
+			});
+	});
+
+	it("backs out of an in-app child but replaces a direct child with its parent", () => {
+		let parent = "/documents/octo-org/score/parent";
+		expect(childCloseAction(
+			{ chopinChildParent: `${parent}?view=decisions#question` },
+			parent,
+		)).toEqual({ type: "back" });
+		expect(childCloseAction(null, parent)).toEqual({
+			type: "replace",
+			destination: parent,
+		});
+	});
+
+	it("keeps the child briefly only while returning to its own parent", () => {
+		expect(childPresentation("open", "parent", true)).toBe("closing");
+		expect(childPresentation("closing", "parent", true)).toBe("closing");
+		expect(childPresentation("open", "parent", false)).toBe("closed");
+		expect(childPresentation("closing", "child", true)).toBe("open");
+		expect(childPresentation("open", "child", false)).toBe("closed");
+	});
+
+	it("builds a nested canonical path from both workspaces' current metadata", () => {
+		expect(
+			anchoredChildPaths(
+				{ owner: "octo-org", repository: "score", slug: "renamed parent" },
+				"renamed child",
+			).child,
+		).toBe(
+			"/documents/octo-org/score/renamed%20parent/children/renamed%20child",
+		);
+	});
+
+	it("rebases the marked parent after a rename without losing its search or hash", () => {
+		expect(rebaseChildHistoryState(
+			{ chopinChildParent: "/documents/octo-org/score/old?view=plan#note", navigation: 4 },
+			"/documents/octo-org/score/new",
+		)).toEqual({
+			chopinChildParent: "/documents/octo-org/score/new?view=plan#note",
+			navigation: 4,
+		});
+	});
+});
+
 describe("hosted login", () => {
 	it("binds the current product location to the OAuth attempt", () => {
 		expect(githubLoginHref("/documents/octo-org/score/release-plan", "?view=plan", "#item"))
@@ -170,6 +251,7 @@ describe("channel recovery", () => {
 
 		expect(await prepareDocumentLoad({ id: child.channel.id }, signal, readers)).toEqual({
 			detail: child,
+			parent,
 			pathname: "/documents/octo-org/score/release-plan/children/source-review",
 		});
 		expect(
@@ -184,6 +266,7 @@ describe("channel recovery", () => {
 			),
 		).toEqual({
 			detail: child,
+			parent,
 			pathname: "/documents/octo-org/score/release-plan/children/source-review",
 		});
 	});

--- a/apps/web/src/hosted.test.ts
+++ b/apps/web/src/hosted.test.ts
@@ -11,13 +11,8 @@ import {
 	childPresentation,
 	rebaseChildHistoryState,
 } from "./anchored-child-surface";
-import {
-	githubLoginHref,
-	hostedRoute,
-	prepareDocumentLoad,
-	retryableChannelFailure,
-	validatedChildPath,
-} from "./hosted";
+import { githubLoginHref, hostedRoute, retryableChannelFailure } from "./hosted";
+import { prepareDocumentLoad, validatedChildPath } from "./document-loader";
 
 import type { ChannelDetail } from "./api";
 

--- a/apps/web/src/hosted.test.ts
+++ b/apps/web/src/hosted.test.ts
@@ -4,6 +4,7 @@ import { ApiError } from "./api";
 import {
 	githubLoginHref,
 	hostedRoute,
+	prepareDocumentLoad,
 	retryableChannelFailure,
 	validatedChildPath,
 } from "./hosted";
@@ -149,5 +150,123 @@ describe("channel recovery", () => {
 		expect(retryableChannelFailure(new ApiError("channel not found", 404))).toBe(false);
 		expect(retryableChannelFailure(new ApiError("repository access is required", 403)))
 			.toBe(false);
+	});
+
+	it("converges restored IDs and flat child slugs on the canonical child URL", async () => {
+		let parent = detail("parent-one", "release-plan");
+		let child = detail("child-one", "source-review", parent.channel.id);
+		let readers = {
+			async channel(id: string) {
+				if (id === child.channel.id) return child;
+				if (id === parent.channel.id) return parent;
+				throw new ApiError("channel not found", 404);
+			},
+			async document(_owner: string, _repository: string, slug: string) {
+				if (slug === child.channel.slug) return child;
+				throw new ApiError("channel not found", 404);
+			},
+		};
+		let signal = new AbortController().signal;
+
+		expect(await prepareDocumentLoad({ id: child.channel.id }, signal, readers)).toEqual({
+			detail: child,
+			pathname: "/documents/octo-org/score/release-plan/children/source-review",
+		});
+		expect(
+			await prepareDocumentLoad(
+				{
+					owner: "octo-org",
+					repository: "score",
+					slug: child.channel.slug,
+				},
+				signal,
+				readers,
+			),
+		).toEqual({
+			detail: child,
+			pathname: "/documents/octo-org/score/release-plan/children/source-review",
+		});
+	});
+
+	it("keeps top-level ID and slug loads on their ordinary canonical URL", async () => {
+		let topLevel = detail("document-one", "release-plan");
+		let readers = {
+			async channel() {
+				return topLevel;
+			},
+			async document() {
+				return topLevel;
+			},
+		};
+		let signal = new AbortController().signal;
+		let expected = {
+			detail: topLevel,
+			pathname: "/documents/octo-org/score/release-plan",
+		};
+
+		expect(await prepareDocumentLoad({ id: topLevel.channel.id }, signal, readers))
+			.toEqual(expected);
+		expect(
+			await prepareDocumentLoad(
+				{
+					owner: "octo-org",
+					repository: "score",
+					slug: topLevel.channel.slug,
+				},
+				signal,
+				readers,
+			),
+		).toEqual(expected);
+	});
+
+	it("fails conservatively when authoritative parent resolution is missing or mismatched", async () => {
+		let parent = detail("parent-one", "release-plan");
+		let child = detail("child-one", "source-review", parent.channel.id);
+		let signal = new AbortController().signal;
+		let document = async () => child;
+
+		await expect(prepareDocumentLoad(
+			{ owner: "octo-org", repository: "score", slug: child.channel.slug },
+			signal,
+			{
+				channel: async () => {
+					throw new ApiError("channel not found", 404);
+				},
+				document,
+			},
+		)).rejects.toMatchObject({ status: 404 });
+		await expect(prepareDocumentLoad(
+			{ owner: "octo-org", repository: "score", slug: child.channel.slug },
+			signal,
+			{
+				channel: async () => detail("different-parent", "release-plan"),
+				document,
+			},
+		)).rejects.toMatchObject({ status: 404 });
+	});
+
+	it("aborts authoritative parent resolution for a stale document load", async () => {
+		let parent = detail("parent-one", "release-plan");
+		let child = detail("child-one", "source-review", parent.channel.id);
+		let controller = new AbortController();
+		let readers = {
+			async channel(_id: string, signal?: AbortSignal): Promise<ChannelDetail> {
+				if (signal?.aborted) throw new Error("stale load aborted");
+				return new Promise((_resolve, reject) => {
+					signal?.addEventListener("abort", () => reject(new Error("stale load aborted")));
+				});
+			},
+			async document() {
+				return child;
+			},
+		};
+		let pending = prepareDocumentLoad(
+			{ owner: "octo-org", repository: "score", slug: child.channel.slug },
+			controller.signal,
+			readers,
+		);
+
+		controller.abort();
+		await expect(pending).rejects.toThrow("stale load aborted");
 	});
 });

--- a/apps/web/src/hosted.test.ts
+++ b/apps/web/src/hosted.test.ts
@@ -1,7 +1,49 @@
 import { describe, expect, it } from "bun:test";
 
 import { ApiError } from "./api";
-import { githubLoginHref, hostedRoute, retryableChannelFailure } from "./hosted";
+import {
+	githubLoginHref,
+	hostedRoute,
+	retryableChannelFailure,
+	validatedChildPath,
+} from "./hosted";
+
+import type { ChannelDetail } from "./api";
+
+function detail(
+	id: string,
+	slug: string,
+	parentChannelId?: string,
+	repositoryId = "R_score",
+): ChannelDetail {
+	return {
+		repository: {
+			id: repositoryId,
+			owner: "octo-org",
+			name: "score",
+			fullName: "octo-org/score",
+			private: false,
+			url: "https://github.com/octo-org/score",
+			defaultBranch: "main",
+			permissions: { pull: true, push: true, admin: false },
+		},
+		canEdit: true,
+		canManage: true,
+		channel: {
+			id,
+			repositoryId,
+			repositoryOwner: "octo-org",
+			repositoryName: "score",
+			...(parentChannelId ? { parentChannelId } : {}),
+			title: slug,
+			slug,
+			createdBy: "user-one",
+			revision: 0,
+			createdAt: "2026-08-24T00:00:00.000Z",
+			updatedAt: "2026-08-24T00:00:00.000Z",
+		},
+	};
+}
 
 describe("hosted routes", () => {
 	it("recognizes canonical document and legacy routes", () => {
@@ -50,6 +92,41 @@ describe("hosted routes", () => {
 			.toEqual({ page: "missing" });
 		expect(hostedRoute("/documents/octo-org/score/plan/research"))
 			.toEqual({ page: "missing" });
+	});
+
+	it("recognizes a child route before the ordinary document route", () => {
+		expect(hostedRoute(
+			"/documents/octo-org/score/release-plan/children/source%20review",
+		)).toEqual({
+			page: "child",
+			owner: "octo-org",
+			repository: "score",
+			parentSlug: "release-plan",
+			childSlug: "source review",
+		});
+	});
+
+	it("accepts direct child entry only for its recorded parent and repository", () => {
+		let parent = detail("parent-one", "canonical-parent");
+		let child = detail("child-one", "canonical-child", parent.channel.id);
+
+		expect(validatedChildPath(child, parent)).toBe(
+			"/documents/octo-org/score/canonical-parent/children/canonical-child",
+		);
+		for (
+			let invalid of [
+				detail("child-one", "canonical-child"),
+				detail("child-one", "canonical-child", "different-parent"),
+				detail("child-one", "canonical-child", parent.channel.id, "R_other"),
+			]
+		) {
+			expect(() => validatedChildPath(invalid, parent)).toThrow(ApiError);
+			try {
+				validatedChildPath(invalid, parent);
+			} catch (error) {
+				expect((error as ApiError).status).toBe(404);
+			}
+		}
 	});
 });
 

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { ContentSwapLayer } from "@chopin/editor/content-swap";
 import {
 	childDocumentPath,
@@ -11,6 +11,7 @@ import {
 } from "@chopin/protocol/document-url";
 
 import * as Api from "./api";
+import { childCloseAction, childHistoryState } from "./anchored-child-surface";
 import { readChannelRecovery, readDocumentRecovery, rememberChannel } from "./channel-recovery";
 import { documentRouteIdentity, transitionDocumentRoute } from "./document-route-swap";
 import { newestDocument } from "./document-actions";
@@ -24,6 +25,9 @@ import type {
 	DocumentRouteIdentitySource,
 	DocumentRouteSwap as DocumentRouteSwapState,
 } from "./document-route-swap";
+import type { WorkspaceSurface } from "./workspace-model";
+
+let DocumentWorkspaceHost = lazy(() => import("./document-workspace-host"));
 
 export type HostedWorkspaceProps = {
 	room: string;
@@ -39,6 +43,18 @@ export type HostedWorkspaceProps = {
 	archivedAt?: string;
 	agent?: boolean;
 	userId: string;
+	onMetadataChanged?: (
+		metadata: Pick<
+			Api.Channel,
+			| "archivedAt"
+			| "description"
+			| "descriptionRevision"
+			| "slug"
+			| "title"
+			| "updatedAt"
+		>,
+	) => void;
+	surface?: WorkspaceSurface;
 };
 
 export type HostedRoute =
@@ -55,7 +71,11 @@ type DocumentRouteRequest = {
 	key: DocumentRouteIdentity;
 	source: DocumentSource;
 };
-type DocumentRouteResolution = { canonicalPath: string; channel: Api.Channel };
+type DocumentRouteResolution = {
+	canonicalPath: string;
+	channel: Api.Channel;
+	routeKey: DocumentRouteIdentity;
+};
 type DocumentRouteLayer = DocumentRouteSwapState<
 	DocumentRouteRequest,
 	DocumentRouteResolution
@@ -64,10 +84,19 @@ type DocumentRouteLayer = DocumentRouteSwapState<
 function keyedDocumentRoute(
 	route: DocumentRoute,
 	immediately: boolean,
+	alias?: DocumentRouteIdentity,
 ): DocumentRouteRequest {
+	let key = alias ?? (route.page === "child"
+		? documentRouteIdentity({
+			owner: route.owner,
+			page: "document",
+			repository: route.repository,
+			slug: route.parentSlug,
+		})
+		: documentRouteIdentity(route));
 	return {
 		immediately,
-		key: documentRouteIdentity(route),
+		key,
 		source: route,
 	};
 }
@@ -160,7 +189,7 @@ export async function prepareDocumentLoad(
 		},
 	signal: AbortSignal,
 	readers: DocumentReaders = Api,
-): Promise<{ detail: Api.ChannelDetail; pathname: string }> {
+): Promise<{ detail: Api.ChannelDetail; parent?: Api.ChannelDetail; pathname: string }> {
 	if ("id" in address) {
 		let detail = await readers.channel(address.id, signal);
 		if (!detail.channel.parentChannelId) {
@@ -174,14 +203,14 @@ export async function prepareDocumentLoad(
 			};
 		}
 		let parent = await readers.channel(detail.channel.parentChannelId, signal);
-		return { detail, pathname: validatedChildPath(detail, parent) };
+		return { detail, parent, pathname: validatedChildPath(detail, parent) };
 	}
 	if (address.parentSlug) {
 		let [detail, parent] = await Promise.all([
 			readers.document(address.owner, address.repository, address.slug, signal),
 			readers.document(address.owner, address.repository, address.parentSlug, signal),
 		]);
-		return { detail, pathname: validatedChildPath(detail, parent) };
+		return { detail, parent, pathname: validatedChildPath(detail, parent) };
 	}
 	let detail = await readers.document(
 		address.owner,
@@ -191,7 +220,7 @@ export async function prepareDocumentLoad(
 	);
 	if (detail.channel.parentChannelId) {
 		let parent = await readers.channel(detail.channel.parentChannelId, signal);
-		return { detail, pathname: validatedChildPath(detail, parent) };
+		return { detail, parent, pathname: validatedChildPath(detail, parent) };
 	}
 	return {
 		detail,
@@ -220,7 +249,7 @@ function repositoryHref(repository: { owner: string; name: string }): string {
 
 function canonicalize(pathname: string): void {
 	if (location.pathname === pathname) return;
-	history.replaceState(null, "", `${pathname}${location.search}${location.hash}`);
+	history.replaceState(history.state, "", `${pathname}${location.search}${location.hash}`);
 }
 
 function Failure(
@@ -422,6 +451,7 @@ function ChannelWorkspace(
 				onReady?.(routeKey, {
 					canonicalPath: resolved.canonicalPath,
 					channel: resolved.detail.channel,
+					routeKey,
 				});
 			}
 		}, reason => {
@@ -513,10 +543,93 @@ function ActiveChannelWorkspace(
 	return <ChannelWorkspace agent={agent} onReady={ready} source={source} user={user} />;
 }
 
-function DocumentRouteSwap(
-	{ agent, route, user }: { agent: boolean; route: DocumentRoute; user: Api.User },
+function DocumentRouteLayerWorkspace(
+	{
+		agent,
+		layerKey,
+		onCanonicalPath,
+		onChildClose,
+		onParentRestored,
+		onReady,
+		source,
+		user,
+	}: {
+		agent: boolean;
+		layerKey: DocumentRouteIdentity;
+		onCanonicalPath: (key: DocumentRouteIdentity, pathname: string) => void;
+		onChildClose: (parentPath: string) => void;
+		onParentRestored: (parentId: string) => void;
+		onReady: (key: DocumentRouteIdentity, resolution?: DocumentRouteResolution) => void;
+		source: DocumentSource;
+		user: Api.User;
+	},
 ) {
-	let requested = keyedDocumentRoute(route, motionImmediately());
+	let channelReady = useCallback((
+		_sourceKey: DocumentRouteIdentity,
+		resolution?: DocumentRouteResolution,
+	) => onReady(layerKey, resolution), [layerKey, onReady]);
+	let documentReady = useCallback((pathname?: string, channel?: Api.Channel) => {
+		if (!pathname || !channel) {
+			onReady(layerKey);
+			return;
+		}
+		let canonicalRoute = hostedRoute(pathname);
+		if (canonicalRoute.page !== "document" && canonicalRoute.page !== "child") {
+			onReady(layerKey);
+			return;
+		}
+		onReady(layerKey, {
+			canonicalPath: pathname,
+			channel,
+			routeKey: documentRouteIdentity(canonicalRoute),
+		});
+	}, [layerKey, onReady]);
+	let metadataPath = useCallback(
+		(pathname: string) => onCanonicalPath(layerKey, pathname),
+		[layerKey, onCanonicalPath],
+	);
+	if (source.page === "document" || source.page === "child") {
+		return (
+			<Suspense fallback={<Loading label="Opening document..." />}>
+				<DocumentWorkspaceHost
+					agent={agent}
+					Failure={Failure}
+					Loading={Loading}
+					loadDocument={prepareDocumentLoad}
+					onCanonicalPath={metadataPath}
+					onChildClose={onChildClose}
+					onParentRestored={onParentRestored}
+					onReady={documentReady}
+					retryable={retryableChannelFailure}
+					route={source}
+					user={user}
+				/>
+			</Suspense>
+		);
+	}
+	return <ChannelWorkspace agent={agent} onReady={channelReady} source={source} user={user} />;
+}
+
+function DocumentRouteSwap(
+	{
+		agent,
+		onCanonicalPath,
+		onChildClose,
+		onParentRestored,
+		route,
+		user,
+	}: {
+		agent: boolean;
+		onCanonicalPath: (pathname: string) => void;
+		onChildClose: (parentPath: string) => void;
+		onParentRestored: (parentId: string) => void;
+		route: DocumentRoute;
+		user: Api.User;
+	},
+) {
+	let aliases = useRef(new Map<DocumentRouteIdentity, DocumentRouteIdentity>());
+	let routeKey = documentRouteIdentity(route);
+	let requested = keyedDocumentRoute(route, motionImmediately(), aliases.current.get(routeKey));
 	let [state, dispatch] = useReducer(
 		transitionDocumentRoute<DocumentRouteRequest, DocumentRouteResolution>,
 		{ current: requested },
@@ -533,22 +646,32 @@ function DocumentRouteSwap(
 		key: DocumentRouteIdentity,
 		resolution?: DocumentRouteResolution,
 	) => {
+		if (resolution) aliases.current.set(resolution.routeKey, key);
 		dispatch({ key, resolution, type: "ready" });
 	}, []);
+	let metadataPath = useCallback((key: DocumentRouteIdentity, pathname: string) => {
+		let canonicalRoute = hostedRoute(pathname);
+		if (canonicalRoute.page === "document" || canonicalRoute.page === "child") {
+			aliases.current.set(documentRouteIdentity(canonicalRoute), key);
+		}
+		onCanonicalPath(pathname);
+	}, [onCanonicalPath]);
 	let { onDocumentLoaded } = useNavigationDocument();
 	let published = useRef<DocumentRouteResolution | undefined>(undefined);
 	useEffect(() => {
 		let resolution = state.current.resolution;
 		if (!resolution || published.current === resolution) return;
 		published.current = resolution;
-		canonicalize(resolution.canonicalPath);
-		void onDocumentLoaded(resolution.channel, state.current.key);
-	}, [onDocumentLoaded, state.current.key, state.current.resolution]);
+		onCanonicalPath(resolution.canonicalPath);
+		void onDocumentLoaded(resolution.channel, resolution.routeKey);
+	}, [onCanonicalPath, onDocumentLoaded, state.current.key, state.current.resolution]);
 
 	return (
 		<div className="document-route-swap content-swap-stack h-full">
-			{layers.map(layer => (
-				<ContentSwapLayer
+			{layers.map(layer => {
+				let source = layer.key === requested.key ? requested.source : layer.source;
+				return (
+					<ContentSwapLayer
 					active={layer.key === state.current.key}
 					className="document-route-layer h-full min-h-0"
 					immediately={state.current.immediately}
@@ -557,15 +680,20 @@ function DocumentRouteSwap(
 					onClosed={layer.key === state.previous?.key
 						? () => dispatch({ key: layer.key, type: "closed" })
 						: undefined}
-				>
-					<ChannelWorkspace
+					>
+						<DocumentRouteLayerWorkspace
 						agent={agent}
+						layerKey={layer.key}
+						onCanonicalPath={metadataPath}
+						onChildClose={onChildClose}
+						onParentRestored={onParentRestored}
 						onReady={ready}
-						source={layer.source}
+						source={source}
 						user={user}
-					/>
-				</ContentSwapLayer>
-			))}
+						/>
+					</ContentSwapLayer>
+				);
+			})}
 		</div>
 	);
 }
@@ -574,6 +702,9 @@ export function HostedApp(
 	{ agent, user }: { agent: boolean; user: Api.User },
 ) {
 	let [route, setRoute] = useState(() => hostedRoute(location.pathname));
+	let hostedRouteRef = useRef(route);
+	hostedRouteRef.current = route;
+	let childOpener = useRef<HTMLElement | undefined>(undefined);
 	let navigate = useCallback((destination: string, options: { replace?: boolean } = {}) => {
 		let target = new URL(destination, location.href);
 		if (target.origin !== location.origin) {
@@ -583,9 +714,51 @@ export function HostedApp(
 		let next = `${target.pathname}${target.search}${target.hash}`;
 		let current = `${location.pathname}${location.search}${location.hash}`;
 		if (next === current) return;
-		if (options.replace) history.replaceState(null, "", next);
-		else history.pushState(null, "", next);
-		setRoute(hostedRoute(target.pathname));
+		let nextRoute = hostedRoute(target.pathname);
+		if (options.replace) history.replaceState(history.state, "", next);
+		else {
+			let currentRoute = hostedRouteRef.current;
+			let inAppChild = nextRoute.page === "child" && currentRoute.page === "document"
+				&& nextRoute.owner.toLocaleLowerCase() === currentRoute.owner.toLocaleLowerCase()
+				&& nextRoute.repository.toLocaleLowerCase() === currentRoute.repository.toLocaleLowerCase()
+				&& nextRoute.parentSlug === currentRoute.slug;
+			if (inAppChild) {
+				let active = document.activeElement;
+				childOpener.current = active instanceof HTMLElement ? active : undefined;
+				history.pushState(
+					childHistoryState(history.state, current),
+					"",
+					next,
+				);
+			} else history.pushState(null, "", next);
+		}
+		setRoute(nextRoute);
+	}, []);
+	let canonicalPath = useCallback((pathname: string) => {
+		if (location.pathname === pathname) return;
+		history.replaceState(
+			history.state,
+			"",
+			`${pathname}${location.search}${location.hash}`,
+		);
+		setRoute(hostedRoute(pathname));
+	}, []);
+	let closeChild = useCallback((parentPath: string) => {
+		let action = childCloseAction(history.state, parentPath);
+		if (action.type === "back") history.back();
+		else navigate(action.destination, { replace: true });
+	}, [navigate]);
+	let restoreParentFocus = useCallback((parentId: string) => {
+		let target = childOpener.current;
+		childOpener.current = undefined;
+		requestAnimationFrame(() => {
+			if (target?.isConnected) target.focus({ preventScroll: true });
+			else {
+				document.querySelector<HTMLElement>(
+					`[data-workspace-room="${CSS.escape(parentId)}"] [data-document-view="plan"] h2`,
+				)?.focus({ preventScroll: true });
+			}
+		});
 	}, []);
 
 	useEffect(() => {
@@ -605,7 +778,16 @@ export function HostedApp(
 		case "document":
 		case "child":
 		case "channel":
-			workspace = <DocumentRouteSwap agent={agent} route={route} user={user} />;
+			workspace = (
+				<DocumentRouteSwap
+					agent={agent}
+					onCanonicalPath={canonicalPath}
+					onChildClose={closeChild}
+					onParentRestored={restoreParentFocus}
+					route={route}
+					user={user}
+				/>
+			);
 			break;
 		case "research":
 			workspace = (

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -139,6 +139,70 @@ export function validatedChildPath(
 	);
 }
 
+type DocumentReaders = {
+	channel: (id: string, signal?: AbortSignal) => Promise<Api.ChannelDetail>;
+	document: (
+		owner: string,
+		repository: string,
+		slug: string,
+		signal?: AbortSignal,
+	) => Promise<Api.ChannelDetail>;
+};
+
+export async function prepareDocumentLoad(
+	address:
+		| { id: string }
+		| {
+			owner: string;
+			repository: string;
+			slug: string;
+			parentSlug?: string;
+		},
+	signal: AbortSignal,
+	readers: DocumentReaders = Api,
+): Promise<{ detail: Api.ChannelDetail; pathname: string }> {
+	if ("id" in address) {
+		let detail = await readers.channel(address.id, signal);
+		if (!detail.channel.parentChannelId) {
+			return {
+				detail,
+				pathname: documentPath(
+					detail.repository.owner,
+					detail.repository.name,
+					detail.channel.slug,
+				),
+			};
+		}
+		let parent = await readers.channel(detail.channel.parentChannelId, signal);
+		return { detail, pathname: validatedChildPath(detail, parent) };
+	}
+	if (address.parentSlug) {
+		let [detail, parent] = await Promise.all([
+			readers.document(address.owner, address.repository, address.slug, signal),
+			readers.document(address.owner, address.repository, address.parentSlug, signal),
+		]);
+		return { detail, pathname: validatedChildPath(detail, parent) };
+	}
+	let detail = await readers.document(
+		address.owner,
+		address.repository,
+		address.slug,
+		signal,
+	);
+	if (detail.channel.parentChannelId) {
+		let parent = await readers.channel(detail.channel.parentChannelId, signal);
+		return { detail, pathname: validatedChildPath(detail, parent) };
+	}
+	return {
+		detail,
+		pathname: documentPath(
+			detail.repository.owner,
+			detail.repository.name,
+			detail.channel.slug,
+		),
+	};
+}
+
 function Loading({ label = "Loading" }: { label?: string }) {
 	return (
 		<div
@@ -302,35 +366,8 @@ function ChannelWorkspace(
 		let controller = new AbortController();
 		setLoaded(undefined);
 		setError(undefined);
-		let prepared: Promise<{ canonicalPath: string; detail: Api.ChannelDetail }>;
-		switch (source.page) {
-			case "channel":
-				prepared = Api.channel(source.id, controller.signal).then(detail => ({
-					canonicalPath: documentPath(
-						detail.repository.owner,
-						detail.repository.name,
-						detail.channel.slug,
-					),
-					detail,
-				}));
-				break;
-			case "document":
-				prepared = Api.document(
-					source.owner,
-					source.repository,
-					source.slug,
-					controller.signal,
-				).then(detail => ({
-					canonicalPath: documentPath(
-						detail.repository.owner,
-						detail.repository.name,
-						detail.channel.slug,
-					),
-					detail,
-				}));
-				break;
-			case "research":
-				prepared = Api.document(
+		let prepared = source.page === "research"
+			? Api.document(
 					source.owner,
 					source.repository,
 					source.slug,
@@ -343,28 +380,18 @@ function ChannelWorkspace(
 						source.workspaceId,
 					),
 					detail,
-				}));
-				break;
-			case "child":
-				prepared = Promise.all([
-					Api.document(
-						source.owner,
-						source.repository,
-						source.childSlug,
-						controller.signal,
-					),
-					Api.document(
-						source.owner,
-						source.repository,
-						source.parentSlug,
-						controller.signal,
-					),
-				]).then(([detail, parent]) => ({
-					canonicalPath: validatedChildPath(detail, parent),
-					detail,
-				}));
-				break;
-		}
+				}))
+			: prepareDocumentLoad(
+				source.page === "channel"
+					? { id: source.id }
+					: {
+						owner: source.owner,
+						parentSlug: source.page === "child" ? source.parentSlug : undefined,
+						repository: source.repository,
+						slug: source.page === "child" ? source.childSlug : source.slug,
+					},
+				controller.signal,
+			).then(({ detail, pathname }) => ({ canonicalPath: pathname, detail }));
 		prepared = prepared.then(resolved => {
 			if (active) {
 				rememberChannel(user.id, resolved.detail.channel, resolved.detail.repository);

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -451,6 +451,8 @@ function DocumentRouteSwap(
 		transitionDocumentRoute<DocumentRouteRequest, DocumentRouteResolution>,
 		{ current: requested },
 	);
+	let requestedRoute = useRef({ key: requested.key, routeKey: requested.routeKey });
+	requestedRoute.current = { key: requested.key, routeKey: requested.routeKey };
 	let presentedRequest = state.pending ?? state.current;
 	if (requested.key !== presentedRequest.key || requested.routeKey !== presentedRequest.routeKey) {
 		dispatch({ route: requested, type: "requested" });
@@ -466,7 +468,13 @@ function DocumentRouteSwap(
 		if (resolution) aliases.current.set(resolution.routeKey, key);
 		dispatch({ key, resolution, type: "ready" });
 	}, []);
-	let metadataPath = useCallback((key: DocumentRouteIdentity, pathname: string) => {
+	let metadataPath = useCallback((
+		key: DocumentRouteIdentity,
+		metadataRouteKey: DocumentRouteIdentity,
+		pathname: string,
+	) => {
+		let authority = requestedRoute.current;
+		if (key !== authority.key || metadataRouteKey !== authority.routeKey) return;
 		let canonicalRoute = hostedRoute(pathname);
 		if (canonicalRoute.page === "document" || canonicalRoute.page === "child") {
 			aliases.current.set(documentRouteIdentity(canonicalRoute), key);

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -1,8 +1,6 @@
 import { lazy, Suspense, useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { ContentSwapLayer } from "@chopin/editor/content-swap";
 import {
-	childDocumentPath,
-	documentPath,
 	documentsPath,
 	parseChildDocumentPath,
 	parseDocumentPath,
@@ -11,8 +9,8 @@ import {
 } from "@chopin/protocol/document-url";
 
 import * as Api from "./api";
-import { childCloseAction, childHistoryState } from "./anchored-child-surface";
 import { readChannelRecovery, readDocumentRecovery, rememberChannel } from "./channel-recovery";
+import { childCloseAction, childHistoryState } from "./child-history";
 import { documentRouteIdentity, transitionDocumentRoute } from "./document-route-swap";
 import { newestDocument } from "./document-actions";
 import { motionContract } from "./motion-contract";
@@ -64,7 +62,7 @@ export type HostedRoute =
 	| { page: "missing" };
 
 type DocumentRoute = Exclude<DocumentRouteIdentitySource, { page: "research" }>;
-type ChannelSource = DocumentRouteIdentitySource;
+type ChannelSource = Extract<DocumentRouteIdentitySource, { page: "channel" | "research" }>;
 type DocumentSource = DocumentRoute;
 type DocumentRouteRequest = {
 	immediately: boolean;
@@ -141,95 +139,6 @@ export function retryableChannelFailure(error: unknown): boolean {
 		|| error.status === 408
 		|| error.status === 429
 		|| error.status >= 500;
-}
-
-export function validatedChildPath(
-	child: Api.ChannelDetail,
-	parent: Api.ChannelDetail,
-): string {
-	let sameRepository = child.repository.id === parent.repository.id
-		&& child.channel.repositoryId === child.repository.id
-		&& parent.channel.repositoryId === parent.repository.id;
-	if (
-		!child.channel.parentChannelId
-		|| child.channel.parentChannelId !== parent.channel.id
-		|| parent.channel.parentChannelId
-		|| !sameRepository
-		|| !parent.channel.slug
-		|| !child.channel.slug
-	) {
-		throw new Api.ApiError("Child document not found", 404);
-	}
-	return childDocumentPath(
-		child.repository.owner,
-		child.repository.name,
-		parent.channel.slug,
-		child.channel.slug,
-	);
-}
-
-type DocumentReaders = {
-	channel: (id: string, signal?: AbortSignal) => Promise<Api.ChannelDetail>;
-	document: (
-		owner: string,
-		repository: string,
-		slug: string,
-		signal?: AbortSignal,
-	) => Promise<Api.ChannelDetail>;
-};
-
-export async function prepareDocumentLoad(
-	address:
-		| { id: string }
-		| {
-			owner: string;
-			repository: string;
-			slug: string;
-			parentSlug?: string;
-		},
-	signal: AbortSignal,
-	readers: DocumentReaders = Api,
-): Promise<{ detail: Api.ChannelDetail; parent?: Api.ChannelDetail; pathname: string }> {
-	if ("id" in address) {
-		let detail = await readers.channel(address.id, signal);
-		if (!detail.channel.parentChannelId) {
-			return {
-				detail,
-				pathname: documentPath(
-					detail.repository.owner,
-					detail.repository.name,
-					detail.channel.slug,
-				),
-			};
-		}
-		let parent = await readers.channel(detail.channel.parentChannelId, signal);
-		return { detail, parent, pathname: validatedChildPath(detail, parent) };
-	}
-	if (address.parentSlug) {
-		let [detail, parent] = await Promise.all([
-			readers.document(address.owner, address.repository, address.slug, signal),
-			readers.document(address.owner, address.repository, address.parentSlug, signal),
-		]);
-		return { detail, parent, pathname: validatedChildPath(detail, parent) };
-	}
-	let detail = await readers.document(
-		address.owner,
-		address.repository,
-		address.slug,
-		signal,
-	);
-	if (detail.channel.parentChannelId) {
-		let parent = await readers.channel(detail.channel.parentChannelId, signal);
-		return { detail, parent, pathname: validatedChildPath(detail, parent) };
-	}
-	return {
-		detail,
-		pathname: documentPath(
-			detail.repository.owner,
-			detail.repository.name,
-			detail.channel.slug,
-		),
-	};
 }
 
 function Loading({ label = "Loading" }: { label?: string }) {
@@ -371,15 +280,6 @@ function ChannelWorkspace(
 		case "channel":
 			recovery = readChannelRecovery(user.id, source.id);
 			break;
-		case "child":
-			recovery = readDocumentRecovery(
-				user.id,
-				source.owner,
-				source.repository,
-				source.childSlug,
-			);
-			break;
-		case "document":
 		case "research":
 			recovery = readDocumentRecovery(
 				user.id,
@@ -410,16 +310,8 @@ function ChannelWorkspace(
 				),
 				detail,
 			}))
-			: prepareDocumentLoad(
-				source.page === "channel"
-					? { id: source.id }
-					: {
-						owner: source.owner,
-						parentSlug: source.page === "child" ? source.parentSlug : undefined,
-						repository: source.repository,
-						slug: source.page === "child" ? source.childSlug : source.slug,
-					},
-				controller.signal,
+			: import("./document-loader").then(module =>
+				module.prepareDocumentLoad({ id: source.id }, controller.signal)
 			).then(({ detail, pathname }) => ({ canonicalPath: pathname, detail }));
 		prepared = prepared.then(resolved => {
 			if (active) {
@@ -430,8 +322,6 @@ function ChannelWorkspace(
 		let workspace;
 		switch (source.page) {
 			case "channel":
-			case "child":
-			case "document":
 				workspace = import("./room-workspace").then(module => ({
 					kind: "document" as const,
 					Workspace: module.RoomWorkspace,
@@ -471,15 +361,6 @@ function ChannelWorkspace(
 		switch (source.page) {
 			case "channel":
 				break;
-			case "child":
-				requestedRepository = {
-					fullName: `${source.owner}/${source.repository}`,
-					name: source.repository,
-					owner: source.owner,
-				};
-				requestedSlug = source.childSlug;
-				break;
-			case "document":
 			case "research":
 				requestedRepository = {
 					fullName: `${source.owner}/${source.repository}`,
@@ -541,73 +422,6 @@ function ActiveChannelWorkspace(
 		void onDocumentLoaded(resolution.channel, key);
 	}, [onDocumentLoaded]);
 	return <ChannelWorkspace agent={agent} onReady={ready} source={source} user={user} />;
-}
-
-function DocumentRouteLayerWorkspace(
-	{
-		agent,
-		layerKey,
-		onCanonicalPath,
-		onChildClose,
-		onParentRestored,
-		onReady,
-		source,
-		user,
-	}: {
-		agent: boolean;
-		layerKey: DocumentRouteIdentity;
-		onCanonicalPath: (key: DocumentRouteIdentity, pathname: string) => void;
-		onChildClose: (parentPath: string) => void;
-		onParentRestored: (parentId: string) => void;
-		onReady: (key: DocumentRouteIdentity, resolution?: DocumentRouteResolution) => void;
-		source: DocumentSource;
-		user: Api.User;
-	},
-) {
-	let channelReady = useCallback((
-		_sourceKey: DocumentRouteIdentity,
-		resolution?: DocumentRouteResolution,
-	) => onReady(layerKey, resolution), [layerKey, onReady]);
-	let documentReady = useCallback((pathname?: string, channel?: Api.Channel) => {
-		if (!pathname || !channel) {
-			onReady(layerKey);
-			return;
-		}
-		let canonicalRoute = hostedRoute(pathname);
-		if (canonicalRoute.page !== "document" && canonicalRoute.page !== "child") {
-			onReady(layerKey);
-			return;
-		}
-		onReady(layerKey, {
-			canonicalPath: pathname,
-			channel,
-			routeKey: documentRouteIdentity(canonicalRoute),
-		});
-	}, [layerKey, onReady]);
-	let metadataPath = useCallback(
-		(pathname: string) => onCanonicalPath(layerKey, pathname),
-		[layerKey, onCanonicalPath],
-	);
-	if (source.page === "document" || source.page === "child") {
-		return (
-			<Suspense fallback={<Loading label="Opening document..." />}>
-				<DocumentWorkspaceHost
-					agent={agent}
-					Failure={Failure}
-					Loading={Loading}
-					loadDocument={prepareDocumentLoad}
-					onCanonicalPath={metadataPath}
-					onChildClose={onChildClose}
-					onParentRestored={onParentRestored}
-					onReady={documentReady}
-					retryable={retryableChannelFailure}
-					route={source}
-					user={user}
-				/>
-			</Suspense>
-		);
-	}
-	return <ChannelWorkspace agent={agent} onReady={channelReady} source={source} user={user} />;
 }
 
 function DocumentRouteSwap(
@@ -681,16 +495,32 @@ function DocumentRouteSwap(
 							? () => dispatch({ key: layer.key, type: "closed" })
 							: undefined}
 					>
-						<DocumentRouteLayerWorkspace
-							agent={agent}
-							layerKey={layer.key}
-							onCanonicalPath={metadataPath}
-							onChildClose={onChildClose}
-							onParentRestored={onParentRestored}
-							onReady={ready}
-							source={source}
-							user={user}
-						/>
+						{source.page === "document" || source.page === "child"
+							? (
+								<Suspense fallback={<Loading label="Opening document..." />}>
+									<DocumentWorkspaceHost
+										agent={agent}
+										Failure={Failure}
+										layerKey={layer.key}
+										Loading={Loading}
+										onCanonicalPath={metadataPath}
+										onChildClose={onChildClose}
+										onParentRestored={onParentRestored}
+										onReady={ready}
+										retryable={retryableChannelFailure}
+										route={source}
+										user={user}
+									/>
+								</Suspense>
+							)
+							: (
+								<ChannelWorkspace
+									agent={agent}
+									onReady={ready}
+									source={source}
+									user={user}
+								/>
+							)}
 					</ContentSwapLayer>
 				);
 			})}

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { ContentSwapLayer } from "@chopin/editor/content-swap";
 import {
+	childDocumentPath,
 	documentPath,
 	documentsPath,
+	parseChildDocumentPath,
 	parseDocumentPath,
 	parseResearchWorkspacePath,
 	researchWorkspacePath,
@@ -82,6 +84,8 @@ export function hostedRoute(pathname: string): HostedRoute {
 	if (pathname === "/" || pathname === "") return { page: "repositories" };
 	let research = parseResearchWorkspacePath(pathname);
 	if (research) return { page: "research", ...research };
+	let child = parseChildDocumentPath(pathname);
+	if (child) return { page: "child", ...child };
 	let document = parseDocumentPath(pathname);
 	if (document?.slug) {
 		return {
@@ -108,6 +112,31 @@ export function retryableChannelFailure(error: unknown): boolean {
 		|| error.status === 408
 		|| error.status === 429
 		|| error.status >= 500;
+}
+
+export function validatedChildPath(
+	child: Api.ChannelDetail,
+	parent: Api.ChannelDetail,
+): string {
+	let sameRepository = child.repository.id === parent.repository.id
+		&& child.channel.repositoryId === child.repository.id
+		&& parent.channel.repositoryId === parent.repository.id;
+	if (
+		!child.channel.parentChannelId
+		|| child.channel.parentChannelId !== parent.channel.id
+		|| parent.channel.parentChannelId
+		|| !sameRepository
+		|| !parent.channel.slug
+		|| !child.channel.slug
+	) {
+		throw new Api.ApiError("Child document not found", 404);
+	}
+	return childDocumentPath(
+		child.repository.owner,
+		child.repository.name,
+		parent.channel.slug,
+		child.channel.slug,
+	);
 }
 
 function Loading({ label = "Loading" }: { label?: string }) {
@@ -249,6 +278,14 @@ function ChannelWorkspace(
 		case "channel":
 			recovery = readChannelRecovery(user.id, source.id);
 			break;
+		case "child":
+			recovery = readDocumentRecovery(
+				user.id,
+				source.owner,
+				source.repository,
+				source.childSlug,
+			);
+			break;
 		case "document":
 		case "research":
 			recovery = readDocumentRecovery(
@@ -265,49 +302,79 @@ function ChannelWorkspace(
 		let controller = new AbortController();
 		setLoaded(undefined);
 		setError(undefined);
-		let detail: Promise<Api.ChannelDetail>;
+		let prepared: Promise<{ canonicalPath: string; detail: Api.ChannelDetail }>;
 		switch (source.page) {
 			case "channel":
-				detail = Api.channel(source.id, controller.signal);
+				prepared = Api.channel(source.id, controller.signal).then(detail => ({
+					canonicalPath: documentPath(
+						detail.repository.owner,
+						detail.repository.name,
+						detail.channel.slug,
+					),
+					detail,
+				}));
 				break;
 			case "document":
-			case "research":
-				detail = Api.document(
+				prepared = Api.document(
 					source.owner,
 					source.repository,
 					source.slug,
 					controller.signal,
-				);
+				).then(detail => ({
+					canonicalPath: documentPath(
+						detail.repository.owner,
+						detail.repository.name,
+						detail.channel.slug,
+					),
+					detail,
+				}));
+				break;
+			case "research":
+				prepared = Api.document(
+					source.owner,
+					source.repository,
+					source.slug,
+					controller.signal,
+				).then(detail => ({
+					canonicalPath: researchWorkspacePath(
+						detail.repository.owner,
+						detail.repository.name,
+						detail.channel.slug,
+						source.workspaceId,
+					),
+					detail,
+				}));
+				break;
+			case "child":
+				prepared = Promise.all([
+					Api.document(
+						source.owner,
+						source.repository,
+						source.childSlug,
+						controller.signal,
+					),
+					Api.document(
+						source.owner,
+						source.repository,
+						source.parentSlug,
+						controller.signal,
+					),
+				]).then(([detail, parent]) => ({
+					canonicalPath: validatedChildPath(detail, parent),
+					detail,
+				}));
 				break;
 		}
-		let prepared = detail.then(value => {
-			let canonicalPath: string;
-			switch (source.page) {
-				case "channel":
-				case "document":
-					canonicalPath = documentPath(
-						value.repository.owner,
-						value.repository.name,
-						value.channel.slug,
-					);
-					break;
-				case "research":
-					canonicalPath = researchWorkspacePath(
-						value.repository.owner,
-						value.repository.name,
-						value.channel.slug,
-						source.workspaceId,
-					);
-					break;
-			}
+		prepared = prepared.then(resolved => {
 			if (active) {
-				rememberChannel(user.id, value.channel, value.repository);
+				rememberChannel(user.id, resolved.detail.channel, resolved.detail.repository);
 			}
-			return { canonicalPath, detail: value };
+			return resolved;
 		});
 		let workspace;
 		switch (source.page) {
 			case "channel":
+			case "child":
 			case "document":
 				workspace = import("./room-workspace").then(module => ({
 					kind: "document" as const,
@@ -341,12 +408,19 @@ function ChannelWorkspace(
 			controller.abort();
 		};
 	}, [onReady, retry, routeKey, source, user.id]);
-
 	if (error) {
 		let requestedRepository;
 		let requestedSlug;
 		switch (source.page) {
 			case "channel":
+				break;
+			case "child":
+				requestedRepository = {
+					fullName: `${source.owner}/${source.repository}`,
+					name: source.repository,
+					owner: source.owner,
+				};
+				requestedSlug = source.childSlug;
 				break;
 			case "document":
 			case "research":
@@ -502,6 +576,7 @@ export function HostedApp(
 		case "repository":
 			break;
 		case "document":
+		case "child":
 		case "channel":
 			workspace = <DocumentRouteSwap agent={agent} route={route} user={user} />;
 			break;

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -67,6 +67,7 @@ type DocumentSource = DocumentRoute;
 type DocumentRouteRequest = {
 	immediately: boolean;
 	key: DocumentRouteIdentity;
+	routeKey: DocumentRouteIdentity;
 	source: DocumentSource;
 };
 type DocumentRouteResolution = {
@@ -84,6 +85,7 @@ function keyedDocumentRoute(
 	immediately: boolean,
 	alias?: DocumentRouteIdentity,
 ): DocumentRouteRequest {
+	let routeKey = documentRouteIdentity(route);
 	let key = alias ?? (route.page === "child"
 		? documentRouteIdentity({
 			owner: route.owner,
@@ -95,6 +97,7 @@ function keyedDocumentRoute(
 	return {
 		immediately,
 		key,
+		routeKey,
 		source: route,
 	};
 }
@@ -449,7 +452,7 @@ function DocumentRouteSwap(
 		{ current: requested },
 	);
 	let presentedRequest = state.pending ?? state.current;
-	if (requested.key !== presentedRequest.key) {
+	if (requested.key !== presentedRequest.key || requested.routeKey !== presentedRequest.routeKey) {
 		dispatch({ route: requested, type: "requested" });
 	}
 	let layers = [state.previous, state.current, state.pending].filter(
@@ -483,7 +486,7 @@ function DocumentRouteSwap(
 	return (
 		<div className="document-route-swap content-swap-stack h-full">
 			{layers.map(layer => {
-				let source = layer.key === requested.key ? requested.source : layer.source;
+				let source = layer.source;
 				return (
 					<ContentSwapLayer
 						active={layer.key === state.current.key}

--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -397,19 +397,19 @@ function ChannelWorkspace(
 		setError(undefined);
 		let prepared = source.page === "research"
 			? Api.document(
-					source.owner,
-					source.repository,
-					source.slug,
-					controller.signal,
-				).then(detail => ({
-					canonicalPath: researchWorkspacePath(
-						detail.repository.owner,
-						detail.repository.name,
-						detail.channel.slug,
-						source.workspaceId,
-					),
-					detail,
-				}))
+				source.owner,
+				source.repository,
+				source.slug,
+				controller.signal,
+			).then(detail => ({
+				canonicalPath: researchWorkspacePath(
+					detail.repository.owner,
+					detail.repository.name,
+					detail.channel.slug,
+					source.workspaceId,
+				),
+				detail,
+			}))
 			: prepareDocumentLoad(
 				source.page === "channel"
 					? { id: source.id }
@@ -672,24 +672,24 @@ function DocumentRouteSwap(
 				let source = layer.key === requested.key ? requested.source : layer.source;
 				return (
 					<ContentSwapLayer
-					active={layer.key === state.current.key}
-					className="document-route-layer h-full min-h-0"
-					immediately={state.current.immediately}
-					key={layer.key}
-					motion={motion}
-					onClosed={layer.key === state.previous?.key
-						? () => dispatch({ key: layer.key, type: "closed" })
-						: undefined}
+						active={layer.key === state.current.key}
+						className="document-route-layer h-full min-h-0"
+						immediately={state.current.immediately}
+						key={layer.key}
+						motion={motion}
+						onClosed={layer.key === state.previous?.key
+							? () => dispatch({ key: layer.key, type: "closed" })
+							: undefined}
 					>
 						<DocumentRouteLayerWorkspace
-						agent={agent}
-						layerKey={layer.key}
-						onCanonicalPath={metadataPath}
-						onChildClose={onChildClose}
-						onParentRestored={onParentRestored}
-						onReady={ready}
-						source={source}
-						user={user}
+							agent={agent}
+							layerKey={layer.key}
+							onCanonicalPath={metadataPath}
+							onChildClose={onChildClose}
+							onParentRestored={onParentRestored}
+							onReady={ready}
+							source={source}
+							user={user}
 						/>
 					</ContentSwapLayer>
 				);
@@ -718,13 +718,21 @@ export function HostedApp(
 		if (options.replace) history.replaceState(history.state, "", next);
 		else {
 			let currentRoute = hostedRouteRef.current;
+			let siblingChild = nextRoute.page === "child" && currentRoute.page === "child"
+				&& nextRoute.owner.toLocaleLowerCase() === currentRoute.owner.toLocaleLowerCase()
+				&& nextRoute.repository.toLocaleLowerCase()
+					=== currentRoute.repository.toLocaleLowerCase()
+				&& nextRoute.parentSlug === currentRoute.parentSlug;
 			let inAppChild = nextRoute.page === "child" && currentRoute.page === "document"
 				&& nextRoute.owner.toLocaleLowerCase() === currentRoute.owner.toLocaleLowerCase()
 				&& nextRoute.repository.toLocaleLowerCase() === currentRoute.repository.toLocaleLowerCase()
 				&& nextRoute.parentSlug === currentRoute.slug;
-			if (inAppChild) {
+			if (siblingChild || inAppChild) {
 				let active = document.activeElement;
 				childOpener.current = active instanceof HTMLElement ? active : undefined;
+			}
+			if (siblingChild) history.replaceState(history.state, "", next);
+			else if (inAppChild) {
 				history.pushState(
 					childHistoryState(history.state, current),
 					"",

--- a/apps/web/src/navigation-model.test.ts
+++ b/apps/web/src/navigation-model.test.ts
@@ -130,11 +130,46 @@ describe("navigation model", () => {
 		expect(documentDestination(projects, "channel-two", "/explicit")).toBe("/explicit");
 	});
 
+	it("resolves a loaded child only through its parent route", () => {
+		let parentEntry = projects[1]!;
+		if (parentEntry.documents.status === "unavailable") throw new Error("fixture is unavailable");
+		let parent = parentEntry.documents.channels[1]!;
+		let child = {
+			...parent,
+			id: "channel-child",
+			parentChannelId: parent.id,
+			slug: "channel-child",
+		};
+		let nested: ProjectDocuments[] = [{
+			...parentEntry,
+			documents: {
+				...parentEntry.documents,
+				channels: [child, parent],
+			},
+		}];
+
+		expect(documentDestination(nested, child.id)).toBe(
+			"/documents/acme/one/channel-one/children/channel-child",
+		);
+		expect(documentDestination([{
+			...parentEntry,
+			documents: { ...parentEntry.documents, channels: [child] },
+		}], child.id)).toBe("/channels/channel-child");
+		expect(landingDocument(nested)).toBe(parent.id);
+		expect(landingDocument(nested, child.id)).toBe(child.id);
+	});
+
 	it("opens a ready research child in its parent repository", () => {
 		expect(researchChildDestination(
-			{ repositoryOwner: "acme space", repositoryName: "docs/tools" },
+			{
+				repositoryOwner: "acme space",
+				repositoryName: "docs/tools",
+				slug: "release plan",
+			},
 			{ slug: "rollout evidence" },
-		)).toBe("/documents/acme%20space/docs%2Ftools/rollout%20evidence");
+		)).toBe(
+			"/documents/acme%20space/docs%2Ftools/release%20plan/children/rollout%20evidence",
+		);
 	});
 
 	it("keeps one Project creating while another creation settles", () => {

--- a/apps/web/src/navigation-model.test.ts
+++ b/apps/web/src/navigation-model.test.ts
@@ -6,6 +6,7 @@ import {
 	canManageProject,
 	documentDestination,
 	finishProjectCreation,
+	isDocumentWorkspaceRoute,
 	landingDocument,
 	navigationMode,
 	researchChildDestination,
@@ -70,6 +71,35 @@ let projects: ProjectDocuments[] = [
 ];
 
 describe("navigation model", () => {
+	it("classifies every route whose visit can be retried", () => {
+		for (
+			let route of [
+				{ id: "document-id", page: "channel" as const },
+				{
+					owner: "acme",
+					page: "document" as const,
+					repository: "one",
+					slug: "parent",
+				},
+				{
+					childSlug: "child",
+					owner: "acme",
+					page: "child" as const,
+					parentSlug: "parent",
+					repository: "one",
+				},
+				{
+					owner: "acme",
+					page: "research" as const,
+					repository: "one",
+					slug: "parent",
+					workspaceId: "research-id",
+				},
+			]
+		) expect(isDocumentWorkspaceRoute(route)).toBe(true);
+		expect(isDocumentWorkspaceRoute({ page: "repositories" })).toBe(false);
+	});
+
 	it("uses the same drawer boundary as the shell", () => {
 		expect(navigationMode(mediaAt(1023))).toBe("drawer");
 		expect(navigationMode(mediaAt(1024))).toBe("inline");

--- a/apps/web/src/navigation-model.test.ts
+++ b/apps/web/src/navigation-model.test.ts
@@ -151,10 +151,6 @@ describe("navigation model", () => {
 		expect(documentDestination(nested, child.id)).toBe(
 			"/documents/acme/one/channel-one/children/channel-child",
 		);
-		expect(documentDestination([{
-			...parentEntry,
-			documents: { ...parentEntry.documents, channels: [child] },
-		}], child.id)).toBe("/channels/channel-child");
 		expect(landingDocument(nested)).toBe(parent.id);
 		expect(landingDocument(nested, child.id)).toBe(child.id);
 	});

--- a/apps/web/src/navigation-model.ts
+++ b/apps/web/src/navigation-model.ts
@@ -1,4 +1,4 @@
-import { documentPath } from "@chopin/protocol/document-url";
+import { childDocumentPath, documentPath } from "@chopin/protocol/document-url";
 
 import type { NavigationProject, ResearchParentChannel } from "./api";
 import type { Research } from "@chopin/protocol";
@@ -42,6 +42,17 @@ export function documentDestination(
 	for (let { documents, project } of projects) {
 		let channel = documents.channels.find(candidate => candidate.id === documentId);
 		if (channel) {
+			if (channel.parentChannelId) {
+				let parent = documents.channels.find(candidate => candidate.id === channel.parentChannelId);
+				return parent
+					? childDocumentPath(
+						project.repositoryOwner,
+						project.repositoryName,
+						parent.slug,
+						channel.slug,
+					)
+					: `/channels/${encodeURIComponent(documentId)}`;
+			}
 			return documentPath(project.repositoryOwner, project.repositoryName, channel.slug);
 		}
 	}
@@ -49,10 +60,15 @@ export function documentDestination(
 }
 
 export function researchChildDestination(
-	parent: Pick<ResearchParentChannel, "repositoryOwner" | "repositoryName">,
+	parent: Pick<ResearchParentChannel, "repositoryOwner" | "repositoryName" | "slug">,
 	child: Pick<Research.ReadyChild, "slug">,
 ): string {
-	return documentPath(parent.repositoryOwner, parent.repositoryName, child.slug);
+	return childDocumentPath(
+		parent.repositoryOwner,
+		parent.repositoryName,
+		parent.slug,
+		child.slug,
+	);
 }
 
 export function beginProjectCreation(
@@ -85,5 +101,5 @@ export function landingDocument(
 		}
 	}
 	if (available.some(({ documents }) => documents.status === "loading")) return undefined;
-	return channels.find(channel => !channel.archivedAt)?.id;
+	return channels.find(channel => !channel.archivedAt && !channel.parentChannelId)?.id;
 }

--- a/apps/web/src/navigation-model.ts
+++ b/apps/web/src/navigation-model.ts
@@ -3,10 +3,23 @@ import { childDocumentPath, documentPath } from "@chopin/protocol/document-url";
 import type { NavigationProject, ResearchParentChannel } from "./api";
 import type { Research } from "@chopin/protocol";
 import type { ProjectDocuments } from "./document-actions";
+import type { DocumentRouteIdentitySource } from "./document-route-swap";
 
 export type NavigationMode = "drawer" | "inline";
 
+export type NavigationRoute =
+	| DocumentRouteIdentitySource
+	| { page: "repositories" }
+	| { page: "repository"; owner: string; repository: string };
+
 export const NAVIGATION_MEDIA = "(max-width: 1023px)";
+
+export function isDocumentWorkspaceRoute(
+	route: NavigationRoute,
+): route is DocumentRouteIdentitySource {
+	return route.page === "channel" || route.page === "document" || route.page === "child"
+		|| route.page === "research";
+}
 
 export function navigationMode(
 	matchMedia: (query: string) => { matches: boolean },

--- a/apps/web/src/navigation-shell.tsx
+++ b/apps/web/src/navigation-shell.tsx
@@ -338,6 +338,7 @@ export function NavigationShell(
 	} = useProjectResearch(navigation, projects, catalogueMode === "archived");
 	let routeKey = route.page === "channel"
 			|| route.page === "document"
+			|| route.page === "child"
 			|| route.page === "research"
 		? documentRouteIdentity(route)
 		: route.page;
@@ -348,16 +349,20 @@ export function NavigationShell(
 	let resolvedChannel = resolvedDocument?.routeKey === routeKey
 		? resolvedDocument.channel
 		: undefined;
-	let routedChannel = route.page === "document" || route.page === "research"
-		? projects.flatMap(project => project.documents.channels).find(channel =>
-			channel.repositoryOwner.toLocaleLowerCase() === route.owner.toLocaleLowerCase()
-			&& channel.repositoryName.toLocaleLowerCase() === route.repository.toLocaleLowerCase()
-			&& channel.slug === route.slug
-		)
-		: undefined;
+	let routedChannel =
+		route.page === "document" || route.page === "research" || route.page === "child"
+			? projects.flatMap(project => project.documents.channels).find(channel =>
+				channel.repositoryOwner.toLocaleLowerCase() === route.owner.toLocaleLowerCase()
+				&& channel.repositoryName.toLocaleLowerCase() === route.repository.toLocaleLowerCase()
+				&& channel.slug === (route.page === "child" ? route.childSlug : route.slug)
+			)
+			: undefined;
 	let currentDocumentId = route.page === "channel"
 		? route.id
 		: routedChannel?.id ?? resolvedChannel?.id;
+	let currentParentDocumentId = route.page === "child"
+		? routedChannel?.parentChannelId ?? resolvedChannel?.parentChannelId
+		: undefined;
 	let currentResearchWorkspaceId = route.page === "research" ? route.workspaceId : undefined;
 
 	let refresh = useCallback((queue = true): Promise<void> => {
@@ -531,6 +536,7 @@ export function NavigationShell(
 	useEffect(() => {
 		if (
 			route.page !== "channel" && route.page !== "document" && route.page !== "research"
+			&& route.page !== "child"
 			&& navigation?.projects.length === 0
 		) {
 			showDialog("add");
@@ -811,6 +817,7 @@ export function NavigationShell(
 				creatingProjectIds={creatingProjectIdsForView}
 				creatingNewDocument={!!active && creatingProjectIdsForView.has(active.repositoryId)}
 				currentDocumentId={currentDocumentId}
+				currentParentDocumentId={currentParentDocumentId}
 				currentResearchWorkspaceId={currentResearchWorkspaceId}
 				onAccount={() => setAccountOpen(open => !open)}
 				onAddProject={() => showDialog("add")}

--- a/apps/web/src/navigation-shell.tsx
+++ b/apps/web/src/navigation-shell.tsx
@@ -110,11 +110,11 @@ let NavigationDocument = createContext<{
 		documentId: string,
 		update: DocumentMetadata,
 	) => void;
-	onDocumentAction: (action: DocumentAction) => void;
+	onDocumentAction: (documentId: string, action: DocumentAction) => void;
 	onDocumentDeleted: (documentId: string) => void;
 	onDocumentLoaded: (channel: Api.Channel, routeKey: DocumentRouteIdentity) => Promise<void>;
 	onRepositoryAccessChanged: () => void;
-	onResearchChildOpen: (child: Research.ReadyChild) => void;
+	onResearchChildOpen: (parentId: string, child: Research.ReadyChild) => void;
 	onResearchWorkspaceChanged: (
 		channel: Api.ResearchParentChannel,
 		workspaceId: string,
@@ -701,12 +701,12 @@ export function NavigationShell(
 			setError({ reason });
 		});
 	}, [acceptChannel, showDialog]);
-	let currentDocumentAction = useCallback((action: DocumentAction) => {
-		let channel = currentChannelRef.current;
+	let workspaceDocumentAction = useCallback((documentId: string, action: DocumentAction) => {
+		let channel = knownChannelsRef.current.get(documentId);
 		if (channel) documentAction(channel, action);
 	}, [documentAction]);
-	let researchChildOpen = useCallback((child: Research.ReadyChild) => {
-		let channel = currentChannelRef.current;
+	let researchChildOpen = useCallback((parentId: string, child: Research.ReadyChild) => {
+		let channel = knownChannelsRef.current.get(parentId);
 		if (!channel) return;
 		setError(undefined);
 		setDialog(undefined);
@@ -731,7 +731,7 @@ export function NavigationShell(
 	}, [refresh]);
 	let navigationDocument = useMemo(() => ({
 		channel: currentChannel,
-		onDocumentAction: currentDocumentAction,
+		onDocumentAction: workspaceDocumentAction,
 		onDocumentChanged: documentChanged,
 		onDocumentDeleted: documentDeleted,
 		onDocumentLoaded: documentLoaded,
@@ -742,7 +742,6 @@ export function NavigationShell(
 		onResearchWorkspacesRefresh: refreshResearchChannel,
 	}), [
 		currentChannel,
-		currentDocumentAction,
 		documentChanged,
 		documentDeleted,
 		documentLoaded,
@@ -751,6 +750,7 @@ export function NavigationShell(
 		researchWorkspaceChanged,
 		researchWorkspaceLoaded,
 		refreshResearchChannel,
+		workspaceDocumentAction,
 	]);
 
 	let signOut = async () => {

--- a/apps/web/src/navigation-shell.tsx
+++ b/apps/web/src/navigation-shell.tsx
@@ -29,6 +29,7 @@ import {
 	canManageProject,
 	documentDestination,
 	finishProjectCreation,
+	isDocumentWorkspaceRoute,
 	landingDocument,
 	NAVIGATION_MEDIA,
 	navigationMode,
@@ -49,8 +50,8 @@ import type { Research } from "@chopin/protocol";
 import type { TransitionPresence } from "@chopin/editor/transition-presence";
 import type { CSSProperties, MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import type { DocumentMetadata } from "./document-actions";
-import type { DocumentRouteIdentity, DocumentRouteIdentitySource } from "./document-route-swap";
-import type { NavigationMode } from "./navigation-model";
+import type { DocumentRouteIdentity } from "./document-route-swap";
+import type { NavigationMode, NavigationRoute } from "./navigation-model";
 
 export type Navigate = (destination: string, options?: { replace?: boolean }) => void;
 
@@ -96,11 +97,6 @@ let RenameDocumentDialog = lazy(() =>
 let DeleteDocumentDialog = lazy(() =>
 	import("./delete-document-dialog").then(module => ({ default: module.DeleteDocumentDialog }))
 );
-
-type Route =
-	| DocumentRouteIdentitySource
-	| { page: "repositories" }
-	| { page: "repository"; owner: string; repository: string };
 
 type NavigationFailure = { reason: unknown; retry?: "refresh" | "visit" };
 
@@ -255,7 +251,7 @@ export function NavigationShell(
 	}: {
 		children?: ReactNode;
 		navigate: Navigate;
-		route: Route;
+		route: NavigationRoute;
 		user: Api.User;
 	},
 ) {
@@ -336,10 +332,7 @@ export function NavigationShell(
 		removeResearchChannel,
 		upsertResearchWorkspace,
 	} = useProjectResearch(navigation, projects, catalogueMode === "archived");
-	let routeKey = route.page === "channel"
-			|| route.page === "document"
-			|| route.page === "child"
-			|| route.page === "research"
+	let routeKey = isDocumentWorkspaceRoute(route)
 		? documentRouteIdentity(route)
 		: route.page;
 	let currentRouteKey = useRef(routeKey);
@@ -765,11 +758,7 @@ export function NavigationShell(
 
 	let retryError = () => {
 		if (!error) return;
-		if (
-			error.retry === "visit"
-			&& currentChannelRef.current
-			&& (route.page === "channel" || route.page === "document" || route.page === "research")
-		) {
+		if (error.retry === "visit" && currentChannelRef.current && isDocumentWorkspaceRoute(route)) {
 			void documentLoaded(currentChannelRef.current, documentRouteIdentity(route));
 		} else void refresh();
 	};

--- a/apps/web/src/navigation-shell.tsx
+++ b/apps/web/src/navigation-shell.tsx
@@ -360,9 +360,6 @@ export function NavigationShell(
 	let currentDocumentId = route.page === "channel"
 		? route.id
 		: routedChannel?.id ?? resolvedChannel?.id;
-	let currentParentDocumentId = route.page === "child"
-		? routedChannel?.parentChannelId ?? resolvedChannel?.parentChannelId
-		: undefined;
 	let currentResearchWorkspaceId = route.page === "research" ? route.workspaceId : undefined;
 
 	let refresh = useCallback((queue = true): Promise<void> => {
@@ -817,7 +814,6 @@ export function NavigationShell(
 				creatingProjectIds={creatingProjectIdsForView}
 				creatingNewDocument={!!active && creatingProjectIdsForView.has(active.repositoryId)}
 				currentDocumentId={currentDocumentId}
-				currentParentDocumentId={currentParentDocumentId}
 				currentResearchWorkspaceId={currentResearchWorkspaceId}
 				onAccount={() => setAccountOpen(open => !open)}
 				onAddProject={() => showDialog("add")}

--- a/apps/web/src/navigation.css
+++ b/apps/web/src/navigation.css
@@ -19,6 +19,124 @@
 	padding-left: 44px;
 }
 
+.anchored-child-host,
+.anchored-child-parent {
+	position: relative;
+	height: 100%;
+	min-height: 0;
+}
+
+.anchored-child-parent {
+	transition:
+		transform 240ms cubic-bezier(0.16, 1, 0.3, 1),
+		opacity 240ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.anchored-child-host[data-child-visible] .anchored-child-parent {
+	transform: translateY(3px) scale(0.985);
+	opacity: 0.58;
+}
+
+.anchored-child-host[data-child-presentation="closing"] .anchored-child-parent {
+	transform: none;
+	opacity: 1;
+	transition-duration: 170ms;
+	transition-timing-function: cubic-bezier(0.55, 0, 1, 0.45);
+}
+
+.anchored-child-surface {
+	position: absolute;
+	z-index: 40;
+	inset: 10px 12px 12px;
+	overflow: hidden;
+	border: var(--edge-width) solid var(--color-edge);
+	border-radius: var(--radius-xl);
+	background: var(--color-ground);
+	box-shadow: var(--shadow-raised);
+	transform-origin: 50% 75%;
+	animation: anchored-child-enter 240ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.anchored-child-host[data-child-presentation="closing"] .anchored-child-surface {
+	animation: anchored-child-exit 170ms cubic-bezier(0.55, 0, 1, 0.45) both;
+}
+
+.anchored-child-back {
+	position: absolute;
+	z-index: 50;
+	top: calc(0.5rem + env(safe-area-inset-top));
+	left: 10px;
+}
+
+.anchored-child-surface .room-header {
+	padding-left: 48px;
+}
+
+@keyframes anchored-child-enter {
+	from {
+		opacity: 0;
+		transform: translateY(10px) scale(0.975);
+	}
+	to {
+		opacity: 1;
+		transform: none;
+	}
+}
+
+@keyframes anchored-child-exit {
+	from {
+		opacity: 1;
+		transform: none;
+	}
+	to {
+		opacity: 0;
+		transform: translateY(6px) scale(0.985);
+	}
+}
+
+@media (max-width: 1023px) {
+	.anchored-child-surface {
+		inset: 0;
+		border: 0;
+		border-radius: 0;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.anchored-child-parent,
+	.anchored-child-host[data-child-visible] .anchored-child-parent {
+		transform: none;
+		transition-duration: 120ms;
+	}
+
+	.anchored-child-surface {
+		animation-name: anchored-child-fade;
+		animation-duration: 120ms;
+	}
+
+	.anchored-child-host[data-child-presentation="closing"] .anchored-child-surface {
+		animation-name: anchored-child-fade-out;
+	}
+
+	@keyframes anchored-child-fade {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+
+	@keyframes anchored-child-fade-out {
+		from {
+			opacity: 1;
+		}
+		to {
+			opacity: 0;
+		}
+	}
+}
+
 .project-sidebar-frame {
 	position: relative;
 	display: flex;

--- a/apps/web/src/navigation.css
+++ b/apps/web/src/navigation.css
@@ -150,6 +150,7 @@
 
 .project-sidebar-projects,
 .project-sidebar-documents,
+.project-sidebar-children,
 .project-sidebar-research {
 	display: flex;
 	flex-direction: column;
@@ -183,6 +184,38 @@
 }
 
 .project-sidebar-document-ancestor {
+	color: var(--color-text-primary);
+}
+
+.project-sidebar-child {
+	display: flex;
+	min-height: 30px;
+	align-items: center;
+	margin-left: 32px;
+	border-left: var(--edge-width) solid var(--color-gray-300);
+	border-radius: 0 6px 6px 0;
+}
+
+.project-sidebar-child:hover,
+.project-sidebar-child:focus-within {
+	background: var(--project-sidebar-hover);
+}
+
+.project-sidebar-child-link {
+	display: flex;
+	min-width: 0;
+	flex: 1;
+	align-items: center;
+	padding: 5px 4px 5px 14px;
+	overflow: hidden;
+	font-size: 0.75rem;
+	font-weight: 500;
+	line-height: 1.25rem;
+}
+
+.project-sidebar-child-current {
+	border-left-color: var(--color-brand);
+	background: var(--project-sidebar-selected);
 	color: var(--color-text-primary);
 }
 
@@ -252,8 +285,10 @@
 	.project-sidebar-action,
 :is(.group\/sidebar-header, .group\/projects-heading, .group\/project):focus-within
 	.project-sidebar-action,
-.group\/document:hover .project-sidebar-document-action,
-.group\/document:focus-within .project-sidebar-document-action {
+.project-sidebar-document:hover .project-sidebar-document-action,
+.project-sidebar-document:focus-within .project-sidebar-document-action,
+.project-sidebar-child:hover .project-sidebar-document-action,
+.project-sidebar-child:focus-within .project-sidebar-document-action {
 	opacity: 1;
 }
 

--- a/apps/web/src/project-sidebar.tsx
+++ b/apps/web/src/project-sidebar.tsx
@@ -11,7 +11,11 @@ import { motionContract } from "./motion-contract";
 import { motionImmediately } from "./motion-input";
 import { canManageProject } from "./navigation-model";
 import { MotionDisclosure, MotionDisclosureIcon } from "@chopin/editor";
-import { documentPath, researchWorkspacePath } from "@chopin/protocol/document-url";
+import {
+	childDocumentPath,
+	documentPath,
+	researchWorkspacePath,
+} from "@chopin/protocol/document-url";
 
 import { useId, useRef, useState } from "react";
 import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react";
@@ -45,11 +49,31 @@ export function newestResearchFirst(
 	);
 }
 
+export function documentGroups(
+	channels: Api.Channel[],
+	archiveMode: boolean,
+): Array<{ parent: Api.Channel; children: Api.Channel[] }> {
+	let visible = channels.filter(channel =>
+		archiveMode ? channel.archivedAt !== undefined : channel.archivedAt === undefined
+	);
+	let parents = visible.filter(channel => channel.parentChannelId === undefined);
+	let parentIds = new Set(parents.map(channel => channel.id));
+	let children = new Map<string, Api.Channel[]>();
+	for (let channel of visible) {
+		if (!channel.parentChannelId || !parentIds.has(channel.parentChannelId)) continue;
+		let nested = children.get(channel.parentChannelId) ?? [];
+		nested.push(channel);
+		children.set(channel.parentChannelId, nested);
+	}
+	return parents.map(parent => ({ parent, children: children.get(parent.id) ?? [] }));
+}
+
 function Project(
 	{
 		archiveMode,
 		creatingProjectIds,
 		currentDocumentId,
+		currentParentDocumentId,
 		currentResearchWorkspaceId,
 		entry,
 		expanded,
@@ -63,6 +87,7 @@ function Project(
 		archiveMode: boolean;
 		creatingProjectIds: ReadonlySet<string>;
 		currentDocumentId?: string;
+		currentParentDocumentId?: string;
 		currentResearchWorkspaceId?: string;
 		entry: ProjectDocuments;
 		expanded: boolean;
@@ -75,9 +100,7 @@ function Project(
 	},
 ) {
 	let { documents, project } = entry;
-	let channels = documents.channels.filter(channel =>
-		archiveMode ? channel.archivedAt !== undefined : channel.archivedAt === undefined
-	);
+	let groups = documentGroups(documents.channels, archiveMode);
 	let label = project.repository?.name ?? project.repositoryName;
 	let canManage = canManageProject(project);
 	let creating = creatingProjectIds.has(project.repositoryId);
@@ -91,14 +114,18 @@ function Project(
 			{documents.status === "error" && (
 				<p className="project-sidebar-status" role="status">{documents.message}</p>
 			)}
-			{documents.status === "loading" && channels.length === 0 && (
+			{documents.status === "loading" && groups.length === 0 && (
 				<p className="project-sidebar-status" role="status">Loading documents…</p>
 			)}
-			{channels.length > 0 && (
+			{groups.length > 0 && (
 				<ul className="project-sidebar-documents">
-					{channels.map(channel => {
-						let children = newestResearchFirst(research.get(channel.id)?.workspaces ?? []);
+					{groups.map(({ children, parent: channel }) => {
+						let researchWorkspaces = newestResearchFirst(
+							research.get(channel.id)?.workspaces ?? [],
+						);
 						let parentCurrent = currentDocumentId === channel.id;
+						let childCurrent = currentParentDocumentId === channel.id
+							&& children.some(child => child.id === currentDocumentId);
 						let researchCurrent = parentCurrent && currentResearchWorkspaceId !== undefined;
 						let parentHref = documentPath(
 							channel.repositoryOwner,
@@ -111,7 +138,7 @@ function Project(
 									className={`project-sidebar-document ${
 										parentCurrent && !researchCurrent
 											? "project-sidebar-document-current"
-											: researchCurrent
+											: researchCurrent || childCurrent
 											? "project-sidebar-document-ancestor"
 											: ""
 									}`}
@@ -154,8 +181,51 @@ function Project(
 									)}
 								</div>
 								{children.length > 0 && (
+									<ul className="project-sidebar-children">
+										{children.map(child => {
+											let current = child.id === currentDocumentId;
+											return (
+												<li
+													className={`project-sidebar-child group/document ${
+														current ? "project-sidebar-child-current" : ""
+													}`}
+													key={child.id}
+												>
+													<a
+														aria-current={current ? "page" : undefined}
+														className="project-sidebar-child-link"
+														href={childDocumentPath(
+															channel.repositoryOwner,
+															channel.repositoryName,
+															channel.slug,
+															child.slug,
+														)}
+													>
+														<span className="truncate">{child.title}</span>
+													</a>
+													{canManage && (
+														<div className="project-sidebar-document-actions">
+															<DocumentActionsMenu
+																channel={child}
+																className="project-sidebar-document-action"
+																onAction={action => onDocumentAction(child, action)}
+																trigger={
+																	<NavigationIcon
+																		className="h-auto w-3.5"
+																		src={documentActionsIcon}
+																	/>
+																}
+															/>
+														</div>
+													)}
+												</li>
+											);
+										})}
+									</ul>
+								)}
+								{researchWorkspaces.length > 0 && (
 									<ul className="project-sidebar-research">
-										{children.map(workspace => (
+										{researchWorkspaces.map(workspace => (
 											<li key={workspace.id}>
 												<a
 													aria-current={parentCurrent
@@ -185,7 +255,7 @@ function Project(
 					})}
 				</ul>
 			)}
-			{documents.status === "loading" && channels.length > 0 && (
+			{documents.status === "loading" && groups.length > 0 && (
 				<p className="project-sidebar-status" role="status">Loading more…</p>
 			)}
 			{documents.status === "ready" && documents.nextCursor && (
@@ -256,6 +326,7 @@ export function ProjectSidebar(
 		creatingNewDocument,
 		creatingProjectIds,
 		currentDocumentId,
+		currentParentDocumentId,
 		currentResearchWorkspaceId,
 		onAccount,
 		onAddProject,
@@ -279,6 +350,7 @@ export function ProjectSidebar(
 		creatingNewDocument: boolean;
 		creatingProjectIds: ReadonlySet<string>;
 		currentDocumentId?: string;
+		currentParentDocumentId?: string;
 		currentResearchWorkspaceId?: string;
 		onAccount: () => void;
 		onAddProject: () => void;
@@ -400,6 +472,7 @@ export function ProjectSidebar(
 									archiveMode={archiveMode}
 									creatingProjectIds={creatingProjectIds}
 									currentDocumentId={currentDocumentId}
+									currentParentDocumentId={currentParentDocumentId}
 									currentResearchWorkspaceId={currentResearchWorkspaceId}
 									entry={entry}
 									expanded={!collapsedProjectIds.has(entry.project.repositoryId)}

--- a/apps/web/src/project-sidebar.tsx
+++ b/apps/web/src/project-sidebar.tsx
@@ -73,7 +73,6 @@ function Project(
 		archiveMode,
 		creatingProjectIds,
 		currentDocumentId,
-		currentParentDocumentId,
 		currentResearchWorkspaceId,
 		entry,
 		expanded,
@@ -87,7 +86,6 @@ function Project(
 		archiveMode: boolean;
 		creatingProjectIds: ReadonlySet<string>;
 		currentDocumentId?: string;
-		currentParentDocumentId?: string;
 		currentResearchWorkspaceId?: string;
 		entry: ProjectDocuments;
 		expanded: boolean;
@@ -124,8 +122,7 @@ function Project(
 							research.get(channel.id)?.workspaces ?? [],
 						);
 						let parentCurrent = currentDocumentId === channel.id;
-						let childCurrent = currentParentDocumentId === channel.id
-							&& children.some(child => child.id === currentDocumentId);
+						let childCurrent = children.some(child => child.id === currentDocumentId);
 						let researchCurrent = parentCurrent && currentResearchWorkspaceId !== undefined;
 						let parentHref = documentPath(
 							channel.repositoryOwner,
@@ -326,7 +323,6 @@ export function ProjectSidebar(
 		creatingNewDocument,
 		creatingProjectIds,
 		currentDocumentId,
-		currentParentDocumentId,
 		currentResearchWorkspaceId,
 		onAccount,
 		onAddProject,
@@ -350,7 +346,6 @@ export function ProjectSidebar(
 		creatingNewDocument: boolean;
 		creatingProjectIds: ReadonlySet<string>;
 		currentDocumentId?: string;
-		currentParentDocumentId?: string;
 		currentResearchWorkspaceId?: string;
 		onAccount: () => void;
 		onAddProject: () => void;
@@ -472,7 +467,6 @@ export function ProjectSidebar(
 									archiveMode={archiveMode}
 									creatingProjectIds={creatingProjectIds}
 									currentDocumentId={currentDocumentId}
-									currentParentDocumentId={currentParentDocumentId}
 									currentResearchWorkspaceId={currentResearchWorkspaceId}
 									entry={entry}
 									expanded={!collapsedProjectIds.has(entry.project.repositoryId)}

--- a/apps/web/src/research-requests.test.ts
+++ b/apps/web/src/research-requests.test.ts
@@ -373,6 +373,39 @@ describe("research request store", () => {
 		store.dispose();
 	});
 
+	it("keeps an immediate re-retain read after the aborted read settles", async () => {
+		let first = deferred<Research.RequestView>();
+		let second = deferred<Research.RequestView>();
+		let calls = 0;
+		let store = new ResearchRequestStore({
+			api: api({
+				get: async () => (++calls === 1 ? first.promise : second.promise),
+			}),
+			channelId: "channel-one",
+			onOpen() {},
+		});
+		let unsubscribe = store.subscribe(() => {});
+		let releaseFirst = store.retain("request-one");
+		releaseFirst();
+		let releaseSecond = store.retain("request-one");
+		expect(calls).toBe(2);
+
+		first.resolve(request("request-one", "searching"));
+		await settle();
+		second.resolve(request("request-one", "writing", {
+			updatedAt: "2026-08-24T09:03:00.000Z",
+		}));
+		await settle();
+
+		expect(store.get("request-one")).toMatchObject({
+			stage: "writing",
+			updatedAt: "2026-08-24T09:03:00.000Z",
+		});
+		releaseSecond();
+		unsubscribe();
+		store.dispose();
+	});
+
 	it("keeps the durable snapshot visible when cancellation fails", async () => {
 		let failure = new Error("Try cancellation again.");
 		let store = new ResearchRequestStore({

--- a/apps/web/src/research-requests.ts
+++ b/apps/web/src/research-requests.ts
@@ -92,7 +92,6 @@ export class ResearchRequestStore implements ResearchStore {
 			}
 			this.#references.delete(id);
 			this.#snapshots.delete(id);
-			this.#generations.delete(id);
 			this.#reads.get(id)?.controller.abort();
 			this.#reads.delete(id);
 			this.#schedulePolling();
@@ -168,15 +167,17 @@ export class ResearchRequestStore implements ResearchStore {
 		this.#reads.set(id, read);
 		try {
 			let snapshot = await this.#api.get(this.#channelId, id, controller.signal);
+			let current = this.#reads.get(id);
 			if (
-				controller.signal.aborted || this.#reads.get(id)?.generation !== generation
+				this.#disposed || controller.signal.aborted
+				|| current !== read || current.generation !== generation
 			) return;
 			this.#accept(id, snapshot);
 		} catch {
 			// Refresh failures leave the last durable snapshot visible. Polling or
 			// the next socket invalidation can retry the observational read.
 		} finally {
-			if (this.#reads.get(id)?.generation === generation) this.#reads.delete(id);
+			if (this.#reads.get(id) === read) this.#reads.delete(id);
 			this.#schedulePolling();
 		}
 	}

--- a/apps/web/src/research-sidebar.test.ts
+++ b/apps/web/src/research-sidebar.test.ts
@@ -147,7 +147,6 @@ describe("research sidebar hierarchy", () => {
 		let markup = renderToStaticMarkup(createElement(ProjectSidebar, {
 			...props,
 			currentDocumentId: child.id,
-			currentParentDocumentId: channel.id,
 			projects: [{
 				...props.projects[0]!,
 				documents: { status: "ready", channels: [channel, child] },

--- a/apps/web/src/research-sidebar.test.ts
+++ b/apps/web/src/research-sidebar.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { ProjectSidebar } from "./project-sidebar";
+import { documentGroups, ProjectSidebar } from "./project-sidebar";
 
 import type { ComponentProps } from "react";
 import type { Research } from "@chopin/protocol";
@@ -81,6 +81,89 @@ let props = {
 } satisfies ComponentProps<typeof ProjectSidebar>;
 
 describe("research sidebar hierarchy", () => {
+	it("groups children beneath present parents without disturbing either order", () => {
+		let secondParent = { ...channel, id: "channel-two", slug: "second", title: "Second" };
+		let firstChild = {
+			...channel,
+			id: "child-one",
+			parentChannelId: channel.id,
+			slug: "child-one",
+			title: "First child",
+		};
+		let secondChild = {
+			...firstChild,
+			id: "child-two",
+			slug: "child-two",
+			title: "Second child",
+		};
+		let orphan = {
+			...firstChild,
+			id: "orphan",
+			parentChannelId: "parent-on-another-page",
+		};
+
+		expect(
+			documentGroups(
+				[secondParent, firstChild, channel, orphan, secondChild],
+				false,
+			).map(group => ({
+				parent: group.parent.id,
+				children: group.children.map(child => child.id),
+			})),
+		).toEqual([
+			{ parent: secondParent.id, children: [] },
+			{ parent: channel.id, children: [firstChild.id, secondChild.id] },
+		]);
+	});
+
+	it("filters archived parents and children before grouping", () => {
+		let archivedParent = {
+			...channel,
+			id: "archived-parent",
+			archivedAt: "2026-08-24T00:00:00.000Z",
+		};
+		let archivedChild = {
+			...channel,
+			id: "archived-child",
+			parentChannelId: archivedParent.id,
+			archivedAt: "2026-08-24T00:00:00.000Z",
+		};
+		let activeChild = { ...archivedChild, id: "active-child", archivedAt: undefined };
+
+		expect(documentGroups([channel, archivedParent, archivedChild, activeChild], false))
+			.toEqual([{ parent: channel, children: [] }]);
+		expect(documentGroups([channel, archivedParent, archivedChild, activeChild], true))
+			.toEqual([{ parent: archivedParent, children: [archivedChild] }]);
+	});
+
+	it("renders an ordinary child row with the same durable route as its ready card", () => {
+		let child = {
+			...channel,
+			id: "child-one",
+			parentChannelId: channel.id,
+			title: "Source review",
+			slug: "source-review",
+		};
+		let markup = renderToStaticMarkup(createElement(ProjectSidebar, {
+			...props,
+			currentDocumentId: child.id,
+			currentParentDocumentId: channel.id,
+			projects: [{
+				...props.projects[0]!,
+				documents: { status: "ready", channels: [channel, child] },
+			}],
+		}));
+
+		expect(markup.match(/aria-current="page"/g)).toHaveLength(1);
+		expect(markup).toContain("project-sidebar-document-ancestor");
+		expect(markup).toContain("project-sidebar-child group/document project-sidebar-child-current");
+		expect(markup).toContain(
+			'aria-current="page" class="project-sidebar-child-link" href="/documents/acme/one/release-plan/children/source-review"',
+		);
+		expect(markup).toContain("Source review");
+		expect(markup).toContain('aria-label="Actions for Source review"');
+	});
+
 	it("uses one real current-page link for the document route", () => {
 		let markup = renderToStaticMarkup(createElement(ProjectSidebar, props));
 

--- a/apps/web/src/research-workspace.tsx
+++ b/apps/web/src/research-workspace.tsx
@@ -878,7 +878,7 @@ export function ResearchWorkspace(
 						<DocumentActionsMenu
 							channel={{ archivedAt: workspaceArchivedAt, title: metadata.title }}
 							className="btn btn-sm btn-ghost"
-							onAction={onDocumentAction}
+							onAction={action => onDocumentAction(room, action)}
 							trigger={<span>Actions</span>}
 						/>
 					)}

--- a/apps/web/src/resizable-pane.test.ts
+++ b/apps/web/src/resizable-pane.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "bun:test";
 
-import { clampPane, keyboardPaneDelta, resizeDelta, restorePaneWidth } from "./resizable-pane";
+import {
+	clampPane,
+	keyboardPaneDelta,
+	readPaneWidth,
+	resizeDelta,
+	restorePaneWidth,
+	writePaneWidth,
+} from "./resizable-pane";
 
 describe("bounded pane resizing", () => {
 	it("keeps a pane width within its inclusive bounds", () => {
@@ -21,6 +28,31 @@ describe("bounded pane resizing", () => {
 		expect(restorePaneWidth("800", bounds)).toBe(400);
 		expect(restorePaneWidth("bad", bounds)).toBe(304);
 		expect(restorePaneWidth(null, bounds)).toBe(304);
+	});
+
+	it("does not read or write shared storage for an isolated pane", () => {
+		let reads: string[] = [];
+		let writes: Array<[string, string]> = [];
+		let storage = {
+			getItem(key: string) {
+				reads.push(key);
+				return "360";
+			},
+			setItem(key: string, value: string) {
+				writes.push([key, value]);
+			},
+		};
+		let bounds = { initial: 304, min: 304, max: 400 };
+
+		expect(readPaneWidth(storage, undefined, bounds)).toBe(304);
+		writePaneWidth(storage, undefined, 320);
+		expect(reads).toEqual([]);
+		expect(writes).toEqual([]);
+
+		expect(readPaneWidth(storage, "chopin:pane:chat", bounds)).toBe(360);
+		writePaneWidth(storage, "chopin:pane:chat", 320);
+		expect(reads).toEqual(["chopin:pane:chat"]);
+		expect(writes).toEqual([["chopin:pane:chat", "320"]]);
 	});
 
 	it("maps keyboard commands to bounded pane movements", () => {

--- a/apps/web/src/resizable-pane.tsx
+++ b/apps/web/src/resizable-pane.tsx
@@ -25,6 +25,24 @@ export function restorePaneWidth(stored: string | null, { initial, min, max }: P
 	return Number.isFinite(value) && value > 0 ? clampPane(value, min, max) : initial;
 }
 
+type PaneStorage = Pick<Storage, "getItem" | "setItem">;
+
+export function readPaneWidth(
+	storage: PaneStorage,
+	storageKey: string | undefined,
+	bounds: PaneBounds,
+): number {
+	return storageKey ? restorePaneWidth(storage.getItem(storageKey), bounds) : bounds.initial;
+}
+
+export function writePaneWidth(
+	storage: PaneStorage,
+	storageKey: string | undefined,
+	width: number,
+): void {
+	if (storageKey) storage.setItem(storageKey, String(width));
+}
+
 export function keyboardPaneDelta(
 	side: PaneSide,
 	key: string,
@@ -94,7 +112,7 @@ export function ResizeHandle(
 export function usePaneWidth(
 	{ active, initial, max, min, storageKey }: PaneBounds & {
 		active: boolean;
-		storageKey: string;
+		storageKey?: string;
 	},
 ): readonly [number, (delta: number) => void] {
 	let [width, setWidth] = useState(initial);
@@ -104,13 +122,13 @@ export function usePaneWidth(
 		if (!active) return;
 		if (!loaded.current) {
 			loaded.current = true;
-			let restored = restorePaneWidth(localStorage.getItem(storageKey), { initial, min, max });
+			let restored = readPaneWidth(localStorage, storageKey, { initial, min, max });
 			if (restored !== width) {
 				setWidth(restored);
 				return;
 			}
 		}
-		localStorage.setItem(storageKey, String(width));
+		writePaneWidth(localStorage, storageKey, width);
 	}, [active, initial, max, min, storageKey, width]);
 
 	let resize = useCallback(

--- a/apps/web/src/room-workspace.tsx
+++ b/apps/web/src/room-workspace.tsx
@@ -37,8 +37,8 @@ import { Wire } from "./wire";
 import { useWorkspaceIds, useWorkspaceMode, useWorkspaceState, Workspace } from "./workspace";
 import {
 	availableDocumentView,
+	initialDocumentView,
 	presentWorkspace,
-	storedDocumentView,
 	workspaceCapabilities,
 } from "./workspace-model";
 
@@ -212,7 +212,7 @@ export function RoomWorkspace(
 		let stored = localStorage.getItem("chopin:view:document");
 		return {
 			phase: "initial",
-			preferred: storedDocumentView(stored),
+			preferred: initialDocumentView(surface, stored),
 		};
 	});
 	let policy = workspaceCapabilities(surface, capabilities.backgroundJobs);

--- a/apps/web/src/room-workspace.tsx
+++ b/apps/web/src/room-workspace.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { documentPath } from "@chopin/protocol/document-url";
 import {
 	advanceDecisionView,
 	aggregateJobs,
@@ -39,7 +38,7 @@ import {
 	availableDocumentView,
 	initialDocumentView,
 	presentWorkspace,
-	workspaceCapabilities,
+	workspaceProfile,
 } from "./workspace-model";
 
 import type { Research, Session } from "@chopin/protocol";
@@ -188,7 +187,9 @@ export function RoomWorkspace(
 	let user = useMemo(() => cursor(handle), [handle]);
 	let mode = useWorkspaceMode();
 	let workspaceIds = useWorkspaceIds();
-	let [workspace, dispatch] = useWorkspaceState(surface);
+	let profile = workspaceProfile(surface, capabilities.backgroundJobs);
+	let researchEnabled = profile.research;
+	let [workspace, dispatch] = useWorkspaceState(profile);
 	let [questions] = useState(() => new QuestionnaireStore());
 	let [threads] = useState(() => new ThreadStore());
 	let [jobs] = useState(() => new JobStore());
@@ -212,13 +213,12 @@ export function RoomWorkspace(
 		let stored = localStorage.getItem("chopin:view:document");
 		return {
 			phase: "initial",
-			preferred: initialDocumentView(surface, stored),
+			preferred: initialDocumentView(profile, stored),
 		};
 	});
-	let policy = workspaceCapabilities(surface, capabilities.backgroundJobs);
 	let view = availableDocumentView(
 		visibleDecisionView(decisionView, hasPlanContent, unanswered),
-		policy.backgroundJobs,
+		profile.backgroundJobs,
 	);
 	let previousUnanswered = useRef(unanswered);
 	let latestCanEdit = useRef(canEdit);
@@ -244,14 +244,7 @@ export function RoomWorkspace(
 		setMetadata(metadata);
 		rememberChannel(userId, { id: room, title: metadata.title, slug: metadata.slug }, repository);
 		onDocumentChanged(room, metadata);
-		if (onMetadataChanged) {
-			onMetadataChanged(metadata);
-			return;
-		}
-		let path = documentPath(repository.owner, repository.name, metadata.slug);
-		if (location.pathname !== path) {
-			history.replaceState(history.state, "", `${path}${location.search}${location.hash}`);
-		}
+		onMetadataChanged?.(metadata);
 	}, [onDocumentChanged, onMetadataChanged, repository, room, userId]);
 
 	useEffect(() => {
@@ -274,7 +267,7 @@ export function RoomWorkspace(
 
 	let selectView = (next: DecisionView, revealFirst = true) => {
 		setDecisionView(state => selectDecisionView(state, next));
-		if (hasPlanContent && surface === "document") {
+		if (hasPlanContent && profile.persistView) {
 			localStorage.setItem("chopin:view:document", next);
 		}
 		if (next === "decisions" && revealFirst) {
@@ -363,7 +356,8 @@ export function RoomWorkspace(
 				setCapabilities({ backgroundJobs: frame.backgroundJobs });
 				setChatReferences({ wire: socket, enabled: frame.chatReferences === true });
 				setChatSendAcks({ wire: socket, enabled: frame.chatSendAcks === true });
-				if (!workspaceCapabilities(surface, frame.backgroundJobs).backgroundJobs) {
+				let nextProfile = workspaceProfile(surface, frame.backgroundJobs);
+				if (!nextProfile.backgroundJobs) {
 					setDecisionView(state =>
 						state.preferred === "background-work"
 							? { phase: "complete", preferred: "plan" }
@@ -372,7 +366,7 @@ export function RoomWorkspace(
 				}
 				updateMetadata(frame);
 				if (accessChanged) onRepositoryAccessChanged();
-				if (surface === "document") {
+				if (nextProfile.research) {
 					onResearchWorkspacesRefresh({
 						id: room,
 						repositoryId: repository.id,
@@ -404,7 +398,7 @@ export function RoomWorkspace(
 				onRepositoryAccessChanged();
 			}),
 			socket.on<Research.Changed>("research:changed", frame => {
-				if (surface === "document") {
+				if (researchEnabled) {
 					onResearchWorkspaceChanged(
 						{
 							id: room,
@@ -437,6 +431,7 @@ export function RoomWorkspace(
 		onResearchWorkspacesRefresh,
 		onRepositoryAccessChanged,
 		research,
+		researchEnabled,
 		repository,
 		room,
 		surface,
@@ -488,9 +483,9 @@ export function RoomWorkspace(
 			controls={
 				<DecisionViewControl
 					attention={attention}
-					backgroundWork={policy.backgroundJobs ? backgroundWorkCount : 0}
-					backgroundWorkEnabled={policy.backgroundJobs}
-					implementationEnabled={policy.implementation}
+					backgroundWork={profile.backgroundJobs ? backgroundWorkCount : 0}
+					backgroundWorkEnabled={profile.backgroundJobs}
+					implementationEnabled={profile.implementation}
 					onView={selectDestination}
 					unanswered={unanswered}
 					view={view}
@@ -525,14 +520,14 @@ export function RoomWorkspace(
 					questionMotion={QUESTION_MOTION}
 					questions={questions}
 					readOnly={!workspaceCanEdit}
-					research={policy.research ? research : undefined}
+					research={profile.research ? research : undefined}
 					scrollTop={planScrollTop}
 					threads={threads}
 					user={user}
 					wire={wire}
 				/>
 			}
-			backgroundWork={policy.backgroundJobs
+			backgroundWork={profile.backgroundJobs
 				? (
 					<BackgroundWork
 						canEdit={workspaceCanEdit}
@@ -545,7 +540,7 @@ export function RoomWorkspace(
 				)
 				: undefined}
 			state={workspace}
-			surface={surface}
+			profile={profile}
 			unanswered={unanswered}
 			view={view}
 		/>

--- a/apps/web/src/room-workspace.tsx
+++ b/apps/web/src/room-workspace.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { documentPath } from "@chopin/protocol/document-url";
 import {
 	advanceDecisionView,
 	aggregateJobs,
@@ -34,7 +35,12 @@ import { peopleHere } from "./presence";
 import { ResearchRequestStore } from "./research-requests";
 import { Wire } from "./wire";
 import { useWorkspaceIds, useWorkspaceMode, useWorkspaceState, Workspace } from "./workspace";
-import { availableDocumentView, presentWorkspace, storedDocumentView } from "./workspace-model";
+import {
+	availableDocumentView,
+	presentWorkspace,
+	storedDocumentView,
+	workspaceCapabilities,
+} from "./workspace-model";
 
 import type { Research, Session } from "@chopin/protocol";
 import type { DecisionView, DecisionViewState } from "@chopin/editor";
@@ -139,9 +145,11 @@ export function RoomWorkspace(
 		descriptionRevision,
 		handle,
 		label,
+		onMetadataChanged,
 		repository,
 		room,
 		slug,
+		surface = "document",
 		updatedAt,
 		userId,
 	}: HostedWorkspaceProps,
@@ -180,7 +188,7 @@ export function RoomWorkspace(
 	let user = useMemo(() => cursor(handle), [handle]);
 	let mode = useWorkspaceMode();
 	let workspaceIds = useWorkspaceIds();
-	let [workspace, dispatch] = useWorkspaceState();
+	let [workspace, dispatch] = useWorkspaceState(surface);
 	let [questions] = useState(() => new QuestionnaireStore());
 	let [threads] = useState(() => new ThreadStore());
 	let [jobs] = useState(() => new JobStore());
@@ -188,7 +196,7 @@ export function RoomWorkspace(
 		() =>
 			new ResearchRequestStore({
 				channelId: room,
-				onOpen: onResearchChildOpen,
+				onOpen: child => onResearchChildOpen(room, child),
 			}),
 		[onResearchChildOpen, room],
 	);
@@ -207,9 +215,10 @@ export function RoomWorkspace(
 			preferred: storedDocumentView(stored),
 		};
 	});
+	let policy = workspaceCapabilities(surface, capabilities.backgroundJobs);
 	let view = availableDocumentView(
 		visibleDecisionView(decisionView, hasPlanContent, unanswered),
-		capabilities.backgroundJobs,
+		policy.backgroundJobs,
 	);
 	let previousUnanswered = useRef(unanswered);
 	let latestCanEdit = useRef(canEdit);
@@ -235,7 +244,15 @@ export function RoomWorkspace(
 		setMetadata(metadata);
 		rememberChannel(userId, { id: room, title: metadata.title, slug: metadata.slug }, repository);
 		onDocumentChanged(room, metadata);
-	}, [onDocumentChanged, repository, room, userId]);
+		if (onMetadataChanged) {
+			onMetadataChanged(metadata);
+			return;
+		}
+		let path = documentPath(repository.owner, repository.name, metadata.slug);
+		if (location.pathname !== path) {
+			history.replaceState(history.state, "", `${path}${location.search}${location.hash}`);
+		}
+	}, [onDocumentChanged, onMetadataChanged, repository, room, userId]);
 
 	useEffect(() => {
 		setDecisionView(state => advanceDecisionView(state, hasPlanContent, unanswered));
@@ -257,7 +274,9 @@ export function RoomWorkspace(
 
 	let selectView = (next: DecisionView, revealFirst = true) => {
 		setDecisionView(state => selectDecisionView(state, next));
-		if (hasPlanContent) localStorage.setItem("chopin:view:document", next);
+		if (hasPlanContent && surface === "document") {
+			localStorage.setItem("chopin:view:document", next);
+		}
 		if (next === "decisions" && revealFirst) {
 			let first = entries.find(entry =>
 				entry.value.questions.some(question => question.answer === undefined)
@@ -281,7 +300,9 @@ export function RoomWorkspace(
 		requestAnimationFrame(() => {
 			questions.reveal(widget, question);
 			let card = document.querySelector<HTMLElement>(
-				`[data-document-view="plan"] article[data-plan-sidecar-questionnaire="${
+				`[data-workspace-room="${
+					CSS.escape(room)
+				}"] [data-document-view="plan"] article[data-plan-sidecar-questionnaire="${
 					CSS.escape(widget)
 				}"]`,
 			);
@@ -342,7 +363,7 @@ export function RoomWorkspace(
 				setCapabilities({ backgroundJobs: frame.backgroundJobs });
 				setChatReferences({ wire: socket, enabled: frame.chatReferences === true });
 				setChatSendAcks({ wire: socket, enabled: frame.chatSendAcks === true });
-				if (!frame.backgroundJobs) {
+				if (!workspaceCapabilities(surface, frame.backgroundJobs).backgroundJobs) {
 					setDecisionView(state =>
 						state.preferred === "background-work"
 							? { phase: "complete", preferred: "plan" }
@@ -351,14 +372,16 @@ export function RoomWorkspace(
 				}
 				updateMetadata(frame);
 				if (accessChanged) onRepositoryAccessChanged();
-				onResearchWorkspacesRefresh({
-					id: room,
-					repositoryId: repository.id,
-					repositoryOwner: repository.owner,
-					repositoryName: repository.name,
-					title: metadataRef.current.title,
-					slug: metadataRef.current.slug,
-				});
+				if (surface === "document") {
+					onResearchWorkspacesRefresh({
+						id: room,
+						repositoryId: repository.id,
+						repositoryOwner: repository.owner,
+						repositoryName: repository.name,
+						title: metadataRef.current.title,
+						slug: metadataRef.current.slug,
+					});
+				}
 			}),
 			socket.on<ManagedChannel>("session:channel", frame => {
 				if (frame.channelId !== room) return;
@@ -381,19 +404,21 @@ export function RoomWorkspace(
 				onRepositoryAccessChanged();
 			}),
 			socket.on<Research.Changed>("research:changed", frame => {
-				onResearchWorkspaceChanged(
-					{
-						id: room,
-						repositoryId: repository.id,
-						repositoryOwner: repository.owner,
-						repositoryName: repository.name,
-						title: metadataRef.current.title,
-						slug: metadataRef.current.slug,
-					},
-					frame.workspaceId,
-					frame.revision,
-				);
-				research.invalidate(frame.workspaceId);
+				if (surface === "document") {
+					onResearchWorkspaceChanged(
+						{
+							id: room,
+							repositoryId: repository.id,
+							repositoryOwner: repository.owner,
+							repositoryName: repository.name,
+							title: metadataRef.current.title,
+							slug: metadataRef.current.slug,
+						},
+						frame.workspaceId,
+						frame.revision,
+					);
+					research.invalidate(frame.workspaceId);
+				}
 			}),
 			threads.listen(socket),
 			jobs.listen(socket),
@@ -414,6 +439,7 @@ export function RoomWorkspace(
 		research,
 		repository,
 		room,
+		surface,
 		threads,
 		updateMetadata,
 	]);
@@ -456,20 +482,22 @@ export function RoomWorkspace(
 					canManage={effectiveCanManage}
 					members={members}
 					label={metadata.title}
-					onAction={onDocumentAction}
+					onAction={action => onDocumentAction(room, action)}
 				/>
 			}
 			controls={
 				<DecisionViewControl
 					attention={attention}
-					backgroundWork={backgroundWorkCount}
-					backgroundWorkEnabled={capabilities.backgroundJobs}
+					backgroundWork={policy.backgroundJobs ? backgroundWorkCount : 0}
+					backgroundWorkEnabled={policy.backgroundJobs}
+					implementationEnabled={policy.implementation}
 					onView={selectDestination}
 					unanswered={unanswered}
 					view={view}
 				/>
 			}
 			ids={workspaceIds}
+			identity={room}
 			mode={mode}
 			onDesktopConversationOpen={setDesktopConversationOpen}
 			onConversationOpen={open => dispatch({ type: "set-conversation", open })}
@@ -497,14 +525,14 @@ export function RoomWorkspace(
 					questionMotion={QUESTION_MOTION}
 					questions={questions}
 					readOnly={!workspaceCanEdit}
-					research={research}
+					research={policy.research ? research : undefined}
 					scrollTop={planScrollTop}
 					threads={threads}
 					user={user}
 					wire={wire}
 				/>
 			}
-			backgroundWork={capabilities.backgroundJobs
+			backgroundWork={policy.backgroundJobs
 				? (
 					<BackgroundWork
 						canEdit={workspaceCanEdit}
@@ -517,6 +545,7 @@ export function RoomWorkspace(
 				)
 				: undefined}
 			state={workspace}
+			surface={surface}
 			unanswered={unanswered}
 			view={view}
 		/>

--- a/apps/web/src/workspace-model.test.ts
+++ b/apps/web/src/workspace-model.test.ts
@@ -5,10 +5,10 @@ import {
 	initialWorkspaceState,
 	presentWorkspace,
 	transitionWorkspace,
-	workspaceCapabilities,
 	workspaceDestinations,
 	workspaceHeadingId,
 	workspaceMode,
+	workspaceProfile,
 } from "./workspace-model";
 
 import type { WorkspaceState } from "./workspace-model";
@@ -24,25 +24,30 @@ function mediaAt(width: number): MatchMedia {
 
 describe("adaptive workspace", () => {
 	it("starts a child with Conversation collapsed without inheriting the desktop preference", () => {
-		expect(initialWorkspaceState("child", true)).toEqual({
+		expect(initialWorkspaceState(workspaceProfile("child", true), true)).toEqual({
 			conversationOpen: false,
 			desktopConversationOpen: false,
 		});
 	});
 
 	it("starts a child on Document without inheriting the parent's saved view", () => {
-		expect(initialDocumentView("child", "decisions")).toBe("plan");
-		expect(initialDocumentView("child", "background-work")).toBe("plan");
-		expect(initialDocumentView("document", "decisions")).toBe("decisions");
+		expect(initialDocumentView(workspaceProfile("child", true), "decisions")).toBe("plan");
+		expect(initialDocumentView(workspaceProfile("child", true), "background-work")).toBe("plan");
+		expect(initialDocumentView(workspaceProfile("document", true), "decisions"))
+			.toBe("decisions");
 	});
 
 	it("limits a child to Document, Decisions, and Conversation", () => {
-		let capabilities = workspaceCapabilities("child", true);
+		let capabilities = workspaceProfile("child", true);
 
 		expect(capabilities).toEqual({
 			backgroundJobs: false,
 			implementation: false,
+			persistConversation: false,
+			persistPaneSize: false,
+			persistView: false,
 			research: false,
+			surface: "child",
 		});
 		expect(workspaceDestinations(capabilities.backgroundJobs)).toEqual([
 			"conversation",
@@ -52,18 +57,20 @@ describe("adaptive workspace", () => {
 	});
 
 	it("keeps the parent's legacy implementation surface without background jobs", () => {
-		expect(workspaceCapabilities("document", false)).toEqual({
+		expect(workspaceProfile("document", false)).toEqual({
 			backgroundJobs: false,
 			implementation: true,
+			persistConversation: true,
+			persistPaneSize: true,
+			persistView: true,
 			research: true,
+			surface: "document",
 		});
 	});
 
 	it("keeps child pane ids distinct from the mounted parent", () => {
 		expect(workspaceHeadingId("plan")).toBe("workspace-plan-heading");
-		expect(workspaceHeadingId("plan", "child-room")).toBe(
-			"workspace-child-room-plan-heading",
-		);
+		expect(workspaceHeadingId("plan", "child-room")).toBe("child-room-workspace-plan-heading");
 	});
 
 	it("classifies the media queries production reads at each boundary", () => {

--- a/apps/web/src/workspace-model.test.ts
+++ b/apps/web/src/workspace-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+	initialDocumentView,
 	initialWorkspaceState,
 	presentWorkspace,
 	transitionWorkspace,
@@ -27,6 +28,12 @@ describe("adaptive workspace", () => {
 			conversationOpen: false,
 			desktopConversationOpen: false,
 		});
+	});
+
+	it("starts a child on Document without inheriting the parent's saved view", () => {
+		expect(initialDocumentView("child", "decisions")).toBe("plan");
+		expect(initialDocumentView("child", "background-work")).toBe("plan");
+		expect(initialDocumentView("document", "decisions")).toBe("decisions");
 	});
 
 	it("limits a child to Document, Decisions, and Conversation", () => {

--- a/apps/web/src/workspace-model.test.ts
+++ b/apps/web/src/workspace-model.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "bun:test";
 
-import { presentWorkspace, transitionWorkspace, workspaceMode } from "./workspace-model";
+import {
+	initialWorkspaceState,
+	presentWorkspace,
+	transitionWorkspace,
+	workspaceCapabilities,
+	workspaceDestinations,
+	workspaceHeadingId,
+	workspaceMode,
+} from "./workspace-model";
 
 import type { WorkspaceState } from "./workspace-model";
 
@@ -14,6 +22,43 @@ function mediaAt(width: number): MatchMedia {
 }
 
 describe("adaptive workspace", () => {
+	it("starts a child with Conversation collapsed without inheriting the desktop preference", () => {
+		expect(initialWorkspaceState("child", true)).toEqual({
+			conversationOpen: false,
+			desktopConversationOpen: false,
+		});
+	});
+
+	it("limits a child to Document, Decisions, and Conversation", () => {
+		let capabilities = workspaceCapabilities("child", true);
+
+		expect(capabilities).toEqual({
+			backgroundJobs: false,
+			implementation: false,
+			research: false,
+		});
+		expect(workspaceDestinations(capabilities.backgroundJobs)).toEqual([
+			"conversation",
+			"plan",
+			"decisions",
+		]);
+	});
+
+	it("keeps the parent's legacy implementation surface without background jobs", () => {
+		expect(workspaceCapabilities("document", false)).toEqual({
+			backgroundJobs: false,
+			implementation: true,
+			research: true,
+		});
+	});
+
+	it("keeps child pane ids distinct from the mounted parent", () => {
+		expect(workspaceHeadingId("plan")).toBe("workspace-plan-heading");
+		expect(workspaceHeadingId("plan", "child-room")).toBe(
+			"workspace-child-room-plan-heading",
+		);
+	});
+
 	it("classifies the media queries production reads at each boundary", () => {
 		expect([1023, 1024].map(width => workspaceMode(mediaAt(width)))).toEqual([
 			"compact",

--- a/apps/web/src/workspace-model.ts
+++ b/apps/web/src/workspace-model.ts
@@ -2,6 +2,8 @@ import type { DecisionView } from "@chopin/editor";
 
 export type WorkspaceMode = "compact" | "split";
 
+export type WorkspaceSurface = "document" | "child";
+
 export type WorkspaceDestination = "plan" | "decisions" | "background-work" | "conversation";
 
 export type WorkspaceState = {
@@ -14,6 +16,35 @@ export type WorkspaceEvent =
 	| { type: "set-desktop-conversation"; open: boolean };
 
 export const WORKSPACE_MEDIA = ["(max-width: 1023px)"] as const;
+
+export function initialWorkspaceState(
+	surface: WorkspaceSurface,
+	desktopConversationOpen: boolean,
+): WorkspaceState {
+	return {
+		conversationOpen: false,
+		desktopConversationOpen: surface === "document" && desktopConversationOpen,
+	};
+}
+
+export function workspaceCapabilities(surface: WorkspaceSurface, backgroundJobs: boolean) {
+	let child = surface === "child";
+	return {
+		backgroundJobs: !child && backgroundJobs,
+		implementation: !child,
+		research: !child,
+	};
+}
+
+export function workspaceDestinations(backgroundWork: boolean): WorkspaceDestination[] {
+	return backgroundWork
+		? ["conversation", "plan", "decisions", "background-work"]
+		: ["conversation", "plan", "decisions"];
+}
+
+export function workspaceHeadingId(destination: WorkspaceDestination, scope?: string): string {
+	return `workspace-${scope ? `${scope}-` : ""}${destination}-heading`;
+}
 
 export function storedDocumentView(value: string | null): DecisionView {
 	if (value === "decisions" || value === "background-work") return value;

--- a/apps/web/src/workspace-model.ts
+++ b/apps/web/src/workspace-model.ts
@@ -4,6 +4,16 @@ export type WorkspaceMode = "compact" | "split";
 
 export type WorkspaceSurface = "document" | "child";
 
+export type WorkspaceProfile = {
+	backgroundJobs: boolean;
+	implementation: boolean;
+	persistConversation: boolean;
+	persistPaneSize: boolean;
+	persistView: boolean;
+	research: boolean;
+	surface: WorkspaceSurface;
+};
+
 export type WorkspaceDestination = "plan" | "decisions" | "background-work" | "conversation";
 
 export type WorkspaceState = {
@@ -18,28 +28,35 @@ export type WorkspaceEvent =
 export const WORKSPACE_MEDIA = ["(max-width: 1023px)"] as const;
 
 export function initialWorkspaceState(
-	surface: WorkspaceSurface,
+	profile: WorkspaceProfile,
 	desktopConversationOpen: boolean,
 ): WorkspaceState {
 	return {
 		conversationOpen: false,
-		desktopConversationOpen: surface === "document" && desktopConversationOpen,
+		desktopConversationOpen: profile.persistConversation && desktopConversationOpen,
 	};
 }
 
 export function initialDocumentView(
-	surface: WorkspaceSurface,
+	profile: WorkspaceProfile,
 	stored: string | null,
 ): DecisionView {
-	return surface === "child" ? "plan" : storedDocumentView(stored);
+	return profile.persistView ? storedDocumentView(stored) : "plan";
 }
 
-export function workspaceCapabilities(surface: WorkspaceSurface, backgroundJobs: boolean) {
+export function workspaceProfile(
+	surface: WorkspaceSurface,
+	backgroundJobs: boolean,
+): WorkspaceProfile {
 	let child = surface === "child";
 	return {
 		backgroundJobs: !child && backgroundJobs,
 		implementation: !child,
+		persistConversation: !child,
+		persistPaneSize: !child,
+		persistView: !child,
 		research: !child,
+		surface,
 	};
 }
 
@@ -50,7 +67,7 @@ export function workspaceDestinations(backgroundWork: boolean): WorkspaceDestina
 }
 
 export function workspaceHeadingId(destination: WorkspaceDestination, scope?: string): string {
-	return `workspace-${scope ? `${scope}-` : ""}${destination}-heading`;
+	return `${scope ? `${scope}-` : ""}workspace-${destination}-heading`;
 }
 
 export function storedDocumentView(value: string | null): DecisionView {

--- a/apps/web/src/workspace-model.ts
+++ b/apps/web/src/workspace-model.ts
@@ -27,6 +27,13 @@ export function initialWorkspaceState(
 	};
 }
 
+export function initialDocumentView(
+	surface: WorkspaceSurface,
+	stored: string | null,
+): DecisionView {
+	return surface === "child" ? "plan" : storedDocumentView(stored);
+}
+
 export function workspaceCapabilities(surface: WorkspaceSurface, backgroundJobs: boolean) {
 	let child = surface === "child";
 	return {

--- a/apps/web/src/workspace.tsx
+++ b/apps/web/src/workspace.tsx
@@ -5,6 +5,7 @@ import { ContentSwapLayer } from "@chopin/editor/content-swap";
 import { useTransitionPresence } from "@chopin/editor/transition-presence";
 
 import {
+	initialWorkspaceState,
 	presentWorkspace,
 	transitionWorkspace,
 	WORKSPACE_MEDIA,
@@ -22,6 +23,7 @@ import type {
 	WorkspaceEvent,
 	WorkspaceMode,
 	WorkspaceState,
+	WorkspaceSurface,
 } from "./workspace-model";
 
 export type Pane = "chat";
@@ -69,18 +71,26 @@ export function useWorkspaceMode(): WorkspaceMode {
 }
 
 /** Only the desktop Conversation preference crosses a page load. */
-export function useWorkspaceState(): [WorkspaceState, Dispatch<WorkspaceEvent>] {
-	let [state, dispatch] = useReducer(transitionWorkspace, undefined, (): WorkspaceState => ({
-		conversationOpen: false,
-		desktopConversationOpen: localStorage.getItem("chopin:pane:chat:open") !== "false",
-	}));
+export function useWorkspaceState(
+	surface: WorkspaceSurface = "document",
+): [WorkspaceState, Dispatch<WorkspaceEvent>] {
+	let [state, dispatch] = useReducer(
+		transitionWorkspace,
+		undefined,
+		() =>
+			initialWorkspaceState(
+				surface,
+				localStorage.getItem("chopin:pane:chat:open") !== "false",
+			),
+	);
 
 	useEffect(() => {
+		if (surface === "child") return;
 		localStorage.setItem(
 			"chopin:pane:chat:open",
 			String(state.desktopConversationOpen),
 		);
-	}, [state.desktopConversationOpen]);
+	}, [state.desktopConversationOpen, surface]);
 
 	return [state, dispatch];
 }
@@ -102,6 +112,8 @@ export type WorkspaceProps = {
 	unanswered: number;
 	conversationActivity: { unread: number; busy: boolean };
 	backgroundActivity?: { active: number; paused: number; failed: number };
+	identity?: string;
+	surface?: WorkspaceSurface;
 };
 
 export function ConversationToggle(
@@ -219,12 +231,14 @@ export function Workspace(
 		conversationActivity,
 		decisions,
 		header,
+		identity,
 		mode,
 		onConversationOpen,
 		onDesktopConversationOpen,
 		onDestination,
 		plan,
 		state,
+		surface = "document",
 		unanswered,
 		view,
 	}: WorkspaceProps,
@@ -292,6 +306,8 @@ export function Workspace(
 		<div
 			className="workspace-root flex h-full flex-col overflow-hidden bg-ground"
 			data-workspace-mode={mode}
+			data-workspace-room={identity}
+			data-workspace-surface={surface}
 			ref={root}
 		>
 			{header}

--- a/apps/web/src/workspace.tsx
+++ b/apps/web/src/workspace.tsx
@@ -9,6 +9,8 @@ import {
 	presentWorkspace,
 	transitionWorkspace,
 	WORKSPACE_MEDIA,
+	workspaceDestinations,
+	workspaceHeadingId,
 	workspaceMode,
 } from "./workspace-model";
 import conversationCloseIcon from "./assets/icons/conversation-close.svg";
@@ -22,8 +24,8 @@ import type {
 	WorkspaceDestination,
 	WorkspaceEvent,
 	WorkspaceMode,
+	WorkspaceProfile,
 	WorkspaceState,
-	WorkspaceSurface,
 } from "./workspace-model";
 
 export type Pane = "chat";
@@ -44,10 +46,10 @@ export function useWorkspaceIds(): WorkspaceIds {
 	let instance = useId();
 	return {
 		heading: {
-			plan: `${instance}-workspace-plan-heading`,
-			decisions: `${instance}-workspace-decisions-heading`,
-			"background-work": `${instance}-workspace-background-work-heading`,
-			conversation: `${instance}-workspace-conversation-heading`,
+			plan: workspaceHeadingId("plan", instance),
+			decisions: workspaceHeadingId("decisions", instance),
+			"background-work": workspaceHeadingId("background-work", instance),
+			conversation: workspaceHeadingId("conversation", instance),
 		},
 		pane: { chat: `${instance}-pane-chat` },
 	};
@@ -72,25 +74,25 @@ export function useWorkspaceMode(): WorkspaceMode {
 
 /** Only the desktop Conversation preference crosses a page load. */
 export function useWorkspaceState(
-	surface: WorkspaceSurface = "document",
+	profile: WorkspaceProfile,
 ): [WorkspaceState, Dispatch<WorkspaceEvent>] {
 	let [state, dispatch] = useReducer(
 		transitionWorkspace,
 		undefined,
 		() =>
 			initialWorkspaceState(
-				surface,
+				profile,
 				localStorage.getItem("chopin:pane:chat:open") !== "false",
 			),
 	);
 
 	useEffect(() => {
-		if (surface === "child") return;
+		if (!profile.persistConversation) return;
 		localStorage.setItem(
 			"chopin:pane:chat:open",
 			String(state.desktopConversationOpen),
 		);
-	}, [state.desktopConversationOpen, surface]);
+	}, [profile.persistConversation, state.desktopConversationOpen]);
 
 	return [state, dispatch];
 }
@@ -113,7 +115,7 @@ export type WorkspaceProps = {
 	conversationActivity: { unread: number; busy: boolean };
 	backgroundActivity?: { active: number; paused: number; failed: number };
 	identity?: string;
-	surface?: WorkspaceSurface;
+	profile: WorkspaceProfile;
 };
 
 export function ConversationToggle(
@@ -238,7 +240,7 @@ export function Workspace(
 		onDestination,
 		plan,
 		state,
-		surface = "document",
+		profile,
 		unanswered,
 		view,
 	}: WorkspaceProps,
@@ -246,7 +248,7 @@ export function Workspace(
 	let [chatWidth, resizeChat] = usePaneWidth({
 		active: mode === "split",
 		...CHAT_PANE,
-		storageKey: surface === "document" ? CHAT_PANE.storageKey : undefined,
+		storageKey: profile.persistPaneSize ? CHAT_PANE.storageKey : undefined,
 	});
 	let root = useRef<HTMLDivElement>(null);
 	let presentation = presentWorkspace(state, mode, view);
@@ -261,9 +263,7 @@ export function Workspace(
 	let edgeTab = useRef<HTMLButtonElement>(null);
 	let previousConversationOpen = useRef(state.conversationOpen);
 	let conversationInactive = !presentation.conversationVisible;
-	let destinations: WorkspaceDestination[] = backgroundWork
-		? ["conversation", "plan", "decisions", "background-work"]
-		: ["conversation", "plan", "decisions"];
+	let destinations = workspaceDestinations(!!backgroundWork);
 	let focusDestination = (destination: WorkspaceDestination) => {
 		root.current?.querySelector<HTMLElement>(`#${CSS.escape(ids.heading[destination])}`)
 			?.focus({ preventScroll: true });
@@ -311,7 +311,7 @@ export function Workspace(
 			className="workspace-root flex h-full flex-col overflow-hidden bg-ground"
 			data-workspace-mode={mode}
 			data-workspace-room={identity}
-			data-workspace-surface={surface}
+			data-workspace-surface={profile.surface}
 			ref={root}
 		>
 			{header}

--- a/apps/web/src/workspace.tsx
+++ b/apps/web/src/workspace.tsx
@@ -243,7 +243,11 @@ export function Workspace(
 		view,
 	}: WorkspaceProps,
 ) {
-	let [chatWidth, resizeChat] = usePaneWidth({ active: mode === "split", ...CHAT_PANE });
+	let [chatWidth, resizeChat] = usePaneWidth({
+		active: mode === "split",
+		...CHAT_PANE,
+		storageKey: surface === "document" ? CHAT_PANE.storageKey : undefined,
+	});
 	let root = useRef<HTMLDivElement>(null);
 	let presentation = presentWorkspace(state, mode, view);
 	let immediately = motionImmediately();

--- a/e2e/database.ts
+++ b/e2e/database.ts
@@ -62,6 +62,32 @@ export async function createChannel(port: number, id: string): Promise<void> {
 	});
 }
 
+export async function seedChildChannel(
+	port: number,
+	parentId: string,
+	id: string,
+	title: string,
+	source: string,
+	state: SeedState = {},
+): Promise<{ id: string; path: string; slug: string }> {
+	await createChannel(port, id);
+	let slug = `child-${id.slice(0, 8)}`;
+	await sql(port, async database => {
+		await database.begin(async transaction => {
+			await transaction`
+				UPDATE channels
+				SET parent_channel_id = ${parentId}, title = ${title}, updated_at = ${new Date()}
+				WHERE id = ${id}
+			`;
+			await transaction`
+				UPDATE channel_slugs SET slug = ${slug} WHERE channel_id = ${id} AND canonical = true
+			`;
+		});
+	});
+	await seedChannel(port, id, source, state);
+	return { id, path: `${testChannelPath(parentId)}/children/${slug}`, slug };
+}
+
 export async function seedChannel(
 	port: number,
 	id: string,

--- a/e2e/hosted.e2e.ts
+++ b/e2e/hosted.e2e.ts
@@ -134,13 +134,16 @@ test("a stale outgoing route cannot canonicalize or publish over the active docu
 		history.pushState(null, "", path);
 		dispatchEvent(new PopStateEvent("popstate"));
 	}, activePath);
-	let routes = page.locator(".document-route-swap > [data-content-swap-state]:not([hidden])");
-	let outgoing = page.locator(
-		'.document-route-swap > [data-content-swap-state="outgoing"]:not([hidden])',
-	);
-	await expect(routes).toHaveCount(2);
-	await expect(outgoing).toHaveAttribute("inert", "");
-	await expect.poll(() => visits).toEqual([room]);
+	await page.waitForFunction(() => {
+		let routes = document.querySelectorAll<HTMLElement>(
+			".document-route-swap > [data-content-swap-state]:not([hidden])",
+		);
+		return routes.length === 2
+			&& [...routes].some(route =>
+				route.dataset.contentSwapState === "outgoing"
+				&& route.hasAttribute("inert")
+			);
+	});
 
 	let staleResponse = page.waitForResponse(response =>
 		new URL(response.url()).pathname === `/api/channels/${stale.id}`
@@ -153,14 +156,16 @@ test("a stale outgoing route cannot canonicalize or publish over the active docu
 		)
 	);
 	await expect(page).toHaveURL(activePath);
-	expect(visits).toEqual([room]);
+	await expect.poll(() => visits).toEqual([room]);
 });
 
-test("outgoing WebSocket metadata cannot canonicalize the active document", async ({ baseURL, page, room }) => {
+test("superseded WebSocket metadata cannot canonicalize a requested document", async ({ baseURL, page, room }) => {
 	let stale = crypto.randomUUID();
 	await createChannel(Number(new URL(baseURL!).port), stale);
 	let captured = Promise.withResolvers<void>();
 	let release = Promise.withResolvers<void>();
+	let activeCaptured = Promise.withResolvers<void>();
+	let activeRelease = Promise.withResolvers<void>();
 	let title = `Renamed outgoing ${stale.slice(0, 8)}`;
 	let slug = `renamed-outgoing-${stale.slice(0, 8)}`;
 	await page.routeWebSocket("**/ws?**", route => {
@@ -186,6 +191,14 @@ test("outgoing WebSocket metadata cannot canonicalize the active document", asyn
 			route.send(message);
 		});
 	});
+	await page.route(
+		new RegExp(`/api/repositories/octo-org/score/documents/test-${room.slice(0, 8)}$`),
+		async route => {
+			activeCaptured.resolve();
+			await activeRelease.promise;
+			await route.continue();
+		},
+	);
 
 	await authenticate(page, "stale-socket", baseURL!);
 	await page.goto(`/channels/${stale}`);
@@ -202,16 +215,15 @@ test("outgoing WebSocket metadata cannot canonicalize the active document", asyn
 		history.pushState(null, "", path);
 		dispatchEvent(new PopStateEvent("popstate"));
 	}, activePath);
+	await activeCaptured.promise;
+	release.resolve();
+	await expect(projects.getByRole("link", { name: title, exact: true })).toBeVisible();
+	await expect(page).toHaveURL(activePath);
+	activeRelease.resolve();
 	let active = page.locator(
 		".document-route-swap > [data-content-swap-state]:not([hidden]):not([inert])",
 	);
 	await expect(active.getByRole("banner")).toContainText(`Test ${room.slice(0, 8)}`);
-	await expect(page.locator(
-		'.document-route-swap > [data-content-swap-state="outgoing"]:not([hidden])',
-	)).toHaveCount(1);
-
-	release.resolve();
-	await expect(projects.getByRole("link", { name: title, exact: true })).toBeVisible();
 	await expect(page).toHaveURL(activePath);
 });
 

--- a/e2e/research-child-documents.e2e.ts
+++ b/e2e/research-child-documents.e2e.ts
@@ -25,11 +25,17 @@ test("an in-app child preserves and restores its mounted parent", async ({ baseU
 		childTitle,
 		CHILD_SOURCE,
 	);
-	await page.addInitScript(() => localStorage.setItem("chopin:pane:chat:open", "true"));
+	await page.addInitScript(() => {
+		localStorage.setItem("chopin:pane:chat:open", "true");
+		localStorage.setItem("chopin:pane:chat", "384");
+	});
 	await join("ana");
 
 	let parent = page.locator(`[data-workspace-room="${room}"]`);
 	let parentScroll = parent.locator("[data-plan-scroll]");
+	await expect(parent.getByRole("separator", { name: "Resize the conversation" }))
+		.toHaveAttribute("aria-valuenow", "384");
+	await page.evaluate(() => localStorage.setItem("chopin:view:document", "decisions"));
 	await parent.evaluate(element => element.setAttribute("data-mount-token", "preserved"));
 	await parentScroll.evaluate(element => element.scrollTop = 240);
 	let originalScroll = await parentScroll.evaluate(element => element.scrollTop);
@@ -42,6 +48,7 @@ test("an in-app child preserves and restores its mounted parent", async ({ baseU
 	let surface = page.getByRole("region", { name: `Child document: ${childTitle}` });
 	await expect(page).toHaveURL(url => url.pathname === child.path);
 	await expect(surface).toBeVisible();
+	await expect(surface).toBeFocused();
 	await expect(parent).toHaveAttribute("data-mount-token", "preserved");
 	await expect(parent.locator("..")).toHaveAttribute("inert", "");
 	await expect(parent.locator("..")).toHaveAttribute("aria-hidden", "true");
@@ -54,6 +61,8 @@ test("an in-app child preserves and restores its mounted parent", async ({ baseU
 		0,
 	);
 	await expect(surface.locator(`[data-workspace-room="${child.id}"]`)).toBeVisible();
+	await expect(surface.locator('[data-document-view="plan"]')).toBeVisible();
+	await expect(surface.locator('[data-document-view="decisions"]')).toHaveAttribute("hidden", "");
 
 	await surface.getByRole("button", { name: "Decisions", exact: true }).click();
 	await expect(surface.locator('[data-document-view="decisions"]')).toBeVisible();
@@ -61,6 +70,11 @@ test("an in-app child preserves and restores its mounted parent", async ({ baseU
 	await surface.getByRole("button", { name: "Document", exact: true }).click();
 	await surface.getByRole("button", { name: "Show conversation pane" }).click();
 	await expect(surface.getByRole("button", { name: "Hide conversation pane" })).toBeVisible();
+	let childResize = surface.getByRole("separator", { name: "Resize the conversation" });
+	await expect(childResize).toHaveAttribute("aria-valuenow", "304");
+	await childResize.press("ArrowRight");
+	await expect.poll(() => page.evaluate(() => localStorage.getItem("chopin:pane:chat")))
+		.toBe("384");
 	await expect(parent.locator('button[aria-label^="Hide conversation pane"]')).toHaveCount(1);
 	await surface.getByRole("button", { name: "Hide conversation pane" }).click();
 	await expect(surface.getByRole("button", { name: "Show conversation pane" })).toBeVisible();
@@ -93,6 +107,101 @@ test("an in-app child preserves and restores its mounted parent", async ({ baseU
 	await expect(childLink).toBeFocused();
 });
 
+test("a delayed sibling route removes the previous editable child immediately", async ({ baseURL, join, page, room, seed }) => {
+	await seed(PARENT_SOURCE);
+	let firstTitle = `First source ${room.slice(0, 8)}`;
+	let secondTitle = `Second source ${room.slice(0, 8)}`;
+	let first = await seedChildChannel(
+		port(baseURL!),
+		room,
+		crypto.randomUUID(),
+		firstTitle,
+		CHILD_SOURCE,
+	);
+	let second = await seedChildChannel(
+		port(baseURL!),
+		room,
+		crypto.randomUUID(),
+		secondTitle,
+		CHILD_SOURCE,
+	);
+	await join("ana");
+	let childLink = (title: string) =>
+		page.getByRole("complementary", { name: "Projects" })
+			.getByRole("link", { name: title, exact: true });
+	await childLink(firstTitle).click();
+	await expect(page.locator(`[data-workspace-room="${first.id}"]`)).toBeVisible();
+
+	let release!: () => void;
+	let gate = new Promise<void>(resolve => release = resolve);
+	await page.route(
+		`**/api/repositories/octo-org/score/documents/${second.slug}`,
+		async route => {
+			let response = await route.fetch();
+			await gate;
+			await route.fulfill({ response });
+		},
+	);
+	await childLink(secondTitle).click();
+	await expect(page).toHaveURL(url => url.pathname === second.path);
+	await expect(page.locator(`[data-workspace-room="${first.id}"]`)).toHaveCount(0);
+	await expect(page.locator(".anchored-child-surface")).toContainText("Opening child document...");
+
+	release();
+	let secondSurface = page.getByRole("region", { name: `Child document: ${secondTitle}` });
+	await expect(secondSurface.locator(`[data-workspace-room="${second.id}"]`)).toBeVisible();
+	await expect(secondSurface).toBeFocused();
+});
+
+test("a child load failure preserves its mounted parent through back and retry", async ({ baseURL, join, page, room, seed }) => {
+	await seed(PARENT_SOURCE);
+	let childTitle = `Unreliable source ${room.slice(0, 8)}`;
+	let child = await seedChildChannel(
+		port(baseURL!),
+		room,
+		crypto.randomUUID(),
+		childTitle,
+		CHILD_SOURCE,
+	);
+	await join("ana");
+	let parent = page.locator(`[data-workspace-room="${room}"]`);
+	await parent.evaluate(element => element.setAttribute("data-mount-token", "preserved"));
+	let attempts = 0;
+	await page.route(
+		`**/api/repositories/octo-org/score/documents/${child.slug}`,
+		async route => {
+			attempts += 1;
+			if (attempts <= 2) {
+				await route.fulfill({
+					body: JSON.stringify({ error: "Child temporarily unavailable" }),
+					contentType: "application/json",
+					status: 503,
+				});
+				return;
+			}
+			await route.continue();
+		},
+	);
+	let childLink = page.getByRole("complementary", { name: "Projects" })
+		.getByRole("link", { name: childTitle, exact: true });
+
+	await childLink.click();
+	let surface = page.locator(".anchored-child-surface");
+	await expect(surface).toContainText("Cannot open Chopin");
+	await expect(surface).toContainText("Child temporarily unavailable");
+	await expect(parent).toHaveAttribute("data-mount-token", "preserved");
+	await expect(parent.locator("..")).toHaveAttribute("inert", "");
+	await surface.getByRole("button", { name: `Back to Test ${room.slice(0, 8)}` }).click();
+	await expect(surface).toHaveCount(0);
+	await expect(parent).toHaveAttribute("data-mount-token", "preserved");
+
+	await childLink.click();
+	await expect(surface).toContainText("Child temporarily unavailable");
+	await surface.getByRole("button", { name: "Try again" }).click();
+	await expect(surface.locator(`[data-workspace-room="${child.id}"]`)).toBeVisible();
+	await expect(parent).toHaveAttribute("data-mount-token", "preserved");
+});
+
 test("a direct compact child fills the canvas and reduces motion to a crossfade", async ({ baseURL, page, room, seed }) => {
 	await seed(PARENT_SOURCE);
 	let childTitle = `Source review ${room.slice(0, 8)}`;
@@ -110,6 +219,7 @@ test("a direct compact child fills the canvas and reduces motion to a crossfade"
 
 	let surface = page.getByRole("region", { name: `Child document: ${childTitle}` });
 	await expect(surface).toBeVisible();
+	await expect(surface).toBeFocused();
 	let geometry = await surface.evaluate(element => {
 		let style = getComputedStyle(element);
 		let box = element.getBoundingClientRect();

--- a/e2e/research-child-documents.e2e.ts
+++ b/e2e/research-child-documents.e2e.ts
@@ -1,0 +1,132 @@
+import { seedChildChannel } from "./database";
+import { authenticate, expect, test } from "./room";
+
+const PARENT_SOURCE = `# Parent document
+
+${Array.from({ length: 36 }, (_, index) => `Parent passage ${index + 1}.`).join("\n\n")}
+`;
+
+const CHILD_SOURCE = `# Source review
+
+This ordinary child has its own editable document, Decisions, and Conversation.
+`;
+
+function port(baseURL: string): number {
+	return Number(new URL(baseURL).port);
+}
+
+test("an in-app child preserves and restores its mounted parent", async ({ baseURL, join, page, room, seed }) => {
+	await seed(PARENT_SOURCE);
+	let childTitle = `Source review ${room.slice(0, 8)}`;
+	let child = await seedChildChannel(
+		port(baseURL!),
+		room,
+		crypto.randomUUID(),
+		childTitle,
+		CHILD_SOURCE,
+	);
+	await page.addInitScript(() => localStorage.setItem("chopin:pane:chat:open", "true"));
+	await join("ana");
+
+	let parent = page.locator(`[data-workspace-room="${room}"]`);
+	let parentScroll = parent.locator("[data-plan-scroll]");
+	await parent.evaluate(element => element.setAttribute("data-mount-token", "preserved"));
+	await parentScroll.evaluate(element => element.scrollTop = 240);
+	let originalScroll = await parentScroll.evaluate(element => element.scrollTop);
+	await page.evaluate(() => history.replaceState({ navigation: 4 }, "", "?view=plan#note"));
+	let childLink = page.getByRole("complementary", { name: "Projects" })
+		.getByRole("link", { name: childTitle, exact: true });
+	await childLink.focus();
+	await childLink.click();
+
+	let surface = page.getByRole("region", { name: `Child document: ${childTitle}` });
+	await expect(page).toHaveURL(url => url.pathname === child.path);
+	await expect(surface).toBeVisible();
+	await expect(parent).toHaveAttribute("data-mount-token", "preserved");
+	await expect(parent.locator("..")).toHaveAttribute("inert", "");
+	await expect(parent.locator("..")).toHaveAttribute("aria-hidden", "true");
+	await expect(surface.getByRole("button", { name: "Show conversation pane" })).toBeVisible();
+	await expect(surface.getByRole("button", { name: "Decisions", exact: true })).toBeVisible();
+	await expect(surface.getByRole("button", { name: "Background Work", exact: true })).toHaveCount(
+		0,
+	);
+	await expect(surface.getByRole("button", { name: "Tasks & Progress", exact: true })).toHaveCount(
+		0,
+	);
+	await expect(surface.locator(`[data-workspace-room="${child.id}"]`)).toBeVisible();
+
+	await surface.getByRole("button", { name: "Decisions", exact: true }).click();
+	await expect(surface.locator('[data-document-view="decisions"]')).toBeVisible();
+	await expect(parent.locator('[data-document-view="decisions"]')).toHaveAttribute("hidden", "");
+	await surface.getByRole("button", { name: "Document", exact: true }).click();
+	await surface.getByRole("button", { name: "Show conversation pane" }).click();
+	await expect(surface.getByRole("button", { name: "Hide conversation pane" })).toBeVisible();
+	await expect(parent.locator('button[aria-label^="Hide conversation pane"]')).toHaveCount(1);
+	await surface.getByRole("button", { name: "Hide conversation pane" }).click();
+	await expect(surface.getByRole("button", { name: "Show conversation pane" })).toBeVisible();
+	await surface.getByRole("button", { name: `Actions for ${childTitle}` }).click();
+	await expect(page.getByRole("menu", { name: `Actions for ${childTitle}` })).toBeVisible();
+	await page.keyboard.press("Escape");
+	await expect(surface).toBeVisible();
+	await expect(page.getByRole("menu", { name: `Actions for ${childTitle}` })).toHaveCount(0);
+
+	await page.keyboard.press("Escape");
+	await expect(page).toHaveURL(url =>
+		url.pathname.endsWith(`/test-${room.slice(0, 8)}`)
+		&& url.search === "?view=plan"
+		&& url.hash === "#note"
+	);
+	await expect(surface).toHaveCount(0);
+	await expect(childLink).toBeFocused();
+	await expect.poll(() => parentScroll.evaluate(element => element.scrollTop)).toBe(originalScroll);
+
+	await childLink.click();
+	await expect(surface).toBeVisible();
+	await page.goBack();
+	await expect(surface).toHaveCount(0);
+	await expect(childLink).toBeFocused();
+
+	await childLink.click();
+	await expect(surface).toBeVisible();
+	await surface.getByRole("button", { name: `Back to Test ${room.slice(0, 8)}` }).click();
+	await expect(surface).toHaveCount(0);
+	await expect(childLink).toBeFocused();
+});
+
+test("a direct compact child fills the canvas and reduces motion to a crossfade", async ({ baseURL, page, room, seed }) => {
+	await seed(PARENT_SOURCE);
+	let childTitle = `Source review ${room.slice(0, 8)}`;
+	let child = await seedChildChannel(
+		port(baseURL!),
+		room,
+		crypto.randomUUID(),
+		childTitle,
+		CHILD_SOURCE,
+	);
+	await page.setViewportSize({ width: 390, height: 844 });
+	await page.emulateMedia({ reducedMotion: "reduce" });
+	await authenticate(page, "ana", baseURL!);
+	await page.goto(child.path);
+
+	let surface = page.getByRole("region", { name: `Child document: ${childTitle}` });
+	await expect(surface).toBeVisible();
+	let geometry = await surface.evaluate(element => {
+		let style = getComputedStyle(element);
+		let box = element.getBoundingClientRect();
+		return {
+			animationName: style.animationName,
+			left: box.left,
+			right: innerWidth - box.right,
+			transform: style.transform,
+		};
+	});
+	expect(geometry).toEqual({
+		animationName: "anchored-child-fade",
+		left: 0,
+		right: 0,
+		transform: "none",
+	});
+
+	await surface.getByRole("button", { name: `Back to Test ${room.slice(0, 8)}` }).click();
+	await expect(page).toHaveURL(url => url.pathname.endsWith(`/test-${room.slice(0, 8)}`));
+});

--- a/e2e/research-child-documents.e2e.ts
+++ b/e2e/research-child-documents.e2e.ts
@@ -126,6 +126,7 @@ test("a delayed sibling route removes the previous editable child immediately", 
 		CHILD_SOURCE,
 	);
 	await join("ana");
+	await page.evaluate(() => history.replaceState({ navigation: 9 }, "", "?view=plan#siblings"));
 	let childLink = (title: string) =>
 		page.getByRole("complementary", { name: "Projects" })
 			.getByRole("link", { name: title, exact: true });
@@ -151,6 +152,76 @@ test("a delayed sibling route removes the previous editable child immediately", 
 	let secondSurface = page.getByRole("region", { name: `Child document: ${secondTitle}` });
 	await expect(secondSurface.locator(`[data-workspace-room="${second.id}"]`)).toBeVisible();
 	await expect(secondSurface).toBeFocused();
+	await secondSurface.getByRole("button", { name: `Back to Test ${room.slice(0, 8)}` }).click();
+	await expect(page).toHaveURL(url =>
+		url.pathname.endsWith(`/test-${room.slice(0, 8)}`)
+		&& url.search === "?view=plan"
+		&& url.hash === "#siblings"
+	);
+	await expect(secondSurface).toHaveCount(0);
+	await expect(childLink(secondTitle)).toBeFocused();
+
+	await childLink(firstTitle).click();
+	await childLink(secondTitle).click();
+	await expect(secondSurface.locator(`[data-workspace-room="${second.id}"]`)).toBeVisible();
+	await page.keyboard.press("Escape");
+	await expect(page).toHaveURL(url =>
+		url.pathname.endsWith(`/test-${room.slice(0, 8)}`)
+		&& url.search === "?view=plan"
+		&& url.hash === "#siblings"
+	);
+	await expect(childLink(secondTitle)).toBeFocused();
+
+	await childLink(firstTitle).click();
+	await childLink(secondTitle).click();
+	await expect(secondSurface.locator(`[data-workspace-room="${second.id}"]`)).toBeVisible();
+	await page.goBack();
+	await expect(page).toHaveURL(url =>
+		url.pathname.endsWith(`/test-${room.slice(0, 8)}`)
+		&& url.search === "?view=plan"
+		&& url.hash === "#siblings"
+	);
+	await expect(page.locator(`[data-workspace-room="${first.id}"]`)).toHaveCount(0);
+	await expect(childLink(secondTitle)).toBeFocused();
+});
+
+test("a direct child keeps direct-entry history when opening a sibling", async ({ baseURL, page, room, seed }) => {
+	await seed(PARENT_SOURCE);
+	let firstTitle = `Direct first ${room.slice(0, 8)}`;
+	let secondTitle = `Direct second ${room.slice(0, 8)}`;
+	let first = await seedChildChannel(
+		port(baseURL!),
+		room,
+		crypto.randomUUID(),
+		firstTitle,
+		CHILD_SOURCE,
+	);
+	let second = await seedChildChannel(
+		port(baseURL!),
+		room,
+		crypto.randomUUID(),
+		secondTitle,
+		CHILD_SOURCE,
+	);
+	await authenticate(page, "ana", baseURL!);
+	await page.goto(first.path);
+	await expect(page.locator(`[data-workspace-room="${first.id}"]`)).toBeVisible();
+	let historyLength = await page.evaluate(() => history.length);
+	let secondLink = page.getByRole("complementary", { name: "Projects" })
+		.getByRole("link", { name: secondTitle, exact: true });
+
+	await secondLink.click();
+	let secondSurface = page.getByRole("region", { name: `Child document: ${secondTitle}` });
+	await expect(secondSurface.locator(`[data-workspace-room="${second.id}"]`)).toBeVisible();
+	expect(await page.evaluate(() => history.length)).toBe(historyLength);
+	await secondSurface.getByRole("button", { name: `Back to Test ${room.slice(0, 8)}` }).click();
+	await expect(page).toHaveURL(url =>
+		url.pathname.endsWith(`/test-${room.slice(0, 8)}`)
+		&& url.search === ""
+		&& url.hash === ""
+	);
+	await expect(secondSurface).toHaveCount(0);
+	await expect(secondLink).toBeFocused();
 });
 
 test("a child load failure preserves its mounted parent through back and retry", async ({ baseURL, join, page, room, seed }) => {

--- a/e2e/research-child-documents.e2e.ts
+++ b/e2e/research-child-documents.e2e.ts
@@ -62,11 +62,11 @@ test("an in-app child preserves and restores its mounted parent", async ({ baseU
 	);
 	await expect(surface.locator(`[data-workspace-room="${child.id}"]`)).toBeVisible();
 	await expect(surface.locator('[data-document-view="plan"]')).toBeVisible();
-	await expect(surface.locator('[data-document-view="decisions"]')).toHaveAttribute("hidden", "");
+	await expect(surface.locator('[data-document-view="decisions"]')).toBeHidden();
 
 	await surface.getByRole("button", { name: "Decisions", exact: true }).click();
 	await expect(surface.locator('[data-document-view="decisions"]')).toBeVisible();
-	await expect(parent.locator('[data-document-view="decisions"]')).toHaveAttribute("hidden", "");
+	await expect(parent.locator('[data-document-view="decisions"]')).toBeHidden();
 	await surface.getByRole("button", { name: "Document", exact: true }).click();
 	await surface.getByRole("button", { name: "Show conversation pane" }).click();
 	await expect(surface.getByRole("button", { name: "Hide conversation pane" })).toBeVisible();

--- a/packages/editor/src/comment-layer.tsx
+++ b/packages/editor/src/comment-layer.tsx
@@ -535,6 +535,7 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 		};
 		let escape = (event: KeyboardEvent) => {
 			if (event.key !== "Escape") return;
+			event.preventDefault();
 			if (pinned) dismiss();
 			else setPreview(undefined);
 		};

--- a/packages/editor/src/comments.tsx
+++ b/packages/editor/src/comments.tsx
@@ -162,7 +162,10 @@ function Composer({
 	};
 
 	let key = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-		if (event.key === "Escape" && onCancel) return onCancel();
+		if (event.key === "Escape" && onCancel) {
+			event.preventDefault();
+			return onCancel();
+		}
 		if (event.key !== "Enter" || event.shiftKey) return;
 		event.preventDefault();
 		send();

--- a/packages/protocol/document-url.test.ts
+++ b/packages/protocol/document-url.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+	childDocumentPath,
 	documentPath,
 	documentsPath,
+	parseChildDocumentPath,
 	parseDocumentPath,
 	parseResearchWorkspacePath,
 	researchWorkspacePath,
@@ -82,6 +84,85 @@ describe("document paths", () => {
 		expect(parseDocumentPath("/repositories/octo-org/score")).toBeUndefined();
 		expect(parseDocumentPath("/channels/019c1234-1234-5123-8123-123456789abc"))
 			.toBeUndefined();
+	});
+});
+
+describe("child document paths", () => {
+	it("builds and parses the canonical nested route", () => {
+		let path = childDocumentPath("octo-org", "score", "release-plan", "source-review");
+		expect(path).toBe(
+			"/documents/octo-org/score/release-plan/children/source-review",
+		);
+		expect(parseChildDocumentPath(path)).toEqual({
+			owner: "octo-org",
+			repository: "score",
+			parentSlug: "release-plan",
+			childSlug: "source-review",
+		});
+		expect(parseDocumentPath(path)).toBeUndefined();
+	});
+
+	it("encodes and decodes every nested route segment", () => {
+		let path = childDocumentPath(
+			"München/org",
+			"計画 roadmap",
+			"café?#100%",
+			"研究/report ?#%",
+		);
+		expect(path).toBe(
+			"/documents/M%C3%BCnchen%2Forg/%E8%A8%88%E7%94%BB%20roadmap/caf%C3%A9%3F%23100%25/children/%E7%A0%94%E7%A9%B6%2Freport%20%3F%23%25",
+		);
+		expect(parseChildDocumentPath(path)).toEqual({
+			owner: "München/org",
+			repository: "計画 roadmap",
+			parentSlug: "café?#100%",
+			childSlug: "研究/report ?#%",
+		});
+	});
+
+	it("accepts one trailing slash and rejects malformed nested routes", () => {
+		expect(
+			parseChildDocumentPath(
+				"/documents/octo-org/score/release-plan/children/source-review/",
+			),
+		).toEqual({
+			owner: "octo-org",
+			repository: "score",
+			parentSlug: "release-plan",
+			childSlug: "source-review",
+		});
+		for (
+			let path of [
+				"/documents/octo-org/score/release-plan/children/source-review//",
+				"/documents/%/score/release-plan/children/source-review",
+				"/documents/octo-org/%E0%A4%A/release-plan/children/source-review",
+				"/documents/octo-org/score/%C0%AF/children/source-review",
+				"/documents/octo-org/score/release-plan/children/%ZZ",
+				"/documents/octo-org/score/release-plan/children",
+				"/documents/octo-org/score/release-plan/children/",
+				"/documents/octo-org/score/release-plan/Children/source-review",
+				"/documents/octo-org/score/release-plan/children/source-review/extra",
+				"/documents/octo-org/score/release-plan/children/source-review?view=all",
+				"documents/octo-org/score/release-plan/children/source-review",
+			]
+		) {
+			expect(parseChildDocumentPath(path)).toBeUndefined();
+		}
+	});
+
+	it("rejects empty nested route helper segments", () => {
+		for (
+			let segments of [
+				["", "score", "release-plan", "source-review"],
+				["octo-org", "", "release-plan", "source-review"],
+				["octo-org", "score", "", "source-review"],
+				["octo-org", "score", "release-plan", ""],
+			] as const
+		) {
+			expect(() => childDocumentPath(segments[0], segments[1], segments[2], segments[3])).toThrow(
+				TypeError,
+			);
+		}
 	});
 });
 

--- a/packages/protocol/document-url.ts
+++ b/packages/protocol/document-url.ts
@@ -11,7 +11,16 @@ export type ParsedResearchWorkspacePath = {
 	workspaceId: string;
 };
 
+export type ParsedChildDocumentPath = {
+	owner: string;
+	repository: string;
+	parentSlug: string;
+	childSlug: string;
+};
+
 const DOCUMENT_PATH = /^\/documents\/([^/]+)\/([^/]+)(?:\/([^/]+))?\/?$/;
+const CHILD_DOCUMENT_PATH =
+	/^\/documents\/([^/?#]+)\/([^/?#]+)\/([^/?#]+)\/children\/([^/?#]+)\/?$/;
 const RESEARCH_WORKSPACE_PATH =
 	/^\/documents\/([^/?#]+)\/([^/?#]+)\/([^/?#]+)\/research\/([^/?#]+)\/?$/;
 
@@ -26,6 +35,15 @@ export function documentsPath(owner: string, repository: string): string {
 
 export function documentPath(owner: string, repository: string, slug: string): string {
 	return `${documentsPath(owner, repository)}/${encodedSegment(slug)}`;
+}
+
+export function childDocumentPath(
+	owner: string,
+	repository: string,
+	parentSlug: string,
+	childSlug: string,
+): string {
+	return `${documentPath(owner, repository, parentSlug)}/children/${encodedSegment(childSlug)}`;
 }
 
 export function researchWorkspacePath(
@@ -47,6 +65,24 @@ export function parseDocumentPath(pathname: string): ParsedDocumentPath | undefi
 		if (match[3] === undefined) return { owner, repository };
 		let slug = decodeURIComponent(match[3]);
 		return slug ? { owner, repository, slug } : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+export function parseChildDocumentPath(
+	pathname: string,
+): ParsedChildDocumentPath | undefined {
+	let match = CHILD_DOCUMENT_PATH.exec(pathname);
+	if (!match) return undefined;
+	try {
+		let owner = decodeURIComponent(match[1]!);
+		let repository = decodeURIComponent(match[2]!);
+		let parentSlug = decodeURIComponent(match[3]!);
+		let childSlug = decodeURIComponent(match[4]!);
+		return owner && repository && parentSlug && childSlug
+			? { owner, repository, parentSlug, childSlug }
+			: undefined;
 	} catch {
 		return undefined;
 	}


### PR DESCRIPTION
## Summary

- base this layer directly on `main` now that Stack 2 landed through PR #129 and its source branch was deleted
- add durable nested child-document URLs, nested sidebar navigation, and direct/restored child route validation
- open child documents over a preserved parent workspace with correct history, scroll, focus, failure, retry, and sibling behavior
- keep document loading and anchored presentation behind the lazy workspace seam; raise only the raw initial-JavaScript budget from 250 KB to 255 KB while retaining the 80 KB gzip limit
- preserve current route-swap, generated-description, and purposeful-motion behavior
- centralize document-route classification, retained-layer retargeting, child lifecycle state, and workspace surface policy after a thermo-nuclear maintainability review

## Integration rulings

- retained Stack 2/current main's centralized route/content-swap ownership and motion layers
- combined Stack 2's stale-read generation guard with Stack 3's disposal and exact-read guards
- kept route/history coordination synchronous while lazily loading child validation and presentation
- adapted the child visibility assertion to current main's ContentSwapLayer contract
- keep URL/history canonicalization in route owners rather than `RoomWorkspace`
- excluded docs/superpowers/plans and docs/superpowers/specs

## Verification

- `bun run fix`
- focused review-fix suite: 44 passed
- `bun test`: 1,364 passed, 2 PostgreSQL tests skipped, 0 failed on the final rebased tree; an earlier sandbox run had 11 wire tests unable to bind ephemeral ports, and those passed 11/11 when rerun outside the sandbox
- `bun run types`
- `bun run ci`
- `bun run build`: 253,133 B raw / 79,238 B gzip
- `bun run e2e -- e2e/research-child-documents.e2e.ts`: 5 passed
- `git diff --check`
- thermo-nuclear follow-up review: approved with no blocking findings
