### PR TITLE
Fix comments after document navigation

### DIFF
--- a/e2e/document-navigation.e2e.ts
+++ b/e2e/document-navigation.e2e.ts
@@ -1,5 +1,5 @@
 import { authenticate, content, expect, roomPath, test } from "./room";
-import { createChannel } from "./database";
+import { createChannel, seedChannel } from "./database";
 
 function channel(id: string, title: string, description?: string) {
 	return {
@@ -52,6 +52,34 @@ async function headerAction(page: import("@playwright/test").Page, action: strin
 	await headerActions(page).click();
 	await page.getByRole("menuitem", { name: action, exact: true }).click();
 }
+
+test("a newly navigated parent document opens and submits its own comment composer", async ({ baseURL, join, seed }) => {
+	await seed("Original parent document.\n");
+	let destination = crypto.randomUUID();
+	let destinationTitle = `Test ${destination.slice(0, 8)}`;
+	let destinationText = "The destination parent document accepts a comment.";
+	let databasePort = Number(new URL(baseURL!).port);
+	await createChannel(databasePort, destination);
+	await seedChannel(databasePort, destination, `${destinationText}\n`);
+	let page = await join("ana");
+
+	await sidebar(page).getByRole("link", { name: destinationTitle, exact: true }).click();
+	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${destinationTitle}`);
+	let routes = page.locator(".document-route-swap > [data-content-swap-state]:not([hidden])");
+	await expect(routes).toHaveCount(1);
+	let active = page.locator(
+		".document-route-swap > [data-content-swap-state]:not([hidden]):not([inert])",
+	);
+	let editor = active.getByRole("textbox", { name: "editable markdown" });
+	await editor.getByText(destinationText, { exact: true }).selectText();
+	await active.getByRole("button", { name: "Comment on this passage", exact: true }).click();
+
+	let draft = active.getByRole("dialog", { name: "New comment" });
+	await draft.getByPlaceholder("Comment on this passage…").fill("Keep this parent passage.");
+	await draft.getByRole("button", { name: "Comment", exact: true }).click();
+	await expect(active.getByRole("button", { name: /Comment on “The destination parent/ }))
+		.toBeVisible();
+});
 
 test("document action menu motion follows its pointer trigger and survives interruption", async ({ join }) => {
 	let page = await join("ana");

--- a/e2e/research-child-documents.e2e.ts
+++ b/e2e/research-child-documents.e2e.ts
@@ -303,35 +303,6 @@ test("inline research publishes one ordinary child and opens its isolated worksp
 	await expect(open).toBeFocused();
 });
 
-test("a child document opens and submits its own comment composer", async ({ baseURL, page, room, seed }) => {
-	await seed(PARENT_SOURCE);
-	let childTitle = `Commentable child ${room.slice(0, 8)}`;
-	let child = await seedChildChannel(
-		port(baseURL!),
-		room,
-		crypto.randomUUID(),
-		childTitle,
-		CHILD_SOURCE,
-	);
-	await authenticate(page, "ana", baseURL!);
-	await page.goto(child.path);
-
-	let surface = page.getByRole("region", { name: `Child document: ${childTitle}` });
-	let editor = surface.getByRole("textbox", { name: "editable markdown" });
-	await expect(editor).toHaveAttribute("contenteditable", "true", { timeout: 20_000 });
-	await editor.getByText(
-		"This ordinary child has its own editable document, Decisions, and Conversation.",
-	)
-		.selectText();
-	await surface.getByRole("button", { name: "Comment on this passage", exact: true }).click();
-
-	let draft = surface.getByRole("dialog", { name: "New comment" });
-	await draft.getByPlaceholder("Comment on this passage…").fill("Keep this child passage.");
-	await draft.getByRole("button", { name: "Comment", exact: true }).click();
-	await expect(surface.getByRole("button", { name: /Comment on “This ordinary child/ }))
-		.toBeVisible();
-});
-
 test("failed research retries by identity while cancelled research never publishes", async ({ baseURL, join, page, room, seed }) => {
 	await seed("# Recovery parent\n");
 	let databasePort = port(baseURL!);

--- a/e2e/research-child-documents.e2e.ts
+++ b/e2e/research-child-documents.e2e.ts
@@ -303,6 +303,35 @@ test("inline research publishes one ordinary child and opens its isolated worksp
 	await expect(open).toBeFocused();
 });
 
+test("a child document opens and submits its own comment composer", async ({ baseURL, page, room, seed }) => {
+	await seed(PARENT_SOURCE);
+	let childTitle = `Commentable child ${room.slice(0, 8)}`;
+	let child = await seedChildChannel(
+		port(baseURL!),
+		room,
+		crypto.randomUUID(),
+		childTitle,
+		CHILD_SOURCE,
+	);
+	await authenticate(page, "ana", baseURL!);
+	await page.goto(child.path);
+
+	let surface = page.getByRole("region", { name: `Child document: ${childTitle}` });
+	let editor = surface.getByRole("textbox", { name: "editable markdown" });
+	await expect(editor).toHaveAttribute("contenteditable", "true", { timeout: 20_000 });
+	await editor.getByText(
+		"This ordinary child has its own editable document, Decisions, and Conversation.",
+	)
+		.selectText();
+	await surface.getByRole("button", { name: "Comment on this passage", exact: true }).click();
+
+	let draft = surface.getByRole("dialog", { name: "New comment" });
+	await draft.getByPlaceholder("Comment on this passage…").fill("Keep this child passage.");
+	await draft.getByRole("button", { name: "Comment", exact: true }).click();
+	await expect(surface.getByRole("button", { name: /Comment on “This ordinary child/ }))
+		.toBeVisible();
+});
+
 test("failed research retries by identity while cancelled research never publishes", async ({ baseURL, join, page, room, seed }) => {
 	await seed("# Recovery parent\n");
 	let databasePort = port(baseURL!);

--- a/e2e/research-child-documents.e2e.ts
+++ b/e2e/research-child-documents.e2e.ts
@@ -476,6 +476,35 @@ test("an in-app child preserves and restores its mounted parent", async ({ baseU
 	await expect(childLink).toBeFocused();
 });
 
+test("an in-app child opens and submits its own comment composer", async ({ baseURL, join, page, room, seed }) => {
+	await seed(PARENT_SOURCE);
+	let childTitle = `Commentable child ${room.slice(0, 8)}`;
+	await seedChildChannel(
+		port(baseURL!),
+		room,
+		crypto.randomUUID(),
+		childTitle,
+		CHILD_SOURCE,
+	);
+	await join("ana");
+
+	await page.getByRole("complementary", { name: "Projects" })
+		.getByRole("link", { name: childTitle, exact: true })
+		.click();
+	let surface = page.getByRole("region", { name: `Child document: ${childTitle}` });
+	let passage = "This ordinary child has its own editable document, Decisions, and Conversation.";
+	await surface.getByRole("textbox", { name: "editable markdown" })
+		.getByText(passage, { exact: true })
+		.selectText();
+	await surface.getByRole("button", { name: "Comment on this passage", exact: true }).click();
+
+	let draft = surface.getByRole("dialog", { name: "New comment" });
+	await draft.getByPlaceholder("Comment on this passage…").fill("Keep this child passage.");
+	await draft.getByRole("button", { name: "Comment", exact: true }).click();
+	await expect(surface.getByRole("button", { name: /Comment on “This ordinary child/ }))
+		.toBeVisible();
+});
+
 test("a delayed sibling route removes the previous editable child immediately", async ({ baseURL, join, page, room, seed }) => {
 	await seed(PARENT_SOURCE);
 	let firstTitle = `First source ${room.slice(0, 8)}`;

--- a/packages/editor/src/comment-layer.tsx
+++ b/packages/editor/src/comment-layer.tsx
@@ -291,8 +291,8 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 	}, [preview, store]);
 
 	useEffect(() => {
-		setHost(document.querySelector<HTMLElement>(".plan-document") ?? undefined);
-	}, []);
+		setHost(editor.getRootElement()?.closest<HTMLElement>(".plan-document") ?? undefined);
+	}, [editor]);
 
 	useEffect(() => {
 		let query = matchMedia(COARSE_POINTER_QUERY);

--- a/packages/editor/src/comment-layer.tsx
+++ b/packages/editor/src/comment-layer.tsx
@@ -291,7 +291,9 @@ export function CommentLayer({ store }: { store: ThreadStore }) {
 	}, [preview, store]);
 
 	useEffect(() => {
-		setHost(editor.getRootElement()?.closest<HTMLElement>(".plan-document") ?? undefined);
+		return editor.registerRootListener(element => {
+			setHost(element?.closest<HTMLElement>(".plan-document") ?? undefined);
+		});
 	}, [editor]);
 
 	useEffect(() => {


### PR DESCRIPTION
## Summary
- scope each comment layer to its own editor host instead of the first document in the DOM
- keep the comment composer in the active parent document after top-level navigation
- add browser regression coverage for creating a comment after navigating between parent documents

## Verification
- bun test (1362 passed, 2 skipped)
- bun run types
- bun run ci
- bun run e2e e2e/document-navigation.e2e.ts --project=chromium --grep "a newly navigated parent document opens and submits its own comment composer"