### PR TITLE
Clarify first-document creation

### DIFF
--- a/apps/web/src/hosted.tsx
+++ b/apps/web/src/hosted.tsx
@@ -379,13 +379,17 @@ function DocumentRouteSwap(
 		(layer): layer is DocumentRouteLayer => layer !== undefined,
 	);
 	let motion = motionContract("content-swap");
+	let { onDocumentLoaded, onDocumentRouteSettled } = useNavigationDocument();
 	let ready = useCallback((
 		key: DocumentRouteIdentity,
 		resolution?: DocumentRouteResolution,
 	) => {
 		if (resolution) aliases.current.set(resolution.routeKey, key);
 		dispatch({ key, resolution, type: "ready" });
-	}, []);
+		if (requestedRoute.current.key === key) {
+			onDocumentRouteSettled(requestedRoute.current.routeKey);
+		}
+	}, [onDocumentRouteSettled]);
 	let metadataPath = useCallback((
 		key: DocumentRouteIdentity,
 		metadataRouteKey: DocumentRouteIdentity,
@@ -399,7 +403,6 @@ function DocumentRouteSwap(
 		}
 		onCanonicalPath(pathname);
 	}, [onCanonicalPath]);
-	let { onDocumentLoaded } = useNavigationDocument();
 	let published = useRef<DocumentRouteResolution | undefined>(undefined);
 	useEffect(() => {
 		let resolution = state.current.resolution;

--- a/apps/web/src/navigation-chrome.test.ts
+++ b/apps/web/src/navigation-chrome.test.ts
@@ -38,8 +38,7 @@ describe("the Figma navigation chrome", () => {
 	test("uses a pen for document creation and a plus for adding a Project", () => {
 		let markup = renderToStaticMarkup(createElement(ProjectSidebar, {
 			canCreateDocument: true,
-			creatingNewDocument: false,
-			creatingProjectIds: new Set<string>(),
+			pendingCreations: new Map(),
 			onAccount: () => {},
 			onAddProject: () => {},
 			onCollapse: () => {},
@@ -104,8 +103,7 @@ describe("the Figma navigation chrome", () => {
 	test("exposes whether the account menu is open", () => {
 		let props = {
 			canCreateDocument: false,
-			creatingNewDocument: false,
-			creatingProjectIds: new Set<string>(),
+			pendingCreations: new Map(),
 			onAccount: () => {},
 			onAddProject: () => {},
 			onCollapse: () => {},
@@ -132,8 +130,7 @@ describe("the Figma navigation chrome", () => {
 	test("offers explicit pagination when a Project has more documents", () => {
 		let markup = renderToStaticMarkup(createElement(ProjectSidebar, {
 			canCreateDocument: true,
-			creatingNewDocument: false,
-			creatingProjectIds: new Set<string>(),
+			pendingCreations: new Map(),
 			onAccount: () => {},
 			onAddProject: () => {},
 			onCollapse: () => {},
@@ -158,6 +155,7 @@ describe("the Figma navigation chrome", () => {
 		}));
 
 		expect(markup).toContain('aria-label="Load more documents in testing-sql-transcripts"');
+		expect(markup).not.toContain("No documents yet.");
 	});
 
 	test("keeps the document header to one project icon and document trigger", () => {

--- a/apps/web/src/navigation-model.test.ts
+++ b/apps/web/src/navigation-model.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, it } from "bun:test";
 
 import {
 	activeProject,
-	beginProjectCreation,
 	canManageProject,
+	documentCreationTarget,
 	documentDestination,
-	finishProjectCreation,
 	isDocumentWorkspaceRoute,
 	landingDocument,
 	navigationMode,
@@ -209,13 +208,6 @@ describe("navigation model", () => {
 		});
 	});
 
-	it("keeps one Project creating while another creation settles", () => {
-		let creating = beginProjectCreation(new Set(), "R_one");
-		creating = beginProjectCreation(creating, "R_two");
-
-		expect([...finishProjectCreation(creating, "R_one")]).toEqual(["R_two"]);
-	});
-
 	it("allows mutations only for push or admin navigation repositories", () => {
 		let viewerProject = {
 			...projects[1]!.project,
@@ -245,5 +237,75 @@ describe("navigation model", () => {
 		expect(canManageProject(viewerProject)).toBe(false);
 		expect(canManageProject(editorProject)).toBe(true);
 		expect(canManageProject(adminProject)).toBe(true);
+	});
+});
+
+function project(id: string, permission: "push" | "admin" | "pull" = "push") {
+	return {
+		repositoryId: id,
+		repositoryOwner: "acme",
+		repositoryName: id,
+		position: 0,
+		available: true,
+		repository: {
+			id,
+			owner: "acme",
+			name: id,
+			fullName: `acme/${id}`,
+			permissions: { pull: true, push: permission === "push", admin: permission === "admin" },
+		},
+	};
+}
+
+describe("document creation targets", () => {
+	let first = project("first");
+	let second = project("second", "admin");
+	let viewer = project("viewer", "pull");
+	let unavailable = { ...project("unavailable"), available: false };
+
+	it("waits for navigation and unresolved current-document context", () => {
+		expect(documentCreationTarget(undefined, undefined)).toEqual({ type: "loading" });
+		expect(documentCreationTarget([first], undefined, true)).toEqual({ type: "loading" });
+		expect(documentCreationTarget([first], first, true)).toEqual({
+			type: "project",
+			project: first,
+		});
+	});
+
+	it("creates in the sole writable project without any document catalogue", () => {
+		expect(documentCreationTarget([viewer, first, unavailable], undefined)).toEqual({
+			type: "project",
+			project: first,
+		});
+		expect(documentCreationTarget([viewer, second], viewer)).toEqual({
+			type: "project",
+			project: second,
+		});
+	});
+
+	it("prefers the current project and asks only when the target is ambiguous", () => {
+		expect(documentCreationTarget([first, second], second)).toEqual({
+			type: "project",
+			project: second,
+		});
+		expect(documentCreationTarget([first, viewer, second, unavailable], undefined)).toEqual({
+			type: "choose",
+			projects: [first, second],
+		});
+	});
+
+	it("uses current navigation permissions rather than stale document context", () => {
+		let revoked = {
+			...first,
+			repository: { ...first.repository, permissions: viewer.repository.permissions },
+		};
+		expect(documentCreationTarget([revoked, second], first)).toEqual({
+			type: "project",
+			project: second,
+		});
+		expect(documentCreationTarget([viewer, unavailable], unavailable)).toEqual({
+			type: "unavailable",
+		});
+		expect(documentCreationTarget([], undefined)).toEqual({ type: "unavailable" });
 	});
 });

--- a/apps/web/src/navigation-model.ts
+++ b/apps/web/src/navigation-model.ts
@@ -46,6 +46,27 @@ export function canManageProject(project: NavigationProject): boolean {
 		&& (project.repository.permissions.push || project.repository.permissions.admin);
 }
 
+export type DocumentCreationTarget =
+	| { type: "loading" }
+	| { type: "project"; project: NavigationProject }
+	| { type: "choose"; projects: NavigationProject[] }
+	| { type: "unavailable" };
+
+export function documentCreationTarget(
+	projects: NavigationProject[] | undefined,
+	current: NavigationProject | undefined,
+	resolvingDocument = false,
+): DocumentCreationTarget {
+	if (!projects || (resolvingDocument && !current)) return { type: "loading" };
+	let eligible = projects.filter(project => project.available && canManageProject(project));
+	let active = eligible.find(project => project.repositoryId === current?.repositoryId);
+	if (active) return { type: "project", project: active };
+	if (eligible.length === 1) return { type: "project", project: eligible[0]! };
+	return eligible.length > 1
+		? { type: "choose", projects: eligible }
+		: { type: "unavailable" };
+}
+
 export function documentDestination(
 	projects: ProjectDocuments[],
 	documentId: string,
@@ -90,22 +111,6 @@ export function researchChildNavigation(
 	opener: ResearchOpener,
 ): { destination: string; opener: ResearchOpener } {
 	return { destination: researchChildDestination(parent, child), opener };
-}
-
-export function beginProjectCreation(
-	creating: ReadonlySet<string>,
-	projectId: string,
-): Set<string> {
-	return new Set(creating).add(projectId);
-}
-
-export function finishProjectCreation(
-	creating: ReadonlySet<string>,
-	projectId: string,
-): Set<string> {
-	let next = new Set(creating);
-	next.delete(projectId);
-	return next;
 }
 
 export function landingDocument(

--- a/apps/web/src/navigation-shell.tsx
+++ b/apps/web/src/navigation-shell.tsx
@@ -25,10 +25,9 @@ import { NavigationFocusScope } from "./navigation-focus";
 import { motionImmediately } from "./motion-input";
 import {
 	activeProject,
-	beginProjectCreation,
 	canManageProject,
+	documentCreationTarget,
 	documentDestination,
-	finishProjectCreation,
 	isDocumentWorkspaceRoute,
 	landingDocument,
 	NAVIGATION_MEDIA,
@@ -44,6 +43,7 @@ import {
 import { clearRepositoryCache } from "./repository-cache";
 import { TerminalAlert } from "./terminal-alert";
 import { useProjectDocuments } from "./use-project-documents";
+import { useDocumentCreation } from "./use-document-creation";
 
 import type { Research } from "@chopin/protocol";
 import type { ResearchOpener } from "@chopin/editor";
@@ -88,6 +88,9 @@ let ProjectSidebar = lazy(() =>
 let AddProjectDialog = lazy(() =>
 	import("./add-project-dialog").then(module => ({ default: module.AddProjectDialog }))
 );
+let NewDocumentDialog = lazy(() =>
+	import("./new-document-dialog").then(module => ({ default: module.NewDocumentDialog }))
+);
 let DocumentSearchDialog = lazy(() =>
 	import("./document-search-dialog").then(module => ({ default: module.DocumentSearchDialog }))
 );
@@ -109,6 +112,7 @@ let NavigationDocument = createContext<{
 	onDocumentAction: (documentId: string, action: DocumentAction) => void;
 	onDocumentDeleted: (documentId: string) => void;
 	onDocumentLoaded: (channel: Api.Channel, routeKey: DocumentRouteIdentity) => Promise<void>;
+	onDocumentRouteSettled: (routeKey: DocumentRouteIdentity) => void;
 	onRepositoryAccessChanged: () => void;
 	onResearchChildOpen: (
 		parentId: string,
@@ -121,6 +125,7 @@ let NavigationDocument = createContext<{
 	onDocumentAction() {},
 	onDocumentDeleted() {},
 	async onDocumentLoaded() {},
+	onDocumentRouteSettled() {},
 	onRepositoryAccessChanged() {},
 	onResearchChildOpen() {},
 	onResearchChildPublished() {},
@@ -272,14 +277,12 @@ export function NavigationShell(
 	let [catalogueMode, setCatalogueMode] = useState<"active" | "archived">("active");
 	let [dialog, setDialog] = useState<
 		| "add"
+		| "new"
 		| "search"
 		| { channel: Api.Channel; type: "delete" | "rename" }
 	>();
 	let [accountOpen, setAccountOpen] = useState(false);
-	let creatingProjectIds = useRef<Set<string>>(new Set());
-	let [creatingProjectIdsForView, setCreatingProjectIdsForView] = useState<ReadonlySet<string>>(
-		() => new Set(),
-	);
+	let [settledRouteKey, setSettledRouteKey] = useState<DocumentRouteIdentity>();
 	let [focusProjectId, setFocusProjectId] = useState<string>();
 	let [width, resize] = useSidebarWidth();
 	let mode = useNavigationMode();
@@ -320,6 +323,8 @@ export function NavigationShell(
 	} = useProjectDocuments(navigation, catalogueMode === "archived");
 	let routeKey = isDocumentWorkspaceRoute(route)
 		? documentRouteIdentity(route)
+		: route.page === "repository"
+		? `repository:${route.owner}/${route.repository}`
 		: route.page;
 	let currentRouteKey = useRef(routeKey);
 	currentRouteKey.current = routeKey;
@@ -477,12 +482,6 @@ export function NavigationShell(
 	}, [refresh]);
 
 	useEffect(() => {
-		if (route.page !== "repositories" || !navigation) return;
-		let destination = landingDocument(projects, navigation.lastDocumentId);
-		if (destination) navigate(documentDestination(projects, destination), { replace: true });
-	}, [navigate, navigation, projects, route.page]);
-
-	useEffect(() => {
 		localStorage.setItem(`${SIDEBAR_STORAGE_KEY}:collapsed`, String(collapsed));
 	}, [collapsed]);
 
@@ -512,20 +511,6 @@ export function NavigationShell(
 		return () => cancelAnimationFrame(frame);
 	}, [focusProjectId, projects]);
 
-	let startProjectCreation = (projectId: string): boolean => {
-		if (creatingProjectIds.current.has(projectId)) return false;
-		let next = beginProjectCreation(creatingProjectIds.current, projectId);
-		creatingProjectIds.current = next;
-		setCreatingProjectIdsForView(next);
-		return true;
-	};
-
-	let completeProjectCreation = (projectId: string) => {
-		let next = finishProjectCreation(creatingProjectIds.current, projectId);
-		creatingProjectIds.current = next;
-		setCreatingProjectIdsForView(next);
-	};
-
 	let navigateToDocument = (documentId: string, path?: string) => {
 		setError(undefined);
 		setDialog(undefined);
@@ -533,27 +518,41 @@ export function NavigationShell(
 		navigate(documentDestination(projects, documentId, path));
 	};
 
-	let createDocument = async (project: Api.NavigationProject) => {
-		if (!canManageProject(project) || !startProjectCreation(project.repositoryId)) return;
-		try {
-			let created = await Api.createChannel(project.repositoryOwner, project.repositoryName);
-			upsertDocument(created.channel);
-			navigateToDocument(
-				created.channel.id,
-				documentPath(
-					created.repository.owner,
-					created.repository.name,
-					created.channel.slug,
-				),
-			);
-		} catch (reason) {
-			setError({ reason, retry: "refresh" });
-		} finally {
-			completeProjectCreation(project.repositoryId);
-		}
+	let creation = useDocumentCreation({
+		routeKey,
+		onCreated: upsertDocument,
+		onNavigate: navigateToDocument,
+		onAccessChanged: () => void refresh(),
+	});
+	useEffect(() => {
+		if (route.page !== "repositories" || !navigation) return;
+		// Catalogue updates from earlier creations must not compete with an explicit creation.
+		if (creation.pending.size > 0 || creation.error) return;
+		let destination = landingDocument(projects, navigation.lastDocumentId);
+		if (destination) navigate(documentDestination(projects, destination), { replace: true });
+	}, [creation.error, creation.pending.size, navigate, navigation, projects, route.page]);
+	let createDocument = (project: Api.NavigationProject) => {
+		let current = navigationRef.current?.projects.find(value =>
+			value.repositoryId === project.repositoryId
+		);
+		if (current) void creation.create(current);
 	};
+	let retryProject = navigation?.projects.find(project =>
+		project.repositoryId === creation.error?.project.repositoryId
+		&& project.available && canManageProject(project)
+	);
+	let documentRouteSettled = useCallback((key: DocumentRouteIdentity) => {
+		if (currentRouteKey.current !== key) return;
+		setSettledRouteKey(key);
+		creation.settled(key);
+	}, [creation.settled]);
 
 	let active = activeProject(projects, currentDocumentId, resolvedChannel?.repositoryId);
+	let creationTarget = documentCreationTarget(
+		navigation?.projects,
+		active,
+		isDocumentWorkspaceRoute(route) && settledRouteKey !== routeKey,
+	);
 	let currentChannel = projects.flatMap(project => project.documents.channels)
 		.find(channel => channel.id === currentDocumentId) ?? resolvedChannel;
 	let currentChannelRef = useRef<Api.Channel | undefined>(undefined);
@@ -603,8 +602,9 @@ export function NavigationShell(
 		};
 	}, [revalidateCatalogues]);
 	let newDocument = () => {
-		if (active && canManageProject(active)) void createDocument(active);
-		else showDialog("add");
+		if (creationTarget.type === "loading") return;
+		if (creationTarget.type === "project") createDocument(creationTarget.project);
+		else showDialog("new");
 	};
 
 	let showDialog = useCallback((next: NonNullable<typeof dialog>) => {
@@ -697,6 +697,7 @@ export function NavigationShell(
 		onDocumentChanged: documentChanged,
 		onDocumentDeleted: documentDeleted,
 		onDocumentLoaded: documentLoaded,
+		onDocumentRouteSettled: documentRouteSettled,
 		onRepositoryAccessChanged: repositoryAccessChanged,
 		onResearchChildOpen: researchChildOpen,
 		onResearchChildPublished: researchChildPublished,
@@ -705,6 +706,7 @@ export function NavigationShell(
 		documentChanged,
 		documentDeleted,
 		documentLoaded,
+		documentRouteSettled,
 		repositoryAccessChanged,
 		researchChildOpen,
 		researchChildPublished,
@@ -767,9 +769,13 @@ export function NavigationShell(
 					</div>
 				)}
 				accountMenuOpen={accountOpen}
-				canCreateDocument={!active || canManageProject(active)}
-				creatingProjectIds={creatingProjectIdsForView}
-				creatingNewDocument={!!active && creatingProjectIdsForView.has(active.repositoryId)}
+				canCreateDocument={creationTarget.type !== "loading"}
+				pendingCreations={creation.pending}
+				newDocumentPhase={creationTarget.type === "loading"
+					? "loading"
+					: creationTarget.type === "project"
+					? creation.pending.get(creationTarget.project.repositoryId)
+					: undefined}
 				currentDocumentId={currentDocumentId}
 				onAccount={() => setAccountOpen(open => !open)}
 				onAddProject={() => showDialog("add")}
@@ -792,6 +798,30 @@ export function NavigationShell(
 	);
 	let content = (
 		<>
+			{!sidebarVisible && !drawerOpen && presentedDialog !== "new" && creation.pending.size > 0 && (
+				<div className="navigation-creation-status" role="status">
+					{[...creation.pending].map(([id, phase]) => (
+						<p key={id}>
+							{phase === "creating" ? "Creating document…" : "Opening document…"}{" "}
+							{navigation?.projects.find(project => project.repositoryId === id)?.repositoryName}
+						</p>
+					))}
+				</div>
+			)}
+			{creation.error && presentedDialog !== "new" && (
+				<TerminalAlert className="navigation-error">
+					{creation.error.message}
+					{retryProject && (
+						<button
+							className="btn btn-sm btn-secondary ml-2"
+							onClick={() => createDocument(retryProject)}
+							type="button"
+						>
+							Try again
+						</button>
+					)}
+				</TerminalAlert>
+			)}
 			{error !== undefined && (
 				<TerminalAlert className="navigation-error">
 					{error.reason instanceof Error
@@ -873,10 +903,33 @@ export function NavigationShell(
 								onAdded={project => {
 									catalogueRefreshes.current.set(project.repositoryId, Date.now());
 									setFocusProjectId(project.repositoryId);
+									setCollapsed(false);
+									if (mode === "drawer") setDrawerOpen(true);
 									void refresh();
 								}}
 								onDismiss={() => setDialog(undefined)}
 								userId={user.id}
+							/>
+						</Suspense>
+					</LazyDialogBoundary>
+				)}
+				{dialogMotion && presentedDialog === "new" && (
+					<LazyDialogBoundary>
+						<Suspense fallback={null}>
+							<NewDocumentDialog
+								error={creation.error?.message}
+								motion={dialogMotion}
+								onAddProject={() => showDialog("add")}
+								onCreate={createDocument}
+								onDismiss={() => {
+									setDialog(undefined);
+									if (mode === "drawer") {
+										requestAnimationFrame(() => drawerOpener.current?.focus());
+									}
+								}}
+								onRetry={retryProject ? () => createDocument(retryProject) : undefined}
+								pending={creation.pending}
+								projects={navigation?.projects ?? []}
 							/>
 						</Suspense>
 					</LazyDialogBoundary>

--- a/apps/web/src/navigation.css
+++ b/apps/web/src/navigation.css
@@ -437,6 +437,27 @@
 	color: var(--color-text-primary);
 }
 
+.project-sidebar-empty {
+	padding: 4px 8px 8px 32px;
+	font-size: var(--text-sm);
+	color: var(--color-text-tertiary);
+}
+
+.project-sidebar-empty-action {
+	margin-top: 4px;
+	color: var(--color-brand);
+	text-decoration: underline;
+}
+
+.project-sidebar-action-pending {
+	opacity: 1;
+}
+
+:is(.project-sidebar-primary-action, .project-sidebar-action, .project-sidebar-empty-action):disabled {
+	cursor: default;
+	color: var(--color-text-quaternary);
+}
+
 .project-sidebar-account {
 	width: 100%;
 	justify-content: flex-start;
@@ -552,6 +573,21 @@
 	height: 100%;
 	width: 100%;
 	box-shadow: var(--shadow-overlay);
+}
+
+.navigation-creation-status {
+	position: absolute;
+	top: calc(var(--document-shell-header-height) + 8px);
+	left: 16px;
+	right: 16px;
+	z-index: 15;
+	border-radius: var(--radius-md);
+	background: var(--color-page);
+	padding: 8px 12px;
+	box-shadow: var(--shadow-resting);
+	font-size: var(--text-sm);
+	color: var(--color-text-tertiary);
+	pointer-events: none;
 }
 
 .navigation-error {

--- a/apps/web/src/new-document-dialog.tsx
+++ b/apps/web/src/new-document-dialog.tsx
@@ -1,0 +1,122 @@
+import { useId, useRef, useState } from "react";
+
+import { NavigationDialog } from "./navigation-dialog";
+import { canManageProject } from "./navigation-model";
+import { TerminalAlert } from "./terminal-alert";
+
+import type * as Api from "./api";
+import type { NavigationDialogMotion } from "./navigation-dialog";
+import type { DocumentCreationPhase } from "./use-document-creation";
+
+export function NewDocumentDialog(
+	{ projects, pending, error, motion, onCreate, onAddProject, onDismiss, onRetry }: {
+		projects: Api.NavigationProject[];
+		pending: ReadonlyMap<string, DocumentCreationPhase>;
+		error?: string;
+		motion: NavigationDialogMotion;
+		onCreate: (project: Api.NavigationProject) => void;
+		onAddProject: () => void;
+		onDismiss: () => void;
+		onRetry?: () => void;
+	},
+) {
+	let input = useRef<HTMLInputElement>(null);
+	let searchId = useId();
+	let [query, setQuery] = useState("");
+	let eligible = projects.filter(project => project.available && canManageProject(project))
+		.sort((first, second) => first.position - second.position);
+	let normalized = query.trim().toLocaleLowerCase();
+	let visible = eligible.filter(project =>
+		`${project.repositoryOwner}/${project.repositoryName}`.toLocaleLowerCase().includes(normalized)
+	);
+	return (
+		<NavigationDialog
+			initialFocus={eligible.length > 0 ? input : undefined}
+			motion={motion}
+			onDismiss={onDismiss}
+			title="New document"
+		>
+			{error && (
+				<TerminalAlert className="mt-4 text-sm text-destructive-ink">
+					{error}
+					{onRetry && (
+						<button className="btn btn-sm btn-secondary ml-2" onClick={onRetry} type="button">
+							Try again
+						</button>
+					)}
+				</TerminalAlert>
+			)}
+			{eligible.length > 0
+				? (
+					<>
+						<p className="mt-4 text-sm text-text-tertiary">
+							Choose a project for your new document.
+						</p>
+						<label className="sr-only" htmlFor={searchId}>Search projects</label>
+						<input
+							className="field mt-3 h-9 w-full px-3 text-sm"
+							id={searchId}
+							onChange={event => setQuery(event.target.value)}
+							placeholder="Search projects"
+							ref={input}
+							value={query}
+						/>
+						<div className="navigation-dialog-list">
+							{visible.length === 0 && (
+								<p className="text-sm text-text-tertiary">No matching projects.</p>
+							)}
+							{visible.map(project => {
+								let phase = pending.get(project.repositoryId);
+								return (
+									<div key={project.repositoryId}>
+										<button
+											aria-busy={!!phase}
+											className="navigation-dialog-option"
+											disabled={!!phase}
+											onClick={() => onCreate(project)}
+											type="button"
+										>
+											<span className="min-w-0 text-left">
+												<span className="block truncate text-sm font-medium">
+													{project.repositoryName}
+												</span>
+												<span className="block truncate text-sm text-text-tertiary">
+													{project.repositoryOwner}
+												</span>
+											</span>
+											<span className="text-sm text-text-tertiary">Create document</span>
+										</button>
+										<div className="text-sm text-text-tertiary" role="status">
+											{phase === "creating"
+												? "Creating document…"
+												: phase
+												? "Opening document…"
+												: ""}
+										</div>
+									</div>
+								);
+							})}
+						</div>
+					</>
+				)
+				: (
+					<div className="mt-4 space-y-3">
+						<p className="text-sm text-text-tertiary">
+							{projects.length === 0
+								? "Add a project to create your first document."
+								: "You need write access to an available project to create a document."}
+						</p>
+						<button className="btn btn-md btn-primary" onClick={onAddProject} type="button">
+							Add Project
+						</button>
+						<a
+							className="block text-sm font-medium text-brand underline"
+							href="/auth/github/install"
+						>
+							Manage repository access
+						</a>
+					</div>
+				)}
+		</NavigationDialog>
+	);
+}

--- a/apps/web/src/project-sidebar.tsx
+++ b/apps/web/src/project-sidebar.tsx
@@ -15,6 +15,7 @@ import { ArchiveIcon, ChevronIcon, DocumentIcon, SearchIcon } from "@chopin/icon
 import type * as Api from "./api";
 import type { DocumentAction } from "./document-actions-menu";
 import type { ProjectDocuments } from "./document-actions";
+import type { DocumentCreationPhase } from "./use-document-creation";
 import type { ReactNode } from "react";
 
 export function NavigationIcon(
@@ -55,7 +56,7 @@ export function documentGroups(
 function Project(
 	{
 		archiveMode,
-		creatingProjectIds,
+		pendingCreations,
 		currentDocumentId,
 		entry,
 		expanded,
@@ -65,7 +66,7 @@ function Project(
 		onToggle,
 	}: {
 		archiveMode: boolean;
-		creatingProjectIds: ReadonlySet<string>;
+		pendingCreations: ReadonlyMap<string, DocumentCreationPhase>;
 		currentDocumentId?: string;
 		entry: ProjectDocuments;
 		expanded: boolean;
@@ -79,11 +80,27 @@ function Project(
 	let groups = documentGroups(documents.channels, archiveMode);
 	let label = project.repository?.name ?? project.repositoryName;
 	let canManage = canManageProject(project);
-	let creating = creatingProjectIds.has(project.repositoryId);
+	let phase = pendingCreations.get(project.repositoryId);
 	let contentId = useId();
 	let collapseMotion = motionContract("collapse");
 	let projectContent = (
 		<>
+			{!archiveMode && documents.status === "ready" && documents.channels.length === 0
+				&& !documents.nextCursor && (
+				<div className="project-sidebar-empty">
+					<p>No documents yet.</p>
+					{project.available && canManage && (
+						<button
+							className="project-sidebar-empty-action"
+							disabled={!!phase}
+							onClick={() => onCreateDocument(project)}
+							type="button"
+						>
+							Create document
+						</button>
+					)}
+				</div>
+			)}
 			{documents.status === "unavailable" && (
 				<p className="project-sidebar-status" role="status">Access unavailable</p>
 			)}
@@ -229,15 +246,20 @@ function Project(
 				</button>
 				{!archiveMode && project.available && canManage && (
 					<button
+						aria-busy={!!phase}
 						aria-label={`New document in ${label}`}
-						className="project-sidebar-action"
-						disabled={creating}
+						className={`project-sidebar-action ${phase ? "project-sidebar-action-pending" : ""}`}
+						disabled={!!phase}
 						onClick={() => onCreateDocument(project)}
+						title={`New document in ${label}`}
 						type="button"
 					>
 						<NavigationIcon src={newDocumentIcon} />
 					</button>
 				)}
+			</div>
+			<div className={phase ? "project-sidebar-status" : undefined} role="status">
+				{phase === "creating" ? "Creating document…" : phase ? "Opening document…" : ""}
 			</div>
 			<MotionDisclosure
 				id={contentId}
@@ -257,8 +279,8 @@ export function ProjectSidebar(
 		accountMenu,
 		accountMenuOpen,
 		canCreateDocument,
-		creatingNewDocument,
-		creatingProjectIds,
+		newDocumentPhase,
+		pendingCreations,
 		currentDocumentId,
 		onAccount,
 		onAddProject,
@@ -277,8 +299,8 @@ export function ProjectSidebar(
 		accountMenuOpen?: boolean;
 		canCreateDocument: boolean;
 		catalogueMode: "active" | "archived";
-		creatingNewDocument: boolean;
-		creatingProjectIds: ReadonlySet<string>;
+		newDocumentPhase?: DocumentCreationPhase | "loading";
+		pendingCreations: ReadonlyMap<string, DocumentCreationPhase>;
 		currentDocumentId?: string;
 		onAccount: () => void;
 		onAddProject: () => void;
@@ -319,13 +341,23 @@ export function ProjectSidebar(
 				: (
 					<>
 						<button
+							aria-busy={!!newDocumentPhase}
+							aria-label="New document"
 							className="project-sidebar-primary-action"
-							disabled={!canCreateDocument || creatingNewDocument}
+							disabled={!canCreateDocument || !!newDocumentPhase}
 							onClick={onNewDocument}
 							type="button"
 						>
 							<NavigationIcon src={newDocumentIcon} />
-							<span>New document</span>
+							<span>
+								{newDocumentPhase === "creating"
+									? "Creating document…"
+									: newDocumentPhase === "opening"
+									? "Opening document…"
+									: newDocumentPhase === "loading"
+									? "Loading projects…"
+									: "New document"}
+							</span>
 						</button>
 						<button
 							className="project-sidebar-primary-action"
@@ -396,7 +428,7 @@ export function ProjectSidebar(
 							.map(entry => (
 								<Project
 									archiveMode={archiveMode}
-									creatingProjectIds={creatingProjectIds}
+									pendingCreations={pendingCreations}
 									currentDocumentId={currentDocumentId}
 									entry={entry}
 									expanded={!collapsedProjectIds.has(entry.project.repositoryId)}

--- a/apps/web/src/research-sidebar.test.ts
+++ b/apps/web/src/research-sidebar.test.ts
@@ -24,8 +24,7 @@ let channel: Api.Channel = {
 
 let props = {
 	canCreateDocument: true,
-	creatingNewDocument: false,
-	creatingProjectIds: new Set<string>(),
+	pendingCreations: new Map(),
 	currentDocumentId: channel.id,
 	onAccount: () => {},
 	onAddProject: () => {},

--- a/apps/web/src/use-document-creation.ts
+++ b/apps/web/src/use-document-creation.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { documentPath } from "@chopin/protocol/document-url";
+
+import * as Api from "./api";
+import { documentRouteIdentity } from "./document-route-swap";
+import { canManageProject } from "./navigation-model";
+
+export type DocumentCreationPhase = "creating" | "opening";
+
+type Attempt = {
+	phase: DocumentCreationPhase;
+	destination?: string;
+};
+
+export function useDocumentCreation(
+	{ routeKey, onCreated, onNavigate, onAccessChanged }: {
+		routeKey: string;
+		onCreated: (channel: Api.Channel) => void;
+		onNavigate: (documentId: string, path: string) => void;
+		onAccessChanged: () => void;
+	},
+) {
+	let attempts = useRef(new Map<string, Attempt>());
+	let [pending, setPending] = useState<ReadonlyMap<string, DocumentCreationPhase>>(() => new Map());
+	let [error, setError] = useState<{ project: Api.NavigationProject; message: string }>();
+	let latest = useRef<Attempt | undefined>(undefined);
+	let location = useRef({ routeKey });
+	if (location.current.routeKey !== routeKey) location.current = { routeKey };
+	let publish = useCallback(() => {
+		setPending(new Map([...attempts.current].map(([id, attempt]) => [id, attempt.phase])));
+	}, []);
+	let finish = useCallback((projectId: string, attempt: Attempt) => {
+		if (attempts.current.get(projectId) !== attempt) return;
+		attempts.current.delete(projectId);
+		publish();
+	}, [publish]);
+
+	useEffect(() => () => {
+		latest.current = undefined;
+		location.current = { routeKey: "" };
+	}, []);
+
+	useEffect(() => {
+		for (let [id, attempt] of attempts.current) {
+			if (attempt.phase === "opening" && attempt.destination !== routeKey) finish(id, attempt);
+		}
+		setError(undefined);
+	}, [finish, routeKey]);
+
+	let settled = useCallback((key: string) => {
+		if (location.current.routeKey !== key) return;
+		for (let [id, attempt] of attempts.current) {
+			if (attempt.phase === "opening" && attempt.destination === key) finish(id, attempt);
+		}
+	}, [finish]);
+
+	let create = async (project: Api.NavigationProject) => {
+		let id = project.repositoryId;
+		if (!project.available || !canManageProject(project) || attempts.current.has(id)) return;
+		let attempt: Attempt = { phase: "creating" };
+		let origin = location.current;
+		attempts.current.set(id, attempt);
+		latest.current = attempt;
+		setError(undefined);
+		publish();
+		try {
+			let created = await Api.createChannel(project.repositoryOwner, project.repositoryName);
+			onCreated(created.channel);
+			// A successful POST still belongs in the catalogue after the user moves on.
+			if (location.current !== origin || latest.current !== attempt) {
+				finish(id, attempt);
+				return;
+			}
+			attempt.phase = "opening";
+			attempt.destination = documentRouteIdentity({
+				page: "document",
+				owner: created.repository.owner,
+				repository: created.repository.name,
+				slug: created.channel.slug,
+			});
+			publish();
+			onNavigate(
+				created.channel.id,
+				documentPath(
+					created.repository.owner,
+					created.repository.name,
+					created.channel.slug,
+				),
+			);
+		} catch (reason) {
+			finish(id, attempt);
+			if (location.current === origin && latest.current === attempt) {
+				setError({
+					project,
+					message: reason instanceof Error ? reason.message : "Could not create document.",
+				});
+			}
+			if (reason instanceof Api.ApiError && reason.status === 403) onAccessChanged();
+		}
+	};
+	return { create, error, pending, settled };
+}

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -228,6 +228,19 @@ and Chat document-reference pickers show generated descriptions when
 present. Search uses the server's title-or-description matching rather than
 filtering only the currently loaded page.
 
+The global **New document** action creates in the current available, writable
+project. With no usable current project, it uses the sole writable project or
+asks which saved project to use when several qualify. Navigation loading is
+distinct from having no eligible project; the latter shows project and access
+guidance. An empty project offers a labeled **Create document** action, and its
+pencil creates directly in that project.
+
+Creation shows separate **Creating document…** and **Opening document…** states.
+Controls targeting the same project stay disabled until the creation request
+and destination load settle. An opening failure retries loading the document
+already created. If the user navigates elsewhere during creation, a late success
+updates the catalogue without taking over their newer navigation.
+
 Historical slug URLs continue to open the document. The legacy
 `/repositories/:owner/:repository` and `/channels/:channelId` browser routes are
 also accepted. After resolving any historical or legacy link, the browser

--- a/e2e/document-creation.e2e.ts
+++ b/e2e/document-creation.e2e.ts
@@ -1,0 +1,408 @@
+import { authenticate, expect, test } from "./room";
+import { createChannel } from "./database";
+
+import type { Page } from "@playwright/test";
+import type { ChannelDetail } from "../apps/web/src/api";
+
+function sidebar(page: Page) {
+	return page.getByRole("complementary", { name: "Projects", exact: true });
+}
+
+function createButton(page: Page) {
+	return sidebar(page).getByRole("button", { name: "New document", exact: true });
+}
+
+function creationRequests(page: Page) {
+	let requests: string[] = [];
+	page.on("request", request => {
+		let path = new URL(request.url()).pathname;
+		if (request.method() === "POST" && /^\/api\/repositories\/[^/]+\/[^/]+\/channels$/.test(path)) {
+			requests.push(path);
+		}
+	});
+	return requests;
+}
+
+async function emptyCatalogues(page: Page) {
+	// Other tests share these repositories; retain real authorization but start with empty lists.
+	await page.route("**/api/navigation", async route => {
+		if (route.request().method() !== "GET") return route.fallback();
+		let response = await route.fetch();
+		let navigation = await response.json();
+		delete navigation.lastDocumentId;
+		await route.fulfill({ response, json: navigation });
+	});
+	await page.route("**/api/repositories/*/*/channels*", async route => {
+		if (route.request().method() !== "GET") return route.fallback();
+		let response = await route.fetch();
+		await route.fulfill({
+			response,
+			json: { ...await response.json(), channels: [], nextCursor: undefined },
+		});
+	});
+}
+
+async function start(page: Page, baseURL: string, names = ["score"]) {
+	await emptyCatalogues(page);
+	await authenticate(page, `document-creator-${crypto.randomUUID()}`, baseURL);
+	for (let repository of names) {
+		let response = await page.request.post("/api/navigation/projects", {
+			data: { owner: repository === "notes" ? "octocat" : "octo-org", repository },
+			headers: { origin: baseURL },
+		});
+		expect(response.status()).toBe(201);
+	}
+	await page.goto("/");
+}
+
+for (let action of ["global", "pencil", "empty"] as const) {
+	test(`first document creation through the ${action} action after adding a project`, async ({ baseURL, page }) => {
+		if (action === "empty") await page.setViewportSize({ width: 390, height: 844 });
+		await emptyCatalogues(page);
+		await authenticate(page, `document-creator-${crypto.randomUUID()}`, baseURL!);
+		let posts = creationRequests(page);
+		await page.goto("/");
+		let add = page.getByRole("dialog", { name: "Add Project", exact: true });
+		await add.getByRole("button", { name: "score octo-org Add", exact: true }).click();
+		let projects = sidebar(page);
+		await expect(projects.getByText("No documents yet.", { exact: true })).toBeVisible();
+		let pencil = projects.getByRole("button", { name: "New document in score", exact: true });
+		await expect(pencil).toHaveAttribute("title", "New document in score");
+		let trigger = action === "global"
+			? createButton(page)
+			: action === "pencil"
+			? pencil
+			: projects.getByRole("button", { name: "Create document", exact: true });
+		await trigger.click();
+		await expect(page).toHaveURL(/\/documents\/octo-org\/score\/[a-z]+-[a-z]+$/);
+		await expect(page.getByRole("textbox", { name: "editable markdown" })).toHaveAttribute(
+			"contenteditable",
+			"true",
+		);
+		expect(posts).toEqual(["/api/repositories/octo-org/score/channels"]);
+	});
+}
+
+test("first-document creation stays guarded through both POST and opening", async ({ baseURL, page }) => {
+	await start(page, baseURL!);
+	await expect(sidebar(page).getByText("No documents yet.")).toBeVisible();
+	let posted = Promise.withResolvers<void>();
+	let releasePost = Promise.withResolvers<void>();
+	let opening = Promise.withResolvers<void>();
+	let releaseOpen = Promise.withResolvers<void>();
+	let posts = creationRequests(page);
+	await page.route("**/api/repositories/octo-org/score/channels", async route => {
+		if (route.request().method() !== "POST") return route.fallback();
+		let response = await route.fetch();
+		posted.resolve();
+		await releasePost.promise;
+		await route.fulfill({ response });
+	});
+	await page.route("**/api/repositories/octo-org/score/documents/*", async route => {
+		opening.resolve();
+		await releaseOpen.promise;
+		await route.continue();
+	});
+	let global = createButton(page);
+	let pencil = sidebar(page).getByRole("button", { name: "New document in score", exact: true });
+	// Two synchronous activations also exercise the guard before React disables the DOM button.
+	await global.evaluate(button => {
+		(button as HTMLButtonElement).click();
+		(button as HTMLButtonElement).click();
+	});
+	await posted.promise;
+	await expect(global).toBeDisabled();
+	await expect(pencil).toBeDisabled();
+	await expect(sidebar(page).getByRole("button", { name: "Create document", exact: true }))
+		.toBeDisabled();
+	await expect(sidebar(page).getByRole("status").filter({ hasText: "Creating document…" }))
+		.toBeVisible();
+
+	releasePost.resolve();
+	await opening.promise;
+	await expect(global).toBeDisabled();
+	await expect(pencil).toBeDisabled();
+	await expect(sidebar(page).getByRole("status").filter({ hasText: "Opening document…" }))
+		.toBeVisible();
+	await pencil.evaluate(button => (button as HTMLButtonElement).click());
+	await page.mouse.move(900, 500);
+	await expect(sidebar(page).getByRole("status").filter({ hasText: "Opening document…" }))
+		.toBeVisible();
+	expect(posts).toHaveLength(1);
+
+	releaseOpen.resolve();
+	await expect(page.getByRole("textbox", { name: "editable markdown" })).toHaveAttribute(
+		"contenteditable",
+		"true",
+	);
+	await expect(global).toBeEnabled();
+	await expect(pencil).toBeEnabled();
+	expect(posts).toHaveLength(1);
+});
+
+test("the project chooser supports keyboard selection and retry in the chosen project", async ({ baseURL, page }) => {
+	await start(page, baseURL!, ["score", "archive-1", "notes"]);
+	let posts = creationRequests(page);
+	let fail = true;
+	await page.route("**/api/repositories/octo-org/archive-1/channels", async route => {
+		if (route.request().method() !== "POST") return route.fallback();
+		if (fail) {
+			fail = false;
+			return route.fulfill({ status: 503, json: { error: "Creation temporarily unavailable" } });
+		}
+		await route.continue();
+	});
+	let global = createButton(page);
+	await global.focus();
+	await global.press("Enter");
+	let dialog = page.getByRole("dialog", { name: "New document", exact: true });
+	let search = dialog.getByRole("textbox", { name: "Search projects", exact: true });
+	await expect(search).toBeFocused();
+	await expect(dialog.getByRole("button", { name: "score octo-org Create document", exact: true }))
+		.toBeVisible();
+	await expect(dialog.getByRole("button", { name: /notes/ })).toHaveCount(0);
+	await page.keyboard.press("Escape");
+	await expect(global).toBeFocused();
+	await global.press("Enter");
+	await search.fill("archive-1");
+	await expect(dialog.getByRole("button", { name: "score octo-org Create document", exact: true }))
+		.toHaveCount(0);
+	await search.press("Tab");
+	let option = dialog.getByRole("button", {
+		name: "archive-1 octo-org Create document",
+		exact: true,
+	});
+	await expect(option).toBeFocused();
+	await option.press("Enter");
+	await expect(dialog.getByRole("alert")).toHaveText(/Creation temporarily unavailable/);
+	await dialog.getByRole("button", { name: "Try again", exact: true }).click();
+	await expect(page).toHaveURL(/\/documents\/octo-org\/archive-1\/[a-z]+-[a-z]+$/);
+	await expect(page.getByRole("textbox", { name: "editable markdown" })).toHaveAttribute(
+		"contenteditable",
+		"true",
+	);
+	expect(posts).toEqual(Array(2).fill("/api/repositories/octo-org/archive-1/channels"));
+	await createButton(page).click();
+	await expect.poll(() => posts.length).toBe(3);
+	expect(posts[2]).toBe("/api/repositories/octo-org/archive-1/channels");
+	await expect(dialog).toHaveCount(0);
+});
+
+test("compact creation restores focus on dismissal and shows progress after the drawer closes", async ({ baseURL, page }) => {
+	await page.setViewportSize({ width: 390, height: 844 });
+	await start(page, baseURL!, ["score", "archive-1"]);
+	let opener = page.getByRole("button", { name: "Open Projects sidebar", exact: true });
+	await opener.click();
+	await createButton(page).click();
+	let dialog = page.getByRole("dialog", { name: "New document", exact: true });
+	await expect(dialog.getByRole("textbox", { name: "Search projects" })).toBeFocused();
+	await page.keyboard.press("Escape");
+	await expect(opener).toBeFocused();
+	await opener.click();
+	await createButton(page).click();
+	let opening = Promise.withResolvers<void>();
+	let release = Promise.withResolvers<void>();
+	await page.route("**/api/repositories/octo-org/score/documents/*", async route => {
+		opening.resolve();
+		await release.promise;
+		await route.continue();
+	});
+	await dialog.getByRole("button", { name: "score octo-org Create document", exact: true }).click();
+	await opening.promise;
+	await expect(page.getByRole("status").filter({ hasText: "Opening document… score" }))
+		.toBeVisible();
+	release.resolve();
+	await expect(page.getByRole("textbox", { name: "editable markdown" })).toHaveAttribute(
+		"contenteditable",
+		"true",
+	);
+	await expect(page.getByRole("status").filter({ hasText: "Opening document… score" })).toHaveCount(
+		0,
+	);
+});
+
+test("a failed opening retries the created document without another POST", async ({ join }) => {
+	let page = await join("ana");
+	let posts = creationRequests(page);
+	let fail = true;
+	await page.route("**/api/repositories/octo-org/score/documents/*", async route => {
+		if (fail) {
+			fail = false;
+			return route.fulfill({ status: 503, json: { error: "Opening temporarily unavailable" } });
+		}
+		await route.continue();
+	});
+	await createButton(page).click();
+	await expect(page.getByRole("heading", { name: "Cannot open Chopin", exact: true }))
+		.toBeVisible();
+	await expect(createButton(page)).toBeEnabled();
+	let path = page.url();
+	await page.getByRole("button", { name: "Try again", exact: true }).click();
+	await expect(page.getByRole("textbox", { name: "editable markdown" })).toHaveAttribute(
+		"contenteditable",
+		"true",
+	);
+	expect(page.url()).toBe(path);
+	expect(posts).toHaveLength(1);
+});
+
+test("overlapping creations keep separate guards and open the latest requested project", async ({ baseURL, page }) => {
+	await start(page, baseURL!, ["score", "archive-1"]);
+	let firstPosted = Promise.withResolvers<ChannelDetail>();
+	let secondPosted = Promise.withResolvers<ChannelDetail>();
+	let releaseFirst = Promise.withResolvers<void>();
+	let releaseSecond = Promise.withResolvers<void>();
+	let posts = creationRequests(page);
+	await page.route("**/api/repositories/octo-org/*/channels", async route => {
+		if (route.request().method() !== "POST") return route.fallback();
+		let response = await route.fetch();
+		let first = new URL(route.request().url()).pathname.includes("/score/");
+		(first ? firstPosted : secondPosted).resolve(await response.json());
+		await (first ? releaseFirst : releaseSecond).promise;
+		await route.fulfill({ response });
+	});
+	let first = sidebar(page).getByRole("button", { name: "New document in score", exact: true });
+	let second = sidebar(page).getByRole("button", {
+		name: "New document in archive-1",
+		exact: true,
+	});
+	await first.click();
+	let firstDocument = await firstPosted.promise;
+	await second.click();
+	let secondDocument = await secondPosted.promise;
+	await expect(first).toBeDisabled();
+	await expect(second).toBeDisabled();
+	releaseFirst.resolve();
+	await expect(sidebar(page).getByRole("link", { name: firstDocument.channel.title, exact: true }))
+		.toBeVisible();
+	await expect(first).toBeEnabled();
+	await expect(second).toBeDisabled();
+	releaseSecond.resolve();
+	await expect(page).toHaveURL(`/documents/octo-org/archive-1/${secondDocument.channel.slug}`);
+	await expect(page.getByRole("banner").locator('[aria-label^="Document:"]'))
+		.toHaveAccessibleName(`Document: ${secondDocument.channel.title}`);
+	await expect(second).toBeEnabled();
+	expect(posts).toEqual([
+		"/api/repositories/octo-org/score/channels",
+		"/api/repositories/octo-org/archive-1/channels",
+	]);
+});
+
+test("global creation without projects explains the next step", async ({ baseURL, page }) => {
+	await authenticate(page, `document-creator-${crypto.randomUUID()}`, baseURL!);
+	let posts = creationRequests(page);
+	await page.goto("/");
+	await expect(page.getByRole("dialog", { name: "Add Project", exact: true })).toBeVisible();
+	await page.keyboard.press("Escape");
+	await createButton(page).click();
+	let dialog = page.getByRole("dialog", { name: "New document", exact: true });
+	await expect(dialog.getByText("Add a project to create your first document.")).toBeVisible();
+	await dialog.getByRole("button", { name: "Add Project", exact: true }).click();
+	await expect(page.getByRole("dialog", { name: "Add Project", exact: true })).toBeVisible();
+	expect(posts).toHaveLength(0);
+});
+
+test("a rejected creation refreshes project permissions and offers access guidance", async ({ baseURL, page }) => {
+	await start(page, baseURL!);
+	await expect(sidebar(page).getByText("No documents yet.")).toBeVisible();
+	let posts = creationRequests(page);
+	await page.route("**/api/navigation", async route => {
+		if (route.request().method() !== "GET") return route.fallback();
+		let response = await route.fetch();
+		let navigation = await response.json();
+		delete navigation.lastDocumentId;
+		for (let project of navigation.projects) {
+			project.repository.permissions.push = false;
+			project.repository.permissions.admin = false;
+		}
+		await route.fulfill({ response, json: navigation });
+	});
+	await page.route("**/api/repositories/octo-org/score/channels", async route => {
+		if (route.request().method() !== "POST") return route.fallback();
+		await route.fulfill({ status: 403, json: { error: "repository write access is required" } });
+	});
+	await createButton(page).click();
+	await expect(page.getByRole("alert")).toHaveText("repository write access is required");
+	await expect(sidebar(page).getByRole("button", { name: "New document in score", exact: true }))
+		.toHaveCount(0);
+	await createButton(page).click();
+	let dialog = page.getByRole("dialog", { name: "New document", exact: true });
+	await expect(
+		dialog.getByText("You need write access to an available project to create a document."),
+	).toBeVisible();
+	await expect(dialog.getByRole("button", { name: "Try again", exact: true })).toHaveCount(0);
+	expect(posts).toHaveLength(1);
+});
+
+test("leaving a pending opening releases its guard without letting stale readiness clear a new one", async ({ join }) => {
+	let page = await join("ana");
+	let originalTitle = (await sidebar(page).locator('a[aria-current="page"]').textContent())!.trim();
+	let firstOpening = Promise.withResolvers<void>();
+	let secondOpening = Promise.withResolvers<void>();
+	let releaseFirst = Promise.withResolvers<void>();
+	let releaseSecond = Promise.withResolvers<void>();
+	let firstReleased = Promise.withResolvers<void>();
+	let reads = 0;
+	await page.route("**/api/repositories/octo-org/score/documents/*", async route => {
+		let first = ++reads === 1;
+		let response = await route.fetch();
+		(first ? firstOpening : secondOpening).resolve();
+		await (first ? releaseFirst : releaseSecond).promise;
+		await route.fulfill({ response });
+		if (first) firstReleased.resolve();
+	});
+	await createButton(page).click();
+	await firstOpening.promise;
+	await expect(createButton(page)).toBeDisabled();
+	await sidebar(page).getByRole("link", { name: originalTitle, exact: true }).click();
+	await expect(createButton(page)).toBeEnabled();
+	await createButton(page).click();
+	await secondOpening.promise;
+	releaseFirst.resolve();
+	await firstReleased.promise;
+	await expect(createButton(page)).toBeDisabled();
+	await expect(sidebar(page).getByRole("status").filter({ hasText: "Opening document…" }))
+		.toBeVisible();
+	releaseSecond.resolve();
+	await expect(createButton(page)).toBeEnabled();
+	await expect(page.getByRole("banner").locator('[aria-label^="Document:"]'))
+		.not.toHaveAccessibleName(`Document: ${originalTitle}`);
+});
+
+for (let returnToOrigin of [false, true]) {
+	test(`a late creation does not take over newer navigation${returnToOrigin ? " back to its origin" : ""}`, async ({ baseURL, join }) => {
+		let destination = crypto.randomUUID();
+		await createChannel(Number(new URL(baseURL!).port), destination);
+		let page = await join("ana");
+		let original = sidebar(page).locator('a[aria-current="page"]');
+		let originalTitle = (await original.textContent())!.trim();
+		let posted = Promise.withResolvers<ChannelDetail>();
+		let release = Promise.withResolvers<void>();
+		await page.route("**/api/repositories/octo-org/score/channels", async route => {
+			if (route.request().method() !== "POST") return route.fallback();
+			let response = await route.fetch();
+			posted.resolve(await response.json());
+			await release.promise;
+			await route.fulfill({ response });
+		});
+		await createButton(page).click();
+		let created = await posted.promise;
+		let target = `Test ${destination.slice(0, 8)}`;
+		await sidebar(page).getByRole("link", { name: target, exact: true }).click();
+		await expect(page.getByRole("banner").locator('[aria-label^="Document:"]'))
+			.toHaveAccessibleName(`Document: ${target}`);
+		if (returnToOrigin) {
+			await sidebar(page).getByRole("link", { name: originalTitle, exact: true }).click();
+			await expect(page.getByRole("banner").locator('[aria-label^="Document:"]'))
+				.toHaveAccessibleName(`Document: ${originalTitle}`);
+		}
+		let path = page.url();
+		release.resolve();
+		await expect(sidebar(page).getByRole("link", { name: created.channel.title, exact: true }))
+			.toBeVisible();
+		await expect(createButton(page)).toBeEnabled();
+		expect(page.url()).toBe(path);
+		await expect(sidebar(page).getByRole("link", { name: created.channel.title, exact: true })).not
+			.toHaveAttribute("aria-current", "page");
+	});
+}

--- a/e2e/document-navigation.e2e.ts
+++ b/e2e/document-navigation.e2e.ts
@@ -345,11 +345,19 @@ test("document switches preserve navigation state and avoid catalogue reloads", 
 		page,
 		'[data-content-swap-state="outgoing"]:not([hidden])',
 	);
-	await expect(visibleRoutes).toHaveCount(2);
-	await expect(interactiveRoutes).toHaveCount(1);
-	await expect(outgoingRoutes).toHaveCount(1);
-	await expect(outgoingRoutes).toHaveAttribute("aria-hidden", "true");
-	await expect(outgoingRoutes).toHaveAttribute("inert", "");
+	// Inspect the short-lived exit layer in one browser turn, before its timer removes it.
+	await expect.poll(() =>
+		visibleRoutes.evaluateAll(routes =>
+			routes.map(route => ({
+				outgoing: route.getAttribute("data-content-swap-state") === "outgoing",
+				inert: route.hasAttribute("inert"),
+				hidden: route.getAttribute("aria-hidden"),
+			}))
+		)
+	).toEqual([
+		{ outgoing: true, inert: true, hidden: "true" },
+		{ outgoing: false, inert: false, hidden: null },
+	]);
 	await expect(headerDocument(page)).toHaveAccessibleName(`Document: ${originalTitle}`);
 	await expect(page).toHaveURL(originalPath!);
 
@@ -587,7 +595,7 @@ test("a delayed rename response cannot overwrite a newer collaborator rename", a
 	await expect(headerDocument(ana)).toHaveAccessibleName(`Document: ${latest}`);
 });
 
-test("read-only visitors can browse documents while mutation actions stay disabled", async ({ baseURL, page, room }) => {
+test("read-only visitors can browse documents and get creation guidance", async ({ baseURL, page, room }) => {
 	await authenticate(page, "readonly", baseURL!);
 	await page.goto(roomPath(room));
 	await expect(page.getByRole("banner")).toBeVisible();
@@ -596,8 +604,14 @@ test("read-only visitors can browse documents while mutation actions stay disabl
 		"false",
 	);
 	await expect(headerActions(page)).toHaveCount(0);
-	await expect(sidebar(page).getByRole("button", { name: "New document", exact: true }))
-		.toBeDisabled();
+	await sidebar(page).getByRole("button", { name: "New document", exact: true }).click();
+	let creation = page.getByRole("dialog", { name: "New document", exact: true });
+	await expect(
+		creation.getByText("You need write access to an available project to create a document."),
+	)
+		.toBeVisible();
+	await expect(creation.getByRole("link", { name: "Manage repository access" })).toBeVisible();
+	await page.keyboard.press("Escape");
 	await sidebar(page).getByRole("button", { name: "Search", exact: true }).click();
 	await expect(page.getByRole("textbox", { name: "Search documents" })).toBeFocused();
 });

--- a/e2e/github.ts
+++ b/e2e/github.ts
@@ -94,6 +94,11 @@ let fake = async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof f
 		let authorized = /^Bearer ghu_e2e_(.+)_\d+$/.exec(authorization);
 		if (!authorized) return json({ message: "Bad credentials" }, { status: 401 });
 		let handle = authorized[1]!;
+		let accessibleRepositories = repositories.map(repository =>
+			handle.startsWith("document-creator-") && repository.name === "archive-1"
+				? { ...repository, permissions: { ...repository.permissions, push: true } }
+				: repository
+		);
 		let tagged = (value: unknown, etag: string, responseInit: ResponseInit = {}) => {
 			let headers = new Headers(responseInit.headers);
 			headers.set("etag", etag);
@@ -121,7 +126,7 @@ let fake = async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof f
 			return tagged({ installations }, `"installations-${handle}"`);
 		}
 		if (url.pathname === "/user/installations/101/repositories") {
-			let available = repositories.filter(value => value.owner.login === "octo-org");
+			let available = accessibleRepositories.filter(value => value.owner.login === "octo-org");
 			if (handle === "readonly") {
 				available = available.map(value => ({
 					...value,
@@ -147,11 +152,13 @@ let fake = async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof f
 		}
 		if (url.pathname === "/user/installations/102/repositories") {
 			return tagged(
-				{ repositories: repositories.filter(value => value.owner.login === "octocat") },
+				{ repositories: accessibleRepositories.filter(value => value.owner.login === "octocat") },
 				`"repositories-${handle}-102-${url.searchParams.get("page") ?? "1"}"`,
 			);
 		}
-		let repository = repositories.find(value => url.pathname === `/repos/${value.full_name}`);
+		let repository = accessibleRepositories.find(value =>
+			url.pathname === `/repos/${value.full_name}`
+		);
 		if (repository) return json(repository);
 		return json({ message: "Not Found" }, { status: 404 });
 	}


### PR DESCRIPTION
## Summary

Fixes #148.

- Create in the current or sole writable project, with a dedicated project chooser and access guidance when needed.
- Add an explicit first-document action, pencil tooltips, and visible creating/opening feedback on desktop and compact layouts.
- Keep per-project creation guards through opening, retry existing documents after opening failures, and prevent late responses or competing landing redirects from taking over newer navigation.
- Document the behavior and add browser regression coverage for first use, permissions, retries, overlapping requests, and focus.

## Validation

- [x] 39 focused unit tests
- [x] 50 targeted Chromium tests across creation, document navigation, and hosted flows
- [x] Re-ran all 13 creation tests after the final empty-state adjustment
- [x] `bun run types`
- [x] `bun run ci`
- [x] Production web build
- [x] CI validation, full browser integration, and container build
- [x] Live preview creation/navigation smoke test (scope and limits below)

## Live preview verification

Tested https://153-chopin.githubnext.com at `7a37d629f052a3b5753b96e2e10996e113d23744`. The trusted deployment-ready timestamp followed PR creation, with no intervening push.

The restricted browser worker verified the configured dedicated test identity (`CHOPIN_PREVIEW_GITHUB_USERNAME`) and sole writable sandbox (`CHOPIN_PREVIEW_REPOSITORY`). Three empty sandbox documents were created within the approved scope.

Passed:
- Empty project displays its explicit first-document action.
- Global **New document** creates and opens the first document directly.
- The project pencil creates and opens a second document.
- Switching documents and reloading preserve the created documents.
- Global creation works at 390×844; compact sidebar navigation and document controls remain reachable.

No application or interaction failures were observed, and no manual authentication step remains. The browser was restored to desktop size.

Limits: native tooltip display and transient creating/opening feedback were not observed with the restricted browser tools; pixel-level overflow/layout was not verifiable. Multi-project selection and forced delay/failure/race scenarios remain covered by local E2E rather than the single-sandbox live smoke test.
